### PR TITLE
[type/feature] Add Repositories listing page with Fluent UI and bUnit testing infrastructure

### DIFF
--- a/.github/prompts/review-and-close.prompt.md
+++ b/.github/prompts/review-and-close.prompt.md
@@ -279,7 +279,7 @@ The Review Agent validates this checklist automatically:
 - [ ] Test naming follows `MethodUnderTest_Scenario_ExpectedOutcome`
 - [ ] Tests pass locally (`dotnet test`)
 - [ ] Test projects mirror source structure
-- [ ] Moq for mocking, FluentAssertions for assertions
+- [ ] Moq for mocking, xUnit built-in `Assert.*` for assertions (FluentAssertions is prohibited per ADR-0008)
 
 ### Documentation
 - [ ] User-facing features have `docs/user-guide/*.md`

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,20 @@
+{
+  "recommendations": [
+    // C# Dev Kit — IntelliSense, debugging, test explorer, solution explorer
+    "ms-dotnettools.csdevkit",
+    // C# language support (transitive dependency of C# Dev Kit)
+    "ms-dotnettools.csharp",
+    // .NET runtime installer (required by C# Dev Kit)
+    "ms-dotnettools.vscode-dotnet-runtime",
+    // GitHub Pull Requests and Issues — PR review, issue tracking
+    "github.vscode-pull-request-github",
+    // GitHub Copilot — AI code completion
+    "github.copilot",
+    // GitHub Copilot Chat — AI assistant
+    "github.copilot-chat",
+    // Bicep — Azure infrastructure templates in infra/
+    "ms-azuretools.vscode-bicep",
+    // EditorConfig — consistent formatting via .editorconfig
+    "editorconfig.editorconfig"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Requires C# Dev Kit extension (ms-dotnettools.csdevkit)
+      "name": "Launch SoloDevBoard (Development)",
+      "type": "dotnet",
+      "request": "launch",
+      "projectPath": "${workspaceFolder}/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj",
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,10 +6,7 @@
       "name": "Launch SoloDevBoard (Development)",
       "type": "dotnet",
       "request": "launch",
-      "projectPath": "${workspaceFolder}/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj",
-      "env": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      "projectPath": "${workspaceFolder}/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,80 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/SoloDevBoard.slnx",
+        "--configuration",
+        "Debug"
+      ],
+      "problemMatcher": "$msCompile",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "test",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "test",
+        "${workspaceFolder}/SoloDevBoard.slnx"
+      ],
+      "problemMatcher": "$msCompile",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "--project",
+        "${workspaceFolder}/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj",
+        "run"
+      ],
+      "problemMatcher": [
+        {
+          "pattern": [
+            {
+              "regexp": ".",
+              "file": 1,
+              "location": 2,
+              "message": 3
+            }
+          ],
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": "^.*Build started.*",
+            "endsPattern": "^.*Now listening on:\\s+(https?://\\S+)"
+          }
+        }
+      ],
+      "isBackground": true,
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      }
+    },
+    {
+      "label": "clean",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "clean",
+        "${workspaceFolder}/SoloDevBoard.slnx"
+      ],
+      "problemMatcher": "$msCompile",
+      "group": "build"
+    }
+  ]
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,27 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <!-- UI -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.13.1" />
+  </ItemGroup>
+
+  <!-- Infrastructure -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
+  </ItemGroup>
+
+  <!-- Testing -->
+  <ItemGroup>
+    <PackageVersion Include="bunit" Version="2.6.2" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+</Project>

