### PR TITLE
[type/enabler] Add RepositoryName to Label domain record and define ILabelRepository interface

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,6 +51,15 @@ SoloDevBoard.Infrastructure  → GitHub API clients, persistence, external integ
 - **App** depends on Application (calls use cases via services/mediators).
 - Use constructor injection throughout; avoid service locator patterns.
 
+### Boundary Data Shapes (ADR-0011)
+
+Two explicit rules govern what types cross each boundary:
+
+1. **Repository boundary (Infrastructure ↔ Application):** `IRepository` interfaces return and accept **domain entity records** (`Label`, `Repository`, etc.). Infrastructure translates external API responses to domain records before crossing this boundary.
+2. **Application→App boundary:** All public Application service interfaces (`I*Service`, `I*Manager`) return and accept **DTO records** (`LabelDto`, `RepositoryDto`, etc.) defined in `SoloDevBoard.Application`. **Domain entities must never appear in the public signature of these interfaces.**
+
+DTOs are `sealed record` types named `<Entity>Dto`, co-located in `SoloDevBoard.Application` alongside the service interface that uses them. Mapping from domain entity to DTO happens in the Application service implementation — not in Razor components, not via AutoMapper.
+
 ---
 
 ## Coding Conventions

--- a/adr/0011-boundary-data-shapes.md
+++ b/adr/0011-boundary-data-shapes.md
@@ -1,0 +1,99 @@
+# ADR-0011: Boundary Data Shapes — DTOs at the Application→App Boundary
+
+**Date:** 2026-03-08
+**Status:** Accepted
+
+---
+
+## Context
+
+[ADR-0004](0004-layered-architecture.md) defines the four-layer architecture and establishes which projects may depend on which. It is explicit on **dependency direction** (Application depends on Domain; App depends on Application) but entirely silent on **what data shapes cross each boundary**. This gap is architecturally significant: without a rule, any code — human or AI-generated — may pass domain entities all the way through to the Blazor UI layer, which violates the original intent of Clean Architecture and accumulates coupling over time.
+
+The question was surfaced during implementation of `ILabelManagerService`, which in its initial stub form returns `IReadOnlyList<Label>` — a domain entity type — to the `App` layer. Given that SoloDevBoard is developed primarily by AI delivery agents (see [ADR-0010](0010-bunit-component-testing.md)), the absence of an explicit rule creates a material risk of **AI model drift**: each subsequent agent session may make a different choice, producing an inconsistent codebase.
+
+### Options Considered
+
+| Option | Description | Assessment |
+|--------|-------------|------------|
+| **Domain entities all the way up** | Application service interfaces return domain entities; Razor components bind directly to `Label`, `Repository`, etc. | Simple, no mapping code. But couples presentation layer directly to domain model. Any domain change ripples into Razor components. |
+| **DTOs at the Application→App boundary** | Repositories and internal Application services operate with domain entities. Public-facing Application service interfaces (called by `App`) return dedicated DTO/ViewModel records defined in the Application layer. | Explicit boundary. Domain model changes do not leak into UI. Aligns with both Uncle Bob's original article and the two dominant .NET reference implementations. |
+| **Full CQRS with separate read/write models** | Separate query models (projections) and command models. Read side never touches domain entities. | Maximum flexibility. Overkill for a solo-developer tool with a small domain. Introduces significant boilerplate with no proportionate benefit at this scale. |
+
+---
+
+## Decision
+
+**Apply a two-tier data-shape rule:**
+
+1. **Repository boundary (Infrastructure ↔ Application):** `IRepository` interfaces return and accept **domain entity records** (`Label`, `Repository`, etc.). Infrastructure implementations translate external API responses (e.g. `LabelResponseDto` from the GitHub REST API) into domain records before crossing this boundary. The Application layer is permitted — and expected — to work directly with domain entities internally.
+
+2. **Application→App boundary:** All public Application service interfaces (`ILabelManagerService`, `IRepositoryService`, etc.) — the interfaces called directly by Blazor components and pages — return and accept **dedicated DTO records** defined in the `SoloDevBoard.Application` layer. Domain entities must not appear in the return types or parameters of these interfaces.
+
+DTOs are named `<Entity>Dto` (e.g. `LabelDto`, `RepositoryDto`) and are defined as `sealed record` types with `init`-only properties, co-located in the Application layer alongside the service interface that uses them.
+
+### Boundary Map
+
+```
+[GitHub REST API]
+        ↓  LabelResponseDto (private to Infrastructure)
+[Infrastructure] — ToDomain() mapping
+        ↓  Label (domain entity) — crosses ILabelRepository boundary
+[Application — internal]
+        ↓  LabelDto (Application DTO) — crosses ILabelManagerService boundary
+[App — Blazor components]
+```
+
+---
+
+## Rationale
+
+### Strict Adherence to Uncle Bob's Original Intent
+
+Robert C. Martin's 2012 "Clean Architecture" article explicitly states:
+
+> *"We don't want to cheat and pass Entity objects across the boundaries… When we pass data across a boundary, it is always in the form that is most convenient for the inner circle."*
+
+Passing a `Label` domain entity through `ILabelManagerService` to a Razor component is precisely the "cheat" Uncle Bob warned against. Domain entities are inner-circle objects; the App layer is outer-circle. A DTO defined in the Application layer is the correct "most convenient form for the inner circle" — it is shaped by the use-case, not by the domain model.
+
+### Alignment with Dominant .NET Reference Implementations
+
+Both leading .NET Clean Architecture reference projects confirm this as the established community pattern:
+
+- **ardalis/CleanArchitecture (18k+ ★):** Handlers fetch domain entities from `IRepository<T>` (internal), then manually map to a DTO record (e.g. `ContributorDto`) at the handler boundary before returning outward. The DTO is defined in the `UseCases` layer — the Application equivalent.
+- **jasontaylordev/CleanArchitecture (20k+ ★):** Uses AutoMapper `ProjectTo<TodoItemBriefDto>()` to project directly to a DTO; the domain entity never reaches the presentation layer. The DTO is defined in the Application layer.
+
+Both projects position the DTO as the single type that crosses outward from Application. SoloDevBoard follows the ardalis pattern (manual mapping) since it wraps a REST API rather than an EF Core `IQueryable`.
+
+### Future-Proofing the Domain Model
+
+By returning DTOs from Application service interfaces, the domain model can evolve (adding properties, removing internal state, extracting value objects) without changing the interface contract visible to Razor components. A `Label` record gaining a new internal field does not require touching any component.
+
+### AI Agent Consistency
+
+SoloDevBoard is primarily developed by AI delivery agents that generate code in isolated sessions without full conversation context. An explicit ADR rule ensures every future agent session produces code consistent with this pattern without requiring the user to re-explain the decision.
+
+---
+
+## Consequences
+
+### Immediate — Retrospective Updates Required
+
+The following existing stubs violate this rule and must be updated before any consumer (Razor component) is built on top of them:
+
+| File | Current (incorrect) | Required |
+|------|---------------------|----------|
+| `src/Application/SoloDevBoard.Application/Services/ILabelManagerService.cs` | Returns `IReadOnlyList<Label>` | Must return `IReadOnlyList<LabelDto>` |
+
+A `LabelDto` record must be created in the Application layer as part of this retrospective fix.
+
+### Ongoing Rules for All Future Work
+
+- **Domain types are internal to Application.** They must not appear in the public signature of any `I*Service` or `I*Manager` interface.
+- **DTOs live in Application.** A `<Entity>Dto` record is defined in `SoloDevBoard.Application`, co-located with the service interface that uses it.
+- **Mapping happens in Application.** The Application service implementation maps from domain entity to DTO before returning. No mapping logic belongs in Razor components.
+- **Repositories remain domain-typed.** `ILabelRepository`, `IRepositoryRepository`, etc., may freely use domain entities in their signatures — this is the correct inner-circle contract.
+- **No AutoMapper.** Mapping is explicit and manual, consistent with the ardalis reference pattern and the project's preference for explicitness over convention-based magic.
+
+### Relationship to ADR-0004
+
+This ADR supplements [ADR-0004](0004-layered-architecture.md). ADR-0004 governs dependency direction (which projects reference which). ADR-0011 governs data-shape direction (which types cross which boundaries). Both rules must be satisfied simultaneously.

