### PR TITLE
[type/story] About page with version and runtime information (#59, #61)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ It is built with the solo developer in mind: opinionated defaults, minimal confi
 
 - 📖 [Getting Started](getting-started.md) — prerequisites, local setup, and configuration
 - 👤 [User Guide](user-guide/) — detailed guides for each feature area
+- ℹ️ [About Guide](user-guide/about.md) — overview of the About page, version information, and repository link.
 
 ---
 

--- a/docs/user-guide/about.md
+++ b/docs/user-guide/about.md
@@ -22,7 +22,7 @@ The About page offers a concise summary of the application's identity and techni
 
 ## How to Access
 
-- Click the **About** link in the sidebar navigation menu.
+- Click the **More options** (three dots) menu in the app bar, then select **About**.
 - Visit the `/about` route directly in your browser.
 
 ## Notes

--- a/docs/user-guide/about.md
+++ b/docs/user-guide/about.md
@@ -1,0 +1,32 @@
+---
+layout: page
+title: About
+parent: User Guide
+nav_order: 10
+---
+
+# About
+
+The About page provides essential information about the SoloDevBoard application, including its version, runtime environment, and repository link.
+
+## Overview
+
+The About page offers a concise summary of the application's identity and technical details. It helps users verify the current version and access the project repository.
+
+## Information Shown
+
+- Application name and branding.
+- Application version, retrieved from the centralised `IAppVersionService`.
+- .NET runtime version currently in use.
+- Link to the SoloDevBoard GitHub repository.
+
+## How to Access
+
+- Click the **About** link in the sidebar navigation menu.
+- Visit the `/about` route directly in your browser.
+
+## Notes
+
+- The application version is sourced from `Directory.Build.props` and exposed via the `AppVersionService`.
+- Version information is centralised to ensure consistency across the application.
+- The About page is designed for transparency and easy access to technical details.

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -182,11 +182,11 @@ Labels: `type/chore`, `area/infrastructure`
 <!-- Feature #56: Application Version Centralisation + About Page (planned 2026-03-08, milestone v0.2.0) -->
 <!-- Enablers: #57 Centralise version in Directory.Build.props + IAppVersionService, #58 Dynamic user-agent from IAppVersionService -->
 <!-- Story: #59 About page showing app version information -->
-<!-- Tests: #60 AppVersionService unit tests (done — 2026-03-10), #61 About page bUnit component tests -->
+<!-- Tests: #60 AppVersionService unit tests (done — 2026-03-10), #61 About page bUnit component tests (done — 2026-03-10) -->
 
 - [x] As a solo developer, I want the application version to be declared in a single place so that all version references (user-agent, About page, build artefacts) remain consistent automatically. _(#57 — done, 2026-03-10)_
 - [x] As a solo developer, I want the GitHub API user-agent string to reflect the running application version so that it never drifts from the actual release. _(#58 — done, 2026-03-10)_
-- [ ] As a solo developer, I want an About page showing the application version and .NET runtime version so that I always know which version I am running. _(#59 status/todo — v0.2.0)_
+- [x] As a solo developer, I want an About page showing the application version and .NET runtime version so that I always know which version I am running. _(#59 — done, 2026-03-10)_
 - [ ] Set up Bicep infrastructure for Azure App Service, Key Vault, and managed identity.
 - [ ] Configure OIDC authentication for GitHub Actions to Azure (no long-lived credentials).
 - [ ] Implement response caching for GitHub API calls to respect rate limits.

--- a/src/App/SoloDevBoard.App/Components/Layout/MainLayout.razor
+++ b/src/App/SoloDevBoard.App/Components/Layout/MainLayout.razor
@@ -12,7 +12,9 @@
         <MudText Typo="Typo.h5" Class="ml-3">SoloDevBoard</MudText>
         <MudSpacer />
         <MudIconButton Icon="@(DarkLightModeButtonIcon)" Color="Color.Inherit" OnClick="@DarkModeToggle" />
-        <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Color="Color.Inherit" Edge="Edge.End" />
+        <MudMenu Icon="@Icons.Material.Filled.MoreVert" Color="Color.Inherit" AriaLabel="More options">
+            <MudMenuItem Href="/about" Icon="@Icons.Material.Filled.Info">About</MudMenuItem>
+        </MudMenu>
     </MudAppBar>
     <MudDrawer id="nav-drawer" @bind-Open="_drawerOpen" ClipMode="DrawerClipMode.Always" Elevation="2">
         <NavMenu />

--- a/src/App/SoloDevBoard.App/Components/Layout/NavMenu.razor
+++ b/src/App/SoloDevBoard.App/Components/Layout/NavMenu.razor
@@ -20,8 +20,5 @@
     <MudNavLink Href="/workflows" Icon="@Icons.Material.Filled.AccountTree">
         Workflows
     </MudNavLink>
-    <MudNavLink Href="/about" Icon="@Icons.Material.Filled.Info">
-        About
-    </MudNavLink>
 </MudNavMenu>
 

--- a/src/App/SoloDevBoard.App/Components/Layout/NavMenu.razor
+++ b/src/App/SoloDevBoard.App/Components/Layout/NavMenu.razor
@@ -20,5 +20,8 @@
     <MudNavLink Href="/workflows" Icon="@Icons.Material.Filled.AccountTree">
         Workflows
     </MudNavLink>
+    <MudNavLink Href="/about" Icon="@Icons.Material.Filled.Info">
+        About
+    </MudNavLink>
 </MudNavMenu>
 

--- a/src/App/SoloDevBoard.App/Components/Pages/About.razor
+++ b/src/App/SoloDevBoard.App/Components/Pages/About.razor
@@ -1,0 +1,32 @@
+@page "/about"
+
+<PageTitle>About</PageTitle>
+
+<MudStack Spacing="3">
+    <MudText Typo="Typo.h4">About</MudText>
+    <MudText Typo="Typo.body1">Version and runtime information for the current SoloDevBoard deployment.</MudText>
+
+    <MudPaper Class="pa-4" Elevation="1">
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.h6" data-testid="about-application-name">@ApplicationName</MudText>
+
+            <MudStack Row="true" Spacing="1">
+                <MudText Typo="Typo.subtitle2">Version:</MudText>
+                <MudText Typo="Typo.body2" data-testid="about-version">@Version</MudText>
+            </MudStack>
+
+            <MudStack Row="true" Spacing="1">
+                <MudText Typo="Typo.subtitle2">.NET runtime:</MudText>
+                <MudText Typo="Typo.body2" data-testid="about-dotnet-version">@DotNetRuntimeVersion</MudText>
+            </MudStack>
+
+            <MudLink Href="@RepositoryUrl"
+                     Target="_blank"
+                     Rel="noopener noreferrer"
+                     Typo="Typo.body2"
+                     data-testid="about-repository-link">
+                View the source repository
+            </MudLink>
+        </MudStack>
+    </MudPaper>
+</MudStack>

--- a/src/App/SoloDevBoard.App/Components/Pages/About.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Pages/About.razor.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Components;
+using SoloDevBoard.Application.Services;
+
+namespace SoloDevBoard.App.Components.Pages;
+
+/// <summary>Displays application and runtime version information.</summary>
+public partial class About : ComponentBase
+{
+    private const string RepositoryAddress = "https://github.com/markheydon/solo-dev-board";
+    private const string ProductName = "SoloDevBoard";
+
+    /// <summary>Gets or sets the service that exposes application version metadata.</summary>
+    [Inject]
+    public IAppVersionService AppVersionService { get; set; } = default!;
+
+    private string ApplicationName => ProductName;
+
+    private string Version => AppVersionService.Version;
+
+    private string DotNetRuntimeVersion => Environment.Version.ToString();
+
+    private string RepositoryUrl => RepositoryAddress;
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
@@ -1,0 +1,107 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MudBlazor.Services;
+using SoloDevBoard.App.Components.Pages;
+using SoloDevBoard.Application.Services;
+
+namespace SoloDevBoard.App.Tests;
+
+/// <summary>Component tests for the <see cref="About"/> page.</summary>
+public sealed class AboutTests : BunitContext
+{
+    private readonly Mock<IAppVersionService> _appVersionServiceMock = new();
+
+    /// <summary>Initialises MudBlazor services and test doubles for About page rendering.</summary>
+    public AboutTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton(_appVersionServiceMock.Object);
+    }
+
+    [Fact]
+    public void AboutPage_RenderedWithMockedVersionService_RendersWithoutError()
+    {
+        // Arrange
+        _appVersionServiceMock
+            .Setup(service => service.Version)
+            .Returns("1.2.3");
+
+        _appVersionServiceMock
+            .Setup(service => service.UserAgent)
+            .Returns("SoloDevBoard/1.2.3");
+
+        // Act
+        Exception? exception = null;
+        try
+        {
+            _ = Render<About>();
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+
+        // Assert
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void AboutPage_RenderedWithMockedVersionService_DisplaysVersionFromService()
+    {
+        // Arrange
+        _appVersionServiceMock
+            .Setup(service => service.Version)
+            .Returns("1.2.3");
+
+        _appVersionServiceMock
+            .Setup(service => service.UserAgent)
+            .Returns("SoloDevBoard/1.2.3");
+
+        // Act
+        var cut = Render<About>();
+
+        // Assert
+        Assert.Contains("1.2.3", cut.Markup);
+    }
+
+    [Fact]
+    public void AboutPage_Rendered_DisplaysRepositoryLink()
+    {
+        // Arrange
+        _appVersionServiceMock
+            .Setup(service => service.Version)
+            .Returns("1.2.3");
+
+        _appVersionServiceMock
+            .Setup(service => service.UserAgent)
+            .Returns("SoloDevBoard/1.2.3");
+
+        // Act
+        var cut = Render<About>();
+
+        // Assert
+        var link = cut.Find("[data-testid='about-repository-link']");
+        Assert.Equal("https://github.com/markheydon/solo-dev-board", link.GetAttribute("href"));
+    }
+
+    [Fact]
+    public void AboutPage_Rendered_DisplaysDotNetVersion()
+    {
+        // Arrange
+        _appVersionServiceMock
+            .Setup(service => service.Version)
+            .Returns("1.2.3");
+
+        _appVersionServiceMock
+            .Setup(service => service.UserAgent)
+            .Returns("SoloDevBoard/1.2.3");
+
+        // Act
+        var cut = Render<About>();
+
+        // Assert
+        Assert.Contains(Environment.Version.ToString(), cut.Markup);
+    }
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
@@ -10,6 +10,7 @@ namespace SoloDevBoard.App.Tests;
 /// <summary>Component tests for the <see cref="About"/> page.</summary>
 public sealed class AboutTests : BunitContext
 {
+    private const string TestVersion = "1.2.3";
     private readonly Mock<IAppVersionService> _appVersionServiceMock = new();
 
     /// <summary>Initialises MudBlazor services and test doubles for About page rendering.</summary>
@@ -17,67 +18,44 @@ public sealed class AboutTests : BunitContext
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
         Services.AddMudServices();
+        ConfigureVersionService();
         Services.AddSingleton(_appVersionServiceMock.Object);
+    }
+
+    private void ConfigureVersionService()
+    {
+        _appVersionServiceMock
+            .Setup(service => service.Version)
+            .Returns(TestVersion);
+
+        _appVersionServiceMock
+            .Setup(service => service.UserAgent)
+            .Returns($"SoloDevBoard/{TestVersion}");
     }
 
     [Fact]
     public void AboutPage_RenderedWithMockedVersionService_RendersWithoutError()
     {
-        // Arrange
-        _appVersionServiceMock
-            .Setup(service => service.Version)
-            .Returns("1.2.3");
-
-        _appVersionServiceMock
-            .Setup(service => service.UserAgent)
-            .Returns("SoloDevBoard/1.2.3");
-
         // Act
-        Exception? exception = null;
-        try
-        {
-            _ = Render<About>();
-        }
-        catch (Exception ex)
-        {
-            exception = ex;
-        }
+        var cut = Render<About>();
 
         // Assert
-        Assert.Null(exception);
+        Assert.NotNull(cut);
     }
 
     [Fact]
     public void AboutPage_RenderedWithMockedVersionService_DisplaysVersionFromService()
     {
-        // Arrange
-        _appVersionServiceMock
-            .Setup(service => service.Version)
-            .Returns("1.2.3");
-
-        _appVersionServiceMock
-            .Setup(service => service.UserAgent)
-            .Returns("SoloDevBoard/1.2.3");
-
         // Act
         var cut = Render<About>();
 
         // Assert
-        Assert.Contains("1.2.3", cut.Markup);
+        Assert.Contains(TestVersion, cut.Markup);
     }
 
     [Fact]
     public void AboutPage_Rendered_DisplaysRepositoryLink()
     {
-        // Arrange
-        _appVersionServiceMock
-            .Setup(service => service.Version)
-            .Returns("1.2.3");
-
-        _appVersionServiceMock
-            .Setup(service => service.UserAgent)
-            .Returns("SoloDevBoard/1.2.3");
-
         // Act
         var cut = Render<About>();
 
@@ -89,15 +67,6 @@ public sealed class AboutTests : BunitContext
     [Fact]
     public void AboutPage_Rendered_DisplaysDotNetVersion()
     {
-        // Arrange
-        _appVersionServiceMock
-            .Setup(service => service.Version)
-            .Returns("1.2.3");
-
-        _appVersionServiceMock
-            .Setup(service => service.UserAgent)
-            .Returns("SoloDevBoard/1.2.3");
-
         // Act
         var cut = Render<About>();
 


### PR DESCRIPTION
## Summary of Changes

Implements the About page (`/about`) for SoloDevBoard, exposing the running application version, .NET runtime version, and a link to the source repository. The version string is sourced from `IAppVersionService` — the single-source-of-truth service introduced in PR #82.

Navigation to the About page is provided via the existing **three-dots (⋮) menu in the app bar**, rather than a dedicated sidebar entry. This placement keeps the sidebar focused on primary workflows and is consistent with how modern web applications expose meta-navigation. (This supersedes the original acceptance criterion that specified a sidebar entry, which was revised at the owner's direction during implementation.)

Covers both stories in Feature #56 not shipped in PR #82.

## Related Issue(s)

Closes #59
Closes #61

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`) — 108 passed, 0 failed
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

N/A — UI is navigable at `/about` in the running app.

## Additional Notes

### Files changed
- `src/App/SoloDevBoard.App/Components/Pages/About.razor` — new page component with MudBlazor layout and `data-testid` attributes
- `src/App/SoloDevBoard.App/Components/Pages/About.razor.cs` — code-behind; injects `IAppVersionService`, exposes `Environment.Version` for .NET runtime display
- `src/App/SoloDevBoard.App/Components/Layout/MainLayout.razor` — `MudIconButton` (MoreVert) replaced with `MudMenu` containing an About `MudMenuItem` (navigates to `/about`)
- `src/App/SoloDevBoard.App/Components/Layout/NavMenu.razor` — no About sidebar entry (moved to app bar menu)
- `tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs` — four bUnit tests covering render, version display, repository link, and .NET version display
- `docs/user-guide/about.md` — new user guide page
- `docs/index.md` — quick link added for About guide
- `plan/BACKLOG.md` — issues #59 and #61 marked complete