--- a/adr/0009-fluent-ui-blazor-component-library.md
+++ b/adr/0009-fluent-ui-blazor-component-library.md
@@ -1,0 +1,78 @@
+# ADR-0009: Use Microsoft Fluent UI Blazor Component Library
+
+**Date:** 2026-03-07
+**Status:** Accepted
+
+---
+
+## Context
+
+SoloDevBoard requires a UI component library for its Blazor Server front-end. The application presents data-heavy views (repository tables, issue grids, audit dashboards) and needs accessible, visually consistent components without requiring custom CSS engineering.
+
+The following options were considered:
+
+| Option | Description |
+|--------|-------------|
+| **Raw HTML + Bootstrap** | Standard CSS framework; UI components hand-rolled as Razor markup. |
+| **MudBlazor** | Feature-rich Blazor component library following Material Design; MIT licensed. |
+| **Radzen Blazor** | Component library with commercial support tier; community edition available. |
+| **Microsoft FluentUI Blazor** | Microsoft's official Blazor implementation of the Fluent Design System; MIT licensed. |
+
+---
+
+## Decision
+
+**Use `Microsoft.FluentUI.AspNetCore.Components`** as the UI component library for SoloDevBoard.
+
+---
+
+## Rationale
+
+### Licence Alignment
+
+`Microsoft.FluentUI.AspNetCore.Components` is published under the **MIT licence**, which is fully compatible with SoloDevBoard's open-source MIT licence. There is no compliance risk for contributors or forks. This was a decisive factor given the lesson learned in [ADR-0008](0008-remove-fluentassertions.md) concerning FluentAssertions' commercial licence.
+
+### First-Party Microsoft Library
+
+The library is developed and maintained by Microsoft. It ships with .NET Aspire templates and receives active investment aligned with the .NET roadmap. Long-term compatibility with .NET 10 and beyond is assured.
+
+### Accessibility
+
+Fluent UI components are built to WCAG 2.1 AA standards. ARIA attributes, keyboard navigation, and screen reader support are built-in properties rather than concerns that must be hand-engineered.
+
+### Design Language
+
+GitHub — the platform SoloDevBoard integrates with — is part of the Microsoft ecosystem and shares visual design sensibilities with the Fluent Design System. Using Fluent UI produces a coherent interface that feels familiar to developers who use GitHub and other Microsoft tooling daily.
+
+### Component Coverage
+
+The library provides all components required by Phase 1–3 of SoloDevBoard:
+
+| Component | Used for |
+|-----------|----------|
+| `FluentDataGrid` | Repository listing, issue tables, label grids |
+| `FluentCard` | Error states, empty states, feature panels |
+| `FluentButton` | Actions, retry buttons |
+| `FluentProgressRing` | Loading states |
+| `FluentToastProvider` | User notifications |
+| `FluentDialogProvider` | Confirmation dialogs |
+| `FluentNavMenu` | Application navigation |
+
+---
+
+## Trade-offs Accepted
+
+- **JavaScript Interop:** Some Fluent UI components (notably `FluentDataGrid`) use JavaScript for column resizing and internal rendering. This limits the depth of automated bUnit component testing for grid interactions (see [ADR-0010](0010-bunit-component-testing.md)).
+- **Fluent Design Lock-in:** Choosing Fluent UI commits all future UI development to the Fluent Design System. Migrating to another library would require component-by-component replacement.
+- **Bundle Size:** The library adds web components JavaScript to the application bundle. For a Blazor Server application this is negligible.
+
+---
+
+## Consequences
+
+- `Microsoft.FluentUI.AspNetCore.Components` is added to `SoloDevBoard.App.csproj`.
+- `AddFluentUIComponents()` is called in `Program.cs` to register required services.
+- `@using Microsoft.FluentUI.AspNetCore.Components` is added to `_Imports.razor`.
+- Five provider components (`FluentToastProvider`, `FluentDialogProvider`, `FluentMessageBarProvider`, `FluentTooltipProvider`, `FluentKeyCodeProvider`) are added to `MainLayout.razor` to enable notification and interaction services.
+- All Blazor pages use `Fluent*`-prefixed components rather than raw HTML for interactive UI elements.
+- bUnit test projects register `AddFluentUIComponents()` and use `JSRuntimeMode.Loose` to handle Fluent UI's JavaScript interop silently in component tests (see [ADR-0010](0010-bunit-component-testing.md)).

