### PR TITLE
[type/chore] Lock branch and migration strategy for GitHub App-first hosted auth

### DIFF
--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -45,6 +45,7 @@ Labels: `type/epic`, `area/infrastructure`, `priority/high`
 - [ ] As a hosted SoloDevBoard operator, I want authenticated GitHub identities mapped to operator-managed user and organisation allow-lists so that hosted access is deny-by-default.
 - [ ] As a SoloDevBoard maintainer, I want the separate OAuth App dependency removed or demoted to a fallback path where GitHub App user authentication satisfies hosted sign-in requirements so that the production architecture stays simpler and safer.
 - [ ] As a solo developer, I want PAT-only local trusted mode preserved so that local development and trusted self-hosted use do not depend on hosted sign-in infrastructure.
+- [x] Chore: As a SoloDevBoard maintainer, I want the hosted-auth branch and migration strategy locked before Feature #103 coding continues so that superseded hybrid work cannot drift into the GitHub App-first delivery path. _(Issue #118 — done, 2026-03-13; see plan/HOSTED_AUTH_MIGRATION_STRATEGY.md.)_
 
 Labels: `type/epic`, `area/dashboard`
 

--- a/plan/HOSTED_AUTH_MIGRATION_STRATEGY.md
+++ b/plan/HOSTED_AUTH_MIGRATION_STRATEGY.md
@@ -24,14 +24,14 @@ The superseded hybrid implementation path is frozen and treated as reference-onl
 
 1. New hosted-auth implementation work proceeds only on issue-scoped feature branches from current main.
 2. No direct merge from the old hybrid branch is permitted.
-3. Cherry-picking from superseded work is allowed only when all checks pass:
+3. Cherry-picking from superseded work is allowed only when all checks pass.
    - The commit is implementation-agnostic and does not enforce hybrid auth behaviour.
    - The commit preserves ADR-0015 direction (GitHub App-first, OAuth fallback-only).
    - The commit preserves PAT-only local trusted mode.
    - The commit is reviewed and referenced in the destination issue or pull request notes.
 4. If a commit fails any check, reimplement it directly on the new branch path rather than importing it.
 
-For this issue, work is locked to branch feature/issue-118-lock-branch-and-migration-strategy.
+Work for this migration gate was carried out on the issue branch for #118 and delivered via PR #120.
 
 ## Hosted Configuration and Secret Migration Expectations
 
@@ -39,7 +39,7 @@ For this issue, work is locked to branch feature/issue-118-lock-branch-and-migra
 2. Hosted baseline for Feature #103 prioritises GitHub App authentication material and admission control configuration.
 3. Existing Key Vault-backed PAT reference remains only for local trusted mode compatibility and operational continuity until the hosted cutover completes.
 4. OAuth App secret material is not required for the default hosted path; introduce it only if explicit fallback criteria are met.
-5. Any new hosted auth settings introduced during implementation must be documented in:
+5. Any new hosted auth settings introduced during implementation must be documented in the following files.
    - docs/getting-started.md.
    - infra/README.md.
 
@@ -52,7 +52,7 @@ For this issue, work is locked to branch feature/issue-118-lock-branch-and-migra
 
 ## Rollout and Fallback Expectations
 
-1. Rollout order for Feature #103 remains:
+1. Rollout order for Feature #103 remains as follows.
    - #111 installation and token lifecycle.
    - #112 user sign-in and per-request user context.
    - #117 hosted admission mapping.
@@ -61,7 +61,7 @@ For this issue, work is locked to branch feature/issue-118-lock-branch-and-migra
    - #119 documentation updates.
 2. Hosted rollout is App-first by default and deny-by-default for admission control.
 3. Fallback to OAuth App is permitted only when a validated hosted requirement cannot be met by GitHub App user authentication.
-4. Any fallback activation must include:
+4. Any fallback activation must include the following.
    - Explicit issue-level rationale.
    - Updated scope and implementation-plan notes.
    - Updated operator documentation.
@@ -71,6 +71,6 @@ For this issue, work is locked to branch feature/issue-118-lock-branch-and-migra
 Issue #118 is complete when:
 
 1. This migration strategy is committed and linked from planning artefacts.
