### PR TITLE
[type/story][type/test] Post-migration summary and test coverage for One-Click Migration

### DIFF
--- a/docs/user-guide/one-click-migration.md
+++ b/docs/user-guide/one-click-migration.md
@@ -84,9 +84,15 @@ Partial failures are reported per target repository — a failure for one target
 
 ### Step 6 — Review the summary
 
-*Post-migration summary view is planned for a future iteration.*
 
-*Project board configuration migration remains planned for a later slice and is not yet available.*
+
+After migration completes, a summary view is shown for each target repository.
+
+- **Labels** and **Milestones** rows display the number of items created, updated, deleted, and skipped for each artefact type.
+- Partial failures are reported per target repository, with error messages shown inline for any unsuccessful operations.
+- If a target has no operations for an enabled artefact type, the summary still displays that artefact row with zero counts.
+
+Project board configuration migration remains planned for a later slice and is not yet available.
 
 ---
 

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -74,7 +74,10 @@ Labels: `type/epic`, `area/migration`
 - [x] As a solo developer, I want to migrate all milestones from a source repository to a target repository so that I can maintain consistent milestone structures. _(Completed as #94 for v0.3.0. Milestone migration create/update/skip/delete delivered; title, description, state, and due date included; GitHub 422 due_on null bug fixed.)_
 - [x] As a solo developer, I want to choose a conflict resolution strategy (skip, overwrite, or merge) so that I have control over how existing items in the target are handled. _(Completed as #91 for v0.3.0. Conflict strategy selection delivered; includes explanatory text and overwrite warning.)_
 - [x] Enabler: Introduce migration contracts and milestone migration support. _(Completed as #89 for v0.3.0. Migration contracts and milestone migration support delivered.)_
-- [ ] As a solo developer, I want to see a post-migration summary so that I know exactly what was created, updated, or skipped. _(Planned as #95 for v0.3.0.)_
+- [x] As a solo developer, I want to see a post-migration summary so that I know exactly what was created, updated, or skipped. _(Completed as #95 for v0.3.0. Per-target summary view delivered: created/updated/deleted/skipped counts shown for labels and milestones; partial failures reported per target.)_
+- [x] Test: Unit tests for migration orchestration and milestone services. _(Completed as #96 for v0.3.0. Coverage added for guard clauses, multi-target aggregation, conflict handling, and partial failure behaviour.)_
+- [x] Test: Infrastructure tests for GitHub milestone migration support. _(Completed as #97 for v0.3.0. Coverage added for response mapping, create/update request behaviour, non-success responses, and guard clauses.)_
+- [x] Test: bUnit tests for the Migration page workflow. _(Completed as #98 for v0.3.0. Coverage added for empty state, selection and preview gating, duplicate apply prevention, and post-migration summary error rendering.)_
 - [ ] As a solo developer, I want to migrate project board column configurations so that new repositories start with the same board structure. _(Deferred follow-on slice; requires GitHub Projects v2 support and is captured in ADR-0013.)_
 
 ---

--- a/src/App/SoloDevBoard.App/Components/Layout/ReconnectModal.razor.css
+++ b/src/App/SoloDevBoard.App/Components/Layout/ReconnectModal.razor.css
@@ -218,3 +218,9 @@ dialog[open].components-resume-failed .components-resume-failed-visible {
         padding: 16px;
     }
 }
+
+/* Override MudBlazor's default hover colour for the reconnect button
+   to ensure it remains visible against the backdrop. */
+#components-reconnect-modal {
+    --mud-palette-action-default-hover: var(--mud-palette-primary-darken, var(--mud-palette-primary));
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
@@ -283,6 +283,7 @@ public sealed class MigrationTests
         await SelectRepositoriesAsync(cut, sourceRepository, targetRepository);
 
         var targetCheckboxes = cut.FindAll("[data-testid='migration-target-checkbox']");
+        Assert.Equal(2, targetCheckboxes.Count);
         targetCheckboxes[1].Change(true);
 
         cut.Find("[data-testid='migration-preview-button']").Click();

--- a/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
@@ -192,6 +192,192 @@ public sealed class MigrationTests
         });
     }
 
+    [Fact]
+    public async Task Migration_NoRepositoriesAvailable_ShowsEmptyStateMessage()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Migration>();
+
+        // Assert
+        cut.WaitForAssertion(() => Assert.Contains("No active repositories are available for migration.", cut.Markup));
+    }
+
+    [Fact]
+    public async Task Migration_PreviewClickedWithoutRequiredSelection_DoesNotInvokePreviewService()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                CreateRepository("owner", "repo-a"),
+                CreateRepository("owner", "repo-b"),
+            ]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Migration>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='migration-preview-button']"));
+        cut.Find("[data-testid='migration-preview-button']").Click();
+
+        // Assert
+        Assert.Empty(cut.FindAll("[data-testid='migration-preview-card']"));
+        _migrationServiceMock.Verify(service => service.PreviewMigrationAsync(
+            It.IsAny<string>(),
+            It.IsAny<IReadOnlyList<string>>(),
+            It.IsAny<MigrationScopeDto>(),
+            It.IsAny<MigrationConflictStrategy>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Migration_ApplyClickedTwiceDuringPendingCall_InvokesApplyServiceOnce()
+    {
+        // Arrange
+        var sourceRepository = CreateRepository("owner", "repo-a");
+        var targetRepository = CreateRepository("owner", "repo-b");
+        var applyTaskSource = new TaskCompletionSource<MigrationResultDto>();
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([sourceRepository, targetRepository]);
+
+        _migrationServiceMock
+            .Setup(service => service.PreviewMigrationAsync(
+                "owner/repo-a",
+                It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
+                It.IsAny<MigrationScopeDto>(),
+                MigrationConflictStrategy.Skip,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MigrationPreviewDto(
+                MigrationConflictStrategy.Skip,
+                [new LabelSyncRepositoryPreviewDto(
+                    "owner/repo-b",
+                    [new LabelDto("priority/high", "d93f0b", "High priority", "owner/repo-b")],
+                    [],
+                    [],
+                    [])],
+                [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])]));
+
+        _migrationServiceMock
+            .Setup(service => service.ApplyMigrationAsync(
+                "owner/repo-a",
+                It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
+                It.IsAny<MigrationScopeDto>(),
+                MigrationConflictStrategy.Skip,
+                It.IsAny<CancellationToken>()))
+            .Returns(applyTaskSource.Task);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Migration>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='migration-repository-autocomplete']"));
+        await SelectRepositoriesAsync(cut, sourceRepository, targetRepository);
+
+        var targetCheckboxes = cut.FindAll("[data-testid='migration-target-checkbox']");
+        targetCheckboxes[1].Change(true);
+
+        cut.Find("[data-testid='migration-preview-button']").Click();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='migration-apply-button']"));
+
+        var applyButton = cut.Find("[data-testid='migration-apply-button']");
+        applyButton.Click();
+        applyButton.Click();
+
+        await cut.InvokeAsync(() => applyTaskSource.SetResult(new MigrationResultDto(
+            MigrationConflictStrategy.Skip,
+            [new LabelSyncRepositoryResultDto("owner/repo-b", 1, 0, 0, 0, null)],
+            [])));
+
+        // Assert
+        cut.WaitForAssertion(() => Assert.Contains("Migration completed successfully", cut.Markup));
+        _migrationServiceMock.Verify(service => service.ApplyMigrationAsync(
+            "owner/repo-a",
+            It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
+            It.IsAny<MigrationScopeDto>(),
+            MigrationConflictStrategy.Skip,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Migration_ApplyReturnsPartialFailure_RendersSummaryAndErrorDetails()
+    {
+        // Arrange
+        var sourceRepository = CreateRepository("owner", "repo-a");
+        var targetRepository = CreateRepository("owner", "repo-b");
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([sourceRepository, targetRepository]);
+
+        _migrationServiceMock
+            .Setup(service => service.PreviewMigrationAsync(
+                "owner/repo-a",
+                It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
+                It.IsAny<MigrationScopeDto>(),
+                MigrationConflictStrategy.Merge,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MigrationPreviewDto(
+                MigrationConflictStrategy.Merge,
+                [new LabelSyncRepositoryPreviewDto(
+                    "owner/repo-b",
+                    [new LabelDto("priority/high", "d93f0b", "High priority", "owner/repo-b")],
+                    [],
+                    [],
+                    [])],
+                [new MilestoneSyncRepositoryPreviewDto(
+                    "owner/repo-b",
+                    [new MilestoneDto(1, 2, "Sprint 2", "Delivery", "open", null, 0, 0)],
+                    [],
+                    [],
+                    [])]));
+
+        _migrationServiceMock
+            .Setup(service => service.ApplyMigrationAsync(
+                "owner/repo-a",
+                It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
+                It.IsAny<MigrationScopeDto>(),
+                MigrationConflictStrategy.Merge,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MigrationResultDto(
+                MigrationConflictStrategy.Merge,
+                [new LabelSyncRepositoryResultDto("owner/repo-b", 1, 0, 0, 0, "GitHub label API rate limit reached")],
+                [new MilestoneSyncRepositoryResultDto("owner/repo-b", 1, 0, 0, 0, null)]));
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Migration>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='migration-repository-autocomplete']"));
+        await SelectRepositoriesAsync(cut, sourceRepository, targetRepository);
+
+        var strategySelect = cut.FindComponents<MudSelect<MigrationConflictStrategy>>().Single();
+        await cut.InvokeAsync(() => strategySelect.Instance.ValueChanged.InvokeAsync(MigrationConflictStrategy.Merge));
+
+        var targetCheckboxes = cut.FindAll("[data-testid='migration-target-checkbox']");
+        targetCheckboxes[1].Change(true);
+
+        cut.Find("[data-testid='migration-preview-button']").Click();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='migration-apply-button']"));
+        cut.Find("[data-testid='migration-apply-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Migration summary (Merge)", cut.Markup);
+            Assert.Contains("Label migration failed.", cut.Markup);
+            Assert.Contains("GitHub label API rate limit reached", cut.Markup);
+        });
+    }
+
     private BunitContext CreateContext()
     {
         var ctx = new BunitContext();

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
@@ -228,6 +228,129 @@ public sealed class MigrationServiceTests
         _labelRepositoryMock.Verify(repository => repository.DeleteLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task PreviewMigrationAsync_NoScopeSelected_ThrowsArgumentException()
+    {
+        // Arrange
+        SetupSourceAndTargetData();
+        var sut = CreateSubject();
+
+        // Act
+        var action = async () => await sut.PreviewMigrationAsync(
+            "owner/source",
+            ["owner/target"],
+            new MigrationScopeDto(false, false),
+            MigrationConflictStrategy.Skip);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
+    }
+
+    [Fact]
+    public async Task ApplyMigrationAsync_TargetRepositoriesContainOnlySource_ThrowsArgumentException()
+    {
+        // Arrange
+        SetupSourceAndTargetData();
+        var sut = CreateSubject();
+
+        // Act
+        var action = async () => await sut.ApplyMigrationAsync(
+            "owner/source",
+            ["owner/source"],
+            new MigrationScopeDto(true, true),
+            MigrationConflictStrategy.Skip);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
+    }
+
+    [Fact]
+    public async Task ApplyMigrationAsync_MultipleTargetsOneLabelOperationFails_ReturnsPartialFailureAndContinues()
+    {
+        // Arrange
+        SetupSourceAndTargetData();
+
+        _labelRepositoryMock
+            .Setup(repository => repository.GetLabelsAsync("owner", "failing", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("label operation failed"));
+
+        _milestoneRepositoryMock
+            .Setup(repository => repository.GetMilestonesAsync("owner", "failing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _labelRepositoryMock
+            .Setup(repository => repository.CreateLabelAsync("owner", "target", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string repo, Label label, CancellationToken _) => label with { RepositoryName = repo });
+
+        _milestoneRepositoryMock
+            .Setup(repository => repository.CreateMilestoneAsync("owner", "target", It.IsAny<Milestone>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string _, Milestone milestone, CancellationToken _) => milestone);
+
+        _milestoneRepositoryMock
+            .Setup(repository => repository.CreateMilestoneAsync("owner", "failing", It.IsAny<Milestone>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string _, Milestone milestone, CancellationToken _) => milestone);
+
+        var sut = CreateSubject();
+
+        // Act
+        var result = await sut.ApplyMigrationAsync(
+            "owner/source",
+            ["owner/target", "owner/failing"],
+            new MigrationScopeDto(true, true),
+            MigrationConflictStrategy.Skip);
+
+        // Assert
+        Assert.Equal(2, result.LabelResults.Count);
+        Assert.Equal(2, result.MilestoneResults.Count);
+
+        var targetLabelResult = Assert.Single(result.LabelResults, item => item.RepositoryFullName == "owner/target");
+        Assert.False(targetLabelResult.HasError);
+        Assert.Equal(1, targetLabelResult.CreatedCount);
+
+        var failingLabelResult = Assert.Single(result.LabelResults, item => item.RepositoryFullName == "owner/failing");
+        Assert.True(failingLabelResult.HasError);
+        Assert.Contains("label operation failed", failingLabelResult.ErrorMessage, StringComparison.Ordinal);
+
+        var targetMilestoneResult = Assert.Single(result.MilestoneResults, item => item.RepositoryFullName == "owner/target");
+        Assert.False(targetMilestoneResult.HasError);
+        Assert.Equal(1, targetMilestoneResult.CreatedCount);
+
+        var failingMilestoneResult = Assert.Single(result.MilestoneResults, item => item.RepositoryFullName == "owner/failing");
+        Assert.False(failingMilestoneResult.HasError);
+        Assert.Equal(2, failingMilestoneResult.CreatedCount);
+    }
+
+    [Fact]
+    public async Task ApplyMigrationAsync_UpdateFailsAfterCreate_ReturnsErrorWithPartialProgressCounts()
+    {
+        // Arrange
+        SetupSourceAndTargetData();
+
+        _labelRepositoryMock
+            .Setup(repository => repository.CreateLabelAsync("owner", "target", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string repo, Label label, CancellationToken _) => label with { RepositoryName = repo });
+
+        _labelRepositoryMock
+            .Setup(repository => repository.UpdateLabelAsync("owner", "target", "type/story", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("update failed"));
+
+        var sut = CreateSubject();
+
+        // Act
+        var result = await sut.ApplyMigrationAsync(
+            "owner/source",
+            ["owner/target"],
+            new MigrationScopeDto(true, false),
+            MigrationConflictStrategy.Overwrite);
+
+        // Assert
+        var labelResult = Assert.Single(result.LabelResults);
+        Assert.True(labelResult.HasError);
+        Assert.Equal(1, labelResult.CreatedCount);
+        Assert.Equal(0, labelResult.UpdatedCount);
+        Assert.Contains("update failed", labelResult.ErrorMessage, StringComparison.Ordinal);
+    }
+
     private void SetupSourceAndTargetData()
     {
         _labelRepositoryMock

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubMilestoneRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubMilestoneRepositoryTests.cs
@@ -170,6 +170,91 @@ public sealed class GitHubMilestoneRepositoryTests
         Assert.Equal("https://api.github.com/repos/owner/repo/milestones/8", handler.Requests[0].RequestUri!.ToString());
     }
 
+    [Fact]
+    public async Task GetMilestonesAsync_NonSuccessResponse_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler([
+            CreateJsonResponse(HttpStatusCode.Forbidden, "{ \"message\": \"Forbidden\" }"),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        var action = async () => await sut.GetMilestonesAsync("owner", "repo");
+
+        // Assert
+        await Assert.ThrowsAsync<HttpRequestException>(action);
+    }
+
+    [Fact]
+    public async Task CreateMilestoneAsync_NonSuccessResponse_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler([
+            CreateJsonResponse(HttpStatusCode.UnprocessableEntity, "{ \"message\": \"Validation Failed\" }"),
+        ]);
+
+        var sut = CreateSubject(handler);
+        var milestone = new Milestone
+        {
+            Title = "Sprint 8",
+            Description = "Next sprint",
+            State = "open",
+        };
+
+        // Act
+        var action = async () => await sut.CreateMilestoneAsync("owner", "repo", milestone);
+
+        // Assert
+        await Assert.ThrowsAsync<HttpRequestException>(action);
+    }
+
+    [Fact]
+    public async Task UpdateMilestoneAsync_MilestoneNumberIsZero_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var sut = CreateSubject(new QueueMessageHandler([]));
+        var milestone = new Milestone
+        {
+            Title = "Sprint 8",
+            Description = "Next sprint",
+            State = "open",
+        };
+
+        // Act
+        var action = async () => await sut.UpdateMilestoneAsync("owner", "repo", 0, milestone);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(action);
+    }
+
+    [Fact]
+    public async Task DeleteMilestoneAsync_RepositoryIsWhitespace_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = CreateSubject(new QueueMessageHandler([]));
+
+        // Act
+        var action = async () => await sut.DeleteMilestoneAsync("owner", " ", 8);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
+    }
+
+    [Fact]
+    public async Task CreateMilestoneAsync_MilestoneIsNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var sut = CreateSubject(new QueueMessageHandler([]));
+
+        // Act
+        var action = async () => await sut.CreateMilestoneAsync("owner", "repo", null!);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(action);
+    }
+
     private static GitHubMilestoneRepository CreateSubject(HttpMessageHandler handler)
     {
         var currentUserContextMock = new Mock<ICurrentUserContext>();


### PR DESCRIPTION
## Summary of Changes

This PR delivers the post-migration summary view (#95) and full test coverage for the One-Click Migration feature (#96–#98), plus a minor reconnect button hover colour fix.

**Post-migration summary (#95):** The migration results page now shows per-target counts (created / updated / deleted / skipped) for labels and milestones. Partial failure error alerts are displayed per target. Summary rows are only shown when the artefact type was included in the selected scope.

**Migration orchestration tests (#96):** Unit tests added to `MigrationServiceTests` covering guard clauses, multi-target aggregation, conflict handling, and partial failure behaviour.

**GitHub milestone infrastructure tests (#97):** HTTP-level tests added to `GitHubMilestoneRepositoryTests` covering response mapping, non-success error handling, and guard clauses.

**Migration page bUnit tests (#98):** Component tests added to `MigrationTests` covering empty state rendering, selection and preview gating, duplicate apply prevention, and post-migration summary error rendering.

**Reconnect button hover fix:** Overrides the Blazor framework-injected `--mud-palette-action-default-hover` token scoped to `#components-reconnect-modal` so the button retains the correct primary palette colour on hover (framework stylesheet was causing a washed-out appearance).

## Related Issue(s)

Closes #95
Closes #96
Closes #97
Closes #98

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Additional Notes

The reconnect button hover override (`ReconnectModal.razor.css`) is a justified exception to the MudBlazor-first CSS rule: the Blazor framework (`blazor.web.js`) injects its own reconnect stylesheet after the scoped CSS and overrides the button hover with a semi-transparent value derived from `--mud-palette-action-default-hover`. Redeclaring that single token scoped to the modal root is the minimal, targeted fix.