### PR TITLE
chore: add GitHub project board sync to planning workflow

### DIFF
--- a/.github/agents/delivery.agent.md
+++ b/.github/agents/delivery.agent.md
@@ -1,6 +1,7 @@
 ---
 name: Delivery Agent
 description: Implements planned GitHub issues following coding standards, creates tests, updates documentation, and ensures all mandatory gates are met before handoff to Review Agent.
+model: GPT-5.3-Codex
 argument-hint: Specify issue number or feature name, e.g., "implement issue #15" or "build Label Manager UI"
 ---
 
@@ -35,6 +36,9 @@ Invoke this agent when you need to:
   - `status/todo` or `status/in-progress` label
   - Technical plan or breakdown in description
 - Flag if issue is not ready for implementation
+- **Project board update (start of work):**
+  - Remove `status/todo` label, add `status/in-progress` label on the issue
+  - Use `github-project` skill (Lifecycle Event 2) to set project Status → "In Progress" and overwrite Start Date with today's actual start date
 
 ### 2. Implementation Execution
 - Follow layered architecture rules from `.github/copilot-instructions.md`:
@@ -128,6 +132,7 @@ Deliver to user:
 
 Implementation is complete when:
 - ✅ All acceptance criteria from issue are met
+- ✅ Project board Status set to "In Progress" and issue label updated
 - ✅ Code compiles without errors/warnings
 - ✅ Tests pass locally
 - ✅ Documentation updated per `plan/DOCS_STRATEGY.md`
@@ -157,6 +162,7 @@ Implementation is complete when:
 - `fluentui-blazor` skill — UI components
 - `csharp-xunit` skill — test creation
 - `csharp-docs` skill — XML comment generation
+- `github-project` skill — project board status update (Lifecycle Event 2: Implementation Started)
 - `create-architectural-decision-record` skill — ADR creation when needed
 - `documentation-writer` skill — user guide updates
 

--- a/.github/agents/pm-orchestrator.agent.md
+++ b/.github/agents/pm-orchestrator.agent.md
@@ -1,6 +1,7 @@
 ---
 name: PM Orchestrator
 description: Selects next backlog item, validates scope alignment, creates technical plan via breakdown-plan skill, and sets up GitHub issues with correct labels/milestones. Hands off to Delivery Agent when planning is complete.
+model: Claude Sonnet 4.6
 argument-hint: Specify "next item", "plan feature X", or "what should I work on"
 ---
 
@@ -59,7 +60,15 @@ Invoke this agent when you need to:
 - Assign to current milestone if applicable
 - Link dependencies and parent/child relationships
 