--- a/adr/README.md
+++ b/adr/README.md
@@ -32,6 +32,7 @@ Each ADR follows this format:
 | [ADR-0008](0008-remove-fluentassertions.md) | Remove FluentAssertions — Use xUnit Built-in Assertions Only | Accepted |
 | [ADR-0009](0009-fluent-ui-blazor-component-library.md) | Use Microsoft Fluent UI Blazor Component Library | Accepted |
 | [ADR-0010](0010-bunit-component-testing.md) | Use bUnit for Blazor Component Testing | Accepted |
+| [ADR-0011](0011-boundary-data-shapes.md) | Boundary Data Shapes — DTOs at the Application→App Boundary | Accepted |
 
 ## Adding a New ADR
 

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -66,7 +66,7 @@ Labels: `type/epic`, `area/migration`
 Labels: `type/epic`, `area/labels`
 
 <!-- Feature #27: Label Manager (planned 2026-03-07, milestone v0.2.0) -->
-<!-- Enablers: #28 Label domain + ILabelRepository, #29 GitHubLabelRepository, #31 LabelService -->
+<!-- Enablers: #28 Label domain + ILabelRepository (done — merged PR #28-pr, 2026-03-08), #29 GitHubLabelRepository, #31 LabelService -->
 <!-- Stories: #35 View labels, #33 CRUD labels, #32 Synchronise labels, #34 Apply taxonomy -->
 <!-- Tests: #38 LabelService unit tests, #37 GitHubLabelRepository unit tests, #36 bUnit UI tests -->
 

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -33,12 +33,17 @@ Labels: `type/epic`, `area/infrastructure`
 
 Labels: `type/epic`, `area/dashboard`
 
