### PR TITLE
[type/story] Apply recommended label taxonomy strategies (#34)

### DIFF
--- a/docs/user-guide/label-manager.md
+++ b/docs/user-guide/label-manager.md
@@ -42,6 +42,28 @@ Planned interactions include:
 - Additional bulk operations for standard label templates.
 
 
+## Applying Recommended Taxonomy
+
+You can apply a recommended label taxonomy to selected repositories using a preview and confirm workflow.
+
+1. Select one or more active repositories in the repository selector.
+2. Choose a recommended strategy.
+3. Select `Preview recommended taxonomy` to review proposed changes per repository.
+4. Confirm or cancel before any changes are applied.
+5. Review the per-repository summary after apply completes.
+
+Current built-in strategies:
+
+- `SoloDevBoard` strategy.
+- `GitHub default` strategy.
+
+The preview shows the labels that will be created, updated, and skipped for each selected repository. Labels that already match the selected strategy exactly are skipped, and no redundant API update call is made for those labels.
+
+The apply summary is shown per repository and includes created, updated, and skipped counts. If one repository fails due to a GitHub API error, the summary marks that repository with an error while still showing successful outcomes for other repositories.
+
+Strategies are currently built in for the MVP stage. Future releases can externalise strategy definitions so custom strategies can be managed without code changes.
+
+
 ## Configuration
 
 *Coming soon — this section will describe configuration options for the Label Manager.*

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -85,7 +85,7 @@ Labels: `type/epic`, `area/labels`
 - [x] As a solo developer, I want to rename a label across multiple repositories simultaneously so that I can refactor my taxonomy without visiting each repo. _(#33 done — 2026-03-08)_
 - [x] As a solo developer, I want to change a label's colour across multiple repositories so that visual consistency is maintained. _(#33 done — 2026-03-08)_
 - [x] As a solo developer, I want to delete a label from multiple repositories at once so that I can clean up obsolete labels. _(#33 done — 2026-03-08)_
-- [ ] As a solo developer, I want to apply the SoloDevBoard recommended label taxonomy (from `plan/LABEL_STRATEGY.md`) to any repository so that I can start with a sensible default set of labels. _(#34 status/todo — v0.2.0)_
+- [x] As a solo developer, I want to apply recommended label taxonomy strategies to any repository so that I can start with a sensible default set of labels. _(#34 done — 2026-03-10; includes SoloDevBoard + GitHub default strategy options, preview, confirm/cancel, and per-repository summary)_
 - [x] As a solo developer, I want to see which repositories do not have a specific label so that I can identify gaps. _(#35 done — 2026-03-08)_
 - [ ] As a solo developer, I want to synchronise a target repository's labels to exactly match a source repository's labels so that they stay in lockstep. _(#32 status/todo — v0.2.0)_
 

--- a/src/App/SoloDevBoard.App/Components/Pages/Labels.razor
+++ b/src/App/SoloDevBoard.App/Components/Pages/Labels.razor
@@ -67,10 +67,161 @@
                             Load selected repositories
                         </MudButton>
                     </MudStack>
+
+                    <MudDivider />
+
+                    <MudText Typo="Typo.h6">Apply recommended taxonomy</MudText>
+                    <MudText Typo="Typo.body2">Choose a strategy, preview changes, then confirm to apply labels across selected repositories.</MudText>
+
+                    <MudSelect T="string"
+                               Label="Recommended strategy"
+                               Value="selectedStrategyId"
+                               ValueChanged="OnStrategySelectedAsync"
+                               Variant="Variant.Outlined"
+                               Disabled="@(ShowLoadingState || !selectedRepositories.Any() || recommendedStrategies.Count == 0)"
+                               data-testid="taxonomy-strategy-select">
+                        @foreach (var strategy in recommendedStrategies)
+                        {
+                            <MudSelectItem T="string" Value="@strategy.Id">@strategy.Name</MudSelectItem>
+                        }
+                    </MudSelect>
+
+                    @if (!string.IsNullOrWhiteSpace(SelectedStrategyDescription))
+                    {
+                        <MudText Typo="Typo.body2">@SelectedStrategyDescription</MudText>
+                    }
+
+                    <MudStack Row="true" Spacing="1">
+                        <MudButton Variant="Variant.Outlined"
+                                   Color="Color.Primary"
+                                   Disabled="@(!CanPreviewRecommendedTaxonomy)"
+                                   OnClick="PreviewRecommendedTaxonomyAsync"
+                                   data-testid="preview-taxonomy-button">
+                            Preview recommended taxonomy
+                        </MudButton>
+
+                        @if (showRecommendedPreview)
+                        {
+                            <MudButton Variant="Variant.Filled"
+                                       Color="Color.Primary"
+                                       Disabled="@(!CanApplyRecommendedTaxonomy)"
+                                       OnClick="ApplyRecommendedTaxonomyAsync"
+                                       data-testid="confirm-apply-taxonomy-button">
+                                Confirm apply taxonomy
+                            </MudButton>
+
+                            <MudButton Variant="Variant.Text"
+                                       Color="Color.Secondary"
+                                       OnClick="CancelRecommendedPreview"
+                                       data-testid="cancel-apply-taxonomy-button">
+                                Cancel
+                            </MudButton>
+                        }
+                    </MudStack>
+
+                    @if (!string.IsNullOrWhiteSpace(taxonomyOperationMessage))
+                    {
+                        <MudAlert Severity="@taxonomyOperationSeverity" Dense="true" Variant="Variant.Outlined" data-testid="taxonomy-operation-message">
+                            @taxonomyOperationMessage
+                        </MudAlert>
+                    }
                 </MudStack>
             }
         </MudStack>
     </MudPaper>
+
+@if (showRecommendedPreview)
+{
+    <MudPaper Class="pa-4" Elevation="1" data-testid="taxonomy-preview-card">
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.h6">Taxonomy preview</MudText>
+            @foreach (var preview in recommendedPreview)
+            {
+                <MudPaper Class="pa-3" Outlined="true">
+                    <MudText Typo="Typo.subtitle1">@preview.RepositoryFullName</MudText>
+                    <MudText Typo="Typo.body2">Create: @preview.ToCreate.Count, Update: @preview.ToUpdate.Count, Skip: @preview.Skipped.Count</MudText>
+
+                    @if (preview.ToCreate.Count > 0)
+                    {
+                        <div class="taxonomy-preview-section">
+                            <MudText Class="taxonomy-preview-heading" Typo="Typo.subtitle2">Labels to create</MudText>
+                            <MudTable T="LabelDto" Items="preview.ToCreate" Dense="true" Hover="true" Class="taxonomy-preview-table">
+                            <HeaderContent>
+                                <MudTh>Label</MudTh>
+                                <MudTh>Colour</MudTh>
+                                <MudTh>Description</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Label">@context.Name</MudTd>
+                                <MudTd DataLabel="Colour">
+                                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                                        <MudIcon Class="taxonomy-colour-icon"
+                                                 Icon="@Icons.Material.Filled.Circle"
+                                                 Style="@GetColourIconStyle(context.Colour)"
+                                                 Title="@($"#{context.Colour}")" />
+                                        <MudChip T="string" Class="colour-chip" Variant="Variant.Outlined" Size="Size.Small">@($"#{context.Colour}")</MudChip>
+                                    </MudStack>
+                                </MudTd>
+                                <MudTd DataLabel="Description">@(string.IsNullOrWhiteSpace(context.Description) ? "No description" : context.Description)</MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                        </div>
+                    }
+
+                    @if (preview.ToUpdate.Count > 0)
+                    {
+                        <div class="taxonomy-preview-section">
+                            <MudText Class="taxonomy-preview-heading" Typo="Typo.subtitle2">Labels to update</MudText>
+                            <MudTable T="LabelDto" Items="preview.ToUpdate" Dense="true" Hover="true" Class="taxonomy-preview-table">
+                            <HeaderContent>
+                                <MudTh>Label</MudTh>
+                                <MudTh>Colour</MudTh>
+                                <MudTh>Description</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Label">@context.Name</MudTd>
+                                <MudTd DataLabel="Colour">
+                                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                                        <MudIcon Class="taxonomy-colour-icon"
+                                                 Icon="@Icons.Material.Filled.Circle"
+                                                 Style="@GetColourIconStyle(context.Colour)"
+                                                 Title="@($"#{context.Colour}")" />
+                                        <MudChip T="string" Class="colour-chip" Variant="Variant.Outlined" Size="Size.Small">@($"#{context.Colour}")</MudChip>
+                                    </MudStack>
+                                </MudTd>
+                                <MudTd DataLabel="Description">@(string.IsNullOrWhiteSpace(context.Description) ? "No description" : context.Description)</MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                        </div>
+                    }
+                </MudPaper>
+            }
+        </MudStack>
+    </MudPaper>
+}
+
+@if (recommendedApplyResults.Count > 0)
+{
+    <MudPaper Class="pa-4" Elevation="1" data-testid="taxonomy-summary-card">
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.h6">Apply summary</MudText>
+            @foreach (var result in recommendedApplyResults)
+            {
+                <MudPaper Class="pa-3" Outlined="true">
+                    <MudText Typo="Typo.subtitle1">@result.RepositoryFullName</MudText>
+                    @if (result.HasError)
+                    {
+                        <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Outlined">@result.ErrorMessage</MudAlert>
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.body2">Created: @result.CreatedCount, Updated: @result.UpdatedCount, Skipped: @result.SkippedCount</MudText>
+                    }
+                </MudPaper>
+            }
+        </MudStack>
+    </MudPaper>
+}
 
 @if (ShowLabelFilter)
 {

--- a/src/App/SoloDevBoard.App/Components/Pages/Labels.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Pages/Labels.razor.cs
@@ -44,6 +44,7 @@ public partial class Labels : ComponentBase
     private IReadOnlyList<RecommendedTaxonomyRepositoryPreviewDto> recommendedPreview = [];
     private IReadOnlyList<RecommendedTaxonomyRepositoryResultDto> recommendedApplyResults = [];
     private bool showRecommendedPreview;
+    private bool isPreviewingRecommendedTaxonomy;
     private bool isApplyingRecommendedTaxonomy;
     private string? taxonomyOperationMessage;
     private Severity taxonomyOperationSeverity = Severity.Info;
@@ -62,7 +63,10 @@ public partial class Labels : ComponentBase
                 .OrderBy(strategy => strategy.Name, StringComparer.OrdinalIgnoreCase)
                 .ToArray();
 
-            selectedStrategyId = recommendedStrategies.FirstOrDefault()?.Id ?? string.Empty;
+            selectedStrategyId = recommendedStrategies
+                .FirstOrDefault(strategy => strategy.Id.Equals("solodevboard", StringComparison.OrdinalIgnoreCase))?.Id
+                ?? recommendedStrategies.FirstOrDefault()?.Id
+                ?? string.Empty;
         }
         catch (Exception ex)
         {
@@ -185,6 +189,11 @@ public partial class Labels : ComponentBase
 
     private async Task PreviewRecommendedTaxonomyAsync()
     {
+        if (isPreviewingRecommendedTaxonomy)
+        {
+            return;
+        }
+
         if (!TryGetSelectedRepositoryFullNames(out var selectedFullNames))
         {
             Snackbar.Add("Select at least one repository before previewing taxonomy changes.", Severity.Warning);
@@ -197,6 +206,7 @@ public partial class Labels : ComponentBase
             return;
         }
 
+        isPreviewingRecommendedTaxonomy = true;
         try
         {
             taxonomyOperationMessage = null;
@@ -219,6 +229,10 @@ public partial class Labels : ComponentBase
             taxonomyOperationMessage = "An unexpected error occurred while previewing taxonomy changes.";
             showRecommendedPreview = false;
             recommendedPreview = [];
+        }
+        finally
+        {
+            isPreviewingRecommendedTaxonomy = false;
         }
     }
 
@@ -699,6 +713,7 @@ public partial class Labels : ComponentBase
     private bool ShowLoadingState => isLoadingRepositories || isLoadingLabels;
 
     private bool CanPreviewRecommendedTaxonomy => !ShowLoadingState
+        && !isPreviewingRecommendedTaxonomy
         && !isApplyingRecommendedTaxonomy
         && selectedRepositories.Count > 0
         && !string.IsNullOrWhiteSpace(selectedStrategyId);

--- a/src/App/SoloDevBoard.App/Components/Pages/Labels.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Pages/Labels.razor.cs
@@ -39,15 +39,54 @@ public partial class Labels : ComponentBase
     private bool hasLoadedLabels;
     private bool hasRepositoryLoadFailure;
     private string? errorMessage;
+    private IReadOnlyList<RecommendedLabelStrategyDto> recommendedStrategies = [];
+    private string selectedStrategyId = string.Empty;
+    private IReadOnlyList<RecommendedTaxonomyRepositoryPreviewDto> recommendedPreview = [];
+    private IReadOnlyList<RecommendedTaxonomyRepositoryResultDto> recommendedApplyResults = [];
+    private bool showRecommendedPreview;
+    private bool isApplyingRecommendedTaxonomy;
+    private string? taxonomyOperationMessage;
+    private Severity taxonomyOperationSeverity = Severity.Info;
 
     protected override async Task OnInitializedAsync()
     {
+        await LoadRecommendedStrategiesAsync();
         await LoadRepositoriesAsync();
+    }
+
+    private async Task LoadRecommendedStrategiesAsync()
+    {
+        try
+        {
+            recommendedStrategies = (await LabelManagerService.GetRecommendedLabelStrategiesAsync())
+                .OrderBy(strategy => strategy.Name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            selectedStrategyId = recommendedStrategies.FirstOrDefault()?.Id ?? string.Empty;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load recommended label strategies.");
+            recommendedStrategies = [];
+            selectedStrategyId = string.Empty;
+            taxonomyOperationSeverity = Severity.Error;
+            taxonomyOperationMessage = "Unable to load recommended taxonomy strategies.";
+        }
     }
 
     private async Task ReloadRepositoriesAsync()
     {
         await LoadRepositoriesAsync();
+    }
+
+    private Task OnStrategySelectedAsync(string strategyId)
+    {
+        selectedStrategyId = strategyId;
+        recommendedPreview = [];
+        showRecommendedPreview = false;
+        recommendedApplyResults = [];
+        taxonomyOperationMessage = null;
+        return Task.CompletedTask;
     }
 
     private async Task LoadRepositoriesAsync()
@@ -67,6 +106,10 @@ public partial class Labels : ComponentBase
 
             selectedRepositories = [];
             repositoryAutocompleteValue = null;
+            recommendedPreview = [];
+            recommendedApplyResults = [];
+            showRecommendedPreview = false;
+            taxonomyOperationMessage = null;
         }
         catch (HttpRequestException ex)
         {
@@ -101,6 +144,10 @@ public partial class Labels : ComponentBase
         }
 
         repositoryAutocompleteValue = null;
+        recommendedPreview = [];
+        showRecommendedPreview = false;
+        recommendedApplyResults = [];
+        taxonomyOperationMessage = null;
         return Task.CompletedTask;
     }
 
@@ -129,6 +176,109 @@ public partial class Labels : ComponentBase
         selectedRepositories = selectedRepositories
             .Where(repository => !repository.FullName.Equals(repositoryFullName, StringComparison.OrdinalIgnoreCase))
             .ToArray();
+
+        recommendedPreview = [];
+        showRecommendedPreview = false;
+        recommendedApplyResults = [];
+        taxonomyOperationMessage = null;
+    }
+
+    private async Task PreviewRecommendedTaxonomyAsync()
+    {
+        if (!TryGetSelectedRepositoryFullNames(out var selectedFullNames))
+        {
+            Snackbar.Add("Select at least one repository before previewing taxonomy changes.", Severity.Warning);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(selectedStrategyId))
+        {
+            Snackbar.Add("Select a recommended strategy before previewing taxonomy changes.", Severity.Warning);
+            return;
+        }
+
+        try
+        {
+            taxonomyOperationMessage = null;
+            recommendedApplyResults = [];
+            recommendedPreview = await LabelManagerService.PreviewRecommendedTaxonomyAsync(selectedStrategyId, selectedFullNames);
+            showRecommendedPreview = true;
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while previewing strategy {StrategyId}.", selectedStrategyId);
+            taxonomyOperationSeverity = Severity.Error;
+            taxonomyOperationMessage = $"GitHub API request failed while previewing taxonomy changes. {ex.Message}";
+            showRecommendedPreview = false;
+            recommendedPreview = [];
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to preview strategy {StrategyId}.", selectedStrategyId);
+            taxonomyOperationSeverity = Severity.Error;
+            taxonomyOperationMessage = "An unexpected error occurred while previewing taxonomy changes.";
+            showRecommendedPreview = false;
+            recommendedPreview = [];
+        }
+    }
+
+    private void CancelRecommendedPreview()
+    {
+        showRecommendedPreview = false;
+        recommendedPreview = [];
+        taxonomyOperationMessage = "Taxonomy apply was cancelled.";
+        taxonomyOperationSeverity = Severity.Info;
+    }
+
+    private async Task ApplyRecommendedTaxonomyAsync()
+    {
+        if (!TryGetSelectedRepositoryFullNames(out var selectedFullNames))
+        {
+            Snackbar.Add("Select at least one repository before applying taxonomy changes.", Severity.Warning);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(selectedStrategyId))
+        {
+            Snackbar.Add("Select a recommended strategy before applying taxonomy changes.", Severity.Warning);
+            return;
+        }
+
+        isApplyingRecommendedTaxonomy = true;
+        try
+        {
+            recommendedApplyResults = await LabelManagerService.ApplyRecommendedTaxonomyAsync(selectedStrategyId, selectedFullNames);
+            showRecommendedPreview = false;
+            recommendedPreview = [];
+
+            var failedCount = recommendedApplyResults.Count(result => result.HasError);
+            var createdCount = recommendedApplyResults.Sum(result => result.CreatedCount);
+            var updatedCount = recommendedApplyResults.Sum(result => result.UpdatedCount);
+            var skippedCount = recommendedApplyResults.Sum(result => result.SkippedCount);
+
+            if (failedCount == 0)
+            {
+                taxonomyOperationSeverity = Severity.Success;
+                taxonomyOperationMessage = $"Applied taxonomy successfully. Created {createdCount}, updated {updatedCount}, skipped {skippedCount}.";
+            }
+            else
+            {
+                taxonomyOperationSeverity = Severity.Warning;
+                taxonomyOperationMessage = $"Applied taxonomy with {failedCount} repository errors. Created {createdCount}, updated {updatedCount}, skipped {skippedCount}.";
+            }
+
+            await LoadLabelsForSelectionAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to apply strategy {StrategyId}.", selectedStrategyId);
+            taxonomyOperationSeverity = Severity.Error;
+            taxonomyOperationMessage = "An unexpected error occurred while applying taxonomy changes.";
+        }
+        finally
+        {
+            isApplyingRecommendedTaxonomy = false;
+        }
     }
 
     private async Task LoadLabelsForSelectionAsync()
@@ -548,6 +698,19 @@ public partial class Labels : ComponentBase
 
     private bool ShowLoadingState => isLoadingRepositories || isLoadingLabels;
 
+    private bool CanPreviewRecommendedTaxonomy => !ShowLoadingState
+        && !isApplyingRecommendedTaxonomy
+        && selectedRepositories.Count > 0
+        && !string.IsNullOrWhiteSpace(selectedStrategyId);
+
+    private bool CanApplyRecommendedTaxonomy => showRecommendedPreview
+        && recommendedPreview.Count > 0
+        && !isApplyingRecommendedTaxonomy;
+
+    private string SelectedStrategyDescription
+        => recommendedStrategies.FirstOrDefault(strategy => strategy.Id.Equals(selectedStrategyId, StringComparison.OrdinalIgnoreCase))?.Description
+            ?? string.Empty;
+
     private bool ShowLabelFilter => hasLoadedLabels && rows.Count > 0 && !ShowLoadingState && string.IsNullOrWhiteSpace(errorMessage);
 
     private string ErrorTitle => hasRepositoryLoadFailure
@@ -572,6 +735,15 @@ public partial class Labels : ComponentBase
             : colour.Trim().TrimStart('#');
 
         return $"background-color: #{normalised};";
+    }
+
+    private static string GetColourIconStyle(string colour)
+    {
+        var normalised = string.IsNullOrWhiteSpace(colour)
+            ? "ededed"
+            : colour.Trim().TrimStart('#');
+
+        return $"color: #{normalised};";
     }
 
     /// <summary>Represents a consolidated label row for the grid view.</summary>

--- a/src/App/SoloDevBoard.App/Components/Pages/Labels.razor.css
+++ b/src/App/SoloDevBoard.App/Components/Pages/Labels.razor.css
@@ -36,3 +36,20 @@
     height: 1rem;
     width: 1rem;
 }
+
+.taxonomy-preview-section {
+    margin-top: 0.5rem;
+}
+
+.taxonomy-preview-heading {
+    margin-bottom: 0.35rem;
+}
+
+.taxonomy-preview-table {
+    margin-bottom: 0.75rem;
+}
+
+.taxonomy-colour-icon {
+    font-size: 1rem;
+    filter: drop-shadow(0 0 0.5px rgb(0 0 0 / 55%));
+}

--- a/src/Application/SoloDevBoard.Application/Services/ILabelManagerService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/ILabelManagerService.cs
@@ -56,4 +56,23 @@ public interface ILabelManagerService
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>A read-only list of recommended taxonomy labels.</returns>
     Task<IReadOnlyList<LabelDto>> GetRecommendedTaxonomyAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves available built-in recommended label strategies.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A read-only list of recommended strategy descriptors.</returns>
+    Task<IReadOnlyList<RecommendedLabelStrategyDto>> GetRecommendedLabelStrategiesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Builds a preview for applying a recommended taxonomy to repositories.</summary>
+    /// <param name="strategyId">The recommended strategy identifier.</param>
+    /// <param name="repositories">The target repositories in owner/repository format.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A read-only list of repository previews showing create, update, and skip actions.</returns>
+    Task<IReadOnlyList<RecommendedTaxonomyRepositoryPreviewDto>> PreviewRecommendedTaxonomyAsync(string strategyId, IReadOnlyList<string> repositories, CancellationToken cancellationToken = default);
+
+    /// <summary>Applies a recommended taxonomy to repositories and returns per-repository summaries.</summary>
+    /// <param name="strategyId">The recommended strategy identifier.</param>
+    /// <param name="repositories">The target repositories in owner/repository format.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A read-only list of per-repository results.</returns>
+    Task<IReadOnlyList<RecommendedTaxonomyRepositoryResultDto>> ApplyRecommendedTaxonomyAsync(string strategyId, IReadOnlyList<string> repositories, CancellationToken cancellationToken = default);
 }

--- a/src/Application/SoloDevBoard.Application/Services/LabelService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/LabelService.cs
@@ -57,10 +57,10 @@ public sealed class LabelService : ILabelManagerService
     ];
 
     private static readonly IReadOnlyList<RecommendedLabelStrategyDto> RecommendedStrategies =
-    [
-        new("solodevboard", "SoloDevBoard", "The SoloDevBoard canonical taxonomy covering type, priority, status, area, and size labels."),
-        new("github-default", "GitHub default", "GitHub's default label set for new repositories."),
-    ];
+        BuildRecommendedStrategies();
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<LabelDto>> RecommendedStrategyLabelsById =
+        BuildRecommendedStrategyLabelsById();
 
     private readonly ILabelRepository _labelRepository;
 
@@ -254,10 +254,10 @@ public sealed class LabelService : ILabelManagerService
         foreach (var repositoryFullName in normalisedRepositories)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var repository = SplitRepositoryFullName(repositoryFullName);
 
             try
             {
+                var repository = SplitRepositoryFullName(repositoryFullName);
                 var existing = await _labelRepository.GetLabelsAsync(repository.Owner, repository.Name, cancellationToken).ConfigureAwait(false);
                 var preview = BuildRepositoryPreview(repositoryFullName, strategyLabels, existing);
 
@@ -284,7 +284,7 @@ public sealed class LabelService : ILabelManagerService
                     preview.Skipped.Count,
                     null));
             }