-### 5. Quality Planning
+### 5. Project Board Sync
+- Use `github-project` skill to add each created issue to the **SoloDevBoard Roadmap** project (#8)
+- Set **Phase** based on the issue's milestone (see Phase Assignment Rules in `github-project` skill)
+- Set **Priority** matching the `priority/` label applied to the issue
+- Set **Status** to "Todo" for all newly created issues
+- Set **Start Date** and **Target Date** using the Roadmap Date Guidelines in `github-project` skill
+- Follow Lifecycle Event 1 command pattern from `.github/skills/github-project/SKILL.md`
+
+### 6. Quality Planning
 - Invoke `breakdown-test` skill for test strategy
 - Ensure test issues are created alongside feature issues
 - Verify Definition of Done criteria are explicit
@@ -117,6 +126,7 @@ Planning is complete when:
 - ✅ GitHub issues created with correct labels/milestones
 - ✅ Test strategy defined via `breakdown-test`
 - ✅ Dependencies and acceptance criteria documented
+- ✅ All created issues added to project board with Phase/Priority/Status/dates set
 - ✅ No scope ambiguity or blockers
 - ✅ Handoff package delivered
 
@@ -137,6 +147,7 @@ Planning is complete when:
 - `breakdown-plan` skill — technical decomposition
 - `breakdown-test` skill — quality planning
 - `github-issues` skill — issue creation/updates
+- `github-project` skill — project board sync (Lifecycle Event 1: Issue Created)
 
 **Hands off to:**
 - **Delivery Agent** — for implementation execution (code, tests, docs)

--- a/.github/agents/review.agent.md
+++ b/.github/agents/review.agent.md
@@ -1,6 +1,7 @@
 ---
 name: Review Agent
 description: Creates PR, validates quality gates, verifies documentation sync, runs tests, and closes issues after approval. Ensures release readiness before marking work complete.
+model: Claude Sonnet 4.6
 argument-hint: Specify "review issue #X" or "create PR and close issue #Y"
 ---
 
@@ -35,7 +36,7 @@ Invoke this agent when you need to:
   - Labels matching primary issue labels
   - Milestone assignment if applicable
 - Use `.github/pull_request_template.md` if present
-- Link PR to GitHub project board if tracking enabled
+- Link PR to GitHub project board — the Linked pull requests field updates automatically when the PR references the issue
 
 ### 2. Quality Gate Validation
 
@@ -76,6 +77,7 @@ Invoke this agent when you need to:
 - Add closing comment summarizing validation results
 - Link PR in issue comments
 - Close issue with "Closes #X" in PR merge commit
+- **Project board update (post-merge):** Use `github-project` skill (Lifecycle Event 3) to set project Status → "Done" and overwrite Target Date with today's actual completion date
 
 ### 5. Handoff to Next Work
 - Update `plan/BACKLOG.md` to mark item as complete
@@ -148,6 +150,7 @@ Review is complete when:
 
 **Post-merge:** After user approves and merge completes:
 - ✅ Issue closed with `status/done`
+- ✅ Project board Status set to "Done" via `github-project` skill
 - ✅ Backlog marked complete
 - ✅ Release plan updated if needed
 
@@ -167,6 +170,7 @@ Review is complete when:
 - `get_errors` tool — compile error check
 - `github-issues` skill — issue updates and closure
 - `gh-cli` skill — PR creation and label management (if bulk operations needed)
+- `github-project` skill — project board status update (Lifecycle Event 3: Issue Closed)
 
 **Hands off to:**
 - **Delivery Agent** — if quality gate failures require fixes

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -174,6 +174,7 @@ Use the following active skill set for this repository:
 - `pm-feature-workflow`
 - `breakdown-plan`
 - `github-issues`
+- `github-project`
 - `gh-cli`
 - `breakdown-test`
 - `create-architectural-decision-record`
@@ -190,7 +191,7 @@ Default workflow order for feature delivery:
 
 1. Orchestration: `pm-feature-workflow`
 2. Planning: `breakdown-plan`
-3. Issue lifecycle: `github-issues` (and `gh-cli` for bulk operations)
+3. Issue lifecycle: `github-issues` (and `gh-cli` for bulk operations), then `github-project` to sync the project board
 4. Test planning: `breakdown-test`
 5. Implementation: `dotnet-best-practices` and `fluentui-blazor` as needed
 6. Architecture decision capture: `create-architectural-decision-record` when required

--- a/.github/prompts/daily-start.prompt.md
+++ b/.github/prompts/daily-start.prompt.md
@@ -1,6 +1,7 @@
 ---
 name: Daily Start
 description: Morning startup workflow for PM — reviews backlog, checks active work, identifies blockers, and recommends next action.
+agent: PM Orchestrator
 ---
 
 # Daily Start Workflow

--- a/.github/prompts/execute-feature.prompt.md
+++ b/.github/prompts/execute-feature.prompt.md
@@ -1,6 +1,7 @@
 ---
 name: Execute Feature
 description: Implements a planned GitHub issue following coding standards, creates tests, updates documentation, and ensures all mandatory gates are met. Invokes Delivery Agent.
+agent: Delivery Agent
 ---
 
 # Execute Feature Workflow
@@ -44,6 +45,7 @@ This prompt invokes the **Delivery Agent**, which executes:
   - `status/todo` or `status/in-progress` label
   - Technical plan or breakdown in description
 - **If issue not ready:** Escalate to PM Orchestrator for re-planning
+- **Project board update:** Remove `status/todo` label, add `status/in-progress`; use `github-project` skill (Lifecycle Event 2) to set project Status → "In Progress"
 
 ### 2. Implementation Execution
 - Follow layered architecture from `.github/copilot-instructions.md`:

--- a/.github/prompts/plan-next-issue.prompt.md
+++ b/.github/prompts/plan-next-issue.prompt.md
@@ -1,6 +1,7 @@
 ---
 name: Plan Next Issue
 description: Selects next backlog item (or specific feature), validates scope, creates technical plan via breakdown-plan skill, and sets up GitHub issues with correct metadata. Invokes PM Orchestrator Agent.
+agent: PM Orchestrator
 ---
 
 # Plan Next Issue Workflow
@@ -72,7 +73,14 @@ This prompt invokes the **PM Orchestrator Agent**, which executes:
 - Assign to current milestone if applicable
 - Link dependencies (parent/child, blocked-by relationships)
 
-### 6. Test Strategy
+### 6. Project Board Sync
+- Use `github-project` skill (Lifecycle Event 1) to add each created issue to the **SoloDevBoard Roadmap** project (#8)
+- Set Phase matching the issue's milestone (see Phase Assignment Rules in `github-project` skill)
+- Set Priority matching the `priority/` label applied to each issue
+- Set Status to "Todo" for all new issues
+- Set Start Date and Target Date from the Roadmap Date Guidelines in `github-project` skill
+
+### 7. Test Strategy
 - Invoke `breakdown-test` skill
 - Create test issues linked to feature issues
 - Define quality gates and acceptance test scenarios
@@ -86,6 +94,7 @@ This prompt invokes the **PM Orchestrator Agent**, which executes:
 - **Technical plan** embedded in epic/feature issue descriptions
 - **Test issues** linked to feature work
 - **ADR** if architectural decision required
+- **Project board items** — all issues added to SoloDevBoard Roadmap with Phase/Priority/Status/dates
 
 ### Artefacts Updated
 - **`plan/BACKLOG.md`** — item marked as planned/in-progress

--- a/.github/prompts/review-and-close.prompt.md
+++ b/.github/prompts/review-and-close.prompt.md
@@ -1,6 +1,7 @@
 ---
 name: Review and Close
 description: Creates PR, validates quality gates, verifies documentation sync, runs tests, and closes issues after approval. Invokes Review Agent.
+agent: Review Agent
 ---
 
 # Review and Close Workflow
@@ -88,6 +89,7 @@ This prompt invokes the **Review Agent**, which executes:
   - Remove `status/in-review`
   - Add `status/done`
 - Close issue with comment linking PR
+- **Project board update:** Use `github-project` skill (Lifecycle Event 3) to set project Status → "Done"
 - Update `plan/BACKLOG.md` marking item complete
 - Suggest next backlog item for PM Orchestrator
 
@@ -105,6 +107,7 @@ This prompt invokes the **Review Agent**, which executes:
 
 ### Artefacts Updated (Post-Merge)
 - **Issue status** — `status/in-review` → `status/done`, issue closed
+- **Project board** — Status set to "Done" via `github-project` skill
 - **`plan/BACKLOG.md`** — item marked complete
 - **`plan/RELEASE_PLAN.md`** — updated if release impact (flagged for user)
 

--- a/.github/prompts/weekly-pm-review.prompt.md
+++ b/.github/prompts/weekly-pm-review.prompt.md
@@ -1,6 +1,7 @@
 ---
 name: Weekly PM Review
 description: Weekly governance ritual — assesses milestone health, scope drift, release confidence, backlog hygiene, and identifies blockers. Produces executive summary and next week's priorities.
+agent: PM Orchestrator
 ---
 
 # Weekly PM Review Workflow

--- a/.github/skills/gh-cli/SKILL.md
+++ b/.github/skills/gh-cli/SKILL.md
@@ -63,6 +63,20 @@ gh run list --repo owner/repo --workflow ci.yml --limit 10
 
 # Add an issue to a project (requires project permissions)
 gh project item-add 5 --owner owner --url https://github.com/owner/repo/issues/123
+
+# === SoloDevBoard Roadmap (Project #8) ===
+
+# List all project items and their current state
+gh project item-list 8 --owner markheydon --format json
+
+# Add an issue to the SoloDevBoard Roadmap
+gh project item-add 8 --owner markheydon --url https://github.com/markheydon/solo-dev-board/issues/123
+
+# View the roadmap board in the browser
+Start-Process "https://github.com/users/markheydon/projects/8"
+
+# NOTE: Updating project field values (Phase, Priority, Status, dates) requires GraphQL mutations.
+# See `.github/skills/github-project/SKILL.md` for complete command patterns and all field/option IDs.
 ```
 
 ### Safety Rules

--- a/.github/skills/github-project/SKILL.md
+++ b/.github/skills/github-project/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: github-project
+description: 'Manage the SoloDevBoard Roadmap GitHub Project (Project #8). Add issues to the board, set Phase/Priority/Status/Date fields, and keep the project in sync with the issue lifecycle. Use this skill whenever creating or updating GitHub issues for SoloDevBoard.'
+---
+
+# GitHub Project Board — SoloDevBoard Roadmap
+
+Centralised reference and command patterns for maintaining the **SoloDevBoard Roadmap** GitHub Projects v2 board in sync with GitHub issues throughout the planning, delivery, and review lifecycle.
+
+---
+
+## Project Reference
+
+| Property | Value |
+|----------|-------|
+| **Project name** | SoloDevBoard Roadmap |
+| **Project number** | `8` |
+| **Project ID** | `PVT_kwHOAJefG84BQ6bh` |
+| **Owner** | `markheydon` |
+| **URL** | https://github.com/users/markheydon/projects/8 |
+
+---
+
+## Field IDs
+
+| Field | ID | Type |
+|-------|----|------|
+| Title | `PVTF_lAHOAJefG84BQ6bhzg-5WGQ` | Text |
+| Assignees | `PVTF_lAHOAJefG84BQ6bhzg-5WGU` | Assignees |
+| Status | `PVTSSF_lAHOAJefG84BQ6bhzg-5WGY` | Single select |
+| Labels | `PVTF_lAHOAJefG84BQ6bhzg-5WGc` | Labels |
+| Linked pull requests | `PVTF_lAHOAJefG84BQ6bhzg-5WGg` | Pull requests |
+| Milestone | `PVTF_lAHOAJefG84BQ6bhzg-5WGk` | Milestone |
+| Repository | `PVTF_lAHOAJefG84BQ6bhzg-5WGo` | Repository |
+| Phase | `PVTSSF_lAHOAJefG84BQ6bhzg-5WLw` | Single select |
+| Priority | `PVTSSF_lAHOAJefG84BQ6bhzg-5WMc` | Single select |
+| Start Date | `PVTF_lAHOAJefG84BQ6bhzg-5WQE` | Date |
+| Target Date | `PVTF_lAHOAJefG84BQ6bhzg-5WQw` | Date |
+
+---
+
+## Option IDs
+
+### Status Options
+
+| Option | ID |
+|--------|----|
+| Todo | `f75ad846` |
+| In Progress | `47fc9ee4` |
+| Done | `98236657` |
+
+### Phase Options
+
+| Phase | Option ID | Milestone |
+|-------|-----------|-----------|
+| Phase 1 — Foundation | `1fbac877` | v0.1.0 |
+| Phase 2 — Label Manager + Audit | `0f90ba94` | v0.2.0 |
+| Phase 3 — Migration + Triage | `f3de38ba` | v0.3.0 |
+| Phase 4 — Board Rules + Workflows | `f5bc6726` | v0.4.0 |
+| Phase 5 — Polish + Release | `dfa36cee` | v1.0.0 |
+
+### Priority Options
+
+| Priority | Option ID |
+|----------|-----------|
+| Critical | `8d63dbb3` |
+| High | `e89555ab` |
+| Medium | `90261711` |
+| Low | `0f0afb94` |
+
+---
+
+## Phase Assignment Rules
+
+Determine the correct **Phase** option from the issue's milestone or area label:
+
+| Milestone assigned | Area labels | → Phase |
+|--------------------|-------------|---------|
+| `v0.1.0` | `area/infrastructure` | Phase 1 — Foundation |
+| `v0.2.0` | `area/labels`, `area/dashboard` | Phase 2 — Label Manager + Audit |
+| `v0.3.0` | `area/migration`, `area/triage` | Phase 3 — Migration + Triage |
+| `v0.4.0` | `area/board-rules`, `area/workflows` | Phase 4 — Board Rules + Workflows |
+| `v1.0.0` | any | Phase 5 — Polish + Release |
+
+**Precedence:** Milestone > area label. When a milestone is assigned, use the milestone to determine the phase.
+
+---
+
+## Roadmap Date Guidelines
+
+Dates evolve through the issue lifecycle from **planned estimates** to **actual dates**:
+
+| Lifecycle Event | Start Date | Target Date |
+|-----------------|------------|-------------|
+| Event 1: Issue Created | Planned start (from Phase table below) | Planned end (from Phase table below) |
+| Event 2: Implementation Started | **Overwritten with actual start date (today)** | Unchanged (still planned end) |
+| Event 3: Issue Closed | Unchanged (actual start intact) | **Overwritten with actual completion date (today)** |
+
+This means the roadmap chart naturally transitions from planned estimates into a true record of when work actually happened. The planned dates are not preserved once overwritten — they serve only as initial placeholders.
+
+### Planned Phase Dates (used at Event 1)
+
+When creating new issues, set Start Date and Target Date based on the issue's **role within the phase**, not a flat phase-wide date. This produces a realistic dependency-ordered Gantt chart from day one.
+
+The ordering within any phase follows: **Epic/Feature → Enablers → Stories → Tests**
+
+#### Phase 1 — Foundation (v0.1.0, March 2026)
+
+| Issue type | Role | Planned Start | Planned Target |
+|------------|------|--------------|----------------|
+| Epic | Spans full phase | `2026-03-05` | `2026-03-31` |
+| Feature | Spans most of phase | `2026-03-05` | `2026-03-28` |
+| Enabler | First (unblocks stories) | `2026-03-06` | `2026-03-13` |
+| Story (REST API) | After enabler | `2026-03-16` | `2026-03-20` |
+| Story (Dashboard shell) | After enabler (parallel) | `2026-03-16` | `2026-03-24` |
+| Story (Repositories page) | After REST API story | `2026-03-23` | `2026-03-27` |
+| Test (Unit tests) | After enabler + REST story | `2026-03-19` | `2026-03-27` |
+| Test (Component tests) | After UI stories | `2026-03-25` | `2026-03-31` |
+
+#### Phase 2 — Label Manager + Audit (v0.2.0, April 2026)
+
+| Issue type | Role | Planned Start | Planned Target |
+|------------|------|--------------|----------------|
+| Epic | Spans full phase | `2026-04-01` | `2026-04-30` |
+| Feature | Spans most of phase | `2026-04-01` | `2026-04-25` |
+| Enabler(s) | First (unblocks stories) | `2026-04-01` | `2026-04-07` |
+| Stories | After enablers | `2026-04-08` | `2026-04-22` |
+| Tests | After stories | `2026-04-18` | `2026-04-30` |
+
+#### Phase 3 — Migration + Triage (v0.3.0, May 2026)
+
+| Issue type | Role | Planned Start | Planned Target |
+|------------|------|--------------|----------------|
+| Epic | Spans full phase | `2026-05-01` | `2026-05-31` |
+| Feature | Spans most of phase | `2026-05-01` | `2026-05-27` |
+| Enabler(s) | First (unblocks stories) | `2026-05-01` | `2026-05-08` |
+| Stories | After enablers | `2026-05-11` | `2026-05-25` |
+| Tests | After stories | `2026-05-20` | `2026-05-31` |
+
+#### Phase 4 — Board Rules + Workflows (v0.4.0, June 2026)
+
+| Issue type | Role | Planned Start | Planned Target |
+|------------|------|--------------|----------------|
+| Epic | Spans full phase | `2026-06-01` | `2026-06-30` |
+| Feature | Spans most of phase | `2026-06-01` | `2026-06-26` |
+| Enabler(s) | First (unblocks stories) | `2026-06-01` | `2026-06-08` |
+| Stories | After enablers | `2026-06-09` | `2026-06-23` |
+| Tests | After stories | `2026-06-18` | `2026-06-30` |
+
+#### Phase 5 — Polish + Release (v1.0.0, July 2026)
+
+| Issue type | Role | Planned Start | Planned Target |
+|------------|------|--------------|----------------|
+| Epic | Spans full phase | `2026-07-01` | `2026-07-31` |
+| Feature | Spans most of phase | `2026-07-01` | `2026-07-28` |
+| Stories | As sequenced | `2026-07-01` | `2026-07-22` |
+| Tests | After stories | `2026-07-18` | `2026-07-31` |
+
+---
+
+## Lifecycle Events
+
+### Event 1: Issue Created (PM Orchestrator responsibility)
+
+After creating a new issue, add it to the project and set all relevant fields. Dates set here are **planned estimates** from the Phase table above — they will be overwritten with actuals as the issue progresses through the lifecycle.
+
+```powershell
+# Step 1: Get the issue node ID
+$nodeId = gh api "repos/markheydon/solo-dev-board/issues/$issueNumber" --jq '.node_id'
+
+# Step 2: Add issue to project — capture the returned project item ID
+$itemId = gh api graphql --field query="mutation { addProjectV2ItemById(input: { projectId: `"PVT_kwHOAJefG84BQ6bh`" contentId: `"$nodeId`" }) { item { id } } }" --jq '.data.addProjectV2ItemById.item.id'
+
+# Step 3: Set Status → Todo
+gh api graphql --field query="mutation { updateProjectV2ItemFieldValue(input: { projectId: `"PVT_kwHOAJefG84BQ6bh`" itemId: `"$itemId`" fieldId: `"PVTSSF_lAHOAJefG84BQ6bhzg-5WGY`" value: { singleSelectOptionId: `"f75ad846`" } }) { projectV2Item { id } } }" | Out-Null
+
+# Step 4: Set Phase (replace $phaseOptionId with value from Phase Options table above)
+gh api graphql --field query="mutation { updateProjectV2ItemFieldValue(input: { projectId: `"PVT_kwHOAJefG84BQ6bh`" itemId: `"$itemId`" fieldId: `"PVTSSF_lAHOAJefG84BQ6bhzg-5WLw`" value: { singleSelectOptionId: `"$phaseOptionId`" } }) { projectV2Item { id } } }" | Out-Null
+
+# Step 5: Set Priority (replace $priorityOptionId with value from Priority Options table above)
+gh api graphql --field query="mutation { updateProjectV2ItemFieldValue(input: { projectId: `"PVT_kwHOAJefG84BQ6bh`" itemId: `"$itemId`" fieldId: `"PVTSSF_lAHOAJefG84BQ6bhzg-5WMc`" value: { singleSelectOptionId: `"$priorityOptionId`" } }) { projectV2Item { id } } }" | Out-Null
+
+# Step 6: Set planned Start Date (ISO 8601 from Phase table, e.g. "2026-03-05")
+# Will be overwritten with actual start date when implementation begins (Event 2)
+gh api graphql --field query="mutation { updateProjectV2ItemFieldValue(input: { projectId: `"PVT_kwHOAJefG84BQ6bh`" itemId: `"$itemId`" fieldId: `"PVTF_lAHOAJefG84BQ6bhzg-5WQE`" value: { date: `"$startDate`" } }) { projectV2Item { id } } }" | Out-Null
+
+# Step 7: Set planned Target Date (ISO 8601 from Phase table, e.g. "2026-03-31")
+# Will be overwritten with actual completion date when issue is closed (Event 3)
+gh api graphql --field query="mutation { updateProjectV2ItemFieldValue(input: { projectId: `"PVT_kwHOAJefG84BQ6bh`" itemId: `"$itemId`" fieldId: `"PVTF_lAHOAJefG84BQ6bhzg-5WQw`" value: { date: `"$targetDate`" } }) { projectV2Item { id } } }" | Out-Null
+```
+
+---
+
+### Event 2: Implementation Started (Delivery Agent responsibility)
+
+When beginning implementation of an issue, update Status to "In Progress" and **overwrite Start Date with today's actual start date**. This replaces the planned estimate set at Event 1.
+
+```powershell
+# Step 1: Find the project item ID for the issue
+$itemId = gh api graphql --field query='query { repository(owner: "markheydon", name: "solo-dev-board") { issue(number: '"$issueNumber"') { projectItems(first: 10) { nodes { id project { number } } } } } }' --jq '.data.repository.issue.projectItems.nodes[] | select(.project.number == 8) | .id'
+
+# Step 2: Update Status → In Progress
+gh api graphql --field query="mutation { updateProjectV2ItemFieldValue(input: { projectId: `"PVT_kwHOAJefG84BQ6bh`" itemId: `"$itemId`" fieldId: `"PVTSSF_lAHOAJefG84BQ6bhzg-5WGY`" value: { singleSelectOptionId: `"47fc9ee4`" } }) { projectV2Item { id } } }" | Out-Null
+
+# Step 3: Overwrite Start Date with today's actual start date
+$actualStartDate = (Get-Date -Format 'yyyy-MM-dd')
+gh api graphql --field query="mutation { updateProjectV2ItemFieldValue(input: { projectId: `"PVT_kwHOAJefG84BQ6bh`" itemId: `"$itemId`" fieldId: `"PVTF_lAHOAJefG84BQ6bhzg-5WQE`" value: { date: `"$actualStartDate`" } }) { projectV2Item { id } } }" | Out-Null
+```
+
+Also update the issue label at the same time:
+
+```powershell
+gh issue edit $issueNumber --repo markheydon/solo-dev-board --remove-label "status/todo" --add-label "status/in-progress"
+```
+
+---
+
+### Event 3: Issue Closed (Review Agent responsibility, post-merge)
+
+When a PR is merged and the issue is closed, update Status to "Done" and **overwrite Target Date with today's actual completion date**. This replaces the planned estimate set at Event 1, giving a true record of when the work finished.
+
+```powershell
+# Step 1: Find the project item ID for the issue
+$itemId = gh api graphql --field query='query { repository(owner: "markheydon", name: "solo-dev-board") { issue(number: '"$issueNumber"') { projectItems(first: 10) { nodes { id project { number } } } } } }' --jq '.data.repository.issue.projectItems.nodes[] | select(.project.number == 8) | .id'
+
+# Step 2: Update Status → Done
+gh api graphql --field query="mutation { updateProjectV2ItemFieldValue(input: { projectId: `"PVT_kwHOAJefG84BQ6bh`" itemId: `"$itemId`" fieldId: `"PVTSSF_lAHOAJefG84BQ6bhzg-5WGY`" value: { singleSelectOptionId: `"98236657`" } }) { projectV2Item { id } } }" | Out-Null
+
+# Step 3: Overwrite Target Date with today's actual completion date
+$actualEndDate = (Get-Date -Format 'yyyy-MM-dd')
+gh api graphql --field query="mutation { updateProjectV2ItemFieldValue(input: { projectId: `"PVT_kwHOAJefG84BQ6bh`" itemId: `"$itemId`" fieldId: `"PVTF_lAHOAJefG84BQ6bhzg-5WQw`" value: { date: `"$actualEndDate`" } }) { projectV2Item { id } } }" | Out-Null
+```
+
+---
+
+## Checking Project State
+
+List all items and their current state:
+
+```powershell
+gh project item-list 8 --owner markheydon --format json | ConvertFrom-Json | Select-Object -ExpandProperty items | Select-Object id, title | Format-Table -AutoSize
+```
+
+View the roadmap in the browser:
+
+```powershell
+Start-Process "https://github.com/users/markheydon/projects/8"
+```
+
+---
+
+## Priority Mapping
+
+Map `priority/` labels to project Priority option IDs:
+
+| Label | Option ID |
+|-------|-----------|
+| `priority/critical` | `8d63dbb3` |
+| `priority/high` | `e89555ab` |
+| `priority/medium` | `90261711` |
+| `priority/low` | `0f0afb94` |
+
+---
+
+## Important Notes
+
+- **Always** add new issues to the project board immediately after creation — never leave issues untracked.
+- **Never** set Status to "Done" before the PR is merged to `main`.
+- The **Linked pull requests** field updates automatically when a PR is created referencing the issue — no manual action needed.
+- The **Milestone** and **Labels** fields sync automatically from the issue — no manual action needed.
+- If an issue is split into sub-issues, add all sub-issues to the project as well.
+- The **Sub-issues progress** field updates automatically from GitHub's sub-issue tracking.