-- [ ] As a solo developer, I want to see a summary of open issues across all my repositories so that I can quickly identify where work is needed.
-- [ ] As a solo developer, I want to see all open pull requests across my repositories so that I can track code review activity.
-- [ ] As a solo developer, I want to see which issues have no labels so that I can identify items that need triage.
-- [ ] As a solo developer, I want to see which pull requests are stale (no activity in the last 14 days) so that I can follow them up.
-- [ ] As a solo developer, I want to see the status of GitHub Actions workflows across my repositories so that I can quickly spot build failures.
-- [ ] As a solo developer, I want to filter the Audit Dashboard by repository so that I can focus on one project at a time.
+<!-- Feature #40: Audit Dashboard (planned 2026-03-08, milestone v0.2.0) -->
+<!-- Enablers: #41 WorkflowRun domain + IGitHubService workflow runs, #42 Full AuditDashboardService -->
+<!-- Stories: #43 Open issues + PR summary, #44 Health indicators, #45 Filter by repository -->
+<!-- Tests: #46 AuditDashboardService unit tests, #47 GitHubService workflow run tests, #48 bUnit UI tests -->
+
+- [ ] As a solo developer, I want to see a summary of open issues across all my repositories so that I can quickly identify where work is needed. _(#43 status/todo — v0.2.0)_
+- [ ] As a solo developer, I want to see all open pull requests across my repositories so that I can track code review activity. _(#43 status/todo — v0.2.0)_
+- [ ] As a solo developer, I want to see which issues have no labels so that I can identify items that need triage. _(#44 status/todo — v0.2.0)_
+- [ ] As a solo developer, I want to see which pull requests are stale (no activity in the last 14 days) so that I can follow them up. _(#44 status/todo — v0.2.0)_
+- [ ] As a solo developer, I want to see the status of GitHub Actions workflows across my repositories so that I can quickly spot build failures. _(#44 status/todo — v0.2.0)_
+- [ ] As a solo developer, I want to filter the Audit Dashboard by repository so that I can focus on one project at a time. _(#45 status/todo — v0.2.0)_
 - [ ] As a solo developer, I want the Audit Dashboard to refresh automatically so that I always see current data.
 - [ ] As a solo developer, I want to export an audit summary as a Markdown report so that I can paste it into a planning document.
 - [ ] As a solo developer, I want to see my project board state at a glance (item count per status column and current active load) so that I can assess capacity before committing to more work.
@@ -66,7 +71,7 @@ Labels: `type/epic`, `area/migration`
 Labels: `type/epic`, `area/labels`
 
 <!-- Feature #27: Label Manager (planned 2026-03-07, milestone v0.2.0) -->
-<!-- Enablers: #28 Label domain + ILabelRepository, #29 GitHubLabelRepository, #31 LabelService -->
+<!-- Enablers: #28 Label domain + ILabelRepository (done — PR #39, 2026-03-08), #29 GitHubLabelRepository, #31 LabelService, #49 ADR-0011 retrospective — LabelDto + ILabelManagerService update -->
 <!-- Stories: #35 View labels, #33 CRUD labels, #32 Synchronise labels, #34 Apply taxonomy -->
 <!-- Tests: #38 LabelService unit tests, #37 GitHubLabelRepository unit tests, #36 bUnit UI tests -->
 

--- a/src/Application/SoloDevBoard.Application/Services/ILabelRepository.cs
+++ b/src/Application/SoloDevBoard.Application/Services/ILabelRepository.cs
@@ -1,0 +1,39 @@
+using SoloDevBoard.Domain.Entities;
+
+namespace SoloDevBoard.Application.Services;
+
+/// <summary>Provides repository operations for managing GitHub labels.</summary>
+public interface ILabelRepository
+{
+    /// <summary>Retrieves all labels for the specified repository.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A read-only list of labels for the repository.</returns>
+    Task<IReadOnlyList<Label>> GetLabelsAsync(string owner, string repo, CancellationToken cancellationToken = default);
+
+    /// <summary>Creates a new label in the specified repository.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="label">The label details to create.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The created label.</returns>
+    Task<Label> CreateLabelAsync(string owner, string repo, Label label, CancellationToken cancellationToken = default);
+
+    /// <summary>Updates an existing label in the specified repository.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="labelName">The current label name to update.</param>
+    /// <param name="label">The new label details to apply.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The updated label.</returns>
+    Task<Label> UpdateLabelAsync(string owner, string repo, string labelName, Label label, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes a label from the specified repository.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="labelName">The label name to delete.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous delete operation.</returns>
+    Task DeleteLabelAsync(string owner, string repo, string labelName, CancellationToken cancellationToken = default);
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/Label.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Label.cs
@@ -11,4 +11,7 @@ public sealed record Label
 
     /// <summary>Gets the label description.</summary>
     public string Description { get; init; } = string.Empty;
+
+    /// <summary>Gets the repository name this label belongs to.</summary>
+    public string RepositoryName { get; init; } = string.Empty;
 }

--- a/src/Domain/SoloDevBoard.Domain/Entities/Label.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Label.cs
@@ -12,6 +12,9 @@ public sealed record Label
     /// <summary>Gets the label description.</summary>
     public string Description { get; init; } = string.Empty;
 
-    /// <summary>Gets the repository name this label belongs to.</summary>
+    /// <summary>
+    /// Gets the short repository name this label belongs to (for example <c>solo-dev-board</c>, not <c>owner/solo-dev-board</c>).
+    /// Use <see cref="Repository.FullName"/> when an owner-qualified repository value is required.
+    /// </summary>
     public string RepositoryName { get; init; } = string.Empty;
 }

--- a/tests/Domain.Tests/SoloDevBoard.Domain.Tests/LabelTests.cs
+++ b/tests/Domain.Tests/SoloDevBoard.Domain.Tests/LabelTests.cs
@@ -1,0 +1,35 @@
+using SoloDevBoard.Domain.Entities;
+
+namespace SoloDevBoard.Domain.Tests;
+
+public sealed class LabelTests
+{
+    [Fact]
+    public void Label_WithInitialisedProperties_ShouldReturnCorrectValues()
+    {
+        // Arrange & Act
+        var label = new Label
+        {
+            Name = "priority/high",
+            Colour = "d93f0b",
+            Description = "High-priority work item",
+            RepositoryName = "solo-dev-board",
+        };
+
+        // Assert
+        Assert.Equal("priority/high", label.Name);
+        Assert.Equal("d93f0b", label.Colour);
+        Assert.Equal("High-priority work item", label.Description);
+        Assert.Equal("solo-dev-board", label.RepositoryName);
+    }
+
+    [Fact]
+    public void Label_RepositoryNameNotProvided_ShouldDefaultToEmptyString()
+    {
+        // Arrange & Act
+        var label = new Label { Name = "bug", Colour = "d73a4a" };
+
+        // Assert
+        Assert.Equal(string.Empty, label.RepositoryName);
+    }
+}


### PR DESCRIPTION
## Summary of Changes

Implements enabler #28 for the Label Manager feature (Phase 2, v0.2.0). Lays the Domain and Application-layer foundations required before `GitHubLabelRepository` (#29) and `LabelService` (#31) can be built.

Two targeted changes:
- Adds a `RepositoryName` property to the `Label` domain record so labels can be scoped to a specific repository in cross-repository list operations.
- Introduces `ILabelRepository` in `SoloDevBoard.Application.Services`, the abstraction between the Application use-case layer and the Infrastructure data-access implementation. Defines the four async CRUD operations (`GetLabelsAsync`, `CreateLabelAsync`, `UpdateLabelAsync`, `DeleteLabelAsync`) with `CancellationToken` support throughout.

No Infrastructure implementation yet — that is the subject of #29.

## Related Issue(s)

Closes #28

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Additional Notes

Internal enabler — no user-facing documentation update required. No ADR needed; design follows the existing layered architecture pattern established in ADR-0004. Unblocks: #29 (GitHubLabelRepository) and subsequently #31 (LabelService).