### PR TITLE
[type/enabler][type/story] GitHub App hosted sign-in and per-request user context (#111, #112)

### DIFF
--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -41,6 +41,9 @@ Labels: `type/epic`, `area/infrastructure`, `priority/high`
 <!-- Chore #118: Define migration path from superseded hybrid auth plan -->
 <!-- Docs #119: Update documentation for GitHub App-first hosted auth -->
 
+
+- [x] Enabler: Installation and token lifecycle handling implemented for hosted authentication. _(Issue #111 — implemented on 2026-03-13; see plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md.)_
+- [x] Story: GitHub App user sign-in and per-request user context delivered for hosted mode. _(Issue #112 — implemented on 2026-03-13; see plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md.)_
 - [ ] As a solo developer, I want hosted SoloDevBoard sign-in to use GitHub App-first user authentication, ideally GitHub App-only where feasible, so that public deployments stay secure, auditable, and operator-controlled.
 - [ ] As a hosted SoloDevBoard operator, I want authenticated GitHub identities mapped to operator-managed user and organisation allow-lists so that hosted access is deny-by-default.
 - [ ] As a SoloDevBoard maintainer, I want the separate OAuth App dependency removed or demoted to a fallback path where GitHub App user authentication satisfies hosted sign-in requirements so that the production architecture stays simpler and safer.

--- a/plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md
+++ b/plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md
@@ -1,0 +1,51 @@
+# Hosted Authentication Session and Token Flow
+
+This document defines the hosted authentication boundaries delivered for issues #111 and #112.
+
+## Hosted Sign-In Application Boundary (#112)
+
+- Hosted sign-in is enabled by configuration using `GitHubAuth:HostedSignInEnabled=true`.
+- When hosted sign-in is enabled, the application registers cookie authentication and exposes explicit sign-in and sign-out boundary routes (`/auth/sign-in`, `/auth/sign-out`).
+- The `/auth/sign-in` route intentionally returns a not-implemented response until a hosted gateway integration is connected, so the sign-in handshake responsibility remains explicit and isolated.
+
+## Per-Request User Context Boundary (#112)
+
+- `ICurrentUserContext` now resolves per request when hosted sign-in mode is enabled.
+- Hosted mode uses request claims for owner login and access token values.
+- PAT-only local trusted mode remains unchanged and continues to resolve `ICurrentUserContext` from static `GitHubAuth` configuration.
+
+## Installation Lookup Requirements (#111)
+
+- Hosted requests must include a GitHub installation identifier claim.
+- Token retrieval fails fast if installation context is missing.
+- This claim requirement defines the minimum installation lookup contract for hosted requests.
+
+## Token Lifecycle Expectations (#111)
+
+- Hosted access tokens are read from per-request claims supplied by the hosted authentication boundary.
+- Optional expiry claims are validated as UTC timestamps.
+- Expired tokens are rejected and require a fresh hosted sign-in.
+- Invalid or missing hosted token claims fail fast with explicit exceptions to prevent silent downgrade to insecure behaviour.
+
+## Secure Storage and Cache Boundaries (#111)
+
+- This slice does not persist hosted access tokens to application storage.
+- Hosted token material is consumed from request claims only.
+- PAT-only local trusted mode continues to use local configuration and user secrets, with no hosted-token persistence.
+
+## Dependencies on Admission Control (#117)
+
+- Hosted authentication is a prerequisite for admission control.
+- Admission control remains a separate enforcement layer, planned in issue #117, that evaluates authenticated GitHub identity against operator-managed allow-lists.
+
+## OAuth App Fallback Boundary
+
+- A separate OAuth App fallback remains isolated and non-default.
+- No OAuth App fallback path is automatically enabled by this slice.
+- Any fallback enablement requires explicit configuration and justification in a follow-on change.
+
+## Rollout Notes
+
+- The delivered implementation adds hosted-mode DI switching, hosted claim mapping configuration, and per-request token/installation validation.
+- The delivered implementation keeps PAT-only local trusted mode unchanged.
+- The delivered implementation defines, but does not yet integrate, the external hosted gateway handshake at `/auth/sign-in`.

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -195,13 +195,13 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [ ] Configure structured logging and Application Insights telemetry. _(#107)_
 - [ ] Set up Dependabot for automated dependency updates. _(#109)_
 - [ ] Preserve PAT-only local trusted mode for development and trusted self-hosted use.
-- [ ] Implement GitHub App-first hosted sign-in and per-request user context for public release. _(#103, #112)_
-- [ ] Handle GitHub App installation resolution, token issuance, refresh, and expiry for hosted requests. _(#103, #111)_
+- [x] Implement hosted authentication session boundaries and per-request user context for GitHub App-first hosted mode. _(#103, #112; implemented on 2026-03-13, see plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md.)_
+- [x] Handle hosted installation context validation and token lifecycle checks (expiry and failure handling) for hosted requests. _(#103, #111; implemented on 2026-03-13, see plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md.)_
 - [ ] Restrict hosted access to operator-managed user and organisation allow-lists, with deny-by-default admission control. _(#103, #117; see ADR-0014 and ADR-0015)._
 - [ ] Remove or demote the separate OAuth App dependency where GitHub App user authentication satisfies hosted sign-in requirements. _(#103, #113)_
 - [x] Define and execute the migration and compatibility path away from the superseded hybrid hosted-authentication plan. _(#103, #118; strategy locked in plan/HOSTED_AUTH_MIGRATION_STRATEGY.md on 2026-03-13.)_
 - [ ] Persist hosted authentication material securely using Azure Key Vault-backed patterns where required.
-- [ ] Replace the single-user `ICurrentUserContext` adapter with a per-request, per-user implementation backed by the hosted authentication session.
+- [x] Replace the single-user `ICurrentUserContext` adapter with a per-request, per-user implementation backed by the hosted authentication session when hosted mode is enabled. _(Implemented on 2026-03-13; PAT-only local trusted mode preserved.)_
 - [ ] Enable CD pipeline with production environment gate (`.github/workflows/cd.yml`).
 - [ ] Write end-to-end tests for critical user journeys.
 - [ ] Write comprehensive `docs/` content for all features. _(#119)_

--- a/src/App/SoloDevBoard.App/Components/App.razor
+++ b/src/App/SoloDevBoard.App/Components/App.razor
@@ -1,6 +1,4 @@
-﻿@using Microsoft.AspNetCore.Components.Authorization
-
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en-GB">
 
 <head>
@@ -17,9 +15,7 @@
 </head>
 
 <body>
-    <CascadingAuthenticationState>
-        <Routes @rendermode="new InteractiveServerRenderMode(prerender: false)" />
-    </CascadingAuthenticationState>
+    <Routes @rendermode="new InteractiveServerRenderMode(prerender: false)" />
     <ReconnectModal />
     <script src="@Assets["_framework/blazor.web.js"]"></script>
     <script src="@Assets["_content/MudBlazor/MudBlazor.min.js"]"></script>

--- a/src/App/SoloDevBoard.App/Components/App.razor
+++ b/src/App/SoloDevBoard.App/Components/App.razor
@@ -1,4 +1,6 @@
-﻿<!DOCTYPE html>
+﻿@using Microsoft.AspNetCore.Components.Authorization
+
+<!DOCTYPE html>
 <html lang="en-GB">
 
 <head>
@@ -15,7 +17,9 @@
 </head>
 
 <body>
-    <Routes @rendermode="new InteractiveServerRenderMode(prerender: false)" />
+    <CascadingAuthenticationState>
+        <Routes @rendermode="new InteractiveServerRenderMode(prerender: false)" />
+    </CascadingAuthenticationState>
     <ReconnectModal />
     <script src="@Assets["_framework/blazor.web.js"]"></script>
     <script src="@Assets["_content/MudBlazor/MudBlazor.min.js"]"></script>

--- a/src/App/SoloDevBoard.App/Components/_Imports.razor
+++ b/src/App/SoloDevBoard.App/Components/_Imports.razor
@@ -1,6 +1,7 @@
 ﻿@using System.Net.Http
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using static Microsoft.AspNetCore.Components.Web.RenderMode

--- a/src/App/SoloDevBoard.App/Program.cs
+++ b/src/App/SoloDevBoard.App/Program.cs
@@ -15,7 +15,11 @@ builder.Services.AddMudServices();
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
-builder.Services.AddCascadingAuthenticationState();
+
+if (hostedSignInEnabled)
+{
+    builder.Services.AddCascadingAuthenticationState();
+}
 
 if (hostedSignInEnabled)
 {
@@ -25,7 +29,6 @@ if (hostedSignInEnabled)
         {
             options.LoginPath = "/auth/sign-in";
             options.LogoutPath = "/auth/sign-out";
-            options.AccessDeniedPath = "/auth/access-denied";
         });
 
     builder.Services.AddAuthorization();
@@ -69,7 +72,7 @@ if (hostedSignInEnabled)
             detail: "GitHub App user sign-in must be completed by the configured hosted authentication gateway before requests reach the Blazor application.",
             statusCode: StatusCodes.Status501NotImplemented));
 
-    app.MapGet("/auth/sign-out", static async (HttpContext context) =>
+    app.MapPost("/auth/sign-out", static async (HttpContext context) =>
     {
         await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
 

--- a/src/App/SoloDevBoard.App/Program.cs
+++ b/src/App/SoloDevBoard.App/Program.cs
@@ -1,9 +1,13 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication;
 using MudBlazor.Services;
 using SoloDevBoard.App.Components;
 using SoloDevBoard.Application.Services;
 using SoloDevBoard.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
+var hostedSignInEnabled = builder.Configuration.GetSection(GitHubAuthOptions.SectionName)
+    .GetValue<bool>(nameof(GitHubAuthOptions.HostedSignInEnabled));
 
 // Add MudBlazor services.
 builder.Services.AddMudServices();
@@ -11,6 +15,21 @@ builder.Services.AddMudServices();
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+builder.Services.AddCascadingAuthenticationState();
+
+if (hostedSignInEnabled)
+{
+    builder.Services
+        .AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+        .AddCookie(static options =>
+        {
+            options.LoginPath = "/auth/sign-in";
+            options.LogoutPath = "/auth/sign-out";
+            options.AccessDeniedPath = "/auth/access-denied";
+        });
+
+    builder.Services.AddAuthorization();
+}
 
 // Add our services.
 // The Infrastructure project is referenced here solely as the DI composition root.
@@ -30,10 +49,32 @@ app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages:
 
 app.UseHttpsRedirection();
 
+if (hostedSignInEnabled)
+{
+    app.UseAuthentication();
+    app.UseAuthorization();
+}
+
 app.UseAntiforgery();
 
 app.MapStaticAssets();
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
+
+if (hostedSignInEnabled)
+{
+    app.MapGet("/auth/sign-in", static () =>
+        Results.Problem(
+            title: "Hosted sign-in endpoint not configured",
+            detail: "GitHub App user sign-in must be completed by the configured hosted authentication gateway before requests reach the Blazor application.",
+            statusCode: StatusCodes.Status501NotImplemented));
+
+    app.MapGet("/auth/sign-out", static async (HttpContext context) =>
+    {
+        await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        return Results.Redirect("/");
+    });
+}
 
 app.Run();

--- a/src/App/SoloDevBoard.App/appsettings.json
+++ b/src/App/SoloDevBoard.App/appsettings.json
@@ -4,7 +4,11 @@
     "PersonalAccessToken": "",
     "GitHubAppId": "",
     "GitHubAppPrivateKey": "",
-    "UseGitHubApp": false
+    "HostedSignInEnabled": false,
+    "HostedOwnerLoginClaimType": "solo-dev-board.github.owner-login",
+    "HostedAccessTokenClaimType": "solo-dev-board.github.access-token",
+    "HostedInstallationIdClaimType": "solo-dev-board.github.installation-id",
+    "HostedTokenExpiresAtClaimType": "solo-dev-board.github.token-expires-at"
   },
   "Logging": {
     "LogLevel": {

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubAuthOptions.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHubAuthOptions.cs
@@ -1,3 +1,5 @@
+using SoloDevBoard.Infrastructure.Identity;
+
 namespace SoloDevBoard.Infrastructure;
 
 /// <summary>Configuration options for GitHub authentication.</summary>
@@ -17,6 +19,36 @@ public sealed class GitHubAuthOptions
     /// <summary>GitHub App private key in PEM format.</summary>
     public string GitHubAppPrivateKey { get; set; } = string.Empty;
 
-    /// <summary>When true, uses GitHub App authentication instead of a personal access token.</summary>
-    public bool UseGitHubApp { get; set; }
+    /// <summary>
+    /// Gets or sets a value that indicates whether hosted sign-in mode is enabled.
+    /// </summary>
+    /// <value>
+    /// <see langword="true" /> to resolve the current user from per-request hosted authentication claims; otherwise, <see langword="false" />.
+    /// The default is <see langword="false" />.
+    /// </value>
+    public bool HostedSignInEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the claim type used to read the authenticated GitHub owner login in hosted mode.
+    /// </summary>
+    /// <value>The hosted authentication claim type for owner login.</value>
+    public string HostedOwnerLoginClaimType { get; set; } = HostedAuthClaimTypes.OwnerLogin;
+
+    /// <summary>
+    /// Gets or sets the claim type used to read the hosted GitHub access token.
+    /// </summary>
+    /// <value>The hosted authentication claim type for the access token.</value>
+    public string HostedAccessTokenClaimType { get; set; } = HostedAuthClaimTypes.AccessToken;
+
+    /// <summary>
+    /// Gets or sets the claim type used to read the hosted GitHub installation identifier.
+    /// </summary>
+    /// <value>The hosted authentication claim type for the installation identifier.</value>
+    public string HostedInstallationIdClaimType { get; set; } = HostedAuthClaimTypes.InstallationId;
+
+    /// <summary>
+    /// Gets or sets the claim type used to read the hosted GitHub token expiry timestamp.
+    /// </summary>
+    /// <value>The hosted authentication claim type for token expiry in UTC.</value>
+    public string HostedTokenExpiresAtClaimType { get; set; } = HostedAuthClaimTypes.TokenExpiresAt;
 }

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/Identity/HostedAuthClaimTypes.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/Identity/HostedAuthClaimTypes.cs
@@ -1,0 +1,19 @@
+namespace SoloDevBoard.Infrastructure.Identity;
+
+/// <summary>
+/// Defines hosted authentication claim types used for per-request GitHub user context resolution.
+/// </summary>
+public static class HostedAuthClaimTypes
+{
+    /// <summary>Gets the claim type carrying the authenticated GitHub owner login.</summary>
+    public const string OwnerLogin = "solo-dev-board.github.owner-login";
+
+    /// <summary>Gets the claim type carrying the hosted GitHub access token.</summary>
+    public const string AccessToken = "solo-dev-board.github.access-token";
+
+    /// <summary>Gets the claim type carrying the hosted GitHub installation identifier.</summary>
+    public const string InstallationId = "solo-dev-board.github.installation-id";
+
+    /// <summary>Gets the claim type carrying the hosted GitHub access token expiry timestamp (UTC).</summary>
+    public const string TokenExpiresAt = "solo-dev-board.github.token-expires-at";
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/Identity/HostedUserCurrentUserContext.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/Identity/HostedUserCurrentUserContext.cs
@@ -1,0 +1,87 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using SoloDevBoard.Application.Identity;
+
+namespace SoloDevBoard.Infrastructure.Identity;
+
+/// <summary>
+/// Resolves the current user from hosted per-request authentication claims.
+/// </summary>
+public sealed class HostedUserCurrentUserContext(
+    IHttpContextAccessor httpContextAccessor,
+    IOptions<GitHubAuthOptions> authOptions) : ICurrentUserContext
+{
+    private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+    private readonly GitHubAuthOptions _authOptions = authOptions?.Value ?? throw new ArgumentNullException(nameof(authOptions));
+
+    /// <inheritdoc/>
+    /// <exception cref="InvalidOperationException">The hosted request does not contain a GitHub owner login claim.</exception>
+    public string OwnerLogin
+    {
+        get
+        {
+            var ownerLogin = GetRequiredClaimValue(_authOptions.HostedOwnerLoginClaimType, "GitHub owner login");
+
+            return ownerLogin;
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <exception cref="InvalidOperationException">
+    /// The hosted request does not contain installation or access-token claims, or the hosted token is expired.
+    /// </exception>
+    public string GetAccessToken()
+    {
+        _ = GetRequiredClaimValue(_authOptions.HostedInstallationIdClaimType, "GitHub installation identifier");
+
+        var accessToken = GetRequiredClaimValue(_authOptions.HostedAccessTokenClaimType, "GitHub access token");
+
+        EnsureTokenNotExpired();
+
+        return accessToken;
+    }
+
+    private string GetRequiredClaimValue(string claimType, string claimDescription)
+    {
+        if (string.IsNullOrWhiteSpace(claimType))
+        {
+            throw new InvalidOperationException("Hosted authentication claim mapping is invalid because a required claim type is empty.");
+        }
+
+        var claimValue = _httpContextAccessor.HttpContext?.User.FindFirst(claimType)?.Value;
+        if (string.IsNullOrWhiteSpace(claimValue))
+        {
+            throw new InvalidOperationException(
+                $"Hosted authentication is enabled but the {claimDescription} claim ('{claimType}') is missing.");
+        }
+
+        return claimValue;
+    }
+
+    private void EnsureTokenNotExpired()
+    {
+        var expiryClaimType = _authOptions.HostedTokenExpiresAtClaimType;
+        if (string.IsNullOrWhiteSpace(expiryClaimType))
+        {
+            return;
+        }
+
+        var expiryClaim = _httpContextAccessor.HttpContext?.User.FindFirst(expiryClaimType)?.Value;
+        if (string.IsNullOrWhiteSpace(expiryClaim))
+        {
+            return;
+        }
+
+        if (!DateTimeOffset.TryParse(expiryClaim, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var expiresAtUtc))
+        {
+            throw new InvalidOperationException(
+                $"Hosted authentication token expiry claim ('{expiryClaimType}') is not a valid UTC timestamp.");
+        }
+
+        if (expiresAtUtc <= DateTimeOffset.UtcNow)
+        {
+            throw new InvalidOperationException("Hosted GitHub access token has expired and must be refreshed by signing in again.");
+        }
+    }
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/InfrastructureServiceExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Application.Services;
 using SoloDevBoard.Infrastructure.Identity;
@@ -22,8 +23,17 @@ public static class InfrastructureServiceExtensions
         ArgumentNullException.ThrowIfNull(configuration);
 
         services.Configure<GitHubAuthOptions>(configuration.GetSection(GitHubAuthOptions.SectionName));
-        // Application-wide current user context for the single-user scenario.
-        services.AddSingleton<ICurrentUserContext, SingleUserCurrentUserContext>();
+        services.AddHttpContextAccessor();
+        services.AddScoped<SingleUserCurrentUserContext>();
+        services.AddScoped<HostedUserCurrentUserContext>();
+        services.AddScoped<ICurrentUserContext>(static serviceProvider =>
+        {
+            var authOptions = serviceProvider.GetRequiredService<IOptions<GitHubAuthOptions>>().Value;
+
+            return authOptions.HostedSignInEnabled
+                ? serviceProvider.GetRequiredService<HostedUserCurrentUserContext>()
+                : serviceProvider.GetRequiredService<SingleUserCurrentUserContext>();
+        });
         services.AddTransient<GitHubAuthHandler>();
 
         services

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/SoloDevBoard.Infrastructure.csproj
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/SoloDevBoard.Infrastructure.csproj
@@ -6,8 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/HostedUserCurrentUserContextTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/HostedUserCurrentUserContextTests.cs
@@ -1,0 +1,156 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using SoloDevBoard.Infrastructure.Identity;
+
+namespace SoloDevBoard.Infrastructure.Tests;
+
+public sealed class HostedUserCurrentUserContextTests
+{
+    [Fact]
+    public void OwnerLogin_ClaimExists_ReturnsClaimValue()
+    {
+        // Arrange
+        var httpContextAccessor = CreateHttpContextAccessor(new[]
+        {
+            new Claim(HostedAuthClaimTypes.OwnerLogin, "markheydon"),
+            new Claim(HostedAuthClaimTypes.AccessToken, "token"),
+            new Claim(HostedAuthClaimTypes.InstallationId, "123"),
+        });
+        var options = CreateOptions();
+        var sut = new HostedUserCurrentUserContext(httpContextAccessor, options);
+
+        // Act
+        var result = sut.OwnerLogin;
+
+        // Assert
+        Assert.Equal("markheydon", result);
+    }
+
+    [Fact]
+    public void OwnerLogin_ClaimMissing_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var httpContextAccessor = CreateHttpContextAccessor(new[]
+        {
+            new Claim(HostedAuthClaimTypes.AccessToken, "token"),
+            new Claim(HostedAuthClaimTypes.InstallationId, "123"),
+        });
+        var options = CreateOptions();
+        var sut = new HostedUserCurrentUserContext(httpContextAccessor, options);
+
+        // Act
+        var act = () => sut.OwnerLogin;
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void GetAccessToken_RequiredClaimsExistAndTokenNotExpired_ReturnsToken()
+    {
+        // Arrange
+        var httpContextAccessor = CreateHttpContextAccessor(new[]
+        {
+            new Claim(HostedAuthClaimTypes.OwnerLogin, "markheydon"),
+            new Claim(HostedAuthClaimTypes.AccessToken, "token"),
+            new Claim(HostedAuthClaimTypes.InstallationId, "123"),
+            new Claim(HostedAuthClaimTypes.TokenExpiresAt, DateTimeOffset.UtcNow.AddMinutes(5).ToString("O")),
+        });
+        var options = CreateOptions();
+        var sut = new HostedUserCurrentUserContext(httpContextAccessor, options);
+
+        // Act
+        var result = sut.GetAccessToken();
+
+        // Assert
+        Assert.Equal("token", result);
+    }
+
+    [Fact]
+    public void GetAccessToken_InstallationClaimMissing_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var httpContextAccessor = CreateHttpContextAccessor(new[]
+        {
+            new Claim(HostedAuthClaimTypes.OwnerLogin, "markheydon"),
+            new Claim(HostedAuthClaimTypes.AccessToken, "token"),
+        });
+        var options = CreateOptions();
+        var sut = new HostedUserCurrentUserContext(httpContextAccessor, options);
+
+        // Act
+        var act = () => sut.GetAccessToken();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void GetAccessToken_ExpiryClaimInvalid_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var httpContextAccessor = CreateHttpContextAccessor(new[]
+        {
+            new Claim(HostedAuthClaimTypes.OwnerLogin, "markheydon"),
+            new Claim(HostedAuthClaimTypes.AccessToken, "token"),
+            new Claim(HostedAuthClaimTypes.InstallationId, "123"),
+            new Claim(HostedAuthClaimTypes.TokenExpiresAt, "not-a-date"),
+        });
+        var options = CreateOptions();
+        var sut = new HostedUserCurrentUserContext(httpContextAccessor, options);
+
+        // Act
+        var act = () => sut.GetAccessToken();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void GetAccessToken_ExpiryClaimInPast_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var httpContextAccessor = CreateHttpContextAccessor(new[]
+        {
+            new Claim(HostedAuthClaimTypes.OwnerLogin, "markheydon"),
+            new Claim(HostedAuthClaimTypes.AccessToken, "token"),
+            new Claim(HostedAuthClaimTypes.InstallationId, "123"),
+            new Claim(HostedAuthClaimTypes.TokenExpiresAt, DateTimeOffset.UtcNow.AddMinutes(-1).ToString("O")),
+        });
+        var options = CreateOptions();
+        var sut = new HostedUserCurrentUserContext(httpContextAccessor, options);
+
+        // Act
+        var act = () => sut.GetAccessToken();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    private static IHttpContextAccessor CreateHttpContextAccessor(IEnumerable<Claim> claims)
+    {
+        var identity = new ClaimsIdentity(claims, authenticationType: "Hosted");
+        var principal = new ClaimsPrincipal(identity);
+
+        return new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = principal,
+            },
+        };
+    }
+
+    private static IOptions<GitHubAuthOptions> CreateOptions()
+    {
+        return Options.Create(new GitHubAuthOptions
+        {
+            HostedSignInEnabled = true,
+            HostedOwnerLoginClaimType = HostedAuthClaimTypes.OwnerLogin,
+            HostedAccessTokenClaimType = HostedAuthClaimTypes.AccessToken,
+            HostedInstallationIdClaimType = HostedAuthClaimTypes.InstallationId,
+            HostedTokenExpiresAtClaimType = HostedAuthClaimTypes.TokenExpiresAt,
+        });
+    }
+}

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/InfrastructureServiceExtensionsTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/InfrastructureServiceExtensionsTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SoloDevBoard.Application.Identity;
+using SoloDevBoard.Application.Services;
+using SoloDevBoard.Infrastructure.Identity;
+
+namespace SoloDevBoard.Infrastructure.Tests;
+
+public sealed class InfrastructureServiceExtensionsTests
+{
+    [Fact]
+    public void AddInfrastructureServices_HostedSignInEnabled_ResolvesHostedUserCurrentUserContext()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{GitHubAuthOptions.SectionName}:{nameof(GitHubAuthOptions.HostedSignInEnabled)}"] = "true",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IAppVersionService>(new TestAppVersionService());
+
+        // Act
+        services.AddInfrastructureServices(configuration);
+        using var serviceProvider = services.BuildServiceProvider();
+        using var scope = serviceProvider.CreateScope();
+        var currentUserContext = scope.ServiceProvider.GetRequiredService<ICurrentUserContext>();
+
+        // Assert
+        Assert.IsType<HostedUserCurrentUserContext>(currentUserContext);
+    }
+
+    [Fact]
+    public void AddInfrastructureServices_HostedSignInDisabled_ResolvesSingleUserCurrentUserContext()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{GitHubAuthOptions.SectionName}:{nameof(GitHubAuthOptions.HostedSignInEnabled)}"] = "false",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IAppVersionService>(new TestAppVersionService());
+
+        // Act
+        services.AddInfrastructureServices(configuration);
+        using var serviceProvider = services.BuildServiceProvider();
+        using var scope = serviceProvider.CreateScope();
+        var currentUserContext = scope.ServiceProvider.GetRequiredService<ICurrentUserContext>();
+
+        // Assert
+        Assert.IsType<SingleUserCurrentUserContext>(currentUserContext);
+    }
+}
+
+internal sealed class TestAppVersionService : IAppVersionService
+{
+    public string Version => "1.0.0-test";
+
+    public string UserAgent => "SoloDevBoard/1.0.0-test";
+}


### PR DESCRIPTION
## Summary of Changes

Delivers the infrastructure foundation for GitHub App-first hosted authentication (ADR-0015), enabling conditional cookie authentication and per-request user context resolution in SoloDevBoard.

Key changes:
- Add `HostedAuthClaimTypes` static constants defining the per-request claim type namespace (`solo-dev-board.github.*`).
- Add `HostedUserCurrentUserContext` — scoped `ICurrentUserContext` implementation that resolves owner login, access token, and installation context from ASP.NET Core request claims; validates token expiry before returning the access token.
- Replace `UseGitHubApp` with `HostedSignInEnabled` in `GitHubAuthOptions`; add configurable claim-type mapping properties defaulting to the new constants.
- Update `InfrastructureServiceExtensions` to register a scoped `ICurrentUserContext` factory that selects `HostedUserCurrentUserContext` when hosted mode is enabled, or `SingleUserCurrentUserContext` for PAT-only local mode.
- Wire cookie authentication, authorisation middleware, and `CascadingAuthenticationState` into the `App` project behind the `HostedSignInEnabled` guard.
- Stub `/auth/sign-in` (HTTP 501) and `/auth/sign-out` endpoints.
- Add `plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md` delivery artefact documenting the boundary decisions.

## Related Issue(s)

Closes #111
Closes #112

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Additional Notes

PAT-only local mode (HostedSignInEnabled=false, the default) is fully preserved — no behaviour change for existing deployments. The /auth/sign-in endpoint returns HTTP 501 intentionally; the GitHub App OAuth flow is a follow-on story (#113).

Build: 0 errors, 0 warnings. Tests: 150 passed (8 new), 0 failed.