-2. Issue #118 and roadmap status are in-progress with actual start date recorded.
-3. Parent feature and epic status are aligned to in-progress for active delivery.
+2. Issue #118 and roadmap item status are marked done with the actual completion date recorded.
+3. Parent feature and epic status are aligned for active delivery and are in-progress unless already done.
 4. Feature #103 implementation proceeds only under this locked strategy.

--- a/plan/HOSTED_AUTH_MIGRATION_STRATEGY.md
+++ b/plan/HOSTED_AUTH_MIGRATION_STRATEGY.md
@@ -1,0 +1,76 @@
+# Hosted Authentication Migration Strategy
+
+Date: 2026-03-13.  
+Issue: #118.  
+Applies to: Feature #103 (ADR-0015).
+
+## Purpose
+
+Lock the delivery path from the superseded hybrid hosted-authentication direction to the GitHub App-first target architecture before coding continues on Feature #103.
+
+## Superseded vs Target Slices
+
+| Area | Superseded Hybrid Direction | GitHub App-First Target | Migration Action |
+|---|---|---|---|
+| Hosted sign-in entrypoint | Parallel GitHub App and separate OAuth App hosted sign-in path. | GitHub App user authentication is the primary hosted sign-in path. | Remove hybrid-first planning assumptions and implement App-first by default. |
+| OAuth App dependency | Planned as a first-class hosted dependency. | Fallback-only for unmet hosted sign-in requirements. | Demote OAuth App work behind explicit fallback criteria and track as conditional scope (#113). |
+| User context model | Hosted session shape expected to support OAuth-centric flow and later App linkage. | Per-request hosted user context derived from GitHub App-first sign-in and installation mapping. | Implement user context directly against App-first hosted claims and installation context (#112, #111). |
+| Secret/config posture | Mixed expectation of OAuth and App credentials in hosted configuration baseline. | Hosted configuration prioritises GitHub App credentials and admission control inputs; PAT remains local trusted mode only. | Re-baseline hosted configuration to App-first requirements and keep PAT-only mode isolated to local trusted environments. |
+| Rollout sequencing | Hybrid implementation branch could be merged incrementally into new work. | Explicit migration gate before hosted auth coding, with controlled fallback plan. | Freeze hybrid branch as reference-only and continue delivery only on the locked App-first plan branch strategy. |
+
+## Branch Strategy Lock
+
+The superseded hybrid implementation path is frozen and treated as reference-only.
+
+1. New hosted-auth implementation work proceeds only on issue-scoped feature branches from current main.
+2. No direct merge from the old hybrid branch is permitted.
+3. Cherry-picking from superseded work is allowed only when all checks pass:
+   - The commit is implementation-agnostic and does not enforce hybrid auth behaviour.
+   - The commit preserves ADR-0015 direction (GitHub App-first, OAuth fallback-only).
+   - The commit preserves PAT-only local trusted mode.
+   - The commit is reviewed and referenced in the destination issue or pull request notes.
+4. If a commit fails any check, reimplement it directly on the new branch path rather than importing it.
+
+For this issue, work is locked to branch feature/issue-118-lock-branch-and-migration-strategy.
+
+## Hosted Configuration and Secret Migration Expectations
+
+1. Hosted deployments continue to source secrets from Azure Key Vault-backed app settings, never from committed files.
+2. Hosted baseline for Feature #103 prioritises GitHub App authentication material and admission control configuration.
+3. Existing Key Vault-backed PAT reference remains only for local trusted mode compatibility and operational continuity until the hosted cutover completes.
+4. OAuth App secret material is not required for the default hosted path; introduce it only if explicit fallback criteria are met.
+5. Any new hosted auth settings introduced during implementation must be documented in:
+   - docs/getting-started.md.
+   - infra/README.md.
+
+## PAT-Only Local Trusted Mode Compatibility
+
+1. Local trusted mode remains supported and unchanged as a first-class development path.
+2. PAT configuration keys and existing local user-secrets flow remain valid during hosted auth migration.
+3. Hosted auth implementation must not introduce runtime coupling that blocks PAT-only local execution.
+4. Validation for each hosted-auth slice must include a local PAT-mode smoke check.
+
+## Rollout and Fallback Expectations
+
+1. Rollout order for Feature #103 remains:
+   - #111 installation and token lifecycle.
+   - #112 user sign-in and per-request user context.
+   - #117 hosted admission mapping.
+   - #113 OAuth dependency demotion and fallback constraints.
+   - #114 authentication coverage.
+   - #119 documentation updates.
+2. Hosted rollout is App-first by default and deny-by-default for admission control.
+3. Fallback to OAuth App is permitted only when a validated hosted requirement cannot be met by GitHub App user authentication.
+4. Any fallback activation must include:
+   - Explicit issue-level rationale.
+   - Updated scope and implementation-plan notes.
+   - Updated operator documentation.
+
+## Completion Criteria for Migration Gate
+
+Issue #118 is complete when:
+
+1. This migration strategy is committed and linked from planning artefacts.
+2. Issue #118 and roadmap status are in-progress with actual start date recorded.
+3. Parent feature and epic status are aligned to in-progress for active delivery.
+4. Feature #103 implementation proceeds only under this locked strategy.

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -199,7 +199,7 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [ ] Handle GitHub App installation resolution, token issuance, refresh, and expiry for hosted requests. _(#103, #111)_
 - [ ] Restrict hosted access to operator-managed user and organisation allow-lists, with deny-by-default admission control. _(#103, #117; see ADR-0014 and ADR-0015)._
 - [ ] Remove or demote the separate OAuth App dependency where GitHub App user authentication satisfies hosted sign-in requirements. _(#103, #113)_
-- [ ] Define and execute the migration and compatibility path away from the superseded hybrid hosted-authentication plan. _(#103, #118)_
+- [x] Define and execute the migration and compatibility path away from the superseded hybrid hosted-authentication plan. _(#103, #118; strategy locked in plan/HOSTED_AUTH_MIGRATION_STRATEGY.md on 2026-03-13.)_
 - [ ] Persist hosted authentication material securely using Azure Key Vault-backed patterns where required.
 - [ ] Replace the single-user `ICurrentUserContext` adapter with a per-request, per-user implementation backed by the hosted authentication session.
 - [ ] Enable CD pipeline with production environment gate (`.github/workflows/cd.yml`).


### PR DESCRIPTION
## Summary of Changes

Lock the hosted-authentication delivery path from the superseded hybrid direction to the GitHub App-first target architecture (ADR-0015), as a gate before Feature #103 coding begins.

## Related Issue(s)

Closes #118
Relates to #103 (GitHub App-first hosted authentication and admission control)

## Type of Change

- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [x] 📝 Documentation (updates to docs, comments, or README)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`) — 148 tests, 0 failures
- [x] I have added or updated tests to cover my changes — no tests required (planning chore, no source changes)
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Files Changed

### Planning Artefacts
- `plan/HOSTED_AUTH_MIGRATION_STRATEGY.md` — new migration strategy document
- `plan/BACKLOG.md` — issue #118 chore marked complete under Epic 101
- `plan/IMPLEMENTATION_PLAN.md` — Phase 6 migration-path task ticked and linked to strategy document

## Migration Strategy Summary

The new `plan/HOSTED_AUTH_MIGRATION_STRATEGY.md` document defines:

1. **Superseded vs target slice comparison** — explicit table of what the hybrid plan promised vs what GitHub App-first requires, with a migration action per area.
2. **Branch lock policy** — superseded hybrid branch treated as reference-only; cherry-pick criteria; all new work on issue-scoped branches from main.
3. **Hosted configuration and secret migration expectations** — Key Vault-backed App credentials as hosted baseline; PAT isolated to local trusted mode; OAuth fallback conditional only.
4. **PAT-only local trusted mode compatibility** — local mode remains first-class; hosted auth must not introduce runtime coupling blocking PAT-only execution.
5. **Rollout order and fallback criteria** — delivery sequence #111 → #112 → #117 → #113 → #114 → #119; OAuth fallback gated behind validated unmet requirement.

## Additional Notes

No source code, test files, Razor components, or Bicep templates were modified. This is a pure planning gate chore with zero runtime impact.