### PR TITLE
[type/story] View health indicators and filter by repository on the Audit Dashboard

### DIFF
--- a/docs/user-guide/audit-dashboard.md
+++ b/docs/user-guide/audit-dashboard.md
@@ -7,7 +7,7 @@ nav_order: 2
 
 # Audit Dashboard
 
-The Audit Dashboard provides a summary of open issues and open pull requests across all your GitHub repositories in SoloDevBoard.
+The Audit Dashboard provides a summary of open issues, open pull requests, and repository health indicators across all your GitHub repositories in SoloDevBoard.
 
 ## Accessing the Audit Dashboard
 
@@ -22,16 +22,28 @@ The Audit Dashboard provides a summary of open issues and open pull requests acr
 - A loading skeleton is shown while data is being fetched.
 - An empty state is displayed if no repositories are returned.
 - The browser page title is set to 'Audit Dashboard — SoloDevBoard'.
+- A repository filter allows you to focus the dashboard on a single repository.
+- The Unlabelled Issues section shows issues without any labels, including repository, issue number, title, and age.
+- The Stale Pull Requests section lists pull requests with no activity in the last 14 days, including repository, pull request number, title, author, and days since update.
+- The Failing Workflows section shows the latest run for each workflow where the conclusion is failure or cancelled, including repository, workflow name, branch, and run link.
+- Each health indicator section shows a badge count and uses MudBlazor expansion panels for expand and collapse behaviour.
+- Links in health indicator sections open in a new browser tab.
 
 ## Usage
 
 1. Open the Audit Dashboard from the dashboard or navigation menu.
-2. Review the grid to see open issues and pull requests for each repository.
-3. Click a repository name to open it directly in GitHub.
-4. Use the summary cards to view total open issues and pull requests.
+2. Use the repository filter to select a specific repository or view all.
+3. Review the grid to see open issues and pull requests for each repository.
+4. Click a repository name to open it directly in GitHub.
+5. Use the summary cards to view total open issues and pull requests.
+6. Expand the health indicator panels to review unlabelled issues, stale pull requests, and failing workflows.
+7. Click links in health sections to open items in GitHub (in a new tab).
 
 ## Notes
 
-- Health indicators (such as label consistency, stale PRs, workflow status) and filtering by repository are planned for future stories and are not included in the current release.
+Zero-state messages are shown when no items are found in a health indicator section:
+- "No unlabelled issues — great!"
+- "No stale pull requests — great!"
+- "No failing workflows  great!"
 
 For more information about upcoming features, see the [BACKLOG](../../plan/BACKLOG.md).

--- a/docs/user-guide/audit-dashboard.md
+++ b/docs/user-guide/audit-dashboard.md
@@ -16,13 +16,13 @@ The Audit Dashboard provides a summary of open issues, open pull requests, and r
 
 ## Features
 
+- A repository selector lets you choose one or more of your active GitHub repositories before loading any data.
 - Each repository is shown as a row in a sortable MudBlazor grid.
 - Columns include repository full name (linked to GitHub), open issue count, and open pull request count.
 - Total summary cards display aggregate open issues and open pull requests across all repositories.
-- A loading skeleton is shown while data is being fetched.
+- A loading skeleton is shown while repository options are loading, and again while audit data is being fetched.
 - An empty state is displayed if no repositories are returned.
 - The browser page title is set to 'Audit Dashboard — SoloDevBoard'.
-- A repository filter allows you to focus the dashboard on a single repository.
 - The Unlabelled Issues section shows issues without any labels, including repository, issue number, title, and age.
 - The Stale Pull Requests section lists pull requests with no activity in the last 14 days, including repository, pull request number, title, author, and days since update.
 - The Failing Workflows section shows the latest run for each workflow where the conclusion is failure or cancelled, including repository, workflow name, branch, and run link.
@@ -32,12 +32,15 @@ The Audit Dashboard provides a summary of open issues, open pull requests, and r
 ## Usage
 
 1. Open the Audit Dashboard from the dashboard or navigation menu.
-2. Use the repository filter to select a specific repository or view all.
-3. Review the grid to see open issues and pull requests for each repository.
-4. Click a repository name to open it directly in GitHub.
-5. Use the summary cards to view total open issues and pull requests.
-6. Expand the health indicator panels to review unlabelled issues, stale pull requests, and failing workflows.
-7. Click links in health sections to open items in GitHub (in a new tab).
+2. Use the repository selector autocomplete to search and select the repositories you want to audit.
+3. Use **Select all** to include every active repository, or **Clear** to reset the selection.
+4. Click **Load selected repositories** to fetch audit data for the chosen set.
+5. Review the summary grid to see open issues and pull requests per repository.
+6. Click a repository name to open it directly in GitHub.
+7. Use the summary cards to view total open issues and pull requests.
+8. Expand the health indicator panels to review unlabelled issues, stale pull requests, and failing workflows.
+9. Click links in health sections to open items in GitHub (in a new tab).
+10. To change the repository set, adjust the selector and click **Load selected repositories** again.
 
 ## Notes
 

--- a/docs/user-guide/audit-dashboard.md
+++ b/docs/user-guide/audit-dashboard.md
@@ -44,6 +44,6 @@ The Audit Dashboard provides a summary of open issues, open pull requests, and r
 Zero-state messages are shown when no items are found in a health indicator section:
 - "No unlabelled issues — great!"
 - "No stale pull requests — great!"
-- "No failing workflows  great!"
+- "No failing workflows — great!"
 
 For more information about upcoming features, see the [BACKLOG](../../plan/BACKLOG.md).

--- a/docs/user-guide/audit-dashboard.md
+++ b/docs/user-guide/audit-dashboard.md
@@ -45,8 +45,8 @@ The Audit Dashboard provides a summary of open issues, open pull requests, and r
 ## Notes
 
 Zero-state messages are shown when no items are found in a health indicator section:
-- "No unlabelled issues — great!"
-- "No stale pull requests — great!"
-- "No failing workflows — great!"
+- "No unlabelled issues — great."
+- "No stale pull requests — great."
+- "No failing workflows — great."
 
 For more information about upcoming features, see the [BACKLOG](../../plan/BACKLOG.md).

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -43,9 +43,9 @@ Labels: `type/epic`, `area/dashboard`
 
 - [x] As a solo developer, I want to see a summary of open issues across all my repositories so that I can quickly identify where work is needed. _(#43 status/done — v0.2.0)_
 - [x] As a solo developer, I want to see all open pull requests across my repositories so that I can track code review activity. _(#43 status/done — v0.2.0)_
-- [ ] As a solo developer, I want to see which issues have no labels so that I can identify items that need triage. _(#44 status/todo — v0.2.0)_
-- [ ] As a solo developer, I want to see which pull requests are stale (no activity in the last 14 days) so that I can follow them up. _(#44 status/todo — v0.2.0)_
-- [ ] As a solo developer, I want to see the status of GitHub Actions workflows across my repositories so that I can quickly spot build failures. _(#44 status/todo — v0.2.0)_
+- [ ] As a solo developer, I want to see which issues have no labels so that I can identify items that need triage. _(#44 status/in-progress — v0.2.0)_
+- [ ] As a solo developer, I want to see which pull requests are stale (no activity in the last 14 days) so that I can follow them up. _(#44 status/in-progress — v0.2.0)_
+- [ ] As a solo developer, I want to see the status of GitHub Actions workflows across my repositories so that I can quickly spot build failures. _(#44 status/in-progress — v0.2.0)_
 - [ ] As a solo developer, I want to filter the Audit Dashboard by repository so that I can focus on one project at a time. _(#45 status/todo — v0.2.0)_
 - [ ] As a solo developer, I want the Audit Dashboard to refresh automatically so that I always see current data.
 - [ ] As a solo developer, I want to export an audit summary as a Markdown report so that I can paste it into a planning document.

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -43,10 +43,10 @@ Labels: `type/epic`, `area/dashboard`
 
 - [x] As a solo developer, I want to see a summary of open issues across all my repositories so that I can quickly identify where work is needed. _(#43 status/done — v0.2.0)_
 - [x] As a solo developer, I want to see all open pull requests across my repositories so that I can track code review activity. _(#43 status/done — v0.2.0)_
-- [ ] As a solo developer, I want to see which issues have no labels so that I can identify items that need triage. _(#44 status/in-progress — v0.2.0)_
-- [ ] As a solo developer, I want to see which pull requests are stale (no activity in the last 14 days) so that I can follow them up. _(#44 status/in-progress — v0.2.0)_
-- [ ] As a solo developer, I want to see the status of GitHub Actions workflows across my repositories so that I can quickly spot build failures. _(#44 status/in-progress — v0.2.0)_
-- [ ] As a solo developer, I want to filter the Audit Dashboard by repository so that I can focus on one project at a time. _(#45 status/todo — v0.2.0)_
+- [x] As a solo developer, I want to see which issues have no labels so that I can identify items that need triage. _(#44 status/done — v0.2.0)_
+- [x] As a solo developer, I want to see which pull requests are stale (no activity in the last 14 days) so that I can follow them up. _(#44 status/done — v0.2.0)_
+- [x] As a solo developer, I want to see the status of GitHub Actions workflows across my repositories so that I can quickly spot build failures. _(#44 status/done — v0.2.0)_
+- [x] As a solo developer, I want to filter the Audit Dashboard by repository so that I can focus on one project at a time. _(#44 status/done — v0.2.0; selection-first multi-select repository filter with shared RepositorySelector component; #45 merged into this story)_
 - [ ] As a solo developer, I want the Audit Dashboard to refresh automatically so that I always see current data.
 - [ ] As a solo developer, I want to export an audit summary as a Markdown report so that I can paste it into a planning document.
 - [ ] As a solo developer, I want to see my project board state at a glance (item count per status column and current active load) so that I can assess capacity before committing to more work.

--- a/src/App/SoloDevBoard.App/Components/Pages/Audit.razor
+++ b/src/App/SoloDevBoard.App/Components/Pages/Audit.razor
@@ -7,36 +7,36 @@
     <MudText Typo="Typo.h4">Audit Dashboard</MudText>
     <MudText Typo="Typo.body1">Review repository health signals across your active repositories.</MudText>
 
-    @if (isLoading)
+    @if (isLoadingRepositories)
     {
-        <MudPaper Class="pa-4" Elevation="1" aria-live="polite" role="status" data-testid="audit-loading-state">
+        <MudPaper Class="pa-3" Outlined="true" data-testid="audit-repository-filter-loading">
             <MudStack Spacing="2">
-                <MudSkeleton Height="28px" Width="260px" Animation="Animation.Wave" />
-                <MudGrid>
-                    <MudItem xs="12" md="4">
-                        <MudSkeleton Height="86px" Animation="Animation.Wave" />
-                    </MudItem>
-                    <MudItem xs="12" md="4">
-                        <MudSkeleton Height="86px" Animation="Animation.Wave" />
-                    </MudItem>
-                    <MudItem xs="12" md="4">
-                        <MudSkeleton Height="86px" Animation="Animation.Wave" />
-                    </MudItem>
-                </MudGrid>
-                <MudSkeleton Height="280px" Animation="Animation.Wave" />
+                <MudText Typo="Typo.subtitle2">Repository filter</MudText>
+                <MudSkeleton Height="56px" Animation="Animation.Wave" />
+                <MudSkeleton Height="36px" Width="220px" Animation="Animation.Wave" />
+                <MudSkeleton Height="20px" Width="340px" Animation="Animation.Wave" />
             </MudStack>
         </MudPaper>
+
+        @if (isLoadingAuditData)
+        {
+            <MudPaper Class="pa-4" Elevation="1" aria-live="polite" role="status" data-testid="audit-loading-state">
+                <MudStack Spacing="2">
+                    <MudSkeleton Height="20px" Width="320px" Animation="Animation.Wave" />
+                </MudStack>
+            </MudPaper>
+        }
     }
-    else if (!string.IsNullOrWhiteSpace(errorMessage))
+    else if (!string.IsNullOrWhiteSpace(repositoryLoadErrorMessage))
     {
         <MudPaper Class="pa-4" Elevation="1" aria-live="assertive" role="alert" data-testid="audit-error-state">
             <MudStack Spacing="2">
-                <MudText Typo="Typo.h6">Unable to load audit summary</MudText>
-                <MudText Typo="Typo.body2">@errorMessage</MudText>
+                <MudText Typo="Typo.h6">Unable to load repositories</MudText>
+                <MudText Typo="Typo.body2">@repositoryLoadErrorMessage</MudText>
             </MudStack>
         </MudPaper>
     }
-    else if (repositorySummaries.Count == 0)
+    else if (repositoryOptions.Count == 0)
     {
         <MudPaper Class="pa-4" Elevation="1" aria-live="polite" data-testid="audit-empty-state">
             <MudStack Spacing="1">
@@ -50,63 +50,100 @@
         <MudPaper Class="pa-3" Outlined="true" data-testid="audit-repository-filter">
             <MudStack Spacing="2">
                 <MudText Typo="Typo.subtitle2">Repository filter</MudText>
-                <MudSelect T="string"
-                           Label="Repositories"
-                           MultiSelection="true"
-                           SelectedValues="selectedRepositories"
-                           SelectedValuesChanged="OnSelectedRepositoriesChanged"
-                           Dense="true"
-                           Clearable="false">
-                    @foreach (var repository in repositoryOptions)
-                    {
-                        <MudSelectItem T="string" Value="@repository">@repository</MudSelectItem>
-                    }
-                </MudSelect>
+                <RepositorySelector
+                    Title=""
+                    Label="Repositories"
+                    Placeholder="Search repositories and add to the filter"
+                    EmptyStateText="No active repositories are available for filtering."
+                    AvailableRepositories="repositoryOptions"
+                    SelectedRepositories="selectedRepositoryNames"
+                    SelectedRepositoriesChanged="OnSelectedRepositoriesChanged"
+                    SummaryText="@RepositoryFilterSummary"
+                    ShowSelectedChips="false"
+                    ShowSelectionActions="true"
+                    Disabled="isLoadingRepositories || isLoadingAuditData"
+                    AutocompleteTestId="audit-repository-autocomplete"
+                    SummaryTestId="audit-repository-summary" />
+
+                <MudButton Variant="Variant.Outlined"
+                           Color="Color.Secondary"
+                           Disabled="@(isLoadingRepositories || isLoadingAuditData || selectedRepositoryNames.Count == 0)"
+                           OnClick="LoadSelectedRepositoriesAsync"
+                           data-testid="audit-load-selected-button">
+                    Load selected repositories
+                </MudButton>
             </MudStack>
         </MudPaper>
 
-        <MudGrid>
-            <MudItem xs="12" sm="6">
-                <MudPaper Class="pa-3" Outlined="true" data-testid="audit-total-issues-card">
-                    <MudText Typo="Typo.caption">Total open issues</MudText>
-                    <MudText Typo="Typo.h5">@totalOpenIssues</MudText>
-                </MudPaper>
-            </MudItem>
-            <MudItem xs="12" sm="6">
-                <MudPaper Class="pa-3" Outlined="true" data-testid="audit-total-prs-card">
-                    <MudText Typo="Typo.caption">Total open pull requests</MudText>
-                    <MudText Typo="Typo.h5">@totalOpenPullRequests</MudText>
-                </MudPaper>
-            </MudItem>
-        </MudGrid>
+        @if (isLoadingAuditData)
+        {
+            <MudPaper Class="pa-4" Elevation="1" aria-live="polite" role="status" data-testid="audit-loading-state">
+                <MudStack Spacing="2">
+                    <MudSkeleton Height="86px" Animation="Animation.Wave" />
+                    <MudSkeleton Height="240px" Animation="Animation.Wave" />
+                    <MudSkeleton Height="240px" Animation="Animation.Wave" />
+                </MudStack>
+            </MudPaper>
+        }
+        else if (!string.IsNullOrWhiteSpace(auditLoadErrorMessage))
+        {
+            <MudPaper Class="pa-4" Elevation="1" aria-live="assertive" role="alert" data-testid="audit-summary-error-state">
+                <MudStack Spacing="2">
+                    <MudText Typo="Typo.h6">Unable to load audit summary</MudText>
+                    <MudText Typo="Typo.body2">@auditLoadErrorMessage</MudText>
+                </MudStack>
+            </MudPaper>
+        }
+        else if (!hasLoadedAuditSummary)
+        {
+            <MudPaper Class="pa-4" Elevation="1" data-testid="audit-selection-prompt">
+                <MudText Typo="Typo.body2">Select one or more repositories, then load the audit summary.</MudText>
+            </MudPaper>
+        }
+        else
+        {
+            <MudGrid>
+                <MudItem xs="12" sm="6">
+                    <MudPaper Class="pa-3" Outlined="true" data-testid="audit-total-issues-card">
+                        <MudText Typo="Typo.caption">Total open issues</MudText>
+                        <MudText Typo="Typo.h5">@totalOpenIssues</MudText>
+                    </MudPaper>
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudPaper Class="pa-3" Outlined="true" data-testid="audit-total-prs-card">
+                        <MudText Typo="Typo.caption">Total open pull requests</MudText>
+                        <MudText Typo="Typo.h5">@totalOpenPullRequests</MudText>
+                    </MudPaper>
+                </MudItem>
+            </MudGrid>
 
-        <MudPaper Class="pa-2" Elevation="1" data-testid="audit-summary-table">
-            <MudDataGrid T="RepositoryAuditSummaryDto"
-                         Items="repositorySummaries"
-                         Hover="true"
-                         Dense="true"
-                         SortMode="SortMode.Multiple">
-                <Columns>
-                    <TemplateColumn Title="Repository" SortBy="summary => summary.RepositoryFullName">
-                        <CellTemplate>
-                            <MudLink Href="@BuildRepositoryUrl(context.Item.RepositoryFullName)"
-                                     Target="_blank"
-                                     rel="noopener noreferrer">
-                                @context.Item.RepositoryFullName
-                            </MudLink>
-                        </CellTemplate>
-                    </TemplateColumn>
-                    <PropertyColumn Property="summary => summary.OpenIssueCount"
-                                    Title="Open issues"
-                                    Sortable="true" />
-                    <PropertyColumn Property="summary => summary.OpenPullRequestCount"
-                                    Title="Open pull requests"
-                                    Sortable="true" />
-                </Columns>
-            </MudDataGrid>
-        </MudPaper>
+            <MudPaper Class="pa-2" Elevation="1" data-testid="audit-summary-table">
+                <MudDataGrid T="RepositoryAuditSummaryDto"
+                             Items="repositorySummaries"
+                             Hover="true"
+                             Dense="true"
+                             SortMode="SortMode.Multiple">
+                    <Columns>
+                        <TemplateColumn Title="Repository" SortBy="summary => summary.RepositoryFullName">
+                            <CellTemplate>
+                                <MudLink Href="@BuildRepositoryUrl(context.Item.RepositoryFullName)"
+                                         Target="_blank"
+                                         rel="noopener noreferrer">
+                                    @context.Item.RepositoryFullName
+                                </MudLink>
+                            </CellTemplate>
+                        </TemplateColumn>
+                        <PropertyColumn Property="summary => summary.OpenIssueCount"
+                                        Title="Open issues"
+                                        Sortable="true" />
+                        <PropertyColumn Property="summary => summary.OpenPullRequestCount"
+                                        Title="Open pull requests"
+                                        Sortable="true" />
+                    </Columns>
+                </MudDataGrid>
+            </MudPaper>
 
-        <MudExpansionPanels MultiExpansion="true" Class="mt-2" data-testid="audit-health-indicator-sections">
+            <MudExpansionPanels MultiExpansion="true" Class="mt-2" data-testid="audit-health-indicator-sections">
             <MudExpansionPanel Expanded="true" data-testid="audit-unlabelled-issues-section">
                 <TitleContent>
                     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
@@ -216,6 +253,7 @@
                     }
                 </ChildContent>
             </MudExpansionPanel>
-        </MudExpansionPanels>
+            </MudExpansionPanels>
+        }
     }
 </MudStack>

--- a/src/App/SoloDevBoard.App/Components/Pages/Audit.razor
+++ b/src/App/SoloDevBoard.App/Components/Pages/Audit.razor
@@ -9,7 +9,7 @@
 
     @if (isLoadingRepositories)
     {
-        <MudPaper Class="pa-3" Outlined="true" data-testid="audit-repository-filter-loading">
+        <MudPaper Class="pa-3" Outlined="true" aria-live="polite" role="status" data-testid="audit-repository-filter-loading">
             <MudStack Spacing="2">
                 <MudText Typo="Typo.subtitle2">Repository filter</MudText>
                 <MudSkeleton Height="56px" Animation="Animation.Wave" />

--- a/src/App/SoloDevBoard.App/Components/Pages/Audit.razor
+++ b/src/App/SoloDevBoard.App/Components/Pages/Audit.razor
@@ -5,7 +5,7 @@
 
 <MudStack Spacing="3">
     <MudText Typo="Typo.h4">Audit Dashboard</MudText>
-    <MudText Typo="Typo.body1">Review open issues and pull requests across your active repositories.</MudText>
+    <MudText Typo="Typo.body1">Review repository health signals across your active repositories.</MudText>
 
     @if (isLoading)
     {
@@ -47,6 +47,24 @@
     }
     else
     {
+        <MudPaper Class="pa-3" Outlined="true" data-testid="audit-repository-filter">
+            <MudStack Spacing="2">
+                <MudText Typo="Typo.subtitle2">Repository filter</MudText>
+                <MudSelect T="string"
+                           Label="Repositories"
+                           MultiSelection="true"
+                           SelectedValues="selectedRepositories"
+                           SelectedValuesChanged="OnSelectedRepositoriesChanged"
+                           Dense="true"
+                           Clearable="false">
+                    @foreach (var repository in repositoryOptions)
+                    {
+                        <MudSelectItem T="string" Value="@repository">@repository</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudStack>
+        </MudPaper>
+
         <MudGrid>
             <MudItem xs="12" sm="6">
                 <MudPaper Class="pa-3" Outlined="true" data-testid="audit-total-issues-card">
@@ -87,5 +105,117 @@
                 </Columns>
             </MudDataGrid>
         </MudPaper>
+
+        <MudExpansionPanels MultiExpansion="true" Class="mt-2" data-testid="audit-health-indicator-sections">
+            <MudExpansionPanel Expanded="true" data-testid="audit-unlabelled-issues-section">
+                <TitleContent>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                        <MudText Typo="Typo.subtitle1">Unlabelled Issues</MudText>
+                        <MudBadge Color="Color.Warning" Content="@unlabelledIssues.Count" />
+                    </MudStack>
+                </TitleContent>
+                <ChildContent>
+                    @if (unlabelledIssues.Count == 0)
+                    {
+                        <MudText Typo="Typo.body2" data-testid="audit-unlabelled-empty">No unlabelled issues — great!</MudText>
+                    }
+                    else
+                    {
+                        <MudTable T="IssueDto" Items="unlabelledIssues" Dense="true" Hover="true" data-testid="audit-unlabelled-table">
+                            <HeaderContent>
+                                <MudTh>Repository</MudTh>
+                                <MudTh>Issue</MudTh>
+                                <MudTh>Title</MudTh>
+                                <MudTh>Age (days)</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Repository">@context.RepositoryFullName</MudTd>
+                                <MudTd DataLabel="Issue">
+                                    <MudLink Href="@context.HtmlUrl" Target="_blank" rel="noopener noreferrer">
+                                        #@context.Number
+                                    </MudLink>
+                                </MudTd>
+                                <MudTd DataLabel="Title">@context.Title</MudTd>
+                                <MudTd DataLabel="Age (days)">@GetDaysBetween(context.CreatedAt)</MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                    }
+                </ChildContent>
+            </MudExpansionPanel>
+
+            <MudExpansionPanel Expanded="true" data-testid="audit-stale-prs-section">
+                <TitleContent>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                        <MudText Typo="Typo.subtitle1">Stale Pull Requests</MudText>
+                        <MudBadge Color="Color.Warning" Content="@stalePullRequests.Count" />
+                    </MudStack>
+                </TitleContent>
+                <ChildContent>
+                    @if (stalePullRequests.Count == 0)
+                    {
+                        <MudText Typo="Typo.body2" data-testid="audit-stale-empty">No stale pull requests — great!</MudText>
+                    }
+                    else
+                    {
+                        <MudTable T="PullRequestDto" Items="stalePullRequests" Dense="true" Hover="true" data-testid="audit-stale-table">
+                            <HeaderContent>
+                                <MudTh>Repository</MudTh>
+                                <MudTh>Pull request</MudTh>
+                                <MudTh>Title</MudTh>
+                                <MudTh>Author</MudTh>
+                                <MudTh>Days since update</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Repository">@context.RepositoryFullName</MudTd>
+                                <MudTd DataLabel="Pull request">
+                                    <MudLink Href="@context.HtmlUrl" Target="_blank" rel="noopener noreferrer">
+                                        #@context.Number
+                                    </MudLink>
+                                </MudTd>
+                                <MudTd DataLabel="Title">@context.Title</MudTd>
+                                <MudTd DataLabel="Author">@context.AuthorLogin</MudTd>
+                                <MudTd DataLabel="Days since update">@GetDaysBetween(context.UpdatedAt)</MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                    }
+                </ChildContent>
+            </MudExpansionPanel>
+
+            <MudExpansionPanel Expanded="true" data-testid="audit-failing-workflows-section">
+                <TitleContent>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                        <MudText Typo="Typo.subtitle1">Failing Workflows</MudText>
+                        <MudBadge Color="Color.Error" Content="@failingWorkflowRuns.Count" />
+                    </MudStack>
+                </TitleContent>
+                <ChildContent>
+                    @if (failingWorkflowRuns.Count == 0)
+                    {
+                        <MudText Typo="Typo.body2" data-testid="audit-workflows-empty">No failing workflows — great!</MudText>
+                    }
+                    else
+                    {
+                        <MudTable T="WorkflowRunDto" Items="failingWorkflowRuns" Dense="true" Hover="true" data-testid="audit-workflows-table">
+                            <HeaderContent>
+                                <MudTh>Repository</MudTh>
+                                <MudTh>Workflow</MudTh>
+                                <MudTh>Branch</MudTh>
+                                <MudTh>Run</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Repository">@context.RepositoryFullName</MudTd>
+                                <MudTd DataLabel="Workflow">@context.WorkflowName</MudTd>
+                                <MudTd DataLabel="Branch">@context.HeadBranch</MudTd>
+                                <MudTd DataLabel="Run">
+                                    <MudLink Href="@context.HtmlUrl" Target="_blank" rel="noopener noreferrer">
+                                        Open run
+                                    </MudLink>
+                                </MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                    }
+                </ChildContent>
+            </MudExpansionPanel>
+        </MudExpansionPanels>
     }
 </MudStack>

--- a/src/App/SoloDevBoard.App/Components/Pages/Audit.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Pages/Audit.razor.cs
@@ -55,7 +55,7 @@ public partial class Audit : ComponentBase
                 .OrderBy(fullName => fullName, StringComparer.OrdinalIgnoreCase)
                 .ToArray();
 
-            selectedRepositories = [];
+            selectedRepositories.Clear();
             hasLoadedAuditSummary = false;
             ResetDashboardData();
         }

--- a/src/App/SoloDevBoard.App/Components/Pages/Audit.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Pages/Audit.razor.cs
@@ -4,7 +4,7 @@ using SoloDevBoard.Application.Services;
 
 namespace SoloDevBoard.App.Components.Pages;
 
-/// <summary>Displays open issue and pull request summary counts across repositories.</summary>
+/// <summary>Displays open issue, pull request, and health indicator summaries across repositories.</summary>
 public partial class Audit : ComponentBase
 {
     private const int StalePullRequestDays = 14;

--- a/src/App/SoloDevBoard.App/Components/Pages/Audit.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Pages/Audit.razor.cs
@@ -9,6 +9,10 @@ public partial class Audit : ComponentBase
 {
     private const int StalePullRequestDays = 14;
 
+    /// <summary>Gets or sets the repository service used to load repository options.</summary>
+    [Inject]
+    public IRepositoryService RepositoryService { get; set; } = default!;
+
     /// <summary>Gets or sets the audit dashboard application service.</summary>
     [Inject]
     public IAuditDashboardService AuditDashboardService { get; set; } = default!;
@@ -25,53 +29,54 @@ public partial class Audit : ComponentBase
     private HashSet<string> selectedRepositories = new(StringComparer.OrdinalIgnoreCase);
     private int totalOpenIssues;
     private int totalOpenPullRequests;
-    private bool isLoading = true;
-    private string? errorMessage;
+    private bool isLoadingRepositories = true;
+    private bool isLoadingAuditData;
+    private bool hasLoadedAuditSummary;
+    private string? repositoryLoadErrorMessage;
+    private string? auditLoadErrorMessage;
 
     protected override async Task OnInitializedAsync()
     {
-        await LoadAuditSummaryAsync();
+        await LoadRepositoryOptionsAsync();
     }
 
-    private async Task LoadAuditSummaryAsync()
+    private async Task LoadRepositoryOptionsAsync()
     {
-        isLoading = true;
-        errorMessage = null;
+        isLoadingRepositories = true;
+        repositoryLoadErrorMessage = null;
+        auditLoadErrorMessage = null;
 
         try
         {
-            var summary = await AuditDashboardService.GetRepositorySummaryAsync();
-            var orderedSummary = summary
-                .OrderBy(result => result.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+            var repositories = await RepositoryService.GetActiveRepositoriesAsync();
+
+            repositoryOptions = repositories
+                .Select(repository => repository.FullName)
+                .OrderBy(fullName => fullName, StringComparer.OrdinalIgnoreCase)
                 .ToArray();
 
-            repositoryOptions = orderedSummary
-                .Select(summaryItem => summaryItem.RepositoryFullName)
-                .ToArray();
-
-            selectedRepositories = repositoryOptions
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-            await LoadFilteredAuditDataAsync(orderedSummary);
+            selectedRepositories = [];
+            hasLoadedAuditSummary = false;
+            ResetDashboardData();
         }
         catch (HttpRequestException ex)
         {
             ResetDashboardData();
-            errorMessage = $"GitHub API request failed. {ex.Message}";
+            repositoryLoadErrorMessage = $"GitHub API request failed. {ex.Message}";
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Failed to load audit dashboard summary.");
+            Logger.LogError(ex, "Failed to load audit dashboard repositories.");
             ResetDashboardData();
-            errorMessage = "An unexpected error occurred while loading the audit dashboard.";
+            repositoryLoadErrorMessage = "An unexpected error occurred while loading repositories for the audit dashboard.";
         }
         finally
         {
-            isLoading = false;
+            isLoadingRepositories = false;
         }
     }
 
-    private async Task OnSelectedRepositoriesChanged(IEnumerable<string> repositories)
+    private Task OnSelectedRepositoriesChanged(IReadOnlyList<string> repositories)
     {
         ArgumentNullException.ThrowIfNull(repositories);
 
@@ -79,10 +84,64 @@ public partial class Audit : ComponentBase
             .Where(static repository => !string.IsNullOrWhiteSpace(repository))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        await LoadFilteredAuditDataAsync();
+        auditLoadErrorMessage = null;
+        hasLoadedAuditSummary = false;
+        ResetDashboardData();
+        return Task.CompletedTask;
     }
 
-    private async Task LoadFilteredAuditDataAsync(IReadOnlyList<RepositoryAuditSummaryDto>? preloadedSummary = null)
+    private IReadOnlyList<string> selectedRepositoryNames
+        => selectedRepositories
+            .OrderBy(repository => repository, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private string RepositoryFilterSummary
+        => $"Showing {selectedRepositories.Count} selected of {repositoryOptions.Count} active repositories.";
+
+    private async Task LoadSelectedRepositoriesAsync()
+    {
+        auditLoadErrorMessage = null;
+
+        if (selectedRepositories.Count == 0)
+        {
+            hasLoadedAuditSummary = false;
+            ResetDashboardData();
+            return;
+        }
+
+        isLoadingAuditData = true;
+        hasLoadedAuditSummary = false;
+        ResetDashboardData();
+
+        // Trigger an immediate render so the loading state is visible before network calls begin.
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            await LoadFilteredAuditDataAsync();
+            hasLoadedAuditSummary = true;
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "Failed to load selected audit repositories due to a GitHub API error.");
+            hasLoadedAuditSummary = false;
+            ResetDashboardData();
+            auditLoadErrorMessage = $"GitHub API request failed. {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load selected audit repositories.");
+            hasLoadedAuditSummary = false;
+            ResetDashboardData();
+            auditLoadErrorMessage = "An unexpected error occurred while loading the audit summary.";
+        }
+        finally
+        {
+            isLoadingAuditData = false;
+        }
+    }
+
+    private async Task LoadFilteredAuditDataAsync()
     {
         var selectedRepoNames = selectedRepositories
             .OrderBy(static repository => repository, StringComparer.OrdinalIgnoreCase)
@@ -94,9 +153,7 @@ public partial class Audit : ComponentBase
             return;
         }
 
-        var summaryTask = preloadedSummary is null
-            ? AuditDashboardService.GetAuditSummaryAsync(selectedRepoNames)
-            : Task.FromResult(preloadedSummary);
+        var summaryTask = AuditDashboardService.GetAuditSummaryAsync(selectedRepoNames);
 
         var unlabelledIssuesTask = AuditDashboardService.GetUnlabelledIssuesAsync(selectedRepoNames);
         var stalePullRequestsTask = AuditDashboardService.GetStalePullRequestsAsync(selectedRepoNames, StalePullRequestDays);

--- a/src/App/SoloDevBoard.App/Components/Pages/Audit.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Pages/Audit.razor.cs
@@ -7,6 +7,8 @@ namespace SoloDevBoard.App.Components.Pages;
 /// <summary>Displays open issue and pull request summary counts across repositories.</summary>
 public partial class Audit : ComponentBase
 {
+    private const int StalePullRequestDays = 14;
+
     /// <summary>Gets or sets the audit dashboard application service.</summary>
     [Inject]
     public IAuditDashboardService AuditDashboardService { get; set; } = default!;
@@ -16,6 +18,11 @@ public partial class Audit : ComponentBase
     public ILogger<Audit> Logger { get; set; } = default!;
 
     private IReadOnlyList<RepositoryAuditSummaryDto> repositorySummaries = [];
+    private IReadOnlyList<IssueDto> unlabelledIssues = [];
+    private IReadOnlyList<PullRequestDto> stalePullRequests = [];
+    private IReadOnlyList<WorkflowRunDto> failingWorkflowRuns = [];
+    private IReadOnlyList<string> repositoryOptions = [];
+    private HashSet<string> selectedRepositories = new(StringComparer.OrdinalIgnoreCase);
     private int totalOpenIssues;
     private int totalOpenPullRequests;
     private bool isLoading = true;
@@ -34,31 +41,106 @@ public partial class Audit : ComponentBase
         try
         {
             var summary = await AuditDashboardService.GetRepositorySummaryAsync();
-            repositorySummaries = summary
+            var orderedSummary = summary
                 .OrderBy(result => result.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
                 .ToArray();
-            totalOpenIssues = repositorySummaries.Sum(result => result.OpenIssueCount);
-            totalOpenPullRequests = repositorySummaries.Sum(result => result.OpenPullRequestCount);
+
+            repositoryOptions = orderedSummary
+                .Select(summaryItem => summaryItem.RepositoryFullName)
+                .ToArray();
+
+            selectedRepositories = repositoryOptions
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            await LoadFilteredAuditDataAsync(orderedSummary);
         }
         catch (HttpRequestException ex)
         {
-            repositorySummaries = [];
-            totalOpenIssues = 0;
-            totalOpenPullRequests = 0;
+            ResetDashboardData();
             errorMessage = $"GitHub API request failed. {ex.Message}";
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to load audit dashboard summary.");
-            repositorySummaries = [];
-            totalOpenIssues = 0;
-            totalOpenPullRequests = 0;
+            ResetDashboardData();
             errorMessage = "An unexpected error occurred while loading the audit dashboard.";
         }
         finally
         {
             isLoading = false;
         }
+    }
+
+    private async Task OnSelectedRepositoriesChanged(IEnumerable<string> repositories)
+    {
+        ArgumentNullException.ThrowIfNull(repositories);
+
+        selectedRepositories = repositories
+            .Where(static repository => !string.IsNullOrWhiteSpace(repository))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        await LoadFilteredAuditDataAsync();
+    }
+
+    private async Task LoadFilteredAuditDataAsync(IReadOnlyList<RepositoryAuditSummaryDto>? preloadedSummary = null)
+    {
+        var selectedRepoNames = selectedRepositories
+            .OrderBy(static repository => repository, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (selectedRepoNames.Length == 0)
+        {
+            ResetDashboardData();
+            return;
+        }
+
+        var summaryTask = preloadedSummary is null
+            ? AuditDashboardService.GetAuditSummaryAsync(selectedRepoNames)
+            : Task.FromResult(preloadedSummary);
+
+        var unlabelledIssuesTask = AuditDashboardService.GetUnlabelledIssuesAsync(selectedRepoNames);
+        var stalePullRequestsTask = AuditDashboardService.GetStalePullRequestsAsync(selectedRepoNames, StalePullRequestDays);
+        var failingWorkflowRunsTask = AuditDashboardService.GetFailingWorkflowRunsAsync(selectedRepoNames);
+
+        await Task.WhenAll(summaryTask, unlabelledIssuesTask, stalePullRequestsTask, failingWorkflowRunsTask);
+
+        repositorySummaries = (await summaryTask)
+            .OrderBy(result => result.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        unlabelledIssues = (await unlabelledIssuesTask)
+            .OrderBy(issue => issue.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(issue => issue.Number)
+            .ToArray();
+
+        stalePullRequests = (await stalePullRequestsTask)
+            .OrderBy(pullRequest => pullRequest.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(pullRequest => pullRequest.Number)
+            .ToArray();
+
+        failingWorkflowRuns = (await failingWorkflowRunsTask)
+            .OrderBy(workflowRun => workflowRun.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(workflowRun => workflowRun.WorkflowName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        totalOpenIssues = repositorySummaries.Sum(result => result.OpenIssueCount);
+        totalOpenPullRequests = repositorySummaries.Sum(result => result.OpenPullRequestCount);
+    }
+
+    private void ResetDashboardData()
+    {
+        repositorySummaries = [];
+        unlabelledIssues = [];
+        stalePullRequests = [];
+        failingWorkflowRuns = [];
+        totalOpenIssues = 0;
+        totalOpenPullRequests = 0;
+    }
+
+    private static int GetDaysBetween(DateTimeOffset value)
+    {
+        var days = (int)Math.Floor((DateTimeOffset.UtcNow - value).TotalDays);
+        return Math.Max(days, 0);
     }
 
     private static string BuildRepositoryUrl(string repositoryFullName)

--- a/src/App/SoloDevBoard.App/Components/Pages/Labels.razor
+++ b/src/App/SoloDevBoard.App/Components/Pages/Labels.razor
@@ -17,38 +17,20 @@
             else
             {
                 <MudStack Spacing="2">
-                    <MudAutocomplete T="RepositoryDto"
-                                     Value="repositoryAutocompleteValue"
-                                     ValueChanged="OnRepositorySelectedAsync"
-                                     SearchFunc="SearchRepositoriesAsync"
-                                     ToStringFunc="repository => repository?.FullName ?? string.Empty"
-                                     Label="Repositories"
-                                     Placeholder="Search repositories and select"
-                                     Variant="Variant.Outlined"
-                                     MinCharacters="0"
-                                     Clearable="true"
-                                     Immediate="true"
-                                     Disabled="ShowLoadingState"
-                                     Adornment="Adornment.Start"
-                                     AdornmentIcon="@Icons.Material.Filled.Search"
-                                     data-testid="repository-autocomplete" />
-
-                    @if (selectedRepositories.Count > 0)
-                    {
-                        <MudStack Row="true" Spacing="1" data-testid="selected-repositories">
-                            @foreach (var repository in selectedRepositories)
-                            {
-                                <MudChip T="string"
-                                         Variant="Variant.Outlined"
-                                         Color="Color.Primary"
-                                         OnClose="() => RemoveSelectedRepository(repository.FullName)">
-                                    @repository.FullName
-                                </MudChip>
-                            }
-                        </MudStack>
-                    }
-
-                    <MudText Typo="Typo.body2" data-testid="repository-selector-summary">@RepositorySelectorSummary</MudText>
+                    <RepositorySelector
+                        Title=""
+                        Label="Repositories"
+                        Placeholder="Search repositories and select"
+                        EmptyStateText="No active repositories are available for label analysis."
+                        AvailableRepositories="availableRepositoryFullNames"
+                        SelectedRepositories="selectedRepositoryFullNames"
+                        SelectedRepositoriesChanged="OnSelectedRepositoriesChangedAsync"
+                        SummaryText="@RepositorySelectorSummary"
+                        ShowSelectedChips="true"
+                        ShowSelectionActions="true"
+                        Disabled="ShowLoadingState"
+                        AutocompleteTestId="repository-autocomplete"
+                        SummaryTestId="repository-selector-summary" />
 
                     <MudStack Row="true" Spacing="1">
                         <MudButton Variant="Variant.Filled"

--- a/src/App/SoloDevBoard.App/Components/Pages/Labels.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Pages/Labels.razor.cs
@@ -31,7 +31,6 @@ public partial class Labels : ComponentBase
 
     private IReadOnlyList<RepositoryDto> availableRepositories = [];
     private IReadOnlyList<RepositoryDto> selectedRepositories = [];
-    private RepositoryDto? repositoryAutocompleteValue;
     private IReadOnlyList<LabelRow> rows = [];
     private IReadOnlyList<LabelRow> filteredRows = [];
     private bool isLoadingRepositories = true;
@@ -118,7 +117,6 @@ public partial class Labels : ComponentBase
                 .ToArray();
 
             selectedRepositories = [];
-            repositoryAutocompleteValue = null;
             recommendedPreview = [];
             recommendedApplyResults = [];
             showRecommendedPreview = false;
@@ -142,54 +140,17 @@ public partial class Labels : ComponentBase
         }
     }
 
-    private Task OnRepositorySelectedAsync(RepositoryDto? repository)
+    private Task OnSelectedRepositoriesChangedAsync(IReadOnlyList<string> repositoryFullNames)
     {
-        if (repository is null || string.IsNullOrWhiteSpace(repository.FullName))
-        {
-            return Task.CompletedTask;
-        }
+        ArgumentNullException.ThrowIfNull(repositoryFullNames);
 
-        if (!selectedRepositories.Any(item => item.FullName.Equals(repository.FullName, StringComparison.OrdinalIgnoreCase)))
-        {
-            selectedRepositories = selectedRepositories
-                .Append(repository)
-                .OrderBy(item => item.FullName, StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-        }
-
-        repositoryAutocompleteValue = null;
-        recommendedPreview = [];
-        showRecommendedPreview = false;
-        recommendedApplyResults = [];
-        taxonomyOperationMessage = null;
-        EnsureSyncSelections();
-        return Task.CompletedTask;
-    }
-
-    private Task<IEnumerable<RepositoryDto>> SearchRepositoriesAsync(string? value, CancellationToken cancellationToken)
-    {
-        IEnumerable<RepositoryDto> matches = availableRepositories;
-
-        if (!string.IsNullOrWhiteSpace(value))
-        {
-            var filter = value.Trim();
-            matches = matches.Where(repository =>
-                repository.FullName.Contains(filter, StringComparison.OrdinalIgnoreCase));
-        }
-
-        var selectedNames = selectedRepositories
-            .Select(repository => repository.FullName)
+        var selectedNames = repositoryFullNames
+            .Where(fullName => !string.IsNullOrWhiteSpace(fullName))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        matches = matches.Where(repository => !selectedNames.Contains(repository.FullName));
-
-        return Task.FromResult(matches);
-    }
-
-    private void RemoveSelectedRepository(string repositoryFullName)
-    {
-        selectedRepositories = selectedRepositories
-            .Where(repository => !repository.FullName.Equals(repositoryFullName, StringComparison.OrdinalIgnoreCase))
+        selectedRepositories = availableRepositories
+            .Where(repository => selectedNames.Contains(repository.FullName))
+            .OrderBy(repository => repository.FullName, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
         recommendedPreview = [];
@@ -197,6 +158,7 @@ public partial class Labels : ComponentBase
         recommendedApplyResults = [];
         taxonomyOperationMessage = null;
         EnsureSyncSelections();
+        return Task.CompletedTask;
     }
 
     private Task OnSyncSourceRepositoryChangedAsync(string value)
@@ -917,6 +879,18 @@ public partial class Labels : ComponentBase
             return $"Showing {repositoryCount} active {repositoryNoun}. {selectedRepositories.Count} selected. Archived repositories are hidden by default.";
         }
     }
+
+    private IReadOnlyList<string> availableRepositoryFullNames
+        => availableRepositories
+            .Select(repository => repository.FullName)
+            .OrderBy(fullName => fullName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private IReadOnlyList<string> selectedRepositoryFullNames
+        => selectedRepositories
+            .Select(repository => repository.FullName)
+            .OrderBy(fullName => fullName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 
     private static string GetColourChipStyle(string colour) => LabelColourStyleHelper.GetColourChipStyle(colour);
 

--- a/src/App/SoloDevBoard.App/Components/Shared/RepositorySelector.razor
+++ b/src/App/SoloDevBoard.App/Components/Shared/RepositorySelector.razor
@@ -1,0 +1,64 @@
+<MudStack Spacing="2">
+    @if (!string.IsNullOrWhiteSpace(Title))
+    {
+        <MudText Typo="Typo.h6">@Title</MudText>
+    }
+
+    @if (AvailableRepositories.Count == 0)
+    {
+        <MudText Typo="Typo.body2">@EmptyStateText</MudText>
+    }
+    else
+    {
+        <MudAutocomplete T="string"
+                         Value="repositoryAutocompleteValue"
+                         ValueChanged="OnRepositorySelectedAsync"
+                         SearchFunc="SearchRepositoriesAsync"
+                         ToStringFunc="repository => repository ?? string.Empty"
+                         Label="@Label"
+                         Placeholder="@Placeholder"
+                         Variant="Variant.Outlined"
+                         MinCharacters="0"
+                         Clearable="true"
+                         Immediate="true"
+                         Disabled="Disabled"
+                         Adornment="Adornment.Start"
+                         AdornmentIcon="@Icons.Material.Filled.Search"
+                         data-testid="@AutocompleteTestId" />
+
+        @if (ShowSelectedChips && SelectedRepositories.Count > 0)
+        {
+            <MudStack Row="true" Spacing="1" data-testid="selected-repositories">
+                @foreach (var repository in SelectedRepositories)
+                {
+                    <MudChip T="string"
+                             Variant="Variant.Outlined"
+                             Color="Color.Primary"
+                             OnClose="() => RemoveSelectedRepositoryAsync(repository)">
+                        @repository
+                    </MudChip>
+                }
+            </MudStack>
+        }
+
+        @if (ShowSelectionActions)
+        {
+            <MudStack Row="true" Spacing="1">
+                <MudButton Variant="Variant.Text"
+                           Color="Color.Secondary"
+                           Disabled="@(Disabled || SelectedRepositories.Count == AvailableRepositories.Count)"
+                           OnClick="SelectAllRepositoriesAsync">
+                    Select all
+                </MudButton>
+                <MudButton Variant="Variant.Text"
+                           Color="Color.Secondary"
+                           Disabled="@(Disabled || SelectedRepositories.Count == 0)"
+                           OnClick="ClearSelectedRepositoriesAsync">
+                    Clear
+                </MudButton>
+            </MudStack>
+        }
+
+        <MudText Typo="Typo.body2" data-testid="@SummaryTestId">@SummaryText</MudText>
+    }
+</MudStack>

--- a/src/App/SoloDevBoard.App/Components/Shared/RepositorySelector.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Shared/RepositorySelector.razor.cs
@@ -1,0 +1,140 @@
+using Microsoft.AspNetCore.Components;
+
+namespace SoloDevBoard.App.Components.Shared;
+
+/// <summary>Provides a reusable repository selection control with search and multi-select behaviour.</summary>
+public partial class RepositorySelector : ComponentBase
+{
+    private string? repositoryAutocompleteValue;
+
+    /// <summary>Gets or sets the heading text displayed above the selector.</summary>
+    [Parameter]
+    public string Title { get; set; } = "Repository selector";
+
+    /// <summary>Gets or sets the input label used by the autocomplete search box.</summary>
+    [Parameter]
+    public string Label { get; set; } = "Repositories";
+
+    /// <summary>Gets or sets the placeholder text used by the autocomplete search box.</summary>
+    [Parameter]
+    public string Placeholder { get; set; } = "Search repositories and select";
+
+    /// <summary>Gets or sets the text shown when no repositories are available.</summary>
+    [Parameter]
+    public string EmptyStateText { get; set; } = "No active repositories are available.";
+
+    /// <summary>Gets or sets the repositories available for selection.</summary>
+    [Parameter]
+    public IReadOnlyList<string> AvailableRepositories { get; set; } = [];
+
+    /// <summary>Gets or sets the currently selected repositories.</summary>
+    [Parameter]
+    public IReadOnlyList<string> SelectedRepositories { get; set; } = [];
+
+    /// <summary>Gets or sets the callback raised when selected repositories change.</summary>
+    [Parameter]
+    public EventCallback<IReadOnlyList<string>> SelectedRepositoriesChanged { get; set; }
+
+    /// <summary>Gets or sets the summary text shown below the selector controls.</summary>
+    [Parameter]
+    public string SummaryText { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets a value indicating whether selected repositories are shown as removable chips.</summary>
+    [Parameter]
+    public bool ShowSelectedChips { get; set; } = true;
+
+    /// <summary>Gets or sets a value indicating whether select-all and clear actions are shown.</summary>
+    [Parameter]
+    public bool ShowSelectionActions { get; set; } = true;
+
+    /// <summary>Gets or sets a value indicating whether interaction with the selector is disabled.</summary>
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    /// <summary>Gets or sets the data-testid value used for the autocomplete element.</summary>
+    [Parameter]
+    public string AutocompleteTestId { get; set; } = "repository-autocomplete";
+
+    /// <summary>Gets or sets the data-testid value used for the summary text element.</summary>
+    [Parameter]
+    public string SummaryTestId { get; set; } = "repository-selector-summary";
+
+    private Task<IEnumerable<string>> SearchRepositoriesAsync(string? value, CancellationToken cancellationToken)
+    {
+        IEnumerable<string> matches = AvailableRepositories;
+
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            var filter = value.Trim();
+            matches = matches.Where(repository => repository.Contains(filter, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var selectedNames = SelectedRepositories
+            .Where(repository => !string.IsNullOrWhiteSpace(repository))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        matches = matches.Where(repository => !selectedNames.Contains(repository));
+
+        return Task.FromResult(matches);
+    }
+
+    private async Task OnRepositorySelectedAsync(string? repository)
+    {
+        if (string.IsNullOrWhiteSpace(repository))
+        {
+            return;
+        }
+
+        if (!AvailableRepositories.Contains(repository, StringComparer.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var selected = SelectedRepositories
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        _ = selected.Add(repository);
+
+        repositoryAutocompleteValue = null;
+
+        await SelectedRepositoriesChanged.InvokeAsync(
+            selected
+                .OrderBy(item => item, StringComparer.OrdinalIgnoreCase)
+                .ToArray());
+    }
+
+    private async Task RemoveSelectedRepositoryAsync(string repository)
+    {
+        if (string.IsNullOrWhiteSpace(repository))
+        {
+            return;
+        }
+
+        var selected = SelectedRepositories
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        _ = selected.Remove(repository);
+
+        await SelectedRepositoriesChanged.InvokeAsync(
+            selected
+                .OrderBy(item => item, StringComparer.OrdinalIgnoreCase)
+                .ToArray());
+    }
+
+    private async Task SelectAllRepositoriesAsync()
+    {
+        await SelectedRepositoriesChanged.InvokeAsync(
+            AvailableRepositories
+                .Where(repository => !string.IsNullOrWhiteSpace(repository))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(repository => repository, StringComparer.OrdinalIgnoreCase)
+                .ToArray());
+    }
+
+    private async Task ClearSelectedRepositoriesAsync()
+    {
+        await SelectedRepositoriesChanged.InvokeAsync([]);
+    }
+}

--- a/src/App/SoloDevBoard.App/Components/_Imports.razor
+++ b/src/App/SoloDevBoard.App/Components/_Imports.razor
@@ -10,5 +10,6 @@
 @using Microsoft.JSInterop
 @using SoloDevBoard.App
 @using SoloDevBoard.App.Components
+@using SoloDevBoard.App.Components.Shared
 @using SoloDevBoard.App.Components.Layout
 @using SoloDevBoard.Application.Services

--- a/src/Application/SoloDevBoard.Application/Services/AuditDashboardService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/AuditDashboardService.cs
@@ -143,6 +143,7 @@ public sealed class AuditDashboardService : IAuditDashboardService
             issue.Title,
             issue.HtmlUrl,
             repositoryFullName,
+            issue.CreatedAt,
             issue.UpdatedAt);
 
     private static PullRequestDto MapPullRequest(PullRequest pullRequest, string repositoryFullName)
@@ -151,6 +152,7 @@ public sealed class AuditDashboardService : IAuditDashboardService
             pullRequest.Title,
             pullRequest.HtmlUrl,
             repositoryFullName,
+            pullRequest.AuthorLogin,
             pullRequest.UpdatedAt);
 
     private static WorkflowRunDto MapWorkflowRun(WorkflowRun workflowRun, string repositoryFullName)
@@ -159,7 +161,8 @@ public sealed class AuditDashboardService : IAuditDashboardService
             workflowRun.Status,
             workflowRun.Conclusion,
             workflowRun.HtmlUrl,
-            repositoryFullName);
+            repositoryFullName,
+            workflowRun.HeadBranch);
 
     private static bool IsFailingConclusion(string conclusion)
         => conclusion.Equals("failure", StringComparison.OrdinalIgnoreCase)

--- a/src/Application/SoloDevBoard.Application/Services/AuditDashboardService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/AuditDashboardService.cs
@@ -26,9 +26,8 @@ public sealed class AuditDashboardService : IAuditDashboardService
     /// <inheritdoc/>
     public async Task<IReadOnlyList<RepositoryAuditSummaryDto>> GetRepositorySummaryAsync(CancellationToken cancellationToken = default)
     {
-        var owner = GetOwnerLogin();
-        var repositories = await _gitHubService.GetActiveRepositoriesAsync(owner, cancellationToken).ConfigureAwait(false);
-        var repoNames = repositories.Select(static repository => repository.Name).ToArray();
+        var repositories = await _gitHubService.GetActiveRepositoriesAsync(cancellationToken).ConfigureAwait(false);
+        var repoNames = repositories.Select(static repository => repository.FullName).ToArray();
 
         return await GetAuditSummaryAsync(repoNames, cancellationToken).ConfigureAwait(false);
     }
@@ -38,14 +37,14 @@ public sealed class AuditDashboardService : IAuditDashboardService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
 
-        var owner = GetOwnerLogin();
-        var repoName = NormaliseRepoName(repo);
-        var repositoryFullName = BuildRepositoryFullName(owner, repoName);
-        var issues = await _gitHubService.GetIssuesAsync(owner, repoName, cancellationToken).ConfigureAwait(false);
+        var repositoryReference = ResolveRepositoryReference(repo);
+        var issues = await _gitHubService
+            .GetIssuesAsync(repositoryReference.Owner, repositoryReference.RepoName, cancellationToken)
+            .ConfigureAwait(false);
 
         return issues
             .Where(static issue => IsOpenState(issue.State))
-            .Select(issue => MapIssue(issue, repositoryFullName))
+            .Select(issue => MapIssue(issue, repositoryReference.FullName))
             .ToArray();
     }
 
@@ -54,9 +53,9 @@ public sealed class AuditDashboardService : IAuditDashboardService
     {
         ArgumentNullException.ThrowIfNull(repos);
 
-        var owner = GetOwnerLogin();
-        var repoNames = GetRepoNames(repos);
-        var summaryTasks = repoNames.Select(repoName => BuildRepositoryAuditSummaryAsync(owner, repoName, cancellationToken));
+        var repositoryReferences = GetRepositoryReferences(repos);
+        var summaryTasks = repositoryReferences.Select(repositoryReference =>
+            BuildRepositoryAuditSummaryAsync(repositoryReference.Owner, repositoryReference.RepoName, cancellationToken));
         var summaries = await Task.WhenAll(summaryTasks).ConfigureAwait(false);
 
         return summaries;
@@ -67,16 +66,16 @@ public sealed class AuditDashboardService : IAuditDashboardService
     {
         ArgumentNullException.ThrowIfNull(repos);
 
-        var owner = GetOwnerLogin();
-        var repoNames = GetRepoNames(repos);
-        var issueTasks = repoNames.Select(async repoName =>
+        var repositoryReferences = GetRepositoryReferences(repos);
+        var issueTasks = repositoryReferences.Select(async repositoryReference =>
         {
-            var issues = await _gitHubService.GetIssuesAsync(owner, repoName, cancellationToken).ConfigureAwait(false);
-            var repositoryFullName = BuildRepositoryFullName(owner, repoName);
+            var issues = await _gitHubService
+                .GetIssuesAsync(repositoryReference.Owner, repositoryReference.RepoName, cancellationToken)
+                .ConfigureAwait(false);
 
             return issues
                 .Where(static issue => IsOpenState(issue.State) && issue.Labels.Count == 0)
-                .Select(issue => MapIssue(issue, repositoryFullName))
+                .Select(issue => MapIssue(issue, repositoryReference.FullName))
                 .ToArray();
         });
 
@@ -94,17 +93,17 @@ public sealed class AuditDashboardService : IAuditDashboardService
             throw new ArgumentOutOfRangeException(nameof(staleDays), staleDays, "Stale days must be greater than zero.");
         }
 
-        var owner = GetOwnerLogin();
         var staleBefore = DateTimeOffset.UtcNow.AddDays(-staleDays);
-        var repoNames = GetRepoNames(repos);
-        var pullRequestTasks = repoNames.Select(async repoName =>
+        var repositoryReferences = GetRepositoryReferences(repos);
+        var pullRequestTasks = repositoryReferences.Select(async repositoryReference =>
         {
-            var pullRequests = await _gitHubService.GetPullRequestsAsync(owner, repoName, cancellationToken).ConfigureAwait(false);
-            var repositoryFullName = BuildRepositoryFullName(owner, repoName);
+            var pullRequests = await _gitHubService
+                .GetPullRequestsAsync(repositoryReference.Owner, repositoryReference.RepoName, cancellationToken)
+                .ConfigureAwait(false);
 
             return pullRequests
                 .Where(pullRequest => pullRequest.State.Equals("open", StringComparison.OrdinalIgnoreCase) && pullRequest.UpdatedAt < staleBefore)
-                .Select(pullRequest => MapPullRequest(pullRequest, repositoryFullName))
+                .Select(pullRequest => MapPullRequest(pullRequest, repositoryReference.FullName))
                 .ToArray();
         });
 
@@ -117,12 +116,12 @@ public sealed class AuditDashboardService : IAuditDashboardService
     {
         ArgumentNullException.ThrowIfNull(repos);
 
-        var owner = GetOwnerLogin();
-        var repoNames = GetRepoNames(repos);
-        var workflowTasks = repoNames.Select(async repoName =>
+        var repositoryReferences = GetRepositoryReferences(repos);
+        var workflowTasks = repositoryReferences.Select(async repositoryReference =>
         {
-            var workflowRuns = await _gitHubService.GetWorkflowRunsAsync(owner, repoName, cancellationToken).ConfigureAwait(false);
-            var repositoryFullName = BuildRepositoryFullName(owner, repoName);
+            var workflowRuns = await _gitHubService
+                .GetWorkflowRunsAsync(repositoryReference.Owner, repositoryReference.RepoName, cancellationToken)
+                .ConfigureAwait(false);
 
             return workflowRuns
                 .Where(static workflowRun => !string.IsNullOrWhiteSpace(workflowRun.WorkflowName))
@@ -132,7 +131,7 @@ public sealed class AuditDashboardService : IAuditDashboardService
                     .ThenByDescending(static workflowRun => workflowRun.CreatedAt)
                     .First())
                 .Where(static workflowRun => IsFailingConclusion(workflowRun.Conclusion))
-                .Select(workflowRun => MapWorkflowRun(workflowRun, repositoryFullName))
+                .Select(workflowRun => MapWorkflowRun(workflowRun, repositoryReference.FullName))
                 .ToArray();
         });
 
@@ -177,17 +176,20 @@ public sealed class AuditDashboardService : IAuditDashboardService
     private static string BuildRepositoryFullName(string owner, string repoName)
         => $"{owner}/{repoName}";
 
-    private static IReadOnlyList<string> GetRepoNames(IReadOnlyList<string> repos)
+    private IReadOnlyList<RepositoryReference> GetRepositoryReferences(IReadOnlyList<string> repos)
     {
         if (repos.Count == 0)
         {
             return [];
         }
 
-        return repos.Select(NormaliseRepoName).ToArray();
+        return repos
+            .Select(ResolveRepositoryReference)
+            .DistinctBy(static repositoryReference => repositoryReference.FullName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
-    private static string NormaliseRepoName(string repo)
+    private RepositoryReference ResolveRepositoryReference(string repo)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
 
@@ -195,12 +197,15 @@ public sealed class AuditDashboardService : IAuditDashboardService
         var separatorIndex = trimmed.IndexOf('/');
         if (separatorIndex >= 0)
         {
+            var owner = trimmed[..separatorIndex];
             var repoName = trimmed[(separatorIndex + 1)..];
+
+            ArgumentException.ThrowIfNullOrWhiteSpace(owner);
             ArgumentException.ThrowIfNullOrWhiteSpace(repoName);
-            return repoName;
+            return new RepositoryReference(owner, repoName);
         }
 
-        return trimmed;
+        return new RepositoryReference(GetOwnerLogin(), trimmed);
     }
 
     private string GetOwnerLogin()
@@ -244,5 +249,10 @@ public sealed class AuditDashboardService : IAuditDashboardService
             openIssues.Count(static issue => issue.Labels.Count == 0),
             openPullRequests.Count(pullRequest => pullRequest.UpdatedAt < staleThreshold),
             failingWorkflowCount);
+    }
+
+    private sealed record RepositoryReference(string Owner, string RepoName)
+    {
+        public string FullName => BuildRepositoryFullName(Owner, RepoName);
     }
 }

--- a/src/Application/SoloDevBoard.Application/Services/AuditDashboardService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/AuditDashboardService.cs
@@ -16,8 +16,11 @@ public sealed class AuditDashboardService : IAuditDashboardService
     /// <param name="currentUserContext">The current user context used to resolve the owner login.</param>
     public AuditDashboardService(IGitHubService gitHubService, ICurrentUserContext currentUserContext)
     {
-        _gitHubService = gitHubService ?? throw new ArgumentNullException(nameof(gitHubService));
-        _currentUserContext = currentUserContext ?? throw new ArgumentNullException(nameof(currentUserContext));
+        ArgumentNullException.ThrowIfNull(gitHubService);
+        ArgumentNullException.ThrowIfNull(currentUserContext);
+
+        _gitHubService = gitHubService;
+        _currentUserContext = currentUserContext;
     }
 
     /// <inheritdoc/>

--- a/src/Application/SoloDevBoard.Application/Services/IssueDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/IssueDto.cs
@@ -5,10 +5,12 @@ namespace SoloDevBoard.Application.Services;
 /// <param name="Title">The issue title.</param>
 /// <param name="HtmlUrl">The web URL of the issue.</param>
 /// <param name="RepositoryFullName">The fully-qualified repository name in owner/name format.</param>
+/// <param name="CreatedAt">The date and time when the issue was created.</param>
 /// <param name="UpdatedAt">The date and time when the issue was last updated.</param>
 public sealed record IssueDto(
     int Number,
     string Title,
     string HtmlUrl,
     string RepositoryFullName,
+    DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt);

--- a/src/Application/SoloDevBoard.Application/Services/PullRequestDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PullRequestDto.cs
@@ -5,10 +5,12 @@ namespace SoloDevBoard.Application.Services;
 /// <param name="Title">The pull request title.</param>
 /// <param name="HtmlUrl">The web URL of the pull request.</param>
 /// <param name="RepositoryFullName">The fully-qualified repository name in owner/name format.</param>
+/// <param name="AuthorLogin">The login of the pull request author.</param>
 /// <param name="UpdatedAt">The date and time when the pull request was last updated.</param>
 public sealed record PullRequestDto(
     int Number,
     string Title,
     string HtmlUrl,
     string RepositoryFullName,
+    string AuthorLogin,
     DateTimeOffset UpdatedAt);

--- a/src/Application/SoloDevBoard.Application/Services/WorkflowRunDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/WorkflowRunDto.cs
@@ -6,9 +6,11 @@ namespace SoloDevBoard.Application.Services;
 /// <param name="Conclusion">The workflow run conclusion.</param>
 /// <param name="HtmlUrl">The web URL of the workflow run.</param>
 /// <param name="RepositoryFullName">The fully-qualified repository name in owner/name format.</param>
+/// <param name="HeadBranch">The branch associated with the workflow run.</param>
 public sealed record WorkflowRunDto(
     string WorkflowName,
     string Status,
     string Conclusion,
     string HtmlUrl,
-    string RepositoryFullName);
+    string RepositoryFullName,
+    string HeadBranch);

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
@@ -143,15 +143,6 @@ public sealed class AuditTests
         _auditDashboardServiceMock
             .Setup(service => service.GetAuditSummaryAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(summary);
-        _auditDashboardServiceMock
-            .Setup(service => service.GetUnlabelledIssuesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(issues);
-        _auditDashboardServiceMock
-            .Setup(service => service.GetStalePullRequestsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(pullRequests);
-        _auditDashboardServiceMock
-            .Setup(service => service.GetFailingWorkflowRunsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(workflows);
 
         await using var ctx = CreateContext();
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using MudBlazor;
 using MudBlazor.Services;
+using SoloDevBoard.App.Components.Shared;
 using SoloDevBoard.App.Components.Pages;
 using SoloDevBoard.Application.Services;
 
@@ -12,15 +13,19 @@ namespace SoloDevBoard.App.Tests;
 public sealed class AuditTests
 {
     private readonly Mock<IAuditDashboardService> _auditDashboardServiceMock = new();
+    private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
 
     [Fact]
     public async Task Audit_WhileServiceIsLoading_ShowsLoadingSkeleton()
     {
         // Arrange
-        var tcs = new TaskCompletionSource<IReadOnlyList<RepositoryAuditSummaryDto>>();
-        _auditDashboardServiceMock
-            .Setup(service => service.GetRepositorySummaryAsync(It.IsAny<CancellationToken>()))
+        var tcs = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
             .Returns(tcs.Task);
+        _auditDashboardServiceMock
+            .Setup(service => service.GetAuditSummaryAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<RepositoryAuditSummaryDto>());
 
         await using var ctx = CreateContext();
 
@@ -28,7 +33,7 @@ public sealed class AuditTests
         var cut = ctx.Render<Audit>();
 
         // Assert
-        Assert.Single(cut.FindAll("[data-testid='audit-loading-state']"));
+        Assert.Single(cut.FindAll("[data-testid='audit-repository-filter-loading']"));
         Assert.Empty(cut.FindAll("[data-testid='audit-summary-table']"));
         Assert.Empty(cut.FindAll("[data-testid='audit-empty-state']"));
     }
@@ -37,9 +42,9 @@ public sealed class AuditTests
     public async Task Audit_WhenServiceReturnsNoRepositories_ShowsEmptyState()
     {
         // Arrange
-        _auditDashboardServiceMock
-            .Setup(service => service.GetRepositorySummaryAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<RepositoryAuditSummaryDto>());
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<RepositoryDto>());
 
         await using var ctx = CreateContext();
 
@@ -65,14 +70,26 @@ public sealed class AuditTests
             new("owner/repo-a", 4, 3, 1, 1, 0),
         };
 
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                CreateRepository("owner", "repo-a"),
+                CreateRepository("owner", "repo-b"),
+            ]);
+
         _auditDashboardServiceMock
-            .Setup(service => service.GetRepositorySummaryAsync(It.IsAny<CancellationToken>()))
+            .Setup(service => service.GetAuditSummaryAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(summary);
 
         await using var ctx = CreateContext();
 
         // Act
         var cut = ctx.Render<Audit>();
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-repository-filter']")));
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo-a", "owner/repo-b" }));
+        cut.Find("[data-testid='audit-load-selected-button']").Click();
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -104,6 +121,10 @@ public sealed class AuditTests
             new("owner/repo-a", 4, 2, 1, 1, 1),
         };
 
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo-a")]);
+
         var issues = new List<IssueDto>
         {
             new(12, "Needs triage", "https://github.com/owner/repo-a/issues/12", "owner/repo-a", DateTimeOffset.UtcNow.AddDays(-5), DateTimeOffset.UtcNow.AddDays(-2)),
@@ -120,7 +141,7 @@ public sealed class AuditTests
         };
 
         _auditDashboardServiceMock
-            .Setup(service => service.GetRepositorySummaryAsync(It.IsAny<CancellationToken>()))
+            .Setup(service => service.GetAuditSummaryAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(summary);
         _auditDashboardServiceMock
             .Setup(service => service.GetUnlabelledIssuesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
@@ -146,6 +167,10 @@ public sealed class AuditTests
 
         // Act
         var cut = ctx.Render<Audit>();
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-repository-filter']")));
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo-a" }));
+        cut.Find("[data-testid='audit-load-selected-button']").Click();
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -178,14 +203,22 @@ public sealed class AuditTests
             new("owner/repo-a", 1, 1, 0, 0, 0),
         };
 
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo-a")]);
+
         _auditDashboardServiceMock
-            .Setup(service => service.GetRepositorySummaryAsync(It.IsAny<CancellationToken>()))
+            .Setup(service => service.GetAuditSummaryAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(summary);
 
         await using var ctx = CreateContext();
 
         // Act
         var cut = ctx.Render<Audit>();
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-repository-filter']")));
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo-a" }));
+        cut.Find("[data-testid='audit-load-selected-button']").Click();
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -206,8 +239,16 @@ public sealed class AuditTests
             new("owner/repo-b", 3, 1, 0, 0, 0),
         };
 
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                CreateRepository("owner", "repo-a"),
+                CreateRepository("owner", "repo-b"),
+            ]);
+
         _auditDashboardServiceMock
-            .Setup(service => service.GetRepositorySummaryAsync(It.IsAny<CancellationToken>()))
+            .Setup(service => service.GetAuditSummaryAsync(It.Is<IReadOnlyList<string>>(repos => repos.Count == 2), It.IsAny<CancellationToken>()))
             .ReturnsAsync(summary);
         _auditDashboardServiceMock
             .Setup(service => service.GetAuditSummaryAsync(It.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), It.IsAny<CancellationToken>()))
@@ -218,8 +259,9 @@ public sealed class AuditTests
         // Act
         var cut = ctx.Render<Audit>();
         cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-repository-filter']")));
-        var select = cut.FindComponent<MudSelect<string>>();
-        await cut.InvokeAsync(() => select.Instance.SelectedValuesChanged.InvokeAsync(new[] { "owner/repo-a" }));
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo-a" }));
+        cut.Find("[data-testid='audit-load-selected-button']").Click();
 
         // Assert
         _auditDashboardServiceMock.Verify(
@@ -260,6 +302,7 @@ public sealed class AuditTests
         var ctx = new BunitContext();
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
+        ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
         ctx.Services.AddScoped(_ => _auditDashboardServiceMock.Object);
 
         ctx.Render<MudPopoverProvider>();
@@ -268,4 +311,16 @@ public sealed class AuditTests
 
         return ctx;
     }
+
+    private static RepositoryDto CreateRepository(string owner, string name)
+        => new(
+            Id: 0,
+            Name: name,
+            FullName: $"{owner}/{name}",
+            Description: string.Empty,
+            Url: string.Empty,
+            IsPrivate: false,
+            IsArchived: false,
+            CreatedAt: DateTimeOffset.UnixEpoch,
+            UpdatedAt: DateTimeOffset.UnixEpoch);
 }

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
@@ -134,6 +134,16 @@ public sealed class AuditTests
 
         await using var ctx = CreateContext();
 
+        _auditDashboardServiceMock
+            .Setup(service => service.GetUnlabelledIssuesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(issues);
+        _auditDashboardServiceMock
+            .Setup(service => service.GetStalePullRequestsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pullRequests);
+        _auditDashboardServiceMock
+            .Setup(service => service.GetFailingWorkflowRunsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(workflows);
+
         // Act
         var cut = ctx.Render<Audit>();
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
@@ -95,8 +95,158 @@ public sealed class AuditTests
         });
     }
 
+    [Fact]
+    public async Task Audit_WhenHealthIndicatorsExist_ShowsHealthSectionsWithCountsAndLinks()
+    {
+        // Arrange
+        var summary = new List<RepositoryAuditSummaryDto>
+        {
+            new("owner/repo-a", 4, 2, 1, 1, 1),
+        };
+
+        var issues = new List<IssueDto>
+        {
+            new(12, "Needs triage", "https://github.com/owner/repo-a/issues/12", "owner/repo-a", DateTimeOffset.UtcNow.AddDays(-5), DateTimeOffset.UtcNow.AddDays(-2)),
+        };
+
+        var pullRequests = new List<PullRequestDto>
+        {
+            new(44, "Update docs", "https://github.com/owner/repo-a/pull/44", "owner/repo-a", "mark", DateTimeOffset.UtcNow.AddDays(-20)),
+        };
+
+        var workflows = new List<WorkflowRunDto>
+        {
+            new("build", "completed", "failure", "https://github.com/owner/repo-a/actions/runs/123", "owner/repo-a", "main"),
+        };
+
+        _auditDashboardServiceMock
+            .Setup(service => service.GetRepositorySummaryAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(summary);
+        _auditDashboardServiceMock
+            .Setup(service => service.GetUnlabelledIssuesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(issues);
+        _auditDashboardServiceMock
+            .Setup(service => service.GetStalePullRequestsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pullRequests);
+        _auditDashboardServiceMock
+            .Setup(service => service.GetFailingWorkflowRunsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(workflows);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Audit>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='audit-health-indicator-sections']"));
+            Assert.Contains("Unlabelled Issues", cut.Markup);
+            Assert.Contains("Stale Pull Requests", cut.Markup);
+            Assert.Contains("Failing Workflows", cut.Markup);
+            Assert.Contains("Needs triage", cut.Markup);
+            Assert.Contains("Update docs", cut.Markup);
+            Assert.Contains("Open run", cut.Markup);
+
+            var links = cut.FindAll("a")
+                .Select(link => link.GetAttribute("href"))
+                .Where(href => !string.IsNullOrWhiteSpace(href))
+                .ToList();
+
+            Assert.Contains("https://github.com/owner/repo-a/issues/12", links);
+            Assert.Contains("https://github.com/owner/repo-a/pull/44", links);
+            Assert.Contains("https://github.com/owner/repo-a/actions/runs/123", links);
+        });
+    }
+
+    [Fact]
+    public async Task Audit_WhenHealthIndicatorsAreEmpty_ShowsZeroStateMessages()
+    {
+        // Arrange
+        var summary = new List<RepositoryAuditSummaryDto>
+        {
+            new("owner/repo-a", 1, 1, 0, 0, 0),
+        };
+
+        _auditDashboardServiceMock
+            .Setup(service => service.GetRepositorySummaryAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(summary);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Audit>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("No unlabelled issues — great!", cut.Markup);
+            Assert.Contains("No stale pull requests — great!", cut.Markup);
+            Assert.Contains("No failing workflows — great!", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task Audit_WhenRepositoryFilterChanges_LoadsFilteredHealthIndicatorData()
+    {
+        // Arrange
+        var summary = new List<RepositoryAuditSummaryDto>
+        {
+            new("owner/repo-a", 4, 2, 1, 1, 0),
+            new("owner/repo-b", 3, 1, 0, 0, 0),
+        };
+
+        _auditDashboardServiceMock
+            .Setup(service => service.GetRepositorySummaryAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(summary);
+        _auditDashboardServiceMock
+            .Setup(service => service.GetAuditSummaryAsync(It.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new RepositoryAuditSummaryDto("owner/repo-a", 4, 2, 1, 1, 0)]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Audit>();
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-repository-filter']")));
+        var select = cut.FindComponent<MudSelect<string>>();
+        await cut.InvokeAsync(() => select.Instance.SelectedValuesChanged.InvokeAsync(new[] { "owner/repo-a" }));
+
+        // Assert
+        _auditDashboardServiceMock.Verify(
+            service => service.GetAuditSummaryAsync(
+                It.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _auditDashboardServiceMock.Verify(
+            service => service.GetUnlabelledIssuesAsync(
+                It.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _auditDashboardServiceMock.Verify(
+            service => service.GetStalePullRequestsAsync(
+                It.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"),
+                14,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _auditDashboardServiceMock.Verify(
+            service => service.GetFailingWorkflowRunsAsync(
+                It.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private BunitContext CreateContext()
     {
+        _auditDashboardServiceMock
+            .Setup(service => service.GetUnlabelledIssuesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<IssueDto>());
+        _auditDashboardServiceMock
+            .Setup(service => service.GetStalePullRequestsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PullRequestDto>());
+        _auditDashboardServiceMock
+            .Setup(service => service.GetFailingWorkflowRunsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<WorkflowRunDto>());
+
         var ctx = new BunitContext();
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();

--- a/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using MudBlazor;
 using MudBlazor.Services;
+using SoloDevBoard.App.Components.Shared;
 using SoloDevBoard.App.Components.Pages;
 using SoloDevBoard.Application.Services;
 using System.Net.Http;
@@ -541,15 +542,10 @@ public sealed class LabelsTests
 
     private static async Task SelectRepositoriesAsync(IRenderedComponent<Labels> cut, params RepositoryDto[] repositories)
     {
-        var autocomplete = cut.FindComponent<MudAutocomplete<RepositoryDto>>();
+        var selector = cut.FindComponent<RepositorySelector>();
+        var selectedFullNames = repositories.Select(repository => repository.FullName).ToArray();
 
-        await cut.InvokeAsync(async () =>
-        {
-            foreach (var repository in repositories)
-            {
-                await autocomplete.Instance.ValueChanged.InvokeAsync(repository);
-            }
-        });
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(selectedFullNames));
     }
 
     private static RepositoryDto CreateRepository(string owner, string name, bool isPrivate = false, bool isArchived = false)

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardServiceTests.cs
@@ -54,8 +54,8 @@ public sealed class AuditDashboardServiceTests
         // Arrange
         var issues = new List<Issue>
         {
-            new() { Id = 1, Number = 7, Title = "First issue", State = "open", HtmlUrl = "https://example/issue/7", UpdatedAt = DateTimeOffset.UtcNow },
-            new() { Id = 2, Number = 8, Title = "Closed issue", State = "closed", HtmlUrl = "https://example/issue/8", UpdatedAt = DateTimeOffset.UtcNow },
+            new() { Id = 1, Number = 7, Title = "First issue", State = "open", HtmlUrl = "https://example/issue/7", CreatedAt = DateTimeOffset.UtcNow.AddDays(-3), UpdatedAt = DateTimeOffset.UtcNow },
+            new() { Id = 2, Number = 8, Title = "Closed issue", State = "closed", HtmlUrl = "https://example/issue/8", CreatedAt = DateTimeOffset.UtcNow.AddDays(-10), UpdatedAt = DateTimeOffset.UtcNow },
         };
         _gitHubServiceMock
             .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
@@ -70,6 +70,7 @@ public sealed class AuditDashboardServiceTests
         Assert.Equal("First issue", dto.Title);
         Assert.Equal("https://example/issue/7", dto.HtmlUrl);
         Assert.Equal("owner/repo", dto.RepositoryFullName);
+        Assert.True(dto.CreatedAt <= dto.UpdatedAt);
     }
 
     [Fact]
@@ -146,7 +147,7 @@ public sealed class AuditDashboardServiceTests
             .ReturnsAsync(
             [
                 new PullRequest { Id = 1, Number = 11, Title = "Stale", HtmlUrl = "https://example/pr/11", State = "open", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-30) },
-                new PullRequest { Id = 2, Number = 12, Title = "Fresh", HtmlUrl = "https://example/pr/12", State = "open", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2) },
+                new PullRequest { Id = 2, Number = 12, Title = "Fresh", HtmlUrl = "https://example/pr/12", State = "open", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2), AuthorLogin = "octo" },
             ]);
 
         // Act
@@ -184,6 +185,7 @@ public sealed class AuditDashboardServiceTests
                     Status = "completed",
                     Conclusion = "failure",
                     HtmlUrl = "https://example/run/2",
+                    HeadBranch = "main",
                     UpdatedAt = DateTimeOffset.UtcNow.AddHours(-1),
                     CreatedAt = DateTimeOffset.UtcNow.AddHours(-1),
                 },
@@ -197,6 +199,7 @@ public sealed class AuditDashboardServiceTests
         Assert.Equal("build", workflowRun.WorkflowName);
         Assert.Equal("failure", workflowRun.Conclusion);
         Assert.Equal("owner/repo", workflowRun.RepositoryFullName);
+        Assert.Equal("main", workflowRun.HeadBranch);
     }
 
     [Fact]

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardServiceTests.cs
@@ -27,7 +27,7 @@ public sealed class AuditDashboardServiceTests
             new() { Id = 2, Name = "repo-two", FullName = "owner/repo-two" },
         };
         _gitHubServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync("owner", It.IsAny<CancellationToken>()))
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(repositories);
         _gitHubServiceMock
             .Setup(service => service.GetIssuesAsync("owner", It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -200,6 +200,33 @@ public sealed class AuditDashboardServiceTests
         Assert.Equal("failure", workflowRun.Conclusion);
         Assert.Equal("owner/repo", workflowRun.RepositoryFullName);
         Assert.Equal("main", workflowRun.HeadBranch);
+    }
+
+    [Fact]
+    public async Task GetAuditSummaryAsync_ReposContainDifferentOwnerPrefix_UsesProvidedOwnerForRequests()
+    {
+        // Arrange
+        var repos = new[] { "another-owner/repo-one" };
+        _gitHubServiceMock
+            .Setup(service => service.GetIssuesAsync("another-owner", "repo-one", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _gitHubServiceMock
+            .Setup(service => service.GetPullRequestsAsync("another-owner", "repo-one", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _gitHubServiceMock
+            .Setup(service => service.GetWorkflowRunsAsync("another-owner", "repo-one", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        // Act
+        var result = await _sut.GetAuditSummaryAsync(repos);
+
+        // Assert
+        var summary = Assert.Single(result);
+        Assert.Equal("another-owner/repo-one", summary.RepositoryFullName);
+
+        _gitHubServiceMock.Verify(service => service.GetIssuesAsync("another-owner", "repo-one", It.IsAny<CancellationToken>()), Times.Once);
+        _gitHubServiceMock.Verify(service => service.GetPullRequestsAsync("another-owner", "repo-one", It.IsAny<CancellationToken>()), Times.Once);
+        _gitHubServiceMock.Verify(service => service.GetWorkflowRunsAsync("another-owner", "repo-one", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary of Changes

Extends the Audit Dashboard with actionable health indicator sections (unlabelled issues, stale pull requests, failing workflows) and a selection-first repository filter. Also extracts a shared `RepositorySelector` component used by both the Audit Dashboard and Label Manager pages.

## Related Issue(s)

Closes #44
Closes #45

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

UI changes include:
- Audit Dashboard now shows a repository selector on load (selection-first flow, matching Label Manager).
- After selecting repositories and clicking **Load selected repositories**, three MudBlazor expansion panels show unlabelled issues, stale PRs, and failing workflows beneath the repository summary grid.
- Both Audit Dashboard and Label Manager share the new `RepositorySelector` component.

## Additional Notes

- Issue #45 (filter by repository) has been addressed within this story — the selection-first multi-select filter covers that acceptance criterion. #45 is closed via this PR.
- `AuditDashboardService` now resolves repository owner from the full `owner/repo` name returned by the authenticated repository list, falling back to the configured `OwnerLogin` for bare repository names. This fixed a 404 regression introduced when switching from the owner-specific to the authenticated repository endpoint.
- Loading UX: the initial skeleton matches the selector shape; subsequent loads trigger an immediate `StateHasChanged` call before API work begins, preventing a perceived hang.