--- a/adr/0010-bunit-component-testing.md
+++ b/adr/0010-bunit-component-testing.md
@@ -1,0 +1,83 @@
+# ADR-0010: Use bUnit for Blazor Component Testing
+
+**Date:** 2026-03-07
+**Status:** Accepted
+
+---
+
+## Context
+
+SoloDevBoard is developed and extended by AI coding agents (see `.github/agents/delivery.agent.md`). For AI-driven delivery to be reliable, every code change must be validated by automated tests before a human reviews the work. The application has Blazor Server UI components that contain meaningful conditional rendering logic — loading states, error states, empty states, and data states — all of which must be verified automatically.
+
+The application already uses xUnit for unit testing service and infrastructure layers (see [ADR-0002](0002-testing-framework.md), [ADR-0006](0006-moq-mocking-library.md)). The question is how to extend that automated validation to cover Blazor component behaviour.
+
+The following approaches were considered:
+
+| Approach | Runs via `dotnet test`? | Requires running browser/server? | AI-manageable? |
+|----------|------------------------|----------------------------------|----------------|
+| **No component tests** | N/A | N/A | ❌ Human review only |
+| **bUnit** | ✅ Yes | ❌ No | ✅ Yes |
+| **Playwright** | ❌ No (standalone runner) | ✅ Yes | ⚠️ Difficult |
+| **Selenium** | ❌ No (standalone runner) | ✅ Yes | ⚠️ Difficult |
+
+---
+
+## Decision
+
+**Use bUnit** for automated Blazor component testing in SoloDevBoard.
+
+---
+
+## Rationale
+
+### AI Delivery Agent Compatibility
+
+AI delivery agents validate their work via `dotnet test`. bUnit tests run via `dotnet test` without a browser or running server, making them fully compatible with the agent's existing build-and-verify loop. End-to-end tools like Playwright require a running application with a configured test environment, which the agent cannot orchestrate within a standard pull request workflow.
+
+### xUnit Integration
+
+bUnit integrates natively with xUnit. Tests follow the same Arrange/Act/Assert pattern, use the same `[Fact]`/`[Theory]` attributes, and use the same `Assert.*` methods as existing service and infrastructure tests. No new testing philosophy or separate tooling is introduced.
+
+### In-Memory Rendering
+
+bUnit renders Blazor components in-memory using a virtual DOM. There is:
+- No browser required
+- No network required
+- Sub-millisecond render time
+- Deterministic execution (no timing-dependent failures)
+
+### Component State Verification
+
+bUnit allows the delivery agent to verify:
+- All conditional rendering states (loading, error, empty, data)
+- Markup content and structure
+- Event interactions (button clicks, form submissions)
+- Service call depth and argument verification (via Moq integration)
+
+### Licence
+
+bUnit is published under the **MIT licence**, consistent with SoloDevBoard's open-source licence policy (see [ADR-0008](0008-remove-fluentassertions.md)).
+
+---
+
+## Limitations and Mitigations
+
+| Limitation | Mitigation |
+|------------|------------|
+| Fluent UI components use JavaScript interop | Use `JSRuntimeMode.Loose` to silently handle all JS calls in tests |
+| `FluentDataGrid` may limit deep row-level DOM assertions | Assert on text content in rendered markup rather than grid-specific DOM structure |
+| Component tests do not validate visual appearance, layout, or responsive behaviour | These remain the responsibility of manual human review before PR approval |
+| End-to-end flow (GitHub API → UI) cannot be tested | Covered by infrastructure unit tests (`GitHubServiceTests`) and developer testing |
+
+---
+
+## Consequences
+
+- `bunit` NuGet package is added to `SoloDevBoard.App.Tests.csproj`.
+- `Microsoft.AspNetCore.App` FrameworkReference is added to `SoloDevBoard.App.Tests.csproj` (required for Blazor component types such as `ComponentBase`).
+- `SoloDevBoard.App` project reference is added to `SoloDevBoard.App.Tests.csproj`.
+- Component test classes inherit from `Bunit.BunitContext` and call `Services.AddFluentUIComponents()` with `JSInterop.Mode = JSRuntimeMode.Loose` in the constructor. Components are rendered with `Render<T>()` (bUnit 2.x API).
+- Test class naming follows the standard convention: `{ComponentName}Tests` with `sealed` modifier.
+- The `PlaceholderTests.cs` file in `SoloDevBoard.App.Tests` is retained until component tests cover each page.
+- End-to-end testing (Playwright or similar) is deferred as a post-Phase 1 decision. Manual human review covers visual, UX, and browser-compatibility concerns in the interim.
+- As each new Blazor page is implemented, a corresponding component test class is added to `tests/App.Tests/SoloDevBoard.App.Tests/` covering at minimum: loading state, error state, empty state, and data state.

--- a/adr/README.md
+++ b/adr/README.md
@@ -30,6 +30,8 @@ Each ADR follows this format:
 | [ADR-0006](0006-moq-mocking-library.md) | Switch Mocking Library from NSubstitute to Moq | Accepted (assertion library aspect superseded by ADR-0008) |
 | [ADR-0007](0007-multi-tenancy-authentication-phased-approach.md) | Multi-Tenancy Authentication — Phased Approach | Accepted |
 | [ADR-0008](0008-remove-fluentassertions.md) | Remove FluentAssertions — Use xUnit Built-in Assertions Only | Accepted |
+| [ADR-0009](0009-fluent-ui-blazor-component-library.md) | Use Microsoft Fluent UI Blazor Component Library | Accepted |
+| [ADR-0010](0010-bunit-component-testing.md) | Use bUnit for Blazor Component Testing | Accepted |
 
 ## Adding a New ADR
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ It is built with the solo developer in mind: opinionated defaults, minimal confi
 ## Quick Links
 
 - 📖 [Getting Started](getting-started.md) — prerequisites, local setup, and configuration
+- 🗂️ [Repositories Guide](user-guide/repositories.md) — view repositories available to your authenticated account
 - 👤 [User Guide](user-guide/) — detailed guides for each feature
 - 🏗️ [Infrastructure](../infra/README.md) — deploying to Azure with Bicep
 - 📋 [Backlog](../plan/BACKLOG.md) — what's planned