--- a/.github/skills/pm-feature-workflow/SKILL.md
+++ b/.github/skills/pm-feature-workflow/SKILL.md
@@ -16,7 +16,7 @@ Run a deterministic feature workflow so the user can act as product manager whil
 1. Select the next candidate from `plan/BACKLOG.md`.
 2. Confirm scope alignment in `plan/SCOPE.md`.
 3. Trigger planning with `breakdown-plan`.
-4. Create or update GitHub issues with `github-issues` (use `gh-cli` for bulk changes).
+4. Create or update GitHub issues with `github-issues` (use `gh-cli` for bulk changes), then sync each issue to the project board with `github-project` skill (set Phase, Priority, Status=Todo, and roadmap dates).
 5. Trigger quality planning with `breakdown-test`.
 6. Implement using repository standards (`dotnet-best-practices`, and `fluentui-blazor` for UI work).
 7. Create or update ADRs when architectural decisions are introduced.

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -10,9 +10,16 @@ This backlog is organised by the six core features (epics) of SoloDevBoard. For 
 
 Labels: `type/epic`, `area/infrastructure`
 
-- [ ] As a solo developer, I want the application to authenticate with GitHub using my Personal Access Token so that I can access my repositories.
+<!-- Epic #4: Phase 1 — Foundation Completion (status/todo, milestone: v0.1.0) -->
+<!-- Feature #5: GitHub API Integration with PAT Authentication -->
+
+- [x] Scaffold solution structure (`App`, `Application`, `Domain`, `Infrastructure` projects) — _done_
+- [x] Configure nullable reference types, implicit usings, and coding conventions — _done_
+- [x] Set up xUnit test projects — _done_
+- [x] Set up CI workflow (`.github/workflows/ci.yml`) — _done_
+- [ ] As a solo developer, I want the application to authenticate with GitHub using my Personal Access Token so that I can access my repositories. _(planned: #6, #7 — status/todo)_
 - [ ] As a solo developer, I want to authenticate with a GitHub App so that I can use fine-grained permissions without a long-lived PAT.
-- [ ] As a solo developer, I want to see a list of all my GitHub repositories so that I can select which ones to manage.
+- [ ] As a solo developer, I want to see a list of all my GitHub repositories so that I can select which ones to manage. _(planned: #8 — status/todo)_
 - [ ] As a solo developer, I want my GitHub token to be stored securely in Azure Key Vault so that it is never exposed in configuration files.
 - [ ] As a solo developer, I want the application to be deployed to Azure App Service so that I can access it from any device.
 


### PR DESCRIPTION
## Summary

Adds full GitHub Projects v2 board integration to the planning, delivery, and review lifecycle. The SoloDevBoard Roadmap (#8) is now kept automatically in sync with GitHub issues throughout the entire workflow.

## Changes

### New

- `.github/skills/github-project/SKILL.md` — Central reference skill containing all project board IDs, field IDs, option IDs, Phase assignment rules, and lifecycle event command patterns (PowerShell GraphQL mutations)

### Updated

- `.github/copilot-instructions.md` — `github-project` added to Skill Trigger Matrix and workflow step 3
- `.github/agents/pm-orchestrator.agent.md` — New step 5 "Project Board Sync": adds each created issue to the board with Phase/Priority/Status=Todo and staggered planned dates
- `.github/agents/delivery.agent.md` — Step 1 now updates project Status → "In Progress" and overwrites Start Date with actual start date when work begins
- `.github/agents/review.agent.md` — Step 4 now updates project Status → "Done" and overwrites Target Date with actual completion date post-merge
- `.github/skills/pm-feature-workflow/SKILL.md` — Step 4 includes `github-project` sync after issue creation
- `.github/skills/gh-cli/SKILL.md` — SoloDevBoard Roadmap project commands added; field mutations deferred to `github-project` skill
- `.github/prompts/plan-next-issue.prompt.md` — New step 6 "Project Board Sync"; Test Strategy renumbered to step 7
- `.github/prompts/execute-feature.prompt.md` — Step 1 includes project Status → "In Progress" update
- `.github/prompts/review-and-close.prompt.md` — Step 5 includes project Status → "Done" update

## Project Board Date Strategy

Planned dates are now set per role within each phase (Epic → Feature → Enabler → Stories → Tests) rather than a flat phase-wide date range, producing a realistic dependency-ordered Gantt chart from day one.

Dates evolve from planned estimates to actuals:
- **Event 1 (Created):** Planned start + target from role-based Phase table
- **Event 2 (Implementation started):** Start Date overwritten with actual start date
- **Event 3 (Closed):** Target Date overwritten with actual completion date

The Phase 1 issues (#4–#11) have been updated on the board with staggered planned dates to reflect their dependency ordering.

## Labels

`type/chore` `area/infrastructure` `size/m`
