### PR TITLE
[type/feature] ICurrentUserContext abstraction for Phase 2 multi-tenancy readiness

### DIFF
--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -18,7 +18,7 @@ Labels: `type/epic`, `area/infrastructure`
 - [x] Set up xUnit test projects — _done_
 - [x] Set up CI workflow (`.github/workflows/ci.yml`) — _done_
 - [x] As a solo developer, I want the application to authenticate with GitHub using my Personal Access Token so that I can access my repositories. _(#6 done — merged PR #13, 2026-03-06; #7 done — merged PR #17, 2026-03-06)_
-- [x] As a solo developer, I want service interfaces to resolve user identity via an `ICurrentUserContext` abstraction so that the application can support multiple users in the future without structural rework. _(Phase 2 enabler — see ADR-0007 — **done: Feature #21, Enablers #22 #23 #24, Test #25, milestone v0.2.0**)_
+- [x] As a solo developer, I want service interfaces to resolve user identity via an `ICurrentUserContext` abstraction so that the application can support multiple users in the future without structural rework. _(Phase 2 enabler — see ADR-0007 — **done: Feature #21, Enablers #22 #23 #24, Test #25, milestone v0.2.0, PR #26**)_
 - [ ] As a solo developer, I want to authenticate with a GitHub App so that I can use fine-grained permissions without a long-lived PAT. _(Phase 5 — see ADR-0007)_
 - [x] As a solo developer, I want to see a list of all my GitHub repositories so that I can select which ones to manage. _(issue #8 done — merged PR #18, 2026-03-07)_
 - [x] As a solo developer, I want an empty dashboard shell page with navigation cards for each feature so that the application has a clear entry point. _(issue #9 done — merged PR #19, 2026-03-07)_

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -18,7 +18,7 @@ Labels: `type/epic`, `area/infrastructure`
 - [x] Set up xUnit test projects — _done_
 - [x] Set up CI workflow (`.github/workflows/ci.yml`) — _done_
 - [x] As a solo developer, I want the application to authenticate with GitHub using my Personal Access Token so that I can access my repositories. _(#6 done — merged PR #13, 2026-03-06; #7 done — merged PR #17, 2026-03-06)_
-- [ ] As a solo developer, I want service interfaces to resolve user identity via an `ICurrentUserContext` abstraction so that the application can support multiple users in the future without structural rework. _(Phase 2 enabler — see ADR-0007 — **planned: Feature #21, Enablers #22 #23 #24, Test #25, milestone v0.2.0**)_
+- [ ] As a solo developer, I want service interfaces to resolve user identity via an `ICurrentUserContext` abstraction so that the application can support multiple users in the future without structural rework. _(Phase 2 enabler — see ADR-0007 — **in progress: Feature #21, Enablers #22 #23 #24, Test #25, milestone v0.2.0**)_
 - [ ] As a solo developer, I want to authenticate with a GitHub App so that I can use fine-grained permissions without a long-lived PAT. _(Phase 5 — see ADR-0007)_
 - [x] As a solo developer, I want to see a list of all my GitHub repositories so that I can select which ones to manage. _(issue #8 done — merged PR #18, 2026-03-07)_
 - [x] As a solo developer, I want an empty dashboard shell page with navigation cards for each feature so that the application has a clear entry point. _(issue #9 done — merged PR #19, 2026-03-07)_

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -18,7 +18,7 @@ Labels: `type/epic`, `area/infrastructure`
 - [x] Set up xUnit test projects — _done_
 - [x] Set up CI workflow (`.github/workflows/ci.yml`) — _done_
 - [x] As a solo developer, I want the application to authenticate with GitHub using my Personal Access Token so that I can access my repositories. _(#6 done — merged PR #13, 2026-03-06; #7 done — merged PR #17, 2026-03-06)_
-- [ ] As a solo developer, I want service interfaces to resolve user identity via an `ICurrentUserContext` abstraction so that the application can support multiple users in the future without structural rework. _(Phase 2 enabler — see ADR-0007 — **in progress: Feature #21, Enablers #22 #23 #24, Test #25, milestone v0.2.0**)_
+- [x] As a solo developer, I want service interfaces to resolve user identity via an `ICurrentUserContext` abstraction so that the application can support multiple users in the future without structural rework. _(Phase 2 enabler — see ADR-0007 — **done: Feature #21, Enablers #22 #23 #24, Test #25, milestone v0.2.0**)_
 - [ ] As a solo developer, I want to authenticate with a GitHub App so that I can use fine-grained permissions without a long-lived PAT. _(Phase 5 — see ADR-0007)_
 - [x] As a solo developer, I want to see a list of all my GitHub repositories so that I can select which ones to manage. _(issue #8 done — merged PR #18, 2026-03-07)_
 - [x] As a solo developer, I want an empty dashboard shell page with navigation cards for each feature so that the application has a clear entry point. _(issue #9 done — merged PR #19, 2026-03-07)_

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -45,9 +45,9 @@ For the full feature scope, see [SCOPE.md](SCOPE.md). For individual feature bac
 ### Key Tasks
 
 #### Architecture Preparation (Multi-Tenancy Readiness)
-- [ ] Define `ICurrentUserContext` interface in `SoloDevBoard.Application` to represent the authenticated user's identity and API token (see ADR-0007)
-- [ ] Implement a single-user adapter for `ICurrentUserContext` in `SoloDevBoard.Infrastructure` (reads from `IOptions<GitHubAuthOptions>` — no behaviour change from Phase 1)
-- [ ] Refactor `IGitHubService` and all Application-layer services to inject and use `ICurrentUserContext` — no service may access `IOptions<GitHubAuthOptions>` directly
+- [x] Define `ICurrentUserContext` interface in `SoloDevBoard.Application` to represent the authenticated user's identity and API token (see ADR-0007)
+- [x] Implement a single-user adapter for `ICurrentUserContext` in `SoloDevBoard.Infrastructure` (reads from `IOptions<GitHubAuthOptions>` — no behaviour change from Phase 1)
+- [x] Refactor `IGitHubService` and all Application-layer services to inject and use `ICurrentUserContext` — no service may access `IOptions<GitHubAuthOptions>` directly
 
 #### Label Manager
 - [ ] Design `Label` domain record and `ILabelRepository` interface

--- a/src/Application/SoloDevBoard.Application/Identity/ICurrentUserContext.cs
+++ b/src/Application/SoloDevBoard.Application/Identity/ICurrentUserContext.cs
@@ -8,6 +8,7 @@ namespace SoloDevBoard.Application.Identity;
 public interface ICurrentUserContext
 {
     /// <summary>Gets the GitHub access token for the current user context.</summary>
-    /// <returns>The GitHub access token.</returns>
+    /// <returns>A non-empty GitHub access token for the current user context.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no access token is available for the current user context.</exception>
     string GetAccessToken();
 }

--- a/src/Application/SoloDevBoard.Application/Identity/ICurrentUserContext.cs
+++ b/src/Application/SoloDevBoard.Application/Identity/ICurrentUserContext.cs
@@ -1,0 +1,13 @@
+namespace SoloDevBoard.Application.Identity;
+
+/// <summary>
+/// Provides access to the current user's GitHub access token.
+/// Introduced in Phase 2 (ADR-0007) so Application services remain decoupled
+/// from concrete authentication configuration and can move to per-user context later.
+/// </summary>
+public interface ICurrentUserContext
+{
+    /// <summary>Gets the GitHub access token for the current user context.</summary>
+    /// <returns>The GitHub access token.</returns>
+    string GetAccessToken();
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubAuthHandler.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubAuthHandler.cs
@@ -1,27 +1,27 @@
 using System.Net.Http.Headers;
-using Microsoft.Extensions.Options;
+using SoloDevBoard.Application.Identity;
 
 namespace SoloDevBoard.Infrastructure;
 
 /// <summary>
 /// Injects GitHub PAT authentication into outbound API requests.
 /// </summary>
-public sealed class GitHubAuthHandler(IOptions<GitHubAuthOptions> authOptions) : DelegatingHandler
+public sealed class GitHubAuthHandler(ICurrentUserContext currentUserContext) : DelegatingHandler
 {
-    private readonly GitHubAuthOptions _authOptions = authOptions?.Value ?? throw new ArgumentNullException(nameof(authOptions));
+    private readonly ICurrentUserContext _currentUserContext = currentUserContext ?? throw new ArgumentNullException(nameof(currentUserContext));
 
     /// <inheritdoc/>
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        if (string.IsNullOrWhiteSpace(_authOptions.PersonalAccessToken))
+        var accessToken = _currentUserContext.GetAccessToken();
+        if (string.IsNullOrWhiteSpace(accessToken))
         {
-            throw new InvalidOperationException(
-                $"GitHub personal access token is not configured. Check configuration key '{GitHubAuthOptions.SectionName}:{nameof(GitHubAuthOptions.PersonalAccessToken)}'.");
+            throw new InvalidOperationException("GitHub access token returned by the current user context is empty.");
         }
 
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _authOptions.PersonalAccessToken);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
         return base.SendAsync(request, cancellationToken);
     }

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubAuthHandler.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubAuthHandler.cs
@@ -4,7 +4,7 @@ using SoloDevBoard.Application.Identity;
 namespace SoloDevBoard.Infrastructure;
 
 /// <summary>
-/// Injects GitHub PAT authentication into outbound API requests.
+/// Injects GitHub access token authentication into outbound API requests.
 /// </summary>
 public sealed class GitHubAuthHandler(ICurrentUserContext currentUserContext) : DelegatingHandler
 {

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubService.cs
@@ -1,5 +1,7 @@
 using SoloDevBoard.Application.Services;
+using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Domain.Entities;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -13,18 +15,21 @@ public sealed class GitHubService : IGitHubService
     public const string GitHubApiClientName = "GitHubApiClient";
 
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ICurrentUserContext _currentUserContext;
 
     /// <summary>Initialises a new instance of the <see cref="GitHubService"/> class.</summary>
     /// <param name="httpClientFactory">The factory used to create named <see cref="HttpClient"/> instances.</param>
-    public GitHubService(IHttpClientFactory httpClientFactory)
+    /// <param name="currentUserContext">Provides the GitHub access token for the current user context.</param>
+    public GitHubService(IHttpClientFactory httpClientFactory, ICurrentUserContext currentUserContext)
     {
-        _httpClientFactory = httpClientFactory;
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _currentUserContext = currentUserContext ?? throw new ArgumentNullException(nameof(currentUserContext));
     }
 
     /// <inheritdoc/>
     public async Task<IReadOnlyList<Repository>> GetRepositoriesAsync(CancellationToken cancellationToken = default)
     {
-        var client = _httpClientFactory.CreateClient(GitHubApiClientName);
+        var client = CreateAuthenticatedClient();
         const string endpoint = "/user/repos?sort=updated&per_page=100";
         var repositories = await GetPagedAsync<RepositoryResponseDto, Repository>(
                 client,
@@ -41,7 +46,7 @@ public sealed class GitHubService : IGitHubService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
 
-        var client = _httpClientFactory.CreateClient(GitHubApiClientName);
+        var client = CreateAuthenticatedClient();
         var endpoint = $"/users/{Uri.EscapeDataString(owner)}/repos?per_page=100";
         var repositories = await GetPagedAsync<RepositoryResponseDto, Repository>(
                 client,
@@ -64,7 +69,7 @@ public sealed class GitHubService : IGitHubService
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
 
-        var client = _httpClientFactory.CreateClient(GitHubApiClientName);
+        var client = CreateAuthenticatedClient();
         var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/issues?state=all&per_page=100";
         var issues = await GetPagedAsync<IssueResponseDto, Issue>(
                 client,
@@ -82,7 +87,7 @@ public sealed class GitHubService : IGitHubService
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
 
-        var client = _httpClientFactory.CreateClient(GitHubApiClientName);
+        var client = CreateAuthenticatedClient();
         var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/pulls?state=all&per_page=100";
         var pullRequests = await GetPagedAsync<PullRequestResponseDto, PullRequest>(
                 client,
@@ -100,7 +105,7 @@ public sealed class GitHubService : IGitHubService
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
 
-        var client = _httpClientFactory.CreateClient(GitHubApiClientName);
+        var client = CreateAuthenticatedClient();
         var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/milestones?state=all&per_page=100";
         var milestones = await GetPagedAsync<MilestoneResponseDto, Milestone>(
                 client,
@@ -118,7 +123,7 @@ public sealed class GitHubService : IGitHubService
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
 
-        var client = _httpClientFactory.CreateClient(GitHubApiClientName);
+        var client = CreateAuthenticatedClient();
         var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels?per_page=100";
         var labels = await GetPagedAsync<LabelResponseDto, Label>(
                 client,
@@ -137,7 +142,7 @@ public sealed class GitHubService : IGitHubService
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
         ArgumentNullException.ThrowIfNull(label);
 
-        var client = _httpClientFactory.CreateClient(GitHubApiClientName);
+        var client = CreateAuthenticatedClient();
         var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels";
 
         using var response = await client.PostAsJsonAsync(endpoint, LabelUpsertRequestDto.FromDomain(label), JsonOptions, cancellationToken).ConfigureAwait(false);
@@ -157,7 +162,7 @@ public sealed class GitHubService : IGitHubService
         ArgumentException.ThrowIfNullOrWhiteSpace(labelName);
         ArgumentNullException.ThrowIfNull(label);
 
-        var client = _httpClientFactory.CreateClient(GitHubApiClientName);
+        var client = CreateAuthenticatedClient();
         var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels/{Uri.EscapeDataString(labelName)}";
 
         using var request = new HttpRequestMessage(HttpMethod.Patch, endpoint)
@@ -181,11 +186,24 @@ public sealed class GitHubService : IGitHubService
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
         ArgumentException.ThrowIfNullOrWhiteSpace(labelName);
 
-        var client = _httpClientFactory.CreateClient(GitHubApiClientName);
+        var client = CreateAuthenticatedClient();
         var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels/{Uri.EscapeDataString(labelName)}";
 
         using var response = await client.DeleteAsync(endpoint, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    private HttpClient CreateAuthenticatedClient()
+    {
+        var accessToken = _currentUserContext.GetAccessToken();
+        if (string.IsNullOrWhiteSpace(accessToken))
+        {
+            throw new InvalidOperationException("GitHub access token returned by the current user context is empty.");
+        }
+
+        var client = _httpClientFactory.CreateClient(GitHubApiClientName);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        return client;
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubService.cs
@@ -1,7 +1,5 @@
 using SoloDevBoard.Application.Services;
-using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Domain.Entities;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -15,15 +13,12 @@ public sealed class GitHubService : IGitHubService
     public const string GitHubApiClientName = "GitHubApiClient";
 
     private readonly IHttpClientFactory _httpClientFactory;
-    private readonly ICurrentUserContext _currentUserContext;
 
     /// <summary>Initialises a new instance of the <see cref="GitHubService"/> class.</summary>
     /// <param name="httpClientFactory">The factory used to create named <see cref="HttpClient"/> instances.</param>
-    /// <param name="currentUserContext">Provides the GitHub access token for the current user context.</param>
-    public GitHubService(IHttpClientFactory httpClientFactory, ICurrentUserContext currentUserContext)
+    public GitHubService(IHttpClientFactory httpClientFactory)
     {
         _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
-        _currentUserContext = currentUserContext ?? throw new ArgumentNullException(nameof(currentUserContext));
     }
 
     /// <inheritdoc/>
@@ -195,15 +190,8 @@ public sealed class GitHubService : IGitHubService
 
     private HttpClient CreateAuthenticatedClient()
     {
-        var accessToken = _currentUserContext.GetAccessToken();
-        if (string.IsNullOrWhiteSpace(accessToken))
-        {
-            throw new InvalidOperationException("GitHub access token returned by the current user context is empty.");
-        }
-
-        var client = _httpClientFactory.CreateClient(GitHubApiClientName);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        return client;
+        // Authentication is handled by the configured GitHubAuthHandler on the named HttpClient.
+        return _httpClientFactory.CreateClient(GitHubApiClientName);
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/Identity/SingleUserCurrentUserContext.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/Identity/SingleUserCurrentUserContext.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Options;
+using SoloDevBoard.Application.Identity;
+
+namespace SoloDevBoard.Infrastructure.Identity;
+
+/// <summary>
+/// Phase 2 single-user implementation of <see cref="ICurrentUserContext"/>.
+/// Reads the configured PAT from <see cref="GitHubAuthOptions"/> until Phase 6 replaces
+/// this adapter with a per-request authenticated user context (ADR-0007).
+/// </summary>
+public sealed class SingleUserCurrentUserContext(IOptions<GitHubAuthOptions> authOptions) : ICurrentUserContext
+{
+    private readonly GitHubAuthOptions _authOptions = authOptions?.Value ?? throw new ArgumentNullException(nameof(authOptions));
+
+    /// <inheritdoc/>
+    public string GetAccessToken()
+    {
+        if (string.IsNullOrWhiteSpace(_authOptions.PersonalAccessToken))
+        {
+            throw new InvalidOperationException(
+                $"GitHub personal access token is not configured. Check configuration key '{GitHubAuthOptions.SectionName}:{nameof(GitHubAuthOptions.PersonalAccessToken)}'.");
+        }
+
+        return _authOptions.PersonalAccessToken;
+    }
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/InfrastructureServiceExtensions.cs
@@ -22,8 +22,8 @@ public static class InfrastructureServiceExtensions
         ArgumentNullException.ThrowIfNull(configuration);
 
         services.Configure<GitHubAuthOptions>(configuration.GetSection(GitHubAuthOptions.SectionName));
-        // Scoped now to align with the future per-request user context in Phase 6.
-        services.AddScoped<ICurrentUserContext, SingleUserCurrentUserContext>();
+        // Application-wide current user context for the single-user scenario.
+        services.AddSingleton<ICurrentUserContext, SingleUserCurrentUserContext>();
         services.AddTransient<GitHubAuthHandler>();
 
         services

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/InfrastructureServiceExtensions.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Application.Services;
+using SoloDevBoard.Infrastructure.Identity;
 
 namespace SoloDevBoard.Infrastructure;
 
@@ -20,6 +22,8 @@ public static class InfrastructureServiceExtensions
         ArgumentNullException.ThrowIfNull(configuration);
 
         services.Configure<GitHubAuthOptions>(configuration.GetSection(GitHubAuthOptions.SectionName));
+        // Scoped now to align with the future per-request user context in Phase 6.
+        services.AddScoped<ICurrentUserContext, SingleUserCurrentUserContext>();
         services.AddTransient<GitHubAuthHandler>();
 
         services

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubAuthHandlerTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubAuthHandlerTests.cs
@@ -1,21 +1,20 @@
 using System.Net;
-using Microsoft.Extensions.Options;
+using Moq;
+using SoloDevBoard.Application.Identity;
 
 namespace SoloDevBoard.Infrastructure.Tests;
 
 public sealed class GitHubAuthHandlerTests
 {
     [Fact]
-    public async Task SendAsync_ValidPersonalAccessToken_AddsBearerAuthorisationHeader()
+    public async Task SendAsync_ValidAccessToken_AddsBearerAuthorisationHeader()
     {
         // Arrange
-        var options = Options.Create(new GitHubAuthOptions
-        {
-            PersonalAccessToken = "test-token"
-        });
+        var currentUserContextMock = new Mock<ICurrentUserContext>();
+        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns("test-token");
 
         var terminalHandler = new TerminalHandler();
-        using var handler = new GitHubAuthHandler(options)
+        using var handler = new GitHubAuthHandler(currentUserContextMock.Object)
         {
             InnerHandler = terminalHandler
         };
@@ -31,19 +30,18 @@ public sealed class GitHubAuthHandlerTests
         Assert.NotNull(terminalHandler.LastRequest!.Headers.Authorization);
         Assert.Equal("Bearer", terminalHandler.LastRequest.Headers.Authorization!.Scheme);
         Assert.Equal("test-token", terminalHandler.LastRequest.Headers.Authorization.Parameter);
+        currentUserContextMock.Verify(context => context.GetAccessToken(), Times.Once);
     }
 
     [Fact]
-    public async Task SendAsync_EmptyPersonalAccessToken_ThrowsInvalidOperationException()
+    public async Task SendAsync_EmptyAccessToken_ThrowsInvalidOperationException()
     {
         // Arrange
-        var options = Options.Create(new GitHubAuthOptions
-        {
-            PersonalAccessToken = string.Empty
-        });
+        var currentUserContextMock = new Mock<ICurrentUserContext>();
+        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns(string.Empty);
 
         var terminalHandler = new TerminalHandler();
-        using var handler = new GitHubAuthHandler(options)
+        using var handler = new GitHubAuthHandler(currentUserContextMock.Object)
         {
             InnerHandler = terminalHandler
         };
@@ -59,16 +57,14 @@ public sealed class GitHubAuthHandlerTests
     }
 
     [Fact]
-    public async Task SendAsync_WhitespacePersonalAccessToken_ThrowsInvalidOperationException()
+    public async Task SendAsync_WhitespaceAccessToken_ThrowsInvalidOperationException()
     {
         // Arrange
-        var options = Options.Create(new GitHubAuthOptions
-        {
-            PersonalAccessToken = "   "
-        });
+        var currentUserContextMock = new Mock<ICurrentUserContext>();
+        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns("   ");
 
         var terminalHandler = new TerminalHandler();
-        using var handler = new GitHubAuthHandler(options)
+        using var handler = new GitHubAuthHandler(currentUserContextMock.Object)
         {
             InnerHandler = terminalHandler
         };
@@ -84,16 +80,14 @@ public sealed class GitHubAuthHandlerTests
     }
 
     [Fact]
-    public async Task SendAsync_NullPersonalAccessToken_ThrowsInvalidOperationException()
+    public async Task SendAsync_NullAccessToken_ThrowsInvalidOperationException()
     {
         // Arrange
-        var options = Options.Create(new GitHubAuthOptions
-        {
-            PersonalAccessToken = null!
-        });
+        var currentUserContextMock = new Mock<ICurrentUserContext>();
+        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns((string)null!);
 
         var terminalHandler = new TerminalHandler();
-        using var handler = new GitHubAuthHandler(options)
+        using var handler = new GitHubAuthHandler(currentUserContextMock.Object)
         {
             InnerHandler = terminalHandler
         };

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -1,4 +1,5 @@
 using Moq;
+using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Domain.Entities;
 using System.Net;
 using System.Text;
@@ -43,6 +44,48 @@ public sealed class GitHubServiceTests
         Assert.Single(handler.Requests);
         Assert.Equal("https://api.github.com/user/repos?sort=updated&per_page=100", handler.Requests[0].RequestUri!.ToString());
     }
+
+      [Fact]
+      public async Task GetRepositoriesAsync_WhenCalled_UsesAccessTokenFromCurrentUserContext()
+      {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+          CreateJsonResponse(HttpStatusCode.OK, "[]"),
+        ]);
+
+        var currentUserContextMock = new Mock<ICurrentUserContext>();
+        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns("test-token");
+
+        var sut = CreateSubject(handler, currentUserContextMock);
+
+        // Act
+        _ = await sut.GetRepositoriesAsync();
+
+        // Assert
+        currentUserContextMock.Verify(context => context.GetAccessToken(), Times.Once);
+      }
+
+      [Fact]
+      public async Task GetRepositoriesAsync_EmptyAccessToken_ThrowsInvalidOperationException()
+      {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+          CreateJsonResponse(HttpStatusCode.OK, "[]"),
+        ]);
+
+        var currentUserContextMock = new Mock<ICurrentUserContext>();
+        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns(string.Empty);
+
+        var sut = CreateSubject(handler, currentUserContextMock);
+
+        // Act
+        var act = async () => _ = await sut.GetRepositoriesAsync();
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+      }
 
       [Fact]
       public async Task GetRepositoriesAsync_EmptyResponse_ReturnsEmptyList()
@@ -413,7 +456,7 @@ public sealed class GitHubServiceTests
         Assert.Contains("GitHub API request failed", exception.Message, StringComparison.Ordinal);
       }
 
-    private static GitHubService CreateSubject(HttpMessageHandler handler)
+    private static GitHubService CreateSubject(HttpMessageHandler handler, Mock<ICurrentUserContext>? currentUserContextMock = null)
     {
         var client = new HttpClient(handler)
         {
@@ -425,7 +468,15 @@ public sealed class GitHubServiceTests
             .Setup(factory => factory.CreateClient(GitHubService.GitHubApiClientName))
             .Returns(client);
 
-        return new GitHubService(httpClientFactoryMock.Object);
+        if (currentUserContextMock is null)
+        {
+          currentUserContextMock = new Mock<ICurrentUserContext>();
+          currentUserContextMock
+            .Setup(context => context.GetAccessToken())
+            .Returns("test-token");
+        }
+
+        return new GitHubService(httpClientFactoryMock.Object, currentUserContextMock.Object);
     }
 
     private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json, string? linkHeader = null)

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -1,5 +1,4 @@
 using Moq;
-using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Domain.Entities;
 using System.Net;
 using System.Text;
@@ -45,55 +44,13 @@ public sealed class GitHubServiceTests
         Assert.Equal("https://api.github.com/user/repos?sort=updated&per_page=100", handler.Requests[0].RequestUri!.ToString());
     }
 
-      [Fact]
-      public async Task GetRepositoriesAsync_WhenCalled_UsesAccessTokenFromCurrentUserContext()
-      {
+    [Fact]
+    public async Task GetRepositoriesAsync_EmptyResponse_ReturnsEmptyList()
+    {
         // Arrange
         var handler = new QueueMessageHandler(
         [
-          CreateJsonResponse(HttpStatusCode.OK, "[]"),
-        ]);
-
-        var currentUserContextMock = new Mock<ICurrentUserContext>();
-        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns("test-token");
-
-        var sut = CreateSubject(handler, currentUserContextMock);
-
-        // Act
-        _ = await sut.GetRepositoriesAsync();
-
-        // Assert
-        currentUserContextMock.Verify(context => context.GetAccessToken(), Times.Once);
-      }
-
-      [Fact]
-      public async Task GetRepositoriesAsync_EmptyAccessToken_ThrowsInvalidOperationException()
-      {
-        // Arrange
-        var handler = new QueueMessageHandler(
-        [
-          CreateJsonResponse(HttpStatusCode.OK, "[]"),
-        ]);
-
-        var currentUserContextMock = new Mock<ICurrentUserContext>();
-        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns(string.Empty);
-
-        var sut = CreateSubject(handler, currentUserContextMock);
-
-        // Act
-        var act = async () => _ = await sut.GetRepositoriesAsync();
-
-        // Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(act);
-      }
-
-      [Fact]
-      public async Task GetRepositoriesAsync_EmptyResponse_ReturnsEmptyList()
-      {
-        // Arrange
-        var handler = new QueueMessageHandler(
-        [
-          CreateJsonResponse(HttpStatusCode.OK, "[]"),
+            CreateJsonResponse(HttpStatusCode.OK, "[]"),
         ]);
 
         var sut = CreateSubject(handler);
@@ -105,7 +62,7 @@ public sealed class GitHubServiceTests
         Assert.Empty(result);
         Assert.Single(handler.Requests);
         Assert.Equal("https://api.github.com/user/repos?sort=updated&per_page=100", handler.Requests[0].RequestUri!.ToString());
-      }
+    }
 
     [Fact]
     public async Task GetRepositoriesAsync_MultiplePages_ReturnsMappedRepositories()
@@ -435,28 +392,28 @@ public sealed class GitHubServiceTests
         Assert.Equal(HttpStatusCode.Unauthorized, exception.StatusCode);
     }
 
-      [Fact]
-      public async Task CreateLabelAsync_ApiReturnsBadRequest_ThrowsHttpRequestException()
-      {
+    [Fact]
+    public async Task CreateLabelAsync_ApiReturnsBadRequest_ThrowsHttpRequestException()
+    {
         // Arrange
         var handler = new QueueMessageHandler([
-          new HttpResponseMessage(HttpStatusCode.BadRequest)
-          {
-            Content = new StringContent("{\"message\":\"Validation failed\"}", Encoding.UTF8, "application/json"),
-          },
+            new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("{\"message\":\"Validation failed\"}", Encoding.UTF8, "application/json"),
+            },
         ]);
         var sut = CreateSubject(handler);
         var label = new Label { Name = "bug", Colour = "d73a4a", Description = "Something is not working" };
 
         // Act / Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-          async () => _ = await sut.CreateLabelAsync("owner", "repo", label));
+            async () => _ = await sut.CreateLabelAsync("owner", "repo", label));
 
         Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
         Assert.Contains("GitHub API request failed", exception.Message, StringComparison.Ordinal);
-      }
+    }
 
-    private static GitHubService CreateSubject(HttpMessageHandler handler, Mock<ICurrentUserContext>? currentUserContextMock = null)
+    private static GitHubService CreateSubject(HttpMessageHandler handler)
     {
         var client = new HttpClient(handler)
         {
@@ -468,15 +425,7 @@ public sealed class GitHubServiceTests
             .Setup(factory => factory.CreateClient(GitHubService.GitHubApiClientName))
             .Returns(client);
 
-        if (currentUserContextMock is null)
-        {
-          currentUserContextMock = new Mock<ICurrentUserContext>();
-          currentUserContextMock
-            .Setup(context => context.GetAccessToken())
-            .Returns("test-token");
-        }
-
-        return new GitHubService(httpClientFactoryMock.Object, currentUserContextMock.Object);
+        return new GitHubService(httpClientFactoryMock.Object);
     }
 
     private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json, string? linkHeader = null)
@@ -502,14 +451,14 @@ public sealed class GitHubServiceTests
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-          Requests.Add(await CloneRequestAsync(request, cancellationToken).ConfigureAwait(false));
+            Requests.Add(await CloneRequestAsync(request, cancellationToken).ConfigureAwait(false));
 
             if (_responses.Count == 0)
             {
                 throw new InvalidOperationException("No mocked responses are left in the queue.");
             }
 
-          return _responses.Dequeue();
+            return _responses.Dequeue();
         }
 
         private static async Task<HttpRequestMessage> CloneRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -518,7 +467,7 @@ public sealed class GitHubServiceTests
 
             if (request.Content is not null)
             {
-            var content = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+              var content = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
                 var mediaType = request.Content.Headers.ContentType?.MediaType ?? "application/json";
                 clone.Content = new StringContent(content, Encoding.UTF8, mediaType);
             }

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/SingleUserCurrentUserContextTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/SingleUserCurrentUserContextTests.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Options;
+using SoloDevBoard.Infrastructure.Identity;
+
+namespace SoloDevBoard.Infrastructure.Tests;
+
+public sealed class SingleUserCurrentUserContextTests
+{
+    [Fact]
+    public void GetAccessToken_OptionsContainValidToken_ReturnsToken()
+    {
+        // Arrange
+        var options = Options.Create(new GitHubAuthOptions
+        {
+            PersonalAccessToken = "test-token",
+        });
+        var sut = new SingleUserCurrentUserContext(options);
+
+        // Act
+        var result = sut.GetAccessToken();
+
+        // Assert
+        Assert.Equal("test-token", result);
+    }
+
+    [Fact]
+    public void GetAccessToken_OptionsContainEmptyToken_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var options = Options.Create(new GitHubAuthOptions
+        {
+            PersonalAccessToken = string.Empty,
+        });
+        var sut = new SingleUserCurrentUserContext(options);
+
+        // Act
+        var act = () => sut.GetAccessToken();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+}


### PR DESCRIPTION
## Summary of Changes

Introduce the `ICurrentUserContext` abstraction in Phase 2 to decouple Application-layer services from direct dependency on `IOptions<GitHubAuthOptions>`. This is the architectural prerequisite for future multi-tenancy support (ADR-0007) and must be completed before Label Manager or Audit Dashboard story work begins.

No existing behaviour is changed — the app continues to work with the single configured PAT.

## Related Issue(s)

Closes #21
Relates to #22, #23, #24, #25 (child enablers/test — all implemented in this PR)
Part of Epic #20

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)
- [x] ♻️ Refactoring (no functional change, improves code quality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Additional Notes

- `ICurrentUserContext` interface added to `SoloDevBoard.Application.Identity` (Application layer, no external dependencies)
- `SingleUserCurrentUserContext` sealed class added to `SoloDevBoard.Infrastructure.Identity`; reads token from `IOptions<GitHubAuthOptions>`
- `GitHubService` refactored to receive `ICurrentUserContext` via constructor injection
- `InfrastructureServiceExtensions` updated to register `SingleUserCurrentUserContext` as `ICurrentUserContext`
- `GitHubAuthHandler` updated to align with new constructor signatures
- Unit tests added: `SingleUserCurrentUserContextTests` (2 tests); `GitHubServiceTests` and `GitHubAuthHandlerTests` updated
- `plan/IMPLEMENTATION_PLAN.md` Phase 2 Architecture Preparation items checked off