-            catch (Exception ex) when (ex is HttpRequestException or KeyNotFoundException)
+            catch (Exception ex) when (ex is HttpRequestException or KeyNotFoundException or ArgumentException)
             {
                 results.Add(new RecommendedTaxonomyRepositoryResultDto(
                     repositoryFullName,
@@ -307,21 +307,25 @@ public sealed class LabelService : ILabelManagerService
     private static LabelDto MapToDto(Label label, string repositoryName)
         => new(label.Name, label.Colour, label.Description, repositoryName);
 
+    /// <summary>Resolves strategy labels by strategy identifier.</summary>
+    /// <param name="strategyId">The strategy identifier to resolve.</param>
+    /// <returns>The label set for the requested strategy.</returns>
+    /// <exception cref="ArgumentException">Thrown when the strategy identifier is unsupported.</exception>
     private static IReadOnlyList<LabelDto> ResolveRecommendedStrategyLabels(string strategyId)
     {
-        if (strategyId.Equals("solodevboard", StringComparison.OrdinalIgnoreCase))
+        if (RecommendedStrategyLabelsById.TryGetValue(strategyId, out var labels))
         {
-            return SoloDevBoardRecommendedTaxonomy;
-        }
-
-        if (strategyId.Equals("github-default", StringComparison.OrdinalIgnoreCase))
-        {
-            return GitHubDefaultTaxonomy;
+            return labels;
         }
 
         throw new ArgumentException($"Unsupported recommended strategy '{strategyId}'.", nameof(strategyId));
     }
 
+    /// <summary>Builds a preview for one repository against a strategy label set.</summary>
+    /// <param name="repositoryFullName">The owner/repository full name.</param>
+    /// <param name="strategyLabels">The strategy labels to compare against.</param>
+    /// <param name="existingLabels">The labels currently present in the repository.</param>
+    /// <returns>A repository preview showing create, update, and skip actions.</returns>
     private static RecommendedTaxonomyRepositoryPreviewDto BuildRepositoryPreview(string repositoryFullName, IReadOnlyList<LabelDto> strategyLabels, IReadOnlyList<Label> existingLabels)
     {
         var existingByName = existingLabels.ToDictionary(label => label.Name, StringComparer.OrdinalIgnoreCase);
@@ -347,6 +351,38 @@ public sealed class LabelService : ILabelManagerService
             .ToArray();
 
         return new RecommendedTaxonomyRepositoryPreviewDto(repositoryFullName, toCreate, toUpdate, skipped);
+    }
+
+    /// <summary>Builds available recommended strategy descriptors.</summary>
+    /// <returns>A read-only list of recommended strategy descriptors.</returns>
+    private static IReadOnlyList<RecommendedLabelStrategyDto> BuildRecommendedStrategies()
+        =>
+        [
+            new("solodevboard", "SoloDevBoard", "The SoloDevBoard canonical taxonomy covering type, priority, status, area, and size labels."),
+            new("github-default", "GitHub default", "GitHub's default label set for new repositories."),
+        ];
+
+    /// <summary>Builds a strategy-to-label-set map keyed by strategy identifier.</summary>
+    /// <returns>A read-only dictionary from strategy identifier to strategy labels.</returns>
+    private static IReadOnlyDictionary<string, IReadOnlyList<LabelDto>> BuildRecommendedStrategyLabelsById()
+    {
+        var labelsById = new Dictionary<string, IReadOnlyList<LabelDto>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["solodevboard"] = SoloDevBoardRecommendedTaxonomy,
+            ["github-default"] = GitHubDefaultTaxonomy,
+        };
+
+        var strategyIds = RecommendedStrategies.Select(strategy => strategy.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var unresolvedIds = strategyIds
+            .Where(strategyId => !labelsById.ContainsKey(strategyId))
+            .ToArray();
+
+        if (unresolvedIds.Length > 0)
+        {
+            throw new InvalidOperationException($"Missing label definitions for recommended strategies: {string.Join(", ", unresolvedIds)}.");
+        }
+
+        return labelsById;
     }
 
     /// <summary>Maps an application label DTO to a domain label record.</summary>
@@ -384,6 +420,10 @@ public sealed class LabelService : ILabelManagerService
         return normalised;
     }
 
+    /// <summary>Splits an owner/repository full name into owner and repository segments.</summary>
+    /// <param name="fullName">The full repository name in owner/repository format.</param>
+    /// <returns>The split repository coordinates.</returns>
+    /// <exception cref="ArgumentException">Thrown when the full name is missing or invalid.</exception>
     private static RepositoryCoordinates SplitRepositoryFullName(string fullName)
     {
         if (string.IsNullOrWhiteSpace(fullName))
@@ -409,5 +449,6 @@ public sealed class LabelService : ILabelManagerService
             && string.Equals(left.Colour, right.Colour, StringComparison.OrdinalIgnoreCase)
             && string.Equals(left.Description, right.Description, StringComparison.Ordinal);
 
+    /// <summary>Represents split owner/repository coordinates.</summary>
     private sealed record RepositoryCoordinates(string Owner, string Name);
 }

--- a/src/Application/SoloDevBoard.Application/Services/LabelService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/LabelService.cs
@@ -5,7 +5,7 @@ namespace SoloDevBoard.Application.Services;
 /// <summary>Default implementation of <see cref="ILabelManagerService"/>.</summary>
 public sealed class LabelService : ILabelManagerService
 {
-    private static readonly IReadOnlyList<LabelDto> RecommendedTaxonomy =
+    private static readonly IReadOnlyList<LabelDto> SoloDevBoardRecommendedTaxonomy =
     [
         new("type/epic", "6f42c1", "A high-level grouping of related features (spans a full phase)", string.Empty),
         new("type/feature", "0075ca", "A Feature — groups related stories within an epic", string.Empty),
@@ -41,6 +41,25 @@ public sealed class LabelService : ILabelManagerService
         new("size/m", "fef2c0", "Medium - half a day to one day", string.Empty),
         new("size/l", "f9d0c4", "Large - two to three days", string.Empty),
         new("size/xl", "d4c5f9", "Extra-large - more than three days; consider splitting", string.Empty),
+    ];
+
+    private static readonly IReadOnlyList<LabelDto> GitHubDefaultTaxonomy =
+    [
+        new("bug", "d73a4a", "Something is not working", string.Empty),
+        new("documentation", "0075ca", "Improvements or additions to documentation", string.Empty),
+        new("duplicate", "cfd3d7", "This issue or pull request already exists", string.Empty),
+        new("enhancement", "a2eeef", "New feature or request", string.Empty),
+        new("good first issue", "7057ff", "Good for newcomers", string.Empty),
+        new("help wanted", "008672", "Extra attention is needed", string.Empty),
+        new("invalid", "e4e669", "This does not appear to be valid", string.Empty),
+        new("question", "d876e3", "Further information is requested", string.Empty),
+        new("wontfix", "ffffff", "This will not be worked on", string.Empty),
+    ];
+
+    private static readonly IReadOnlyList<RecommendedLabelStrategyDto> RecommendedStrategies =
+    [
+        new("solodevboard", "SoloDevBoard", "The SoloDevBoard canonical taxonomy covering type, priority, status, area, and size labels."),
+        new("github-default", "GitHub default", "GitHub's default label set for new repositories."),
     ];
 
     private readonly ILabelRepository _labelRepository;
@@ -191,7 +210,94 @@ public sealed class LabelService : ILabelManagerService
     public Task<IReadOnlyList<LabelDto>> GetRecommendedTaxonomyAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return Task.FromResult<IReadOnlyList<LabelDto>>(RecommendedTaxonomy.ToArray());
+        return Task.FromResult<IReadOnlyList<LabelDto>>(SoloDevBoardRecommendedTaxonomy.ToArray());
+    }
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<RecommendedLabelStrategyDto>> GetRecommendedLabelStrategiesAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<IReadOnlyList<RecommendedLabelStrategyDto>>(RecommendedStrategies.ToArray());
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<RecommendedTaxonomyRepositoryPreviewDto>> PreviewRecommendedTaxonomyAsync(string strategyId, IReadOnlyList<string> repositories, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(strategyId);
+        var normalisedRepositories = NormaliseRepositories(repositories);
+
+        var strategyLabels = ResolveRecommendedStrategyLabels(strategyId);
+        var previews = new List<RecommendedTaxonomyRepositoryPreviewDto>();
+
+        foreach (var repositoryFullName in normalisedRepositories)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var repository = SplitRepositoryFullName(repositoryFullName);
+            var existing = await _labelRepository.GetLabelsAsync(repository.Owner, repository.Name, cancellationToken).ConfigureAwait(false);
+            previews.Add(BuildRepositoryPreview(repositoryFullName, strategyLabels, existing));
+        }
+
+        return previews
+            .OrderBy(preview => preview.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<RecommendedTaxonomyRepositoryResultDto>> ApplyRecommendedTaxonomyAsync(string strategyId, IReadOnlyList<string> repositories, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(strategyId);
+        var normalisedRepositories = NormaliseRepositories(repositories);
+
+        var strategyLabels = ResolveRecommendedStrategyLabels(strategyId);
+        var results = new List<RecommendedTaxonomyRepositoryResultDto>();
+
+        foreach (var repositoryFullName in normalisedRepositories)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var repository = SplitRepositoryFullName(repositoryFullName);
+
+            try
+            {
+                var existing = await _labelRepository.GetLabelsAsync(repository.Owner, repository.Name, cancellationToken).ConfigureAwait(false);
+                var preview = BuildRepositoryPreview(repositoryFullName, strategyLabels, existing);
+
+                foreach (var labelToCreate in preview.ToCreate)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await _labelRepository
+                        .CreateLabelAsync(repository.Owner, repository.Name, MapToDomain(labelToCreate, repository.Name), cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                foreach (var labelToUpdate in preview.ToUpdate)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await _labelRepository
+                        .UpdateLabelAsync(repository.Owner, repository.Name, labelToUpdate.Name, MapToDomain(labelToUpdate, repository.Name), cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                results.Add(new RecommendedTaxonomyRepositoryResultDto(
+                    repositoryFullName,
+                    preview.ToCreate.Count,
+                    preview.ToUpdate.Count,
+                    preview.Skipped.Count,
+                    null));
+            }
+            catch (Exception ex) when (ex is HttpRequestException or KeyNotFoundException)
+            {
+                results.Add(new RecommendedTaxonomyRepositoryResultDto(
+                    repositoryFullName,
+                    0,
+                    0,
+                    0,
+                    ex.Message));
+            }
+        }
+
+        return results
+            .OrderBy(result => result.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     /// <summary>Maps a domain label record to the application DTO shape.</summary>
@@ -200,6 +306,48 @@ public sealed class LabelService : ILabelManagerService
     /// <returns>A mapped application label DTO.</returns>
     private static LabelDto MapToDto(Label label, string repositoryName)
         => new(label.Name, label.Colour, label.Description, repositoryName);
+
+    private static IReadOnlyList<LabelDto> ResolveRecommendedStrategyLabels(string strategyId)
+    {
+        if (strategyId.Equals("solodevboard", StringComparison.OrdinalIgnoreCase))
+        {
+            return SoloDevBoardRecommendedTaxonomy;
+        }
+
+        if (strategyId.Equals("github-default", StringComparison.OrdinalIgnoreCase))
+        {
+            return GitHubDefaultTaxonomy;
+        }
+
+        throw new ArgumentException($"Unsupported recommended strategy '{strategyId}'.", nameof(strategyId));
+    }
+
+    private static RecommendedTaxonomyRepositoryPreviewDto BuildRepositoryPreview(string repositoryFullName, IReadOnlyList<LabelDto> strategyLabels, IReadOnlyList<Label> existingLabels)
+    {
+        var existingByName = existingLabels.ToDictionary(label => label.Name, StringComparer.OrdinalIgnoreCase);
+
+        var toCreate = strategyLabels
+            .Where(label => !existingByName.ContainsKey(label.Name))
+            .Select(label => label with { RepositoryName = repositoryFullName })
+            .OrderBy(label => label.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var toUpdate = strategyLabels
+            .Where(label => existingByName.TryGetValue(label.Name, out var existing)
+                && !HasSameValues(MapToDomain(label, repositoryFullName), existing))
+            .Select(label => label with { RepositoryName = repositoryFullName })
+            .OrderBy(label => label.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var skipped = strategyLabels
+            .Where(label => existingByName.TryGetValue(label.Name, out var existing)
+                && HasSameValues(MapToDomain(label, repositoryFullName), existing))
+            .Select(label => label with { RepositoryName = repositoryFullName })
+            .OrderBy(label => label.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return new RecommendedTaxonomyRepositoryPreviewDto(repositoryFullName, toCreate, toUpdate, skipped);
+    }
 
     /// <summary>Maps an application label DTO to a domain label record.</summary>
     /// <param name="label">The application label DTO to map.</param>
@@ -236,6 +384,22 @@ public sealed class LabelService : ILabelManagerService
         return normalised;
     }
 
+    private static RepositoryCoordinates SplitRepositoryFullName(string fullName)
+    {
+        if (string.IsNullOrWhiteSpace(fullName))
+        {
+            throw new ArgumentException("Repository full name must be provided.", nameof(fullName));
+        }
+
+        var parts = fullName.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length != 2)
+        {
+            throw new ArgumentException($"Repository '{fullName}' must be in owner/repository format.", nameof(fullName));
+        }
+
+        return new RepositoryCoordinates(parts[0], parts[1]);
+    }
+
     /// <summary>Determines whether two labels have equivalent values for synchronisation purposes.</summary>
     /// <param name="left">The first label to compare.</param>
     /// <param name="right">The second label to compare.</param>
@@ -244,4 +408,6 @@ public sealed class LabelService : ILabelManagerService
         => string.Equals(left.Name, right.Name, StringComparison.OrdinalIgnoreCase)
             && string.Equals(left.Colour, right.Colour, StringComparison.OrdinalIgnoreCase)
             && string.Equals(left.Description, right.Description, StringComparison.Ordinal);
+
+    private sealed record RepositoryCoordinates(string Owner, string Name);
 }

--- a/src/Application/SoloDevBoard.Application/Services/RecommendedLabelStrategyDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/RecommendedLabelStrategyDto.cs
@@ -1,0 +1,7 @@
+namespace SoloDevBoard.Application.Services;
+
+/// <summary>Represents a built-in recommended label strategy.</summary>
+/// <param name="Id">The stable strategy identifier.</param>
+/// <param name="Name">The display name for the strategy.</param>
+/// <param name="Description">The strategy description shown to users.</param>
+public sealed record RecommendedLabelStrategyDto(string Id, string Name, string Description);

--- a/src/Application/SoloDevBoard.Application/Services/RecommendedTaxonomyRepositoryPreviewDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/RecommendedTaxonomyRepositoryPreviewDto.cs
@@ -1,0 +1,12 @@
+namespace SoloDevBoard.Application.Services;
+
+/// <summary>Represents a taxonomy preview for a single repository.</summary>
+/// <param name="RepositoryFullName">The owner/repository full name.</param>
+/// <param name="ToCreate">Labels that would be created.</param>
+/// <param name="ToUpdate">Labels that would be updated.</param>
+/// <param name="Skipped">Labels already matching the strategy exactly.</param>
+public sealed record RecommendedTaxonomyRepositoryPreviewDto(
+    string RepositoryFullName,
+    IReadOnlyList<LabelDto> ToCreate,
+    IReadOnlyList<LabelDto> ToUpdate,
+    IReadOnlyList<LabelDto> Skipped);

--- a/src/Application/SoloDevBoard.Application/Services/RecommendedTaxonomyRepositoryResultDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/RecommendedTaxonomyRepositoryResultDto.cs
@@ -1,0 +1,18 @@
+namespace SoloDevBoard.Application.Services;
+
+/// <summary>Represents the taxonomy apply result for a single repository.</summary>
+/// <param name="RepositoryFullName">The owner/repository full name.</param>
+/// <param name="CreatedCount">The number of labels created.</param>
+/// <param name="UpdatedCount">The number of labels updated.</param>
+/// <param name="SkippedCount">The number of labels skipped because they already matched.</param>
+/// <param name="ErrorMessage">The repository-specific error message when apply fails.</param>
+public sealed record RecommendedTaxonomyRepositoryResultDto(
+    string RepositoryFullName,
+    int CreatedCount,
+    int UpdatedCount,
+    int SkippedCount,
+    string? ErrorMessage)
+{
+    /// <summary>Gets a value indicating whether the apply operation failed for this repository.</summary>
+    public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
@@ -334,6 +334,74 @@ public sealed class LabelsTests
             Times.Once);
     }
 
+    [Fact]
+    public async Task Labels_InitialLoad_DefaultsToSoloDevBoardStrategy()
+    {
+        // Arrange
+        var repoA = CreateRepository("owner", "repo-a");
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repoA]);
+
+        _labelManagerServiceMock
+            .Setup(service => service.PreviewRecommendedTaxonomyAsync("solodevboard", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new RecommendedTaxonomyRepositoryPreviewDto("owner/repo-a", [], [], []),
+            ]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Labels>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
+        await SelectRepositoriesAsync(cut, repoA);
+        cut.Find("[data-testid='preview-taxonomy-button']").Click();
+
+        // Assert
+        _labelManagerServiceMock.Verify(
+            service => service.PreviewRecommendedTaxonomyAsync("solodevboard", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Labels_PreviewRecommendedTaxonomy_WhenClickedTwiceDuringPendingCall_CallsServiceOnce()
+    {
+        // Arrange
+        var repoA = CreateRepository("owner", "repo-a");
+        var previewTask = new TaskCompletionSource<IReadOnlyList<RecommendedTaxonomyRepositoryPreviewDto>>();
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repoA]);
+
+        _labelManagerServiceMock
+            .Setup(service => service.PreviewRecommendedTaxonomyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .Returns(previewTask.Task);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Labels>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
+        await SelectRepositoriesAsync(cut, repoA);
+
+        var previewButton = cut.Find("[data-testid='preview-taxonomy-button']");
+        previewButton.Click();
+        previewButton.Click();
+
+        await cut.InvokeAsync(() => previewTask.SetResult([
+            new RecommendedTaxonomyRepositoryPreviewDto("owner/repo-a", [], [], []),
+        ]));
+
+        cut.WaitForAssertion(() => Assert.Contains("Taxonomy preview", cut.Markup));
+
+        // Assert
+        _labelManagerServiceMock.Verify(
+            service => service.PreviewRecommendedTaxonomyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private BunitContext CreateContext()
     {
         var ctx = new BunitContext();

--- a/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
@@ -239,11 +239,114 @@ public sealed class LabelsTests
         });
     }
 
+    [Fact]
+    public async Task Labels_PreviewRecommendedTaxonomy_WhenSelected_ShowsPreviewCard()
+    {
+        // Arrange
+        var repoA = CreateRepository("owner", "repo-a");
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repoA]);
+
+        _labelManagerServiceMock
+            .Setup(service => service.PreviewRecommendedTaxonomyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new RecommendedTaxonomyRepositoryPreviewDto(
+                    "owner/repo-a",
+                    [new LabelDto("type/story", "1d76db", "Story", "owner/repo-a")],
+                    [new LabelDto("priority/high", "d93f0b", "High", "owner/repo-a")],
+                    [new LabelDto("status/todo", "ffffff", "Ready", "owner/repo-a")]),
+            ]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Labels>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
+
+        await SelectRepositoriesAsync(cut, repoA);
+        cut.Find("[data-testid='preview-taxonomy-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Taxonomy preview", cut.Markup);
+            Assert.Contains("owner/repo-a", cut.Markup);
+            Assert.Contains("Labels to create", cut.Markup);
+            Assert.Contains("Labels to update", cut.Markup);
+            Assert.Contains("Confirm apply taxonomy", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task Labels_ApplyRecommendedTaxonomy_WhenConfirmed_ShowsSummary()
+    {
+        // Arrange
+        var repoA = CreateRepository("owner", "repo-a");
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repoA]);
+
+        _labelManagerServiceMock
+            .Setup(service => service.PreviewRecommendedTaxonomyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new RecommendedTaxonomyRepositoryPreviewDto(
+                    "owner/repo-a",
+                    [new LabelDto("type/story", "1d76db", "Story", "owner/repo-a")],
+                    [],
+                    []),
+            ]);
+
+        _labelManagerServiceMock
+            .Setup(service => service.ApplyRecommendedTaxonomyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new RecommendedTaxonomyRepositoryResultDto("owner/repo-a", 1, 0, 0, null),
+            ]);
+
+        _labelManagerServiceMock
+            .Setup(service => service.GetLabelsForRepositoriesAsync("owner", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<LabelDto>());
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Labels>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
+
+        await SelectRepositoriesAsync(cut, repoA);
+        cut.Find("[data-testid='preview-taxonomy-button']").Click();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='confirm-apply-taxonomy-button']"));
+
+        cut.Find("[data-testid='confirm-apply-taxonomy-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Apply summary", cut.Markup);
+            Assert.Contains("Created: 1, Updated: 0, Skipped: 0", cut.Markup);
+            Assert.Contains("Applied taxonomy successfully", cut.Markup);
+        });
+
+        _labelManagerServiceMock.Verify(
+            service => service.ApplyRecommendedTaxonomyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private BunitContext CreateContext()
     {
         var ctx = new BunitContext();
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
+
+        _labelManagerServiceMock
+            .Setup(service => service.GetRecommendedLabelStrategiesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new RecommendedLabelStrategyDto("solodevboard", "SoloDevBoard", "SoloDevBoard canonical taxonomy"),
+                new RecommendedLabelStrategyDto("github-default", "GitHub default", "GitHub default labels"),
+            ]);
+
         ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
         ctx.Services.AddScoped(_ => _labelManagerServiceMock.Object);
 

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelServiceTests.cs
@@ -469,6 +469,105 @@ public sealed class LabelServiceTests
     }
 
     [Fact]
+    public async Task GetRecommendedLabelStrategiesAsync_WhenCalled_ReturnsBuiltInStrategies()
+    {
+        // Arrange
+        var sut = new LabelService(_labelRepositoryMock.Object);
+
+        // Act
+        var result = await sut.GetRecommendedLabelStrategiesAsync();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, strategy => strategy.Id == "solodevboard");
+        Assert.Contains(result, strategy => strategy.Id == "github-default");
+    }
+
+    [Fact]
+    public async Task PreviewRecommendedTaxonomyAsync_RepositoryHasMixedState_ReturnsCreateUpdateAndSkipped()
+    {
+        // Arrange
+        _labelRepositoryMock
+            .Setup(repository => repository.GetLabelsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new Label { Name = "bug", Colour = "000000", Description = "Outdated", RepositoryName = "repo-a" },
+                new Label { Name = "documentation", Colour = "0075ca", Description = "Improvements or additions to documentation", RepositoryName = "repo-a" },
+            ]);
+
+        var sut = new LabelService(_labelRepositoryMock.Object);
+
+        // Act
+        var result = await sut.PreviewRecommendedTaxonomyAsync("github-default", ["owner/repo-a"]);
+
+        // Assert
+        var preview = Assert.Single(result);
+        Assert.Equal("owner/repo-a", preview.RepositoryFullName);
+        Assert.Contains(preview.ToCreate, label => label.Name == "enhancement");
+        Assert.Contains(preview.ToUpdate, label => label.Name == "bug");
+        Assert.Contains(preview.Skipped, label => label.Name == "documentation");
+    }
+
+    [Fact]
+    public async Task ApplyRecommendedTaxonomyAsync_LabelAlreadyMatches_SkipsWithoutMutatingApiCalls()
+    {
+        // Arrange
+        _labelRepositoryMock
+            .Setup(repository => repository.GetLabelsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new Label { Name = "bug", Colour = "d73a4a", Description = "Something is not working", RepositoryName = "repo-a" },
+                new Label { Name = "documentation", Colour = "0075ca", Description = "Improvements or additions to documentation", RepositoryName = "repo-a" },
+                new Label { Name = "duplicate", Colour = "cfd3d7", Description = "This issue or pull request already exists", RepositoryName = "repo-a" },
+                new Label { Name = "enhancement", Colour = "a2eeef", Description = "New feature or request", RepositoryName = "repo-a" },
+                new Label { Name = "good first issue", Colour = "7057ff", Description = "Good for newcomers", RepositoryName = "repo-a" },
+                new Label { Name = "help wanted", Colour = "008672", Description = "Extra attention is needed", RepositoryName = "repo-a" },
+                new Label { Name = "invalid", Colour = "e4e669", Description = "This does not appear to be valid", RepositoryName = "repo-a" },
+                new Label { Name = "question", Colour = "d876e3", Description = "Further information is requested", RepositoryName = "repo-a" },
+                new Label { Name = "wontfix", Colour = "ffffff", Description = "This will not be worked on", RepositoryName = "repo-a" },
+            ]);
+
+        var sut = new LabelService(_labelRepositoryMock.Object);
+
+        // Act
+        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a"]);
+
+        // Assert
+        var summary = Assert.Single(result);
+        Assert.Equal(0, summary.CreatedCount);
+        Assert.Equal(0, summary.UpdatedCount);
+        Assert.Equal(9, summary.SkippedCount);
+        Assert.False(summary.HasError);
+        _labelRepositoryMock.Verify(repository => repository.CreateLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
+        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ApplyRecommendedTaxonomyAsync_OneRepositoryFails_ReturnsErrorAndContinues()
+    {
+        // Arrange
+        _labelRepositoryMock
+            .Setup(repository => repository.GetLabelsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Label>());
+
+        _labelRepositoryMock
+            .Setup(repository => repository.GetLabelsAsync("owner", "repo-b", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Rate limited"));
+
+        _labelRepositoryMock
+            .Setup(repository => repository.CreateLabelAsync("owner", "repo-a", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string repo, Label value, CancellationToken _) => value with { RepositoryName = repo });
+
+        var sut = new LabelService(_labelRepositoryMock.Object);
+
+        // Act
+        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a", "owner/repo-b"]);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, item => item.RepositoryFullName == "owner/repo-a" && item.CreatedCount == 9 && !item.HasError);
+        Assert.Contains(result, item => item.RepositoryFullName == "owner/repo-b" && item.HasError && item.ErrorMessage == "Rate limited");
+    }
+
+    [Fact]
     public async Task GetLabelsForRepositoriesAsync_RepositoriesEmpty_ThrowsArgumentException()
     {
         // Arrange

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelServiceTests.cs
@@ -568,6 +568,29 @@ public sealed class LabelServiceTests
     }
 
     [Fact]
+    public async Task ApplyRecommendedTaxonomyAsync_OneRepositoryHasInvalidFormat_ReturnsErrorAndContinues()
+    {
+        // Arrange
+        _labelRepositoryMock
+            .Setup(repository => repository.GetLabelsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Label>());
+
+        _labelRepositoryMock
+            .Setup(repository => repository.CreateLabelAsync("owner", "repo-a", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string repo, Label value, CancellationToken _) => value with { RepositoryName = repo });
+
+        var sut = new LabelService(_labelRepositoryMock.Object);
+
+        // Act
+        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a", "invalid-format"]);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, item => item.RepositoryFullName == "owner/repo-a" && item.CreatedCount == 9 && !item.HasError);
+        Assert.Contains(result, item => item.RepositoryFullName == "invalid-format" && item.HasError && item.ErrorMessage!.Contains("owner/repository format", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task GetLabelsForRepositoriesAsync_RepositoriesEmpty_ThrowsArgumentException()
     {
         // Arrange


### PR DESCRIPTION
## Summary of Changes

Implements the full recommended taxonomy workflow for the Label Manager page:

- Two built-in strategies: **SoloDevBoard Recommended** (30 labels across `type/`, `priority/`, `status/`, `area/`, `size/`) and **GitHub Default** (9 standard labels).
- Strategy selector in the Label Manager UI with description text.
- **Preview** step: per-repository breakdown of labels to create, to update, and to skip, rendered in colour-coded tables with hex swatches.
- **Confirm / Cancel** flow before any changes are applied.
- **Apply summary**: per-repository counts of created, updated, and skipped labels; graceful per-repository error isolation so one failing repository does not abort the others.
- All taxonomy constants live in the Application layer (offline, not fetched externally — per the issue acceptance criteria).

## Related Issue(s)

Closes #34

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`) — 93 tests, 0 failures
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

UI changes included: strategy selector, colour-swatch preview tables, apply summary card.

## Additional Notes

New DTOs: `RecommendedLabelStrategyDto`, `RecommendedTaxonomyRepositoryPreviewDto`, `RecommendedTaxonomyRepositoryResultDto` — all in `SoloDevBoard.Application`.

New private helper `GetColourIconStyle` in `Labels.razor.cs` normalises hex colour values for the `MudIcon` circle swatch rendered in the preview table.

Four new `LabelService` unit tests and two new `Labels` bUnit component tests added.