### PR TITLE
[type/enabler] Align IRepositoryService with ADR-0011: introduce RepositoryDto boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -419,3 +419,6 @@ FodyWeavers.xsd
 
 # Client-side library files (managed by libman/npm)
 **/wwwroot/lib/
+
+# Playwright files
+.playwright-mcp/

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -169,6 +169,13 @@ Labels: `type/epic`, `area/dashboard`
 
 Labels: `type/chore`, `area/infrastructure`
 
+<!-- ADR-0011 IRepositoryService alignment (planned 2026-03-10, milestone v0.2.0) -->
+<!-- Enabler: #54 Introduce RepositoryDto; migrate IRepositoryService to DTO boundary (done — 2026-03-10) -->
+<!-- Test: #55 Verify RepositoryDto boundary compliance — RepositoryService mapping tests + bUnit consumer updates (done — 2026-03-10) -->
+
+- [x] Enabler: Align `IRepositoryService` with ADR-0011 by introducing `RepositoryDto` as the Application→App boundary shape for repository operations; map domain `Repository` → `RepositoryDto` inside `RepositoryService`. _(#54 — done, 2026-03-10)_
+- [x] Test: Verify `RepositoryDto` boundary compliance — unit tests for `RepositoryService` field-level DTO mapping and updated bUnit tests for `Labels` and `Repositories` components. _(#55 — done, 2026-03-10)_
+
 <!-- Feature #56: Application Version Centralisation + About Page (planned 2026-03-08, milestone v0.2.0) -->
 <!-- Enablers: #57 Centralise version in Directory.Build.props + IAppVersionService, #58 Dynamic user-agent from IAppVersionService -->
 <!-- Story: #59 About page showing app version information -->

--- a/src/App/SoloDevBoard.App/Components/Pages/Labels.razor
+++ b/src/App/SoloDevBoard.App/Components/Pages/Labels.razor
@@ -1,5 +1,4 @@
 @page "/labels"
-@using SoloDevBoard.Domain.Entities
 
 <PageTitle>Label Manager</PageTitle>
 
@@ -18,7 +17,7 @@
             else
             {
                 <MudStack Class="repository-selector-controls" Spacing="2">
-                    <MudAutocomplete T="Repository"
+                    <MudAutocomplete T="SoloDevBoard.Application.Services.RepositoryDto"
                                      Value="repositoryAutocompleteValue"
                                      ValueChanged="OnRepositorySelectedAsync"
                                      SearchFunc="SearchRepositoriesAsync"

--- a/src/App/SoloDevBoard.App/Components/Pages/Labels.razor
+++ b/src/App/SoloDevBoard.App/Components/Pages/Labels.razor
@@ -17,7 +17,7 @@
             else
             {
                 <MudStack Class="repository-selector-controls" Spacing="2">
-                    <MudAutocomplete T="SoloDevBoard.Application.Services.RepositoryDto"
+                    <MudAutocomplete T="RepositoryDto"
                                      Value="repositoryAutocompleteValue"
                                      ValueChanged="OnRepositorySelectedAsync"
                                      SearchFunc="SearchRepositoriesAsync"

--- a/src/App/SoloDevBoard.App/Components/Pages/Labels.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Pages/Labels.razor.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging;
 using MudBlazor;
 using SoloDevBoard.App.Components.Dialogs;
 using SoloDevBoard.Application.Services;
-using SoloDevBoard.Domain.Entities;
 
 namespace SoloDevBoard.App.Components.Pages;
 
@@ -30,9 +29,9 @@ public partial class Labels : ComponentBase
     [Inject]
     public ISnackbar Snackbar { get; set; } = default!;
 
-    private IReadOnlyList<Repository> availableRepositories = [];
-    private IReadOnlyList<Repository> selectedRepositories = [];
-    private Repository? repositoryAutocompleteValue;
+    private IReadOnlyList<RepositoryDto> availableRepositories = [];
+    private IReadOnlyList<RepositoryDto> selectedRepositories = [];
+    private RepositoryDto? repositoryAutocompleteValue;
     private IReadOnlyList<LabelRow> rows = [];
     private IReadOnlyList<LabelRow> filteredRows = [];
     private bool isLoadingRepositories = true;
@@ -86,7 +85,7 @@ public partial class Labels : ComponentBase
         }
     }
 
-    private Task OnRepositorySelectedAsync(Repository? repository)
+    private Task OnRepositorySelectedAsync(RepositoryDto? repository)
     {
         if (repository is null || string.IsNullOrWhiteSpace(repository.FullName))
         {
@@ -105,9 +104,9 @@ public partial class Labels : ComponentBase
         return Task.CompletedTask;
     }
 
-    private Task<IEnumerable<Repository>> SearchRepositoriesAsync(string? value, CancellationToken cancellationToken)
+    private Task<IEnumerable<RepositoryDto>> SearchRepositoriesAsync(string? value, CancellationToken cancellationToken)
     {
-        IEnumerable<Repository> matches = availableRepositories;
+        IEnumerable<RepositoryDto> matches = availableRepositories;
 
         if (!string.IsNullOrWhiteSpace(value))
         {

--- a/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor
+++ b/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor
@@ -47,7 +47,7 @@
                               Clearable="true"
                               Class="repository-search" />
 
-                <MudDataGrid T="SoloDevBoard.Application.Services.RepositoryDto"
+                <MudDataGrid T="RepositoryDto"
                              Items="FilteredRepositories"
                              Hover="true"
                              Dense="true"

--- a/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor
+++ b/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor
@@ -47,7 +47,7 @@
                               Clearable="true"
                               Class="repository-search" />
 
-                <MudDataGrid T="SoloDevBoard.Domain.Entities.Repository"
+                <MudDataGrid T="SoloDevBoard.Application.Services.RepositoryDto"
                              Items="FilteredRepositories"
                              Hover="true"
                              Dense="true"

--- a/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Pages/Repositories.razor.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using SoloDevBoard.Application.Services;
-using SoloDevBoard.Domain.Entities;
 
 namespace SoloDevBoard.App.Components.Pages;
 
@@ -16,12 +15,12 @@ public partial class Repositories : ComponentBase
     [Inject]
     public ILogger<Repositories> Logger { get; set; } = default!;
 
-    private IReadOnlyList<Repository> repositories = [];
+    private IReadOnlyList<RepositoryDto> repositories = [];
     private bool isLoading = true;
     private string? errorMessage;
     private string? repositorySearchTerm;
 
-    private IReadOnlyList<Repository> FilteredRepositories =>
+    private IReadOnlyList<RepositoryDto> FilteredRepositories =>
         string.IsNullOrWhiteSpace(repositorySearchTerm)
             ? repositories
             : repositories

--- a/src/App/SoloDevBoard.App/Components/_Imports.razor
+++ b/src/App/SoloDevBoard.App/Components/_Imports.razor
@@ -10,3 +10,4 @@
 @using SoloDevBoard.App
 @using SoloDevBoard.App.Components
 @using SoloDevBoard.App.Components.Layout
+@using SoloDevBoard.Application.Services

--- a/src/Application/SoloDevBoard.Application/Services/IRepositoryService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/IRepositoryService.cs
@@ -1,5 +1,3 @@
-using SoloDevBoard.Domain.Entities;
-
 namespace SoloDevBoard.Application.Services;
 
 /// <summary>Provides repository listing operations for the authenticated user.</summary>
@@ -7,11 +5,11 @@ public interface IRepositoryService
 {
     /// <summary>Retrieves repositories accessible to the authenticated GitHub user.</summary>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    /// <returns>A read-only list of repositories visible to the authenticated user.</returns>
-    Task<IReadOnlyList<Repository>> GetRepositoriesAsync(CancellationToken cancellationToken = default);
+    /// <returns>A read-only list of repository DTOs visible to the authenticated user.</returns>
+    Task<IReadOnlyList<RepositoryDto>> GetRepositoriesAsync(CancellationToken cancellationToken = default);
 
     /// <summary>Retrieves active repositories accessible to the authenticated GitHub user.</summary>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    /// <returns>A read-only list of non-archived repositories visible to the authenticated user.</returns>
-    Task<IReadOnlyList<Repository>> GetActiveRepositoriesAsync(CancellationToken cancellationToken = default);
+    /// <returns>A read-only list of non-archived repository DTOs visible to the authenticated user.</returns>
+    Task<IReadOnlyList<RepositoryDto>> GetActiveRepositoriesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Application/SoloDevBoard.Application/Services/RepositoryDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/RepositoryDto.cs
@@ -1,0 +1,22 @@
+namespace SoloDevBoard.Application.Services;
+
+/// <summary>Represents a repository returned from Application-layer repository operations.</summary>
+/// <param name="Id">The unique GitHub identifier of the repository.</param>
+/// <param name="Name">The short repository name.</param>
+/// <param name="FullName">The fully-qualified repository name in owner/name form.</param>
+/// <param name="Description">The repository description.</param>
+/// <param name="Url">The web URL of the repository.</param>
+/// <param name="IsPrivate"><see langword="true"/> if the repository is private; otherwise <see langword="false"/>.</param>
+/// <param name="IsArchived"><see langword="true"/> if the repository is archived; otherwise <see langword="false"/>.</param>
+/// <param name="CreatedAt">The date and time when the repository was created.</param>
+/// <param name="UpdatedAt">The date and time when the repository was last updated.</param>
+public sealed record RepositoryDto(
+    int Id,
+    string Name,
+    string FullName,
+    string Description,
+    string Url,
+    bool IsPrivate,
+    bool IsArchived,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt);

--- a/src/Application/SoloDevBoard.Application/Services/RepositoryService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/RepositoryService.cs
@@ -16,10 +16,31 @@ public sealed class RepositoryService : IRepositoryService
     }
 
     /// <inheritdoc/>
-    public Task<IReadOnlyList<Repository>> GetRepositoriesAsync(CancellationToken cancellationToken = default)
-        => _gitHubService.GetRepositoriesAsync(cancellationToken);
+    public async Task<IReadOnlyList<RepositoryDto>> GetRepositoriesAsync(CancellationToken cancellationToken = default)
+    {
+        var repositories = await _gitHubService.GetRepositoriesAsync(cancellationToken).ConfigureAwait(false);
+        return repositories.Select(MapToDto).ToArray();
+    }
 
     /// <inheritdoc/>
-    public Task<IReadOnlyList<Repository>> GetActiveRepositoriesAsync(CancellationToken cancellationToken = default)
-        => _gitHubService.GetActiveRepositoriesAsync(cancellationToken);
+    public async Task<IReadOnlyList<RepositoryDto>> GetActiveRepositoriesAsync(CancellationToken cancellationToken = default)
+    {
+        var repositories = await _gitHubService.GetActiveRepositoriesAsync(cancellationToken).ConfigureAwait(false);
+        return repositories.Select(MapToDto).ToArray();
+    }
+
+    /// <summary>Maps a domain repository record to the application DTO shape.</summary>
+    /// <param name="repository">The domain repository to map.</param>
+    /// <returns>A mapped application repository DTO.</returns>
+    private static RepositoryDto MapToDto(Repository repository)
+        => new(
+            repository.Id,
+            repository.Name,
+            repository.FullName,
+            repository.Description,
+            repository.Url,
+            repository.IsPrivate,
+            repository.IsArchived,
+            repository.CreatedAt,
+            repository.UpdatedAt);
 }

--- a/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
@@ -5,7 +5,6 @@ using MudBlazor;
 using MudBlazor.Services;
 using SoloDevBoard.App.Components.Pages;
 using SoloDevBoard.Application.Services;
-using SoloDevBoard.Domain.Entities;
 using System.Net.Http;
 
 namespace SoloDevBoard.App.Tests;
@@ -20,7 +19,7 @@ public sealed class LabelsTests
     public async Task Labels_WhileRepositoryServiceIsLoading_ShowsLoadingState()
     {
         // Arrange
-        var repositoriesTask = new TaskCompletionSource<IReadOnlyList<Repository>>();
+        var repositoriesTask = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
         _repositoryServiceMock
             .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
             .Returns(repositoriesTask.Task);
@@ -41,7 +40,7 @@ public sealed class LabelsTests
         _repositoryServiceMock
             .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([
-                new Repository { Name = "repo-a", FullName = "owner/repo-a" },
+                CreateRepository("owner", "repo-a"),
             ]);
 
         await using var ctx = CreateContext();
@@ -71,7 +70,7 @@ public sealed class LabelsTests
         _repositoryServiceMock
             .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([
-                new Repository { Name = "repo-a", FullName = "owner/repo-a", IsArchived = false },
+                CreateRepository("owner", "repo-a", isArchived: false),
             ]);
 
         await using var ctx = CreateContext();
@@ -91,7 +90,7 @@ public sealed class LabelsTests
     public async Task Labels_LoadRequestedAndNoLabelsReturned_ShowsEmptyState()
     {
         // Arrange
-        var repoA = new Repository { Name = "repo-a", FullName = "owner/repo-a" };
+        var repoA = CreateRepository("owner", "repo-a");
 
         _repositoryServiceMock
             .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
@@ -122,8 +121,8 @@ public sealed class LabelsTests
     public async Task Labels_SelectedRepositoriesAcrossOwners_LoadsEachOwnerAndShowsGapAnalysis()
     {
         // Arrange
-        var repoA = new Repository { Name = "repo-a", FullName = "owner-a/repo-a" };
-        var repoB = new Repository { Name = "repo-b", FullName = "owner-b/repo-b" };
+        var repoA = CreateRepository("owner-a", "repo-a");
+        var repoB = CreateRepository("owner-b", "repo-b");
 
         _repositoryServiceMock
             .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
@@ -173,7 +172,7 @@ public sealed class LabelsTests
     public async Task Labels_FilterAppliedAfterLoad_FiltersRowsByName()
     {
         // Arrange
-        var repoA = new Repository { Name = "repo-a", FullName = "owner/repo-a" };
+        var repoA = CreateRepository("owner", "repo-a");
 
         _repositoryServiceMock
             .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
@@ -255,9 +254,9 @@ public sealed class LabelsTests
         return ctx;
     }
 
-    private static async Task SelectRepositoriesAsync(IRenderedComponent<Labels> cut, params Repository[] repositories)
+    private static async Task SelectRepositoriesAsync(IRenderedComponent<Labels> cut, params RepositoryDto[] repositories)
     {
-        var autocomplete = cut.FindComponent<MudAutocomplete<Repository>>();
+        var autocomplete = cut.FindComponent<MudAutocomplete<RepositoryDto>>();
 
         await cut.InvokeAsync(async () =>
         {
@@ -267,4 +266,16 @@ public sealed class LabelsTests
             }
         });
     }
+
+    private static RepositoryDto CreateRepository(string owner, string name, bool isPrivate = false, bool isArchived = false)
+        => new(
+            Id: 0,
+            Name: name,
+            FullName: $"{owner}/{name}",
+            Description: string.Empty,
+            Url: string.Empty,
+            IsPrivate: isPrivate,
+            IsArchived: isArchived,
+            CreatedAt: DateTimeOffset.UnixEpoch,
+            UpdatedAt: DateTimeOffset.UnixEpoch);
 }

--- a/tests/App.Tests/SoloDevBoard.App.Tests/RepositoriesTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/RepositoriesTests.cs
@@ -5,7 +5,6 @@ using MudBlazor;
 using MudBlazor.Services;
 using SoloDevBoard.App.Components.Pages;
 using SoloDevBoard.Application.Services;
-using SoloDevBoard.Domain.Entities;
 
 namespace SoloDevBoard.App.Tests;
 
@@ -18,7 +17,7 @@ public sealed class RepositoriesTests
     public async Task Repositories_WhileServiceIsLoading_ShowsLoadingIndicator()
     {
         // Arrange
-        var tcs = new TaskCompletionSource<IReadOnlyList<Repository>>();
+        var tcs = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
         _repositoryServiceMock
             .Setup(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
             .Returns(tcs.Task);
@@ -80,7 +79,7 @@ public sealed class RepositoriesTests
         // Arrange
         _repositoryServiceMock
             .Setup(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<Repository>());
+            .ReturnsAsync(Array.Empty<RepositoryDto>());
 
         await using var ctx = CreateContext();
 
@@ -99,10 +98,10 @@ public sealed class RepositoriesTests
     public async Task Repositories_ServiceReturnsRepositories_ShowsRepositoryNamesInGrid()
     {
         // Arrange
-        var repositories = new List<Repository>
+        var repositories = new List<RepositoryDto>
         {
-            new() { Id = 1, Name = "my-first-repo", FullName = "owner/my-first-repo", IsPrivate = false, UpdatedAt = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero) },
-            new() { Id = 2, Name = "my-private-repo", FullName = "owner/my-private-repo", IsPrivate = true, UpdatedAt = new DateTimeOffset(2026, 2, 20, 12, 0, 0, TimeSpan.Zero) },
+            new(1, "my-first-repo", "owner/my-first-repo", string.Empty, string.Empty, false, false, DateTimeOffset.UnixEpoch, new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero)),
+            new(2, "my-private-repo", "owner/my-private-repo", string.Empty, string.Empty, true, false, DateTimeOffset.UnixEpoch, new DateTimeOffset(2026, 2, 20, 12, 0, 0, TimeSpan.Zero)),
         };
 
         _repositoryServiceMock

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/RepositoryServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/RepositoryServiceTests.cs
@@ -35,6 +35,48 @@ public sealed class RepositoryServiceTests
     }
 
     [Fact]
+    public async Task GetRepositoriesAsync_GitHubServiceReturnsRepository_MapsAllFieldsToRepositoryDto()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2025, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        var updatedAt = new DateTimeOffset(2026, 2, 3, 4, 5, 6, TimeSpan.Zero);
+
+        _gitHubServiceMock
+            .Setup(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new Repository
+                {
+                    Id = 42,
+                    Name = "repo-a",
+                    FullName = "owner/repo-a",
+                    Description = "Repository description",
+                    Url = "https://github.com/owner/repo-a",
+                    IsPrivate = true,
+                    IsArchived = false,
+                    CreatedAt = createdAt,
+                    UpdatedAt = updatedAt,
+                },
+            ]);
+
+        var sut = new RepositoryService(_gitHubServiceMock.Object);
+
+        // Act
+        var result = await sut.GetRepositoriesAsync();
+
+        // Assert
+        var dto = Assert.Single(result);
+        Assert.Equal(42, dto.Id);
+        Assert.Equal("repo-a", dto.Name);
+        Assert.Equal("owner/repo-a", dto.FullName);
+        Assert.Equal("Repository description", dto.Description);
+        Assert.Equal("https://github.com/owner/repo-a", dto.Url);
+        Assert.True(dto.IsPrivate);
+        Assert.False(dto.IsArchived);
+        Assert.Equal(createdAt, dto.CreatedAt);
+        Assert.Equal(updatedAt, dto.UpdatedAt);
+    }
+
+    [Fact]
     public async Task GetRepositoriesAsync_WhenCalled_PassesCancellationTokenToGitHubService()
     {
         // Arrange


### PR DESCRIPTION
## Summary of Changes

Introduces `RepositoryDto` as the Application→App boundary shape for repository operations, completing ADR-0011 compliance for `IRepositoryService`. Previously, `IRepositoryService` returned `SoloDevBoard.Domain.Entities.Repository` directly to the App layer; this PR fixes that architectural debt so the boundary is consistent with the pattern already applied to labels (`LabelDto`).

## Related Issue(s)

Closes #54
Closes #55

## Type of Change

- [x] ♻️ Refactoring (no functional change, improves code quality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Files Changed

### Application Layer
- `src/Application/SoloDevBoard.Application/Services/RepositoryDto.cs` — new `sealed record RepositoryDto(...)` with all nine repository fields and XML doc comments
- `src/Application/SoloDevBoard.Application/Services/IRepositoryService.cs` — both public methods updated to return `IReadOnlyList<RepositoryDto>` instead of `IReadOnlyList<Repository>`; Domain `using` removed
- `src/Application/SoloDevBoard.Application/Services/RepositoryService.cs` — added `MapToDto(Repository)` private helper; both methods now `async`, mapping before returning to caller; `ConfigureAwait(false)` on all awaits

### App Layer (Blazor)
- `src/App/SoloDevBoard.App/Components/Pages/Repositories.razor.cs` — field types changed to `IReadOnlyList<RepositoryDto>`; Domain `using` removed
- `src/App/SoloDevBoard.App/Components/Pages/Repositories.razor` — `MudDataGrid T=` updated to `RepositoryDto`; Domain qualified type removed
- `src/App/SoloDevBoard.App/Components/Pages/Labels.razor.cs` — repository collection, autocomplete value, and query method types changed to `RepositoryDto`; Domain `using` removed
- `src/App/SoloDevBoard.App/Components/Pages/Labels.razor` — `MudAutocomplete T=` updated to `RepositoryDto`; `@using SoloDevBoard.Domain.Entities` removed

### Tests
- `tests/Application.Tests/SoloDevBoard.Application.Tests/RepositoryServiceTests.cs` — new `GetRepositoriesAsync_GitHubServiceReturnsRepository_MapsAllFieldsToRepositoryDto` test verifying all nine fields; pre-existing tests updated to work against new return type
- `tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs` — Domain `using` removed; all `Repository` usages replaced with `RepositoryDto`; helper `CreateRepository(...)` factory method added; `MudAutocomplete<Repository>` updated to `MudAutocomplete<RepositoryDto>`
- `tests/App.Tests/SoloDevBoard.App.Tests/RepositoriesTests.cs` — Domain `using` removed; all `Repository` usages replaced with `RepositoryDto`

### Planning
- `plan/BACKLOG.md` — entries for #54 and #55 added to the Infrastructure & Cross-Cutting section, marked as done

## ADR-0011 Compliance
- ✅ `IRepositoryService` public methods return DTOs only
- ✅ No Razor component references `SoloDevBoard.Domain.Entities.Repository`
- ✅ Infrastructure→Application boundary unchanged (`IGitHubService` still returns domain entities)
- ✅ Mapping from Domain to DTO occurs exclusively in `RepositoryService` (Application layer)

## Additional Notes

This enabler is prerequisite work for any feature that consumes `IRepositoryService` in consumer components. The test count increased from 75 to 76 (one new mapping test added).