--- a/docs/user-guide/repositories.md
+++ b/docs/user-guide/repositories.md
@@ -1,0 +1,40 @@
+---
+layout: page
+title: Repositories
+parent: User Guide
+nav_order: 0
+---
+
+# Repositories
+
+The Repositories page shows the repositories available to your authenticated GitHub account in one place.
+
+---
+
+## Overview
+
+Use this page to quickly confirm which repositories SoloDevBoard can access before you start using other features.
+
+For each repository, the page shows:
+- Repository name
+- Visibility (`Public` or `Private`)
+- Last updated date
+
+---
+
+## How to Use
+
+1. Open **Repositories** from the left navigation.
+2. Wait for the repository list to load.
+3. Review repository visibility and recency.
+
+If loading fails, use **Try again** after checking your GitHub authentication settings.
+
+---
+
+## Troubleshooting
+
+If no repositories appear or loading fails:
+- Confirm your GitHub token is configured via user secrets or environment variables.
+- Confirm the token has scopes required by your repositories.
+- Confirm your network can reach `api.github.com`.

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -20,7 +20,10 @@ Labels: `type/epic`, `area/infrastructure`
 - [x] As a solo developer, I want the application to authenticate with GitHub using my Personal Access Token so that I can access my repositories. _(#6 done — merged PR #13, 2026-03-06; #7 done — merged PR #17, 2026-03-06)_
 - [ ] As a solo developer, I want service interfaces to resolve user identity via an `ICurrentUserContext` abstraction so that the application can support multiple users in the future without structural rework. _(Phase 2 enabler — see ADR-0007)_
 - [ ] As a solo developer, I want to authenticate with a GitHub App so that I can use fine-grained permissions without a long-lived PAT. _(Phase 5 — see ADR-0007)_
-- [ ] As a solo developer, I want to see a list of all my GitHub repositories so that I can select which ones to manage. _(planned: #8 — status/todo)_
+- [ ] As a solo developer, I want to see a list of all my GitHub repositories so that I can select which ones to manage. _(issue #8 — implementation complete, pending PR review)_
+- [ ] As a solo developer, I want an empty dashboard shell page with navigation cards for each feature so that the application has a clear entry point. _(issue #9 — status/todo)_
+- [ ] As a solo developer, I want comprehensive unit tests for `GitHubService` and `GitHubAuthHandler` so that infrastructure reliability is verified. _(issue #10 — status/todo)_
+- [ ] As a solo developer, I want Blazor component tests using bUnit so that UI behaviour is verified automatically without a browser. _(issue #11 — bUnit infrastructure set up 2026-03-07, `RepositoriesTests` added; awaiting issue #9 Dashboard shell for full completion)_
 - [ ] As a solo developer, I want my GitHub token to be stored securely in Azure Key Vault so that it is never exposed in configuration files.
 - [ ] As a solo developer, I want the application to be deployed to Azure App Service so that I can access it from any device.
 

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -22,7 +22,7 @@ For the full feature scope, see [SCOPE.md](SCOPE.md). For individual feature bac
 - [ ] Implement GitHub App authentication flow (optional in this phase, required before v1.0)
 - [ ] Implement `IGitHubService` interface in `Application` layer
 - [ ] Implement `GitHubRestClient` in `Infrastructure` layer (using `Octokit` or `HttpClient` + `System.Text.Json`)
-- [ ] Implement basic repository listing: fetch and display all repositories the authenticated user has access to
+- [x] Implement basic repository listing: fetch and display all repositories the authenticated user has access to _(issue #8 done — 2026-03-07)_
 - [ ] Create a basic dashboard shell page in Blazor (empty panels for each of the 6 features)
 - [ ] Configure `appsettings.json` and user secrets for local development
 - [ ] Set up xUnit test projects; write smoke tests for `GitHubRestClient`

--- a/src/App/SoloDevBoard.App/Components/Layout/MainLayout.razor
+++ b/src/App/SoloDevBoard.App/Components/Layout/MainLayout.razor
@@ -16,6 +16,12 @@
     </main>
 </div>
 
+<FluentToastProvider />
+<FluentDialogProvider />
+<FluentMessageBarProvider />
+<FluentTooltipProvider />
+<FluentKeyCodeProvider />
+
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.
     <a href="." class="reload">Reload</a>

--- a/src/App/SoloDevBoard.App/Components/Layout/NavMenu.razor
+++ b/src/App/SoloDevBoard.App/Components/Layout/NavMenu.razor
@@ -14,6 +14,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="repositories">
+                <span class="bi bi-folder-fill-nav-menu" aria-hidden="true"></span> Repositories
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="migrate">
                 <span class="bi bi-arrow-left-right-nav-menu" aria-hidden="true"></span> Migrate
             </NavLink>

--- a/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor
+++ b/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor
@@ -1,0 +1,46 @@
+@page "/repositories"
+
+<PageTitle>Repositories</PageTitle>
+
+<h1>Repositories</h1>
+
+<p>Browse repositories available to your authenticated GitHub account.</p>
+
+@if (isLoading)
+{
+    <div aria-live="polite" role="status">
+        <FluentProgressRing aria-label="Loading repositories" />
+        <p>Loading repositories...</p>
+    </div>
+}
+else if (!string.IsNullOrWhiteSpace(errorMessage))
+{
+    <FluentCard aria-live="assertive" role="alert">
+        <h2>Unable to load repositories</h2>
+        <p>@errorMessage</p>
+        <FluentButton Appearance="Appearance.Accent" @onclick="ReloadAsync">Try again</FluentButton>
+    </FluentCard>
+}
+else if (repositories.Count == 0)
+{
+    <FluentCard aria-live="polite">
+        <h2>No repositories found</h2>
+        <p>No repositories were returned for your account.</p>
+    </FluentCard>
+}
+else
+{
+    <FluentDataGrid TGridItem="SoloDevBoard.Domain.Entities.Repository"
+                    Items="@repositories.AsQueryable()"
+                    AriaLabel="GitHub repositories"
+                    GridTemplateColumns="2fr 1fr 1fr"
+                    ResizeColumnOnAllRows="true">
+        <PropertyColumn Property="@(repository => repository.Name)" Title="Name" Sortable="true" />
+        <TemplateColumn Title="Visibility" Align="Align.Center">
+            @(context.IsPrivate ? "Private" : "Public")
+        </TemplateColumn>
+        <TemplateColumn Title="Last Updated" Align="Align.End">
+            @context.UpdatedAt.ToLocalTime().ToString("dd MMM yyyy")
+        </TemplateColumn>
+    </FluentDataGrid>
+}

--- a/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor
+++ b/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor
@@ -1,4 +1,5 @@
 @page "/repositories"
+@rendermode InteractiveServer
 
 <PageTitle>Repositories</PageTitle>
 
@@ -39,8 +40,8 @@ else
         <TemplateColumn Title="Visibility" Align="Align.Center">
             @(context.IsPrivate ? "Private" : "Public")
         </TemplateColumn>
-        <TemplateColumn Title="Last Updated" Align="Align.End">
-            @context.UpdatedAt.ToLocalTime().ToString("dd MMM yyyy")
+        <TemplateColumn Title="Last Updated (UTC)" Align="Align.End">
+            @context.UpdatedAt.UtcDateTime.ToString("dd MMM yyyy", System.Globalization.CultureInfo.InvariantCulture)
         </TemplateColumn>
     </FluentDataGrid>
 }

--- a/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Components;
+using SoloDevBoard.Application.Services;
+using SoloDevBoard.Domain.Entities;
+
+namespace SoloDevBoard.App.Components.Pages;
+
+/// <summary>Displays repositories available to the authenticated GitHub account.</summary>
+public partial class Repositories : ComponentBase
+{
+    /// <summary>Gets or sets the application service used to retrieve repositories.</summary>
+    [Inject]
+    public IRepositoryService RepositoryService { get; set; } = default!;
+
+    private IReadOnlyList<Repository> repositories = [];
+    private bool isLoading = true;
+    private string? errorMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadRepositoriesAsync();
+    }
+
+    private async Task ReloadAsync()
+    {
+        await LoadRepositoriesAsync();
+    }
+
+    private async Task LoadRepositoriesAsync()
+    {
+        isLoading = true;
+        errorMessage = null;
+
+        try
+        {
+            repositories = await RepositoryService.GetRepositoriesAsync();
+        }
+        catch (HttpRequestException ex)
+        {
+            errorMessage = $"GitHub API request failed. {ex.Message}";
+            repositories = [];
+        }
+        catch (Exception)
+        {
+            errorMessage = "An unexpected error occurred while loading repositories.";
+            repositories = [];
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+}

--- a/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
 using SoloDevBoard.Application.Services;
 using SoloDevBoard.Domain.Entities;
 
@@ -10,6 +11,10 @@ public partial class Repositories : ComponentBase
     /// <summary>Gets or sets the application service used to retrieve repositories.</summary>
     [Inject]
     public IRepositoryService RepositoryService { get; set; } = default!;
+
+    /// <summary>Gets or sets the logger for repository page diagnostics.</summary>
+    [Inject]
+    public ILogger<Repositories> Logger { get; set; } = default!;
 
     private IReadOnlyList<Repository> repositories = [];
     private bool isLoading = true;
@@ -39,8 +44,9 @@ public partial class Repositories : ComponentBase
             errorMessage = $"GitHub API request failed. {ex.Message}";
             repositories = [];
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Logger.LogError(ex, "Failed to load repositories.");
             errorMessage = "An unexpected error occurred while loading repositories.";
             repositories = [];
         }

--- a/src/App/SoloDevBoard.App/Components/_Imports.razor
+++ b/src/App/SoloDevBoard.App/Components/_Imports.razor
@@ -5,6 +5,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.FluentUI.AspNetCore.Components
 @using Microsoft.JSInterop
 @using SoloDevBoard.App
 @using SoloDevBoard.App.Components

--- a/src/App/SoloDevBoard.App/Program.cs
+++ b/src/App/SoloDevBoard.App/Program.cs
@@ -1,4 +1,6 @@
+using Microsoft.FluentUI.AspNetCore.Components;
 using SoloDevBoard.App.Components;
+using SoloDevBoard.Application.Services;
 using SoloDevBoard.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -6,6 +8,9 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+
+builder.Services.AddFluentUIComponents();
+builder.Services.AddScoped<IRepositoryService, RepositoryService>();
 
 // Register Infrastructure services (GitHub API integration).
 // The Infrastructure project is referenced here solely as the DI composition root.

--- a/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj
+++ b/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
     <ProjectReference Include="..\..\Application\SoloDevBoard.Application\SoloDevBoard.Application.csproj" />
@@ -14,6 +14,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
+    <UserSecretsId>cbdadc72-0914-4dd0-928d-5f374af9c526</UserSecretsId>
   </PropertyGroup>
 
 </Project>

--- a/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj
+++ b/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj
@@ -5,6 +5,10 @@
     <ProjectReference Include="..\..\Infrastructure\SoloDevBoard.Infrastructure\SoloDevBoard.Infrastructure.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/src/Application/SoloDevBoard.Application/Services/IGitHubService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/IGitHubService.cs
@@ -5,6 +5,11 @@ namespace SoloDevBoard.Application.Services;
 /// <summary>Provides access to GitHub API operations.</summary>
 public interface IGitHubService
 {
+    /// <summary>Retrieves repositories accessible to the authenticated GitHub user.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A read-only list of repositories visible to the authenticated user.</returns>
+    Task<IReadOnlyList<Repository>> GetRepositoriesAsync(CancellationToken cancellationToken = default);
+
     /// <summary>Retrieves all repositories for the specified owner.</summary>
     /// <param name="owner">The GitHub account owner login.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>

--- a/src/Application/SoloDevBoard.Application/Services/IRepositoryService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/IRepositoryService.cs
@@ -1,0 +1,12 @@
+using SoloDevBoard.Domain.Entities;
+
+namespace SoloDevBoard.Application.Services;
+
+/// <summary>Provides repository listing operations for the authenticated user.</summary>
+public interface IRepositoryService
+{
+    /// <summary>Retrieves repositories accessible to the authenticated GitHub user.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A read-only list of repositories visible to the authenticated user.</returns>
+    Task<IReadOnlyList<Repository>> GetRepositoriesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Application/SoloDevBoard.Application/Services/RepositoryService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/RepositoryService.cs
@@ -1,0 +1,21 @@
+using SoloDevBoard.Domain.Entities;
+
+namespace SoloDevBoard.Application.Services;
+
+/// <summary>Default implementation of <see cref="IRepositoryService"/>.</summary>
+public sealed class RepositoryService : IRepositoryService
+{
+    private readonly IGitHubService _gitHubService;
+
+    /// <summary>Initialises a new instance of the <see cref="RepositoryService"/> class.</summary>
+    /// <param name="gitHubService">The GitHub service used to fetch repository data.</param>
+    public RepositoryService(IGitHubService gitHubService)
+    {
+        ArgumentNullException.ThrowIfNull(gitHubService);
+        _gitHubService = gitHubService;
+    }
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<Repository>> GetRepositoriesAsync(CancellationToken cancellationToken = default)
+        => _gitHubService.GetRepositoriesAsync(cancellationToken);
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubService.cs
@@ -22,6 +22,21 @@ public sealed class GitHubService : IGitHubService
     }
 
     /// <inheritdoc/>
+    public async Task<IReadOnlyList<Repository>> GetRepositoriesAsync(CancellationToken cancellationToken = default)
+    {
+        var client = _httpClientFactory.CreateClient(GitHubApiClientName);
+        const string endpoint = "/user/repos?sort=updated&per_page=100";
+        var repositories = await GetPagedAsync<RepositoryResponseDto, Repository>(
+                client,
+                endpoint,
+                static dto => dto.ToDomain(),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return repositories;
+    }
+
+    /// <inheritdoc/>
     public async Task<IReadOnlyList<Repository>> GetRepositoriesAsync(string owner, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/SoloDevBoard.Infrastructure.csproj
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/SoloDevBoard.Infrastructure.csproj
@@ -6,8 +6,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/App.Tests/SoloDevBoard.App.Tests/RepositoriesTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/RepositoriesTests.cs
@@ -1,0 +1,125 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Moq;
+using SoloDevBoard.App.Components.Pages;
+using SoloDevBoard.Application.Services;
+using SoloDevBoard.Domain.Entities;
+
+namespace SoloDevBoard.App.Tests;
+
+/// <summary>Component tests for the <see cref="Repositories"/> page.</summary>
+public sealed class RepositoriesTests : BunitContext
+{
+    private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
+
+    /// <summary>
+    /// Initialises the bUnit test context with Fluent UI services and a loose JS interop mode
+    /// so that Fluent UI web components render without requiring a real browser JavaScript runtime.
+    /// </summary>
+    public RepositoriesTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddFluentUIComponents();
+        Services.AddScoped(_ => _repositoryServiceMock.Object);
+    }
+
+    [Fact]
+    public void Repositories_WhileServiceIsLoading_ShowsLoadingIndicator()
+    {
+        // Arrange — keep the service call permanently pending so the component stays in loading state
+        var tcs = new TaskCompletionSource<IReadOnlyList<Repository>>();
+        _repositoryServiceMock
+            .Setup(s => s.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .Returns(tcs.Task);
+
+        // Act — render before the async initialisation completes
+        var cut = Render<Repositories>();
+
+        // Assert — initial render must show loading indicator, not data or error states
+        Assert.Contains("Loading repositories", cut.Markup);
+        Assert.DoesNotContain("Unable to load repositories", cut.Markup);
+        Assert.DoesNotContain("No repositories found", cut.Markup);
+    }
+
+    [Fact]
+    public void Repositories_ServiceThrowsHttpRequestException_ShowsErrorMessage()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(s => s.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Connection refused"));
+
+        // Act
+        var cut = Render<Repositories>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Unable to load repositories", cut.Markup);
+            Assert.Contains("Connection refused", cut.Markup);
+            Assert.Contains("Try again", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void Repositories_ServiceThrowsUnexpectedException_ShowsGenericErrorMessage()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(s => s.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Internal failure"));
+
+        // Act
+        var cut = Render<Repositories>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            Assert.Contains("An unexpected error occurred while loading repositories", cut.Markup));
+    }
+
+    [Fact]
+    public void Repositories_ServiceReturnsEmptyList_ShowsEmptyState()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(s => s.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Repository>());
+
+        // Act
+        var cut = Render<Repositories>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("No repositories found", cut.Markup);
+            Assert.DoesNotContain("Loading repositories", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void Repositories_ServiceReturnsRepositories_ShowsRepositoryNamesInGrid()
+    {
+        // Arrange
+        var repositories = new List<Repository>
+        {
+            new() { Id = 1, Name = "my-first-repo", FullName = "owner/my-first-repo", IsPrivate = false, UpdatedAt = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero) },
+            new() { Id = 2, Name = "my-private-repo", FullName = "owner/my-private-repo", IsPrivate = true, UpdatedAt = new DateTimeOffset(2026, 2, 20, 12, 0, 0, TimeSpan.Zero) },
+        };
+
+        _repositoryServiceMock
+            .Setup(s => s.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(repositories);
+
+        // Act
+        var cut = Render<Repositories>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("my-first-repo", cut.Markup);
+            Assert.Contains("my-private-repo", cut.Markup);
+            Assert.DoesNotContain("Loading repositories", cut.Markup);
+        });
+    }
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/SoloDevBoard.App.Tests.csproj
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/SoloDevBoard.App.Tests.csproj
@@ -8,14 +8,24 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="bunit" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\App\SoloDevBoard.App\SoloDevBoard.App.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/RepositoryServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/RepositoryServiceTests.cs
@@ -1,0 +1,54 @@
+using Moq;
+using SoloDevBoard.Application.Services;
+using SoloDevBoard.Domain.Entities;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="RepositoryService"/>.</summary>
+public sealed class RepositoryServiceTests
+{
+    private readonly Mock<IGitHubService> _gitHubServiceMock = new();
+
+    [Fact]
+    public async Task GetRepositoriesAsync_GitHubServiceReturnsRepositories_ReturnsRepositories()
+    {
+        // Arrange
+        var expectedRepositories = new List<Repository>
+        {
+            new() { Id = 1, Name = "repo-one", FullName = "owner/repo-one" },
+            new() { Id = 2, Name = "repo-two", FullName = "owner/repo-two" },
+        };
+
+        _gitHubServiceMock
+            .Setup(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedRepositories);
+
+        var sut = new RepositoryService(_gitHubServiceMock.Object);
+
+        // Act
+        var result = await sut.GetRepositoriesAsync();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("repo-one", result[0].Name);
+        _gitHubServiceMock.Verify(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetRepositoriesAsync_WhenCalled_PassesCancellationTokenToGitHubService()
+    {
+        // Arrange
+        var cancellationTokenSource = new CancellationTokenSource();
+        _gitHubServiceMock
+            .Setup(service => service.GetRepositoriesAsync(cancellationTokenSource.Token))
+            .ReturnsAsync([]);
+
+        var sut = new RepositoryService(_gitHubServiceMock.Object);
+
+        // Act
+        _ = await sut.GetRepositoriesAsync(cancellationTokenSource.Token);
+
+        // Assert
+        _gitHubServiceMock.Verify(service => service.GetRepositoriesAsync(cancellationTokenSource.Token), Times.Once);
+    }
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/SoloDevBoard.Application.Tests.csproj
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/SoloDevBoard.Application.Tests.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Domain.Tests/SoloDevBoard.Domain.Tests/SoloDevBoard.Domain.Tests.csproj
+++ b/tests/Domain.Tests/SoloDevBoard.Domain.Tests/SoloDevBoard.Domain.Tests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -9,6 +9,42 @@ namespace SoloDevBoard.Infrastructure.Tests;
 public sealed class GitHubServiceTests
 {
     [Fact]
+    public async Task GetRepositoriesAsync_AuthenticatedUser_UsesUserReposEndpoint()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "id": 3,
+                    "name": "repo-auth",
+                    "full_name": "mark/repo-auth",
+                    "description": "Authenticated repo",
+                    "html_url": "https://github.com/mark/repo-auth",
+                    "private": false,
+                    "created_at": "2026-03-01T10:00:00Z",
+                    "updated_at": "2026-03-02T11:00:00Z"
+                  }
+                ]
+                """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        var result = await sut.GetRepositoriesAsync();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("repo-auth", result[0].Name);
+        Assert.Single(handler.Requests);
+        Assert.Equal("https://api.github.com/user/repos?sort=updated&per_page=100", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
     public async Task GetRepositoriesAsync_MultiplePages_ReturnsMappedRepositories()
     {
         // Arrange

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests.csproj
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of Changes

Implements the Repositories listing page for SoloDevBoard. Authenticated users can view all their GitHub repositories in a `FluentDataGrid` with name, visibility, and last-updated date columns. Also introduces the Fluent UI component library, bUnit component testing infrastructure, Central Package Management, and VS Code workspace configuration.

## Related Issue(s)

Closes #8
Relates to #5
Partially implements #11 (bUnit infrastructure + `RepositoriesTests`)

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [x] 📝 Documentation (updates to docs, comments, or README)

## What's in this PR

### Feature: Repositories listing page (issue #8)
- `IRepositoryService` and `RepositoryService` added to `SoloDevBoard.Application`
- `IGitHubService` extended with authenticated-user overload (`GET /user/repos`)
- `Repositories.razor` + `Repositories.razor.cs` at route `/repositories`
- Loading, error, empty, and data states with ARIA attributes
- `FluentDataGrid` with Name, Visibility, and Last Updated columns
- Navigation menu entry added

### UI framework: Microsoft Fluent UI Blazor (ADR-0009)
- `Microsoft.FluentUI.AspNetCore.Components` 4.13.1 added to App project
- `AddFluentUIComponents()` registered in `Program.cs`
- Providers added to `MainLayout.razor`

### Component testing: bUnit (ADR-0010)
- `bunit` 2.6.2 added to `App.Tests` project
- `RepositoriesTests` — 5 component tests covering all render states
- `RepositoryServiceTests` — 2 unit tests
- `GitHubServiceTests` — 1 new infrastructure test

### Architecture records
- `adr/0009-fluent-ui-blazor-component-library.md` — Fluent UI decision
- `adr/0010-bunit-component-testing.md` — bUnit decision

### Tooling improvements
- `Directory.Packages.props` — Central Package Management for all 9 packages
- `.vscode/extensions.json`, `tasks.json`, `launch.json` — VS Code workspace setup

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`) — 26 tests, 0 failed
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

Manual runtime testing pending — UI states verified via bUnit component tests.

## Additional Notes

Central Package Management was not set up at initial scaffold. All csproj files in the solution now use `Directory.Packages.props` for version management; only `PackageVersion` entries need updating when dependencies change.
