### PR TITLE
[type/enabler] Implement GitHubLabelRepository in Infrastructure layer (#29)

### DIFF
--- a/.github/agents/delivery.agent.md
+++ b/.github/agents/delivery.agent.md
@@ -65,6 +65,7 @@ All source code, tests, and documentation changes are committed to this branch. 
 - Apply C# 14 and .NET 10 conventions per `.github/instructions/dotnet-framework.instructions.md`
 - Use Fluent UI Blazor components per `.github/skills/fluentui-blazor/SKILL.md` when building UI
 - **UK English requirement:** All code comments, string literals, user-facing text in UK English
+- **Search before you write (DRY):** Before writing any helper method, paging loop, error-handling utility, or serialisation logic, search the assembly being modified (and adjacent assemblies in the same layer) for an existing method that already does it. If an equivalent `private static` method exists in a sibling class, promote it to `internal static` rather than duplicating it. Only create new utilities when no equivalent exists anywhere in the codebase.
 
 ### 4. Test Creation
 - Add or update xUnit tests following `.github/skills/csharp-xunit/SKILL.md`
@@ -100,6 +101,7 @@ All source code, tests, and documentation changes are committed to this branch. 
 - Run `get_errors` on each modified file — no diagnostics permitted.
 
 #### Review each changed source file for:
+- **DRY / no duplication** — for every new `private static` or `internal static` helper introduced, verify no equivalent method already exists elsewhere in the same assembly or a sibling assembly at the same layer. If a duplicate is found, remove it and reuse the existing method (promoting its visibility if necessary).
 - **XML doc comments** — every `public` type, method, property, and constructor has a `///` summary; no public member is undocumented.
 - **UK English** — scan all comments, string literals, exception messages, and user-facing text for US spellings (`behavior`, `color`, `organize`, `center`, `favorite`, etc.).
 - **Guard clauses** — every public constructor uses `ArgumentNullException.ThrowIfNull` (or `ArgumentException.ThrowIfNullOrWhiteSpace` for strings) for each injected dependency.

--- a/.github/agents/delivery.agent.md
+++ b/.github/agents/delivery.agent.md
@@ -87,8 +87,35 @@ All source code, tests, and documentation changes are committed to this branch. 
 - Update `adr/README.md` index
 
 ### 7. Backlog Synchronisation
-- Update `plan/BACKLOG.md` to reflect implementation progress
-- Update `plan/SCOPE.md` if scope changed during implementation (flag for user review)
+- Update `plan/BACKLOG.md` to reflect implementation progress.
+- Update `plan/SCOPE.md` if scope changed during implementation (flag for user review).
+
+### 8. Self-Review (Pre-Handoff)
+
+**Mandatory before marking implementation complete.** Perform an explicit pass over every file changed in this implementation. This step exists to catch issues before the GitHub coding review agent sees the PR — resolving them now avoids a second implementation round-trip.
+
+#### Run automated checks first
+- Run `dotnet build` — zero errors, zero warnings required.
+- Run `dotnet test` — all tests must pass.
+- Run `get_errors` on each modified file — no diagnostics permitted.
+
+#### Review each changed source file for:
+- **XML doc comments** — every `public` type, method, property, and constructor has a `///` summary; no public member is undocumented.
+- **UK English** — scan all comments, string literals, exception messages, and user-facing text for US spellings (`behavior`, `color`, `organize`, `center`, `favorite`, etc.).
+- **Guard clauses** — every public constructor uses `ArgumentNullException.ThrowIfNull` (or `ArgumentException.ThrowIfNullOrWhiteSpace` for strings) for each injected dependency.
+- **Async correctness** — every `await` in Application/Infrastructure code appends `.ConfigureAwait(false)`; no `.Result`, `.Wait()`, or `.GetAwaiter().GetResult()` present.
+- **Layer boundaries** — no domain entity types in public Application service interface signatures (use DTOs); no Application or Infrastructure types referenced directly in Razor components.
+- **Collection types** — public API methods return `IReadOnlyList<T>` or `IReadOnlyDictionary<TKey,TValue>`, not `List<T>` or `Dictionary<TKey,TValue>`.
+- **File-scoped namespaces** — all `.cs` files use `namespace Foo.Bar;` (not block-scoped).
+- **No business logic in Razor** — `.razor` files contain only rendering and event wiring; non-trivial logic lives in code-behind or Application layer.
+
+#### Review each changed test file for:
+- **Test naming** — every test method follows `MethodUnderTest_Scenario_ExpectedOutcome`.
+- **AAA structure** — Arrange, Act, and Assert blocks each separated by a blank line.
+- **Assertion library** — only `Assert.*` from xUnit; no `FluentAssertions` imports or usage.
+- **No magic strings** — shared literals extracted to constants where reused across tests.
+
+**If any item above fails:** fix it before proceeding. Do not hand off to the Review Agent with known self-review findings outstanding.
 
 ---
 

--- a/.github/agents/review.agent.md
+++ b/.github/agents/review.agent.md
@@ -35,8 +35,9 @@ Invoke this agent when you need to:
 - Create pull request targeting `main` from the feature branch with:
   - Descriptive title following convention: `[type/label] Brief description`
   - PR body linking to issues: `Closes #X`, `Relates to #Y`
-  - Labels matching primary issue labels
-  - Milestone assignment if applicable
+  - **Assignee:** always assign to `markheydon` (the sole developer on this project)
+  - **Labels:** copy `type/`, `priority/`, `area/`, and `size/` labels from the linked issue; add `status/in-review`; do **not** carry over `status/in-progress` or `status/todo`
+  - Milestone assignment if applicable (same milestone as the linked issue)
 - Use `.github/pull_request_template.md` if present
 - Link PR to GitHub project board — the Linked pull requests field updates automatically when the PR references the issue
 
@@ -223,6 +224,11 @@ Output: "PR created. ⚠️ Breaking change detected—update RELEASE_PLAN.md be
 
 Use this checklist for every review:
 
+### Pull Request Metadata
+- [ ] PR assigned to `markheydon`
+- [ ] PR labels: `type/`, `priority/`, `area/`, `size/` copied from issue; `status/in-review` added; `status/in-progress` and `status/todo` excluded
+- [ ] PR milestone matches linked issue milestone
+
 ### Code Quality
 - [ ] `get_errors` shows zero errors/warnings
 - [ ] UK English verified (no "behavior", "color", "organize", etc.)
@@ -235,7 +241,7 @@ Use this checklist for every review:
 - [ ] Test naming follows `MethodUnderTest_Scenario_ExpectedOutcome`
 - [ ] Tests pass locally (`dotnet test`)
 - [ ] Test projects mirror source project structure
-- [ ] Moq used for mocking, FluentAssertions for assertions
+- [ ] Moq used for mocking, xUnit built-in `Assert.*` for assertions (**FluentAssertions is prohibited** per ADR-0008)
 
 ### Documentation
 - [ ] User-facing features have `docs/user-guide/*.md`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,8 @@
 
 > **All code comments, string literals, user-facing text, documentation, and commit messages MUST be written in UK English.**
 
+> **All bullet point list items that form complete sentences MUST end with a full stop (`.`).** This applies to all documentation: planning files, user guides, ADRs, agent definitions, prompt files, and inline code comments.
+
 Use the following spellings consistently:
 - `colour` (not color)
 - `organise` (not organize)

--- a/.github/prompts/execute-feature.prompt.md
+++ b/.github/prompts/execute-feature.prompt.md
@@ -92,8 +92,34 @@ All source code, tests, and documentation changes are committed to this branch. 
 - Update `adr/README.md` index
 
 ### 7. Backlog Synchronisation
-- Update `plan/BACKLOG.md` to reflect implementation progress
-- Flag scope changes in `plan/SCOPE.md` for user review
+- Update `plan/BACKLOG.md` to reflect implementation progress.
+- Flag scope changes in `plan/SCOPE.md` for user review.
+
+### 8. Self-Review (Pre-Handoff)
+
+**Mandatory before marking implementation complete.** The Delivery Agent performs an explicit review pass over every file it has changed. This catches issues before the GitHub coding review agent sees the PR, avoiding a second implementation round-trip.
+
+#### Automated checks
+- `dotnet build` — zero errors, zero warnings.
+- `dotnet test` — all tests passing.
+- `get_errors` on each modified file — no diagnostics.
+
+#### Source file checks
+- Every `public` type, method, property, and constructor has a `///` XML doc comment.
+- All comments, strings, and user-facing text use UK English (no `behavior`, `color`, `organize`, `center`, etc.).
+- Every public constructor guards injected dependencies with `ArgumentNullException.ThrowIfNull` / `ArgumentException.ThrowIfNullOrWhiteSpace`.
+- Every `await` in Application/Infrastructure uses `.ConfigureAwait(false)`; no sync-over-async (`.Result`, `.Wait()`).
+- Public API methods return `IReadOnlyList<T>` / `IReadOnlyDictionary<TKey,TValue>`, not mutable collection types.
+- All `.cs` files use file-scoped namespaces.
+- No business logic in `.razor` files — logic lives in code-behind or Application layer.
+- No layer boundary violations (no domain entities in Application service public signatures; no Infrastructure types in Razor components).
+
+#### Test file checks
+- Every test method is named `MethodUnderTest_Scenario_ExpectedOutcome`.
+- Arrange / Act / Assert blocks are each separated by a blank line.
+- Only `Assert.*` from xUnit — no `FluentAssertions` (prohibited, ADR-0008).
+
+**If any check fails:** fix before handing off. Do not pass known self-review findings to the Review Agent.
 
 ---
 
@@ -271,14 +297,15 @@ Your choice?
 ## Mandatory Gates (Before Implementation Complete)
 
 Implementation is NOT complete until:
-- ✅ All acceptance criteria met
-- ✅ Code compiles without errors/warnings
-- ✅ Tests pass locally
-- ✅ Documentation updated (user-facing features only)
-- ✅ ADR created (architectural decisions only)
-- ✅ UK English verified throughout
-- ✅ Layered architecture rules followed
-- ✅ Backlog synchronised
+- ✅ All acceptance criteria met.
+- ✅ Code compiles without errors/warnings.
+- ✅ Tests pass locally.
+- ✅ Documentation updated (user-facing features only).
+- ✅ ADR created (architectural decisions only).
+- ✅ UK English verified throughout.
+- ✅ Layered architecture rules followed.
+- ✅ Backlog synchronised.
+- ✅ **Self-review (Step 8) completed** — all source and test file checks passed with no outstanding findings.
 
 **If any gate fails:** Agent escalates to you for resolution, does NOT proceed to review.
 

--- a/.github/skills/dotnet-best-practices/SKILL.md
+++ b/.github/skills/dotnet-best-practices/SKILL.md
@@ -80,7 +80,7 @@ Your task is to ensure .NET/C# code in `${selection}` meets the SoloDevBoard sta
 ## Code Quality
 
 - Ensure SOLID principles compliance
-- Avoid code duplication through base classes and utilities
+- **Avoid code duplication (DRY):** Before writing any helper, paging loop, error-handling utility, or serialisation logic, search the same assembly (and sibling assemblies at the same layer) for an existing method that already does it. Prefer promoting an existing `private static` to `internal static` over copy-pasting. New helpers are only justified when no equivalent exists.
 - Use meaningful names that reflect domain concepts
 - Keep methods focused and cohesive
 - Implement proper disposal patterns for resources

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -71,7 +71,7 @@ Labels: `type/epic`, `area/migration`
 Labels: `type/epic`, `area/labels`
 
 <!-- Feature #27: Label Manager (planned 2026-03-07, milestone v0.2.0) -->
-<!-- Enablers: #28 Label domain + ILabelRepository (done — PR #39, 2026-03-08), #29 GitHubLabelRepository, #31 LabelService, #49 ADR-0011 retrospective — LabelDto + ILabelManagerService update (done — 2026-03-08) -->
+<!-- Enablers: #28 Label domain + ILabelRepository (done — PR #39, 2026-03-08), #29 GitHubLabelRepository (done — 2026-03-08), #31 LabelService, #49 ADR-0011 retrospective — LabelDto + ILabelManagerService update (done — 2026-03-08) -->
 <!-- Stories: #35 View labels, #33 CRUD labels, #32 Synchronise labels, #34 Apply taxonomy -->
 <!-- Tests: #38 LabelService unit tests, #37 GitHubLabelRepository unit tests, #36 bUnit UI tests -->
 

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubLabelRepository.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubLabelRepository.cs
@@ -1,0 +1,260 @@
+using SoloDevBoard.Application.Identity;
+using SoloDevBoard.Application.Services;
+using SoloDevBoard.Domain.Entities;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SoloDevBoard.Infrastructure;
+
+/// <summary>
+/// GitHub REST API implementation of <see cref="ILabelRepository"/> using <see cref="IHttpClientFactory"/>.
+/// </summary>
+public sealed class GitHubLabelRepository : ILabelRepository
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ICurrentUserContext _currentUserContext;
+
+    /// <summary>Initialises a new instance of the <see cref="GitHubLabelRepository"/> class.</summary>
+    /// <param name="httpClientFactory">The factory used to create named <see cref="HttpClient"/> instances.</param>
+    /// <param name="currentUserContext">The current user context that provides the authenticated GitHub access token.</param>
+    public GitHubLabelRepository(IHttpClientFactory httpClientFactory, ICurrentUserContext currentUserContext)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _currentUserContext = currentUserContext ?? throw new ArgumentNullException(nameof(currentUserContext));
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<Label>> GetLabelsAsync(string owner, string repo, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var client = CreateAuthenticatedClient();
+        var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels?per_page=100";
+
+        return await GetPagedAsync<LabelResponseDto, Label>(
+                client,
+                endpoint,
+            dto => dto.ToDomain(repo),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Label> CreateLabelAsync(string owner, string repo, Label label, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentNullException.ThrowIfNull(label);
+
+        var client = CreateAuthenticatedClient();
+        var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels";
+
+        using var response = await client.PostAsJsonAsync(endpoint, LabelUpsertRequestDto.FromDomain(label), JsonOptions, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var created = await response.Content.ReadFromJsonAsync<LabelResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw CreateInvalidResponseException("Label response was empty.", endpoint);
+
+        return created.ToDomain(repo);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Label> UpdateLabelAsync(string owner, string repo, string labelName, Label label, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(labelName);
+        ArgumentNullException.ThrowIfNull(label);
+
+        var client = CreateAuthenticatedClient();
+        var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels/{Uri.EscapeDataString(labelName)}";
+
+        using var request = new HttpRequestMessage(HttpMethod.Patch, endpoint)
+        {
+            Content = JsonContent.Create(UpdateLabelRequestDto.FromDomain(label), options: JsonOptions),
+        };
+
+        using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var updated = await response.Content.ReadFromJsonAsync<LabelResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw CreateInvalidResponseException("Label response was empty.", endpoint);
+
+        return updated.ToDomain(repo);
+    }
+
+    /// <inheritdoc/>
+    public async Task DeleteLabelAsync(string owner, string repo, string labelName, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(labelName);
+
+        var client = CreateAuthenticatedClient();
+        var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels/{Uri.EscapeDataString(labelName)}";
+
+        using var response = await client.DeleteAsync(endpoint, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    private HttpClient CreateAuthenticatedClient()
+    {
+        var accessToken = _currentUserContext.GetAccessToken();
+        if (string.IsNullOrWhiteSpace(accessToken))
+        {
+            throw new InvalidOperationException("GitHub access token returned by the current user context is empty.");
+        }
+
+        var client = _httpClientFactory.CreateClient(GitHubService.GitHubApiClientName);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        return client;
+    }
+
+    private static async Task EnsureSuccessStatusCodeAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        throw new HttpRequestException(
+            $"GitHub API request failed with status code {(int)response.StatusCode} ({response.StatusCode}). Response body: {responseBody}",
+            null,
+            response.StatusCode);
+    }
+
+    private static HttpRequestException CreateInvalidResponseException(string message, string endpoint)
+        => new($"GitHub API returned an invalid response for endpoint '{endpoint}'. {message}");
+
+    private static async Task<IReadOnlyList<TDomain>> GetPagedAsync<TDto, TDomain>(
+        HttpClient client,
+        string initialEndpoint,
+        Func<TDto, TDomain?> map,
+        CancellationToken cancellationToken)
+        where TDomain : class
+    {
+        var results = new List<TDomain>();
+        string? nextUrl = initialEndpoint;
+
+        while (!string.IsNullOrWhiteSpace(nextUrl))
+        {
+            using var response = await client.GetAsync(nextUrl, cancellationToken).ConfigureAwait(false);
+            await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+
+            var dtos = await response.Content.ReadFromJsonAsync<List<TDto>>(JsonOptions, cancellationToken).ConfigureAwait(false)
+                ?? throw CreateInvalidResponseException("The list response body was empty.", nextUrl);
+
+            foreach (var dto in dtos)
+            {
+                var mapped = map(dto);
+                if (mapped is not null)
+                {
+                    results.Add(mapped);
+                }
+            }
+
+            nextUrl = GetNextPageUrl(response);
+        }
+
+        return results;
+    }
+
+    private static string? GetNextPageUrl(HttpResponseMessage response)
+    {
+        if (!response.Headers.TryGetValues("Link", out var values))
+        {
+            return null;
+        }
+
+        foreach (var value in values)
+        {
+            var segments = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            foreach (var segment in segments)
+            {
+                if (!segment.Contains("rel=\"next\"", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var startIndex = segment.IndexOf('<');
+                var endIndex = segment.IndexOf('>');
+
+                if (startIndex >= 0 && endIndex > startIndex)
+                {
+                    return segment[(startIndex + 1)..endIndex];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private sealed record LabelResponseDto
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = string.Empty;
+
+        [JsonPropertyName("color")]
+        public string Colour { get; init; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string? Description { get; init; }
+
+        public Label ToDomain(string repoName) => new()
+        {
+            Name = Name,
+            Colour = Colour,
+            Description = Description ?? string.Empty,
+            RepositoryName = repoName,
+        };
+    }
+
+    private sealed record LabelUpsertRequestDto
+    {
+        [JsonPropertyName("name")]
+        public required string Name { get; init; }
+
+        [JsonPropertyName("color")]
+        public required string Colour { get; init; }
+
+        [JsonPropertyName("description")]
+        public string Description { get; init; } = string.Empty;
+
+        public static LabelUpsertRequestDto FromDomain(Label label)
+            => new()
+            {
+                Name = label.Name,
+                Colour = label.Colour,
+                Description = label.Description,
+            };
+    }
+
+    private sealed record UpdateLabelRequestDto
+    {
+        [JsonPropertyName("new_name")]
+        public required string NewName { get; init; }
+
+        [JsonPropertyName("color")]
+        public required string Colour { get; init; }
+
+        [JsonPropertyName("description")]
+        public string Description { get; init; } = string.Empty;
+
+        public static UpdateLabelRequestDto FromDomain(Label label)
+            => new()
+            {
+                NewName = label.Name,
+                Colour = label.Colour,
+                Description = label.Description,
+            };
+    }
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubLabelRepository.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubLabelRepository.cs
@@ -1,7 +1,5 @@
-using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Application.Services;
 using SoloDevBoard.Domain.Entities;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -19,15 +17,11 @@ public sealed class GitHubLabelRepository : ILabelRepository
     };
 
     private readonly IHttpClientFactory _httpClientFactory;
-    private readonly ICurrentUserContext _currentUserContext;
-
     /// <summary>Initialises a new instance of the <see cref="GitHubLabelRepository"/> class.</summary>
     /// <param name="httpClientFactory">The factory used to create named <see cref="HttpClient"/> instances.</param>
-    /// <param name="currentUserContext">The current user context that provides the authenticated GitHub access token.</param>
-    public GitHubLabelRepository(IHttpClientFactory httpClientFactory, ICurrentUserContext currentUserContext)
+    public GitHubLabelRepository(IHttpClientFactory httpClientFactory)
     {
         _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
-        _currentUserContext = currentUserContext ?? throw new ArgumentNullException(nameof(currentUserContext));
     }
 
     /// <inheritdoc/>
@@ -36,13 +30,14 @@ public sealed class GitHubLabelRepository : ILabelRepository
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
 
-        var client = CreateAuthenticatedClient();
+        var client = CreateClient();
         var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels?per_page=100";
 
-        return await GetPagedAsync<LabelResponseDto, Label>(
+        return await GitHubService.GetPagedAsync<LabelResponseDto, Label>(
                 client,
                 endpoint,
             dto => dto.ToDomain(repo),
+            JsonOptions,
                 cancellationToken)
             .ConfigureAwait(false);
     }
@@ -54,14 +49,14 @@ public sealed class GitHubLabelRepository : ILabelRepository
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
         ArgumentNullException.ThrowIfNull(label);
 
-        var client = CreateAuthenticatedClient();
+        var client = CreateClient();
         var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels";
 
         using var response = await client.PostAsJsonAsync(endpoint, LabelUpsertRequestDto.FromDomain(label), JsonOptions, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+        await GitHubService.EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
 
         var created = await response.Content.ReadFromJsonAsync<LabelResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
-            ?? throw CreateInvalidResponseException("Label response was empty.", endpoint);
+            ?? throw GitHubService.CreateInvalidResponseException("Label response was empty.", endpoint);
 
         return created.ToDomain(repo);
     }
@@ -74,7 +69,7 @@ public sealed class GitHubLabelRepository : ILabelRepository
         ArgumentException.ThrowIfNullOrWhiteSpace(labelName);
         ArgumentNullException.ThrowIfNull(label);
 
-        var client = CreateAuthenticatedClient();
+        var client = CreateClient();
         var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels/{Uri.EscapeDataString(labelName)}";
 
         using var request = new HttpRequestMessage(HttpMethod.Patch, endpoint)
@@ -83,10 +78,10 @@ public sealed class GitHubLabelRepository : ILabelRepository
         };
 
         using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+        await GitHubService.EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
 
         var updated = await response.Content.ReadFromJsonAsync<LabelResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
-            ?? throw CreateInvalidResponseException("Label response was empty.", endpoint);
+            ?? throw GitHubService.CreateInvalidResponseException("Label response was empty.", endpoint);
 
         return updated.ToDomain(repo);
     }
@@ -98,104 +93,18 @@ public sealed class GitHubLabelRepository : ILabelRepository
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
         ArgumentException.ThrowIfNullOrWhiteSpace(labelName);
 
-        var client = CreateAuthenticatedClient();
+        var client = CreateClient();
         var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels/{Uri.EscapeDataString(labelName)}";
 
         using var response = await client.DeleteAsync(endpoint, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+        await GitHubService.EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
-    private HttpClient CreateAuthenticatedClient()
+    private HttpClient CreateClient()
     {
-        var accessToken = _currentUserContext.GetAccessToken();
-        if (string.IsNullOrWhiteSpace(accessToken))
-        {
-            throw new InvalidOperationException("GitHub access token returned by the current user context is empty.");
-        }
-
+        // Authentication is handled by the configured GitHubAuthHandler on the named HttpClient.
         var client = _httpClientFactory.CreateClient(GitHubService.GitHubApiClientName);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         return client;
-    }
-
-    private static async Task EnsureSuccessStatusCodeAsync(HttpResponseMessage response, CancellationToken cancellationToken)
-    {
-        if (response.IsSuccessStatusCode)
-        {
-            return;
-        }
-
-        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        throw new HttpRequestException(
-            $"GitHub API request failed with status code {(int)response.StatusCode} ({response.StatusCode}). Response body: {responseBody}",
-            null,
-            response.StatusCode);
-    }
-
-    private static HttpRequestException CreateInvalidResponseException(string message, string endpoint)
-        => new($"GitHub API returned an invalid response for endpoint '{endpoint}'. {message}");
-
-    private static async Task<IReadOnlyList<TDomain>> GetPagedAsync<TDto, TDomain>(
-        HttpClient client,
-        string initialEndpoint,
-        Func<TDto, TDomain?> map,
-        CancellationToken cancellationToken)
-        where TDomain : class
-    {
-        var results = new List<TDomain>();
-        string? nextUrl = initialEndpoint;
-
-        while (!string.IsNullOrWhiteSpace(nextUrl))
-        {
-            using var response = await client.GetAsync(nextUrl, cancellationToken).ConfigureAwait(false);
-            await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
-
-            var dtos = await response.Content.ReadFromJsonAsync<List<TDto>>(JsonOptions, cancellationToken).ConfigureAwait(false)
-                ?? throw CreateInvalidResponseException("The list response body was empty.", nextUrl);
-
-            foreach (var dto in dtos)
-            {
-                var mapped = map(dto);
-                if (mapped is not null)
-                {
-                    results.Add(mapped);
-                }
-            }
-
-            nextUrl = GetNextPageUrl(response);
-        }
-
-        return results;
-    }
-
-    private static string? GetNextPageUrl(HttpResponseMessage response)
-    {
-        if (!response.Headers.TryGetValues("Link", out var values))
-        {
-            return null;
-        }
-
-        foreach (var value in values)
-        {
-            var segments = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            foreach (var segment in segments)
-            {
-                if (!segment.Contains("rel=\"next\"", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                var startIndex = segment.IndexOf('<');
-                var endIndex = segment.IndexOf('>');
-
-                if (startIndex >= 0 && endIndex > startIndex)
-                {
-                    return segment[(startIndex + 1)..endIndex];
-                }
-            }
-        }
-
-        return null;
     }
 
     private sealed record LabelResponseDto

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubService.cs
@@ -30,6 +30,7 @@ public sealed class GitHubService : IGitHubService
                 client,
                 endpoint,
                 static dto => dto.ToDomain(),
+            JsonOptions,
                 cancellationToken)
             .ConfigureAwait(false);
 
@@ -47,6 +48,7 @@ public sealed class GitHubService : IGitHubService
                 client,
                 endpoint,
                 static dto => dto.ToDomain(),
+            JsonOptions,
                 cancellationToken)
             .ConfigureAwait(false);
 
@@ -70,6 +72,7 @@ public sealed class GitHubService : IGitHubService
                 client,
                 endpoint,
                 static dto => dto.PullRequest is null ? dto.ToDomain() : null,
+            JsonOptions,
                 cancellationToken)
             .ConfigureAwait(false);
 
@@ -88,6 +91,7 @@ public sealed class GitHubService : IGitHubService
                 client,
                 endpoint,
                 static dto => dto.ToDomain(),
+            JsonOptions,
                 cancellationToken)
             .ConfigureAwait(false);
 
@@ -106,6 +110,7 @@ public sealed class GitHubService : IGitHubService
                 client,
                 endpoint,
                 static dto => dto.ToDomain(),
+            JsonOptions,
                 cancellationToken)
             .ConfigureAwait(false);
 
@@ -124,6 +129,7 @@ public sealed class GitHubService : IGitHubService
                 client,
                 endpoint,
                 static dto => dto.ToDomain(),
+            JsonOptions,
                 cancellationToken)
             .ConfigureAwait(false);
 
@@ -205,7 +211,7 @@ public sealed class GitHubService : IGitHubService
     /// </summary>
     /// <param name="response">The HTTP response to inspect.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    private static async Task EnsureSuccessStatusCodeAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    internal static async Task EnsureSuccessStatusCodeAsync(HttpResponseMessage response, CancellationToken cancellationToken)
     {
         if (response.IsSuccessStatusCode)
         {
@@ -222,7 +228,7 @@ public sealed class GitHubService : IGitHubService
     /// <summary>Creates an <see cref="HttpRequestException"/> describing an unexpected or empty API response body.</summary>
     /// <param name="message">A description of the specific problem with the response.</param>
     /// <param name="endpoint">The API endpoint URL that produced the invalid response.</param>
-    private static HttpRequestException CreateInvalidResponseException(string message, string endpoint)
+    internal static HttpRequestException CreateInvalidResponseException(string message, string endpoint)
         => new($"GitHub API returned an invalid response for endpoint '{endpoint}'. {message}");
 
     /// <summary>
@@ -239,10 +245,11 @@ public sealed class GitHubService : IGitHubService
     /// </param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>A read-only list of all mapped domain entities across all pages.</returns>
-    private static async Task<IReadOnlyList<TDomain>> GetPagedAsync<TDto, TDomain>(
+    internal static async Task<IReadOnlyList<TDomain>> GetPagedAsync<TDto, TDomain>(
         HttpClient client,
         string initialEndpoint,
         Func<TDto, TDomain?> map,
+        JsonSerializerOptions jsonOptions,
         CancellationToken cancellationToken)
         where TDomain : class
     {
@@ -255,7 +262,7 @@ public sealed class GitHubService : IGitHubService
             using var response = await client.GetAsync(nextUrl, cancellationToken).ConfigureAwait(false);
             await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
 
-            var dtos = await response.Content.ReadFromJsonAsync<List<TDto>>(JsonOptions, cancellationToken).ConfigureAwait(false)
+            var dtos = await response.Content.ReadFromJsonAsync<List<TDto>>(jsonOptions, cancellationToken).ConfigureAwait(false)
                 ?? throw CreateInvalidResponseException("The list response body was empty.", nextUrl);
 
             foreach (var dto in dtos)
@@ -283,7 +290,7 @@ public sealed class GitHubService : IGitHubService
     /// <c>&lt;https://api.github.com/...?page=2&gt;; rel="next", &lt;...&gt;; rel="last"</c>.
     /// This method parses that header and returns the URL for the <c>rel="next"</c> entry.
     /// </remarks>
-    private static string? GetNextPageUrl(HttpResponseMessage response)
+    internal static string? GetNextPageUrl(HttpResponseMessage response)
     {
         if (!response.Headers.TryGetValues("Link", out var values))
         {

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/InfrastructureServiceExtensions.cs
@@ -35,6 +35,7 @@ public static class InfrastructureServiceExtensions
             .AddHttpMessageHandler<GitHubAuthHandler>();
 
         services.AddScoped<IGitHubService, GitHubService>();
+        services.AddScoped<ILabelRepository, GitHubLabelRepository>();
 
         return services;
     }

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubLabelRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubLabelRepositoryTests.cs
@@ -173,17 +173,12 @@ public sealed class GitHubLabelRepositoryTests
             .Setup(context => context.GetAccessToken())
             .Throws(new InvalidOperationException("Token missing."));
 
-        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
-        var sut = new GitHubLabelRepository(httpClientFactoryMock.Object, currentUserContextMock.Object);
+        var authHandler = new GitHubAuthHandler(currentUserContextMock.Object)
+        {
+            InnerHandler = new QueueMessageHandler([new HttpResponseMessage(HttpStatusCode.OK)]),
+        };
 
-        // Act / Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => _ = await sut.GetLabelsAsync("owner", "repo"));
-    }
-
-    private static GitHubLabelRepository CreateSubject(HttpMessageHandler handler)
-    {
-        var client = new HttpClient(handler)
+        var client = new HttpClient(authHandler)
         {
             BaseAddress = new Uri("https://api.github.com"),
         };
@@ -193,12 +188,36 @@ public sealed class GitHubLabelRepositoryTests
             .Setup(factory => factory.CreateClient(GitHubService.GitHubApiClientName))
             .Returns(client);
 
+        var sut = new GitHubLabelRepository(httpClientFactoryMock.Object);
+
+        // Act / Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => _ = await sut.GetLabelsAsync("owner", "repo"));
+    }
+
+    private static GitHubLabelRepository CreateSubject(HttpMessageHandler handler)
+    {
         var currentUserContextMock = new Mock<ICurrentUserContext>();
         currentUserContextMock
             .Setup(context => context.GetAccessToken())
             .Returns("test-token");
 
-        return new GitHubLabelRepository(httpClientFactoryMock.Object, currentUserContextMock.Object);
+        var authHandler = new GitHubAuthHandler(currentUserContextMock.Object)
+        {
+            InnerHandler = handler,
+        };
+
+        var client = new HttpClient(authHandler)
+        {
+            BaseAddress = new Uri("https://api.github.com"),
+        };
+
+        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+        httpClientFactoryMock
+            .Setup(factory => factory.CreateClient(GitHubService.GitHubApiClientName))
+            .Returns(client);
+
+        return new GitHubLabelRepository(httpClientFactoryMock.Object);
     }
 
     private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json)

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubLabelRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubLabelRepositoryTests.cs
@@ -1,0 +1,249 @@
+using Moq;
+using SoloDevBoard.Application.Identity;
+using SoloDevBoard.Domain.Entities;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+namespace SoloDevBoard.Infrastructure.Tests;
+
+/// <summary>Tests for <see cref="GitHubLabelRepository"/>.</summary>
+public sealed class GitHubLabelRepositoryTests
+{
+    [Fact]
+    public async Task GetLabelsAsync_ValidResponse_ReturnsMappedLabels()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "name": "enhancement",
+                    "color": "a2eeef",
+                    "description": null
+                  }
+                ]
+                """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        var result = await sut.GetLabelsAsync("owner", "repo");
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("enhancement", result[0].Name);
+        Assert.Equal("a2eeef", result[0].Colour);
+        Assert.Equal(string.Empty, result[0].Description);
+        Assert.Equal("repo", result[0].RepositoryName);
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+        Assert.Equal("https://api.github.com/repos/owner/repo/labels?per_page=100", handler.Requests[0].RequestUri!.ToString());
+        Assert.Equal("Bearer", handler.Requests[0].Headers.Authorization?.Scheme);
+        Assert.Equal("test-token", handler.Requests[0].Headers.Authorization?.Parameter);
+    }
+
+    [Fact]
+    public async Task CreateLabelAsync_ValidLabel_PostsPayloadAndReturnsLabel()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.Created,
+                """
+                {
+                  "name": "bug",
+                  "color": "d73a4a",
+                  "description": "Something is not working"
+                }
+                """),
+        ]);
+
+        var sut = CreateSubject(handler);
+        var label = new Label { Name = "bug", Colour = "d73a4a", Description = "Something is not working" };
+
+        // Act
+        var result = await sut.CreateLabelAsync("owner", "repo", label);
+
+        // Assert
+        Assert.Equal("bug", result.Name);
+        Assert.Equal("d73a4a", result.Colour);
+        Assert.Equal("Something is not working", result.Description);
+        Assert.Equal("repo", result.RepositoryName);
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+        Assert.Equal("https://api.github.com/repos/owner/repo/labels", handler.Requests[0].RequestUri!.ToString());
+
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        Assert.Equal("bug", document.RootElement.GetProperty("name").GetString());
+        Assert.Equal("d73a4a", document.RootElement.GetProperty("color").GetString());
+        Assert.Equal("Something is not working", document.RootElement.GetProperty("description").GetString());
+    }
+
+    [Fact]
+    public async Task UpdateLabelAsync_ValidLabel_SendsPatchPayloadWithNewName()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                {
+                  "name": "enhancement",
+                  "color": "a2eeef",
+                  "description": "Feature request"
+                }
+                """),
+        ]);
+
+        var sut = CreateSubject(handler);
+        var label = new Label { Name = "enhancement", Colour = "a2eeef", Description = "Feature request" };
+
+        // Act
+        var result = await sut.UpdateLabelAsync("owner", "repo", "feature", label);
+
+        // Assert
+        Assert.Equal("enhancement", result.Name);
+        Assert.Equal("Feature request", result.Description);
+        Assert.Equal("repo", result.RepositoryName);
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Patch, handler.Requests[0].Method);
+        Assert.Equal("https://api.github.com/repos/owner/repo/labels/feature", handler.Requests[0].RequestUri!.ToString());
+
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        Assert.Equal("enhancement", document.RootElement.GetProperty("new_name").GetString());
+        Assert.Equal("a2eeef", document.RootElement.GetProperty("color").GetString());
+        Assert.Equal("Feature request", document.RootElement.GetProperty("description").GetString());
+    }
+
+    [Fact]
+    public async Task DeleteLabelAsync_ValidLabelName_SendsDeleteRequest()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler([
+            new HttpResponseMessage(HttpStatusCode.NoContent),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        await sut.DeleteLabelAsync("owner", "repo", "bug");
+
+        // Assert
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Delete, handler.Requests[0].Method);
+        Assert.Equal("https://api.github.com/repos/owner/repo/labels/bug", handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task CreateLabelAsync_ApiReturnsBadRequest_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler([
+            new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("{\"message\":\"Validation failed\"}", Encoding.UTF8, "application/json"),
+            },
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act / Assert
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            async () => _ = await sut.CreateLabelAsync("owner", "repo", new Label { Name = "bug", Colour = "d73a4a" }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+        Assert.Contains("GitHub API request failed", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetLabelsAsync_CurrentUserTokenMissing_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var currentUserContextMock = new Mock<ICurrentUserContext>();
+        currentUserContextMock
+            .Setup(context => context.GetAccessToken())
+            .Throws(new InvalidOperationException("Token missing."));
+
+        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+        var sut = new GitHubLabelRepository(httpClientFactoryMock.Object, currentUserContextMock.Object);
+
+        // Act / Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => _ = await sut.GetLabelsAsync("owner", "repo"));
+    }
+
+    private static GitHubLabelRepository CreateSubject(HttpMessageHandler handler)
+    {
+        var client = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.github.com"),
+        };
+
+        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+        httpClientFactoryMock
+            .Setup(factory => factory.CreateClient(GitHubService.GitHubApiClientName))
+            .Returns(client);
+
+        var currentUserContextMock = new Mock<ICurrentUserContext>();
+        currentUserContextMock
+            .Setup(context => context.GetAccessToken())
+            .Returns("test-token");
+
+        return new GitHubLabelRepository(httpClientFactoryMock.Object, currentUserContextMock.Object);
+    }
+
+    private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json)
+    {
+        return new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+    }
+
+    private sealed class QueueMessageHandler(IEnumerable<HttpResponseMessage> responses) : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new(responses);
+
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(await CloneRequestAsync(request, cancellationToken).ConfigureAwait(false));
+
+            if (_responses.Count == 0)
+            {
+                throw new InvalidOperationException("No mocked responses are left in the queue.");
+            }
+
+            return _responses.Dequeue();
+        }
+
+        private static async Task<HttpRequestMessage> CloneRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri);
+
+            foreach (var header in request.Headers)
+            {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            if (request.Content is not null)
+            {
+                var content = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                var mediaType = request.Content.Headers.ContentType?.MediaType ?? "application/json";
+                clone.Content = new StringContent(content, Encoding.UTF8, mediaType);
+            }
+
+            return clone;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of Changes

Implements `GitHubLabelRepository` in `SoloDevBoard.Infrastructure`, providing the concrete `ILabelRepository` data-access layer for the Label Manager feature. The repository wraps the four GitHub REST API label endpoints and maps responses to the `Label` domain record.

**Changes:**
- `src/Infrastructure/SoloDevBoard.Infrastructure/GitHubLabelRepository.cs` — new class implementing all four CRUD operations (`GetLabelsAsync`, `CreateLabelAsync`, `UpdateLabelAsync`, `DeleteLabelAsync`) using `ICurrentUserContext` for the authenticated token, paged response handling via `Link` header, and `HttpRequestException` error surfacing.
- `src/Infrastructure/SoloDevBoard.Infrastructure/InfrastructureServiceExtensions.cs` — DI registration: `services.AddScoped<ILabelRepository, GitHubLabelRepository>()`
- `tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubLabelRepositoryTests.cs` — 6 new tests covering all four operations, API error propagation, and missing-token behaviour.
- `plan/BACKLOG.md` — enabler #29 marked done.

## Related Issue(s)

Closes #29

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`) — 46 total, 0 failed
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Additional Notes

- `[JsonPropertyName("color")]` attributes use the GitHub API's own field names (US English JSON keys); the C# property is named `Colour` throughout.
- No user-facing documentation required — this is an infrastructure enabler.
- No architectural decision record required — this follows the established `ICurrentUserContext` pattern from ADR-0007.
