### PR TITLE
docs(mudblazor): expand component chooser with additional official components and cross-links to category guides

### DIFF
--- a/.github/skills/mudblazor/SKILL.md
+++ b/.github/skills/mudblazor/SKILL.md
@@ -115,6 +115,20 @@ Use page-level `MudContainer`, `MudPaper`, `MudStack`, and `MudGrid` composition
 
 See [references/COMPONENT-CHOOSER.md](references/COMPONENT-CHOOSER.md) for the full mapping.
 
+### Reference Map
+
+Use these references after the chooser points you to a component family:
+
+- [references/INPUTS.md](references/INPUTS.md) for text, selection, picker, and validation-oriented input components.
+- [references/BUTTONS.md](references/BUTTONS.md) for action components, grouped actions, and icon toggle actions.
+- [references/LAYOUT-NAVIGATION.md](references/LAYOUT-NAVIGATION.md) for shell structure, responsive layout, and navigation components.
+- [references/DATA-DISPLAY.md](references/DATA-DISPLAY.md) for tabular, list, timeline, tree, and media display components.
+- [references/FEEDBACK-OVERLAYS.md](references/FEEDBACK-OVERLAYS.md) for alerts, progress, dialogs, snackbars, overlays, and placeholders.
+- [references/DATAGRID.md](references/DATAGRID.md) for detailed `MudDataGrid<T>` usage patterns.
+- [references/KNOWN-PITFALLS.md](references/KNOWN-PITFALLS.md) for operational troubleshooting.
+- [references/THEMING.md](references/THEMING.md) for palette and typography customisation.
+- [references/BUNIT.md](references/BUNIT.md) for component testing patterns.
+
 ### Text Input
 
 ```razor

--- a/.github/skills/mudblazor/references/BUTTONS.md
+++ b/.github/skills/mudblazor/references/BUTTONS.md
@@ -1,0 +1,28 @@
+# MudBlazor Buttons
+
+Use this reference when choosing between action-oriented MudBlazor components.
+
+## Decision Guidance
+
+- Use `MudButton` for most text-labelled actions.
+- Use `MudIconButton` for compact icon-only actions where the icon is unambiguous.
+- Use `MudButtonGroup` when multiple related actions should read as one control set.
+- Use `MudFab` for the primary floating action on a page.
+- Use `MudToggleIconButton` when a boolean state needs icon-based on/off feedback.
+- Use `MudScrollToTop` for long pages where users need a fast return to top.
+
+## Component Coverage
+
+| Component | When to use it. | Notes. |
+|-----------|-----------------|--------|
+| `MudButton` | Primary, secondary, neutral, and destructive actions with a text label. | Prefer `Variant` and `Color` over custom CSS styling. |
+| `MudButtonGroup` | Grouped actions where visual adjacency communicates relationship. | Useful for segmented controls and grouped command bars. |
+| `MudFab` | Prominent page-level call to action. | Keep usage rare; one floating primary action per page section is usually enough. |
+| `MudIconButton` | Small icon-only actions in tables, lists, cards, or toolbars. | Pair with tooltip text when icon meaning may be ambiguous. |
+| `MudToggleIconButton` | Toggled states such as favourite, pinned, muted, or enabled/disabled. | Use stateful icon and colour differences to make state clear. |
+| `MudScrollToTop` | Long vertically scrolling content. | Prefer this over custom JavaScript scroll controls. |
+
+## Related References
+
+- For button colour and intent hierarchy, see `COMPONENT-CHOOSER.md`.
+- For top bar and command placement, see `LAYOUT-NAVIGATION.md`.

--- a/.github/skills/mudblazor/references/COMPONENT-CHOOSER.md
+++ b/.github/skills/mudblazor/references/COMPONENT-CHOOSER.md
@@ -68,3 +68,40 @@ Use button colour and variant to communicate intent consistently across pages.
 | Breakpoint visibility | `MudHidden` | Prefer over custom media-query CSS for show/hide behaviour. |
 | Avatar / icon circle | `MudAvatar` | |
 | Colour swatch display | `MudChip` with background colour style | |
+
+## Additional Official Components
+
+Use this section for components available in the official MudBlazor overview that are less common in current SoloDevBoard screens.
+
+| UI Pattern | MudBlazor Component | Notes |
+|------------|---------------------|-------|
+| Grouped adjacent actions | `MudButtonGroup` | See `BUTTONS.md` for grouping guidance. |
+| Icon toggle state control | `MudToggleIconButton` | Use for pinned, favourite, and similar icon-first booleans. |
+| Long-page return affordance | `MudScrollToTop` | Prefer over custom JavaScript scrolling controls. |
+| Section command strip | `MudToolBar` | Use for local command areas inside sections and cards. |
+| Custom field shell around bespoke content | `MudField` | Use for consistent labels and helper text around custom content. |
+| File selection and upload | `MudFileUpload<T>` | Validate file type and size constraints explicitly. |
+| Coordinated validation across fields | `MudForm` | Keep form-level validity and submit behaviour centralised. |
+| Focus-trapped interaction region | `MudFocusTrap` | Useful in constrained overlays and accessibility-sensitive flows. |
+| Text highlight of search matches | `MudHighlighter` | Pair with filtered search result rendering. |
+| Rating input or display | `MudRating` | Use for sentiment scoring interactions. |
+| Range and threshold tuning | `MudSlider<T>` | Prefer over free-form numeric text for bounded ranges. |
+| Segmented mode toggles | `MudToggleGroup<T>` | Good for compact option groups. |
+| Rich contextual menu | `MudMenu` | Use for overflow and contextual actions. |
+| Hierarchical breadcrumb path | `MudBreadcrumbs` | Use for deep navigation context. |
+| Themed inline navigation link | `MudLink` | Prefer over raw styled anchors where appropriate. |
+| Structured non-tabular lists | `MudList<T>` + `MudListItem<T>` | Use when table columns are unnecessary. |
+| Lightweight paging controls | `MudPagination` | Pair with server or in-memory paging. |
+| Anchored contextual surface | `MudPopover` | Ensure dismiss and focus behaviour are clear. |
+| Lightweight static table | `MudSimpleTable` | Use for simple read-only tabular summaries. |
+| Chronological event feed | `MudTimeline` | Useful for audit and history visualisation. |
+| Hierarchical data explorer | `MudTreeView<T>` | Use for nested repository and rule structures. |
+| Drag-and-drop target and reorder region | `MudDropZone<T>` | Useful for visual ordering workflows. |
+| Rotating visual panels | `MudCarousel` | Use sparingly and avoid critical information in carousels. |
+| Conversational message thread view | `MudChat` | Suitable for chat-like audit or assistant interactions. |
+| Themed responsive image display | `MudImage` | Prefer over raw image tags when component features are needed. |
+| Standard confirmation prompt | `MudMessageBox` | Use for straightforward confirm and acknowledge flows. |
+| Loading-state placeholders | `MudSkeleton` | Improves perceived loading quality on content-heavy views. |
+| Backdrop and blocking layer | `MudOverlay` | Use for blocking busy states and modal emphasis. |
+
+For complete grouped guidance, see `INPUTS.md`, `BUTTONS.md`, `LAYOUT-NAVIGATION.md`, `DATA-DISPLAY.md`, and `FEEDBACK-OVERLAYS.md`.

--- a/.github/skills/mudblazor/references/DATA-DISPLAY.md
+++ b/.github/skills/mudblazor/references/DATA-DISPLAY.md
@@ -1,0 +1,39 @@
+# MudBlazor Data Display
+
+Use this reference for read-heavy views, structured information, and visual presentation components.
+
+## Component Coverage
+
+| Component | When to use it. | Notes. |
+|-----------|-----------------|--------|
+| `MudAvatar` | User or entity avatar visuals. | Use in lists, cards, and activity streams. |
+| `MudCard` | Information grouped as card content. | Suitable for dashboard summaries and compact records. |
+| `MudCarousel` | Rotating set of visual slides. | Use sparingly; avoid for critical information. |
+| `MudChat` | Chat-style message thread presentation. | Suitable for conversational or timeline-style interactions. |
+| `MudChip<T>` | Compact labels, facets, or status indicators. | Works well with filters and taxonomy badges. |
+| `MudChipSet<T>` | Coordinated chip selection groups. | Useful for filter bars and quick selectors. |
+| `MudDataGrid<T>` | Rich tabular data with filtering, sorting, and templates. | Prefer for feature-rich interactive tables. |
+| `MudDropZone<T>` | Drag-and-drop target and reorder interactions. | Useful for visual ordering and workflow mapping interfaces. |
+| `MudExpansionPanels` | Collapsible grouped sections. | Ideal for advanced settings and dense forms. |
+| `MudImage` | Responsive and themed image rendering. | Prefer over raw `<img>` when MudBlazor behaviours are useful. |
+| `MudList<T>` + `MudListItem<T>` | Lightweight list presentation and selection. | Choose over table when columns are unnecessary. |
+| `MudPagination` | Page navigation controls for paged content. | Pair with server-side paging logic where needed. |
+| `MudPopover` | Anchored content surface for contextual detail. | Use with care; ensure focus and dismiss behaviour are clear. |
+| `MudSimpleTable` | Low-friction static table rendering. | Good for read-only compact tabular details. |
+| `MudTable<T>` | Data table with moderate capabilities. | Prefer when `MudDataGrid` features are unnecessary. |
+| `MudTabs` + `MudTabPanel` | Segmented content areas. | Useful for mode switches and detail partitioning. |
+| `MudTimeline` + timeline items | Chronological event display. | Good fit for audit and activity histories. |
+| `MudTreeView<T>` + `MudTreeViewItem<T>` | Hierarchical data and nested structures. | Suitable for file-like trees and rule hierarchies. |
+
+## Table and Grid Guidance
+
+- Use `MudSimpleTable` for static data with no interactive operations.
+- Use `MudTable<T>` for moderate interaction needs.
+- Use `MudDataGrid<T>` when advanced filtering, template columns, or richer interactions are required.
+
+For concrete grid patterns, see `DATAGRID.md`.
+
+## Related References
+
+- For action controls within displayed data, see `BUTTONS.md`.
+- For notifications and transient UI tied to display actions, see `FEEDBACK-OVERLAYS.md`.

--- a/.github/skills/mudblazor/references/DATAGRID.md
+++ b/.github/skills/mudblazor/references/DATAGRID.md
@@ -4,6 +4,18 @@ Reference for `MudDataGrid<T>` usage in SoloDevBoard.
 
 ---
 
+## Table Selection Guidance
+
+Choose the lightest table component that satisfies the scenario.
+
+- Use `MudSimpleTable` for static read-only tabular summaries with no interaction.
+- Use `MudTable<T>` for moderate tabular interaction and straightforward templating.
+- Use `MudDataGrid<T>` when richer interactions are needed, such as multi-sort, filtering, selectable rows, and template-heavy columns.
+
+If uncertain, start with `MudTable<T>` and move to `MudDataGrid<T>` only when a concrete feature requires advanced grid capabilities.
+
+---
+
 ## Basic Setup
 
 ```razor

--- a/.github/skills/mudblazor/references/FEEDBACK-OVERLAYS.md
+++ b/.github/skills/mudblazor/references/FEEDBACK-OVERLAYS.md
@@ -1,0 +1,28 @@
+# MudBlazor Feedback and Overlays
+
+Use this reference for user feedback, status communication, and transient surfaces.
+
+## Component Coverage
+
+| Component | When to use it. | Notes. |
+|-----------|-----------------|--------|
+| `MudAlert` | Inline contextual information, warnings, or errors. | Use for page-local messages that should remain visible. |
+| `MudBadge` | Counts and concise status markers. | Pair with icons and tabs for lightweight indicators. |
+| `MudDialog` via `IDialogService` | Modal flows requiring focused interaction. | Requires `MudDialogProvider` in layout. |
+| `MudMessageBox` via service helpers | Standard confirmation and acknowledgement prompts. | Prefer for straightforward yes/no or ok/cancel prompts. |
+| `MudProgressCircular` and `MudProgressLinear` | Loading and progress indication. | Choose circular for localised loading and linear for process progression. |
+| `MudSkeleton` | Loading placeholders while content hydrates. | Improves perceived performance in content-heavy views. |
+| `ISnackbar` with `MudSnackbarProvider` | Non-blocking global toasts. | Use for operation outcomes and short-lived notifications. |
+| `MudOverlay` | Backdrop or blocking surface overlays. | Useful for busy states and controlled modal emphasis. |
+
+## Decision Guidance
+
+- Use `MudAlert` when the message should stay anchored in page context.
+- Use snackbar for brief outcomes that do not require immediate action.
+- Use dialog or message box when explicit acknowledgement is required.
+- Use skeletons for content loading states where layout stability matters.
+
+## Related References
+
+- For provider setup and service injection patterns, see `../SKILL.md`.
+- For common provider and popup failures, see `KNOWN-PITFALLS.md`.

--- a/.github/skills/mudblazor/references/INPUTS.md
+++ b/.github/skills/mudblazor/references/INPUTS.md
@@ -1,0 +1,41 @@
+# MudBlazor Inputs
+
+Use this reference when selecting data entry and input components.
+
+## Decision Guidance
+
+- Use `MudTextField<T>` for most text capture scenarios.
+- Use `MudNumericField<T>` for constrained numeric values.
+- Use `MudSelect<T>` for known finite choices.
+- Use `MudAutocomplete<T>` for large option sets and type-ahead.
+- Use picker components (`MudDatePicker`, `MudTimePicker`, `MudColorPicker`) for specialised value types.
+- Use `MudForm` when coordinating validation and submission across multiple fields.
+
+## Component Coverage
+
+| Component | When to use it. | Notes. |
+|-----------|-----------------|--------|
+| `MudAutocomplete<T>` | Type-ahead selection from larger collections. | Requires `MudPopoverProvider` in layout. |
+| `MudCheckBox<T>` | Boolean input or checklist options. | Prefer over raw HTML checkboxes. |
+| `MudColorPicker` | Colour selection with HEX, RGB, or palette style workflows. | Use `@bind-Text` for hex string models. |
+| `MudDatePicker` | Single date capture. | Use for due dates, schedule dates, or report filters. |
+| `MudField` | Shared field shell for custom input experiences. | Use when composing custom field content with consistent label and helper behaviour. |
+| `MudFileUpload<T>` | File selection and upload workflows. | Keep validation explicit for file type and size constraints. |
+| `MudForm` | Coordinated validation and submit flow across fields. | Use `Validate()` and form-level state instead of ad hoc per-control checks. |
+| `MudFocusTrap` | Keep focus within a scoped region. | Useful for accessibility in dialogs and constrained overlays. |
+| `MudHighlighter` | Highlight matched text fragments in search results. | Pair with user search text and sanitised matching logic. |
+| `MudNumericField<T>` | Numeric values with min, max, and step. | Prefer this over text field parsing for numbers. |
+| `MudRadioGroup<T>` + `MudRadio<T>` | Single selection from a short mutually exclusive set. | Better choice than select for small visible option groups. |
+| `MudRating` | Rating input or display using stars or custom symbols. | Use for sentiment-style scoring, not critical binary decisions. |
+| `MudSelect<T>` + `MudSelectItem<T>` | Dropdown for finite known options. | Supports multi-select when `MultiSelection="true"`. |
+| `MudSlider<T>` | Range-based value selection. | Useful for bounded thresholds and tuning values. |
+| `MudSwitch<T>` | Binary on/off state with immediate affordance. | Prefer where toggle semantics are clearer than checkbox semantics. |
+| `MudTextField<T>` | Single-line and multi-line text input. | Supports adornments, masks, counters, and input type variants. |
+| `MudTimePicker` | Time selection with 12h or 24h modes. | Bind with `@bind-Time` for `TimeSpan?` models. |
+| `MudToggleGroup<T>` | Exclusive or multi-toggle selection via button-like options. | Useful for quick mode switches and compact option sets. |
+
+## Related References
+
+- For provider requirements and baseline setup, see `../SKILL.md`.
+- For popover-related issues, see `KNOWN-PITFALLS.md`.
+- For quick pattern matching, see `COMPONENT-CHOOSER.md`.

--- a/.github/skills/mudblazor/references/KNOWN-PITFALLS.md
+++ b/.github/skills/mudblazor/references/KNOWN-PITFALLS.md
@@ -126,3 +126,83 @@ private async Task<IEnumerable<string>> SearchRepos(string value, CancellationTo
                  .Select(r => r.Name);
 }
 ```
+
+---
+
+## Pitfall 9: MudMenu and MudPopover clipped or hidden
+
+**Symptom:** Menu or popover content appears cut off, hidden behind other surfaces, or not visible near container edges.
+
+**Cause:** Missing provider setup, restrictive parent overflow styling, or assumptions about local z-index stacking.
+
+**Fix:**
+
+- Confirm `MudPopoverProvider` is present in `MainLayout.razor`.
+- Avoid custom container styles such as `overflow: hidden` around menu and popover triggers unless clipping is intentional.
+- Prefer MudBlazor layout primitives and defaults over custom z-index adjustments.
+
+---
+
+## Pitfall 10: MudForm validation state not updating as expected
+
+**Symptom:** Submit actions proceed while invalid fields are present, or validation messages do not appear until too late.
+
+**Cause:** Form-level validation is bypassed and controls are validated ad hoc.
+
+**Fix:** Keep validation coordinated through `MudForm`.
+
+```razor
+<MudForm @ref="_form">
+    <MudTextField @bind-Value="_name" Label="Name" Required="true" />
+    <MudButton OnClick="@SubmitAsync">Save</MudButton>
+</MudForm>
+
+@code {
+    private MudForm? _form;
+    private string _name = string.Empty;
+
+    private async Task SubmitAsync()
+    {
+        await _form!.Validate();
+        if (!_form.IsValid)
+            return;
+
+        // Continue with save.
+    }
+}
+```
+
+---
+
+## Pitfall 11: File upload accepted with no guardrails
+
+**Symptom:** Unexpected file types or oversized files are processed.
+
+**Cause:** File selection is treated as trusted input.
+
+**Fix:** Validate uploaded files explicitly before processing.
+
+- Validate file count, file extension, and content type.
+- Enforce maximum file size in code.
+- Provide clear snackbar or inline validation feedback.
+
+---
+
+## Pitfall 12: Tabs lose intended active panel after rerender
+
+**Symptom:** Active tab jumps back unexpectedly after state changes.
+
+**Cause:** Active tab selection is not controlled when tab collection or conditional visibility changes.
+
+**Fix:** Bind and manage active panel explicitly when tabs are dynamic.
+
+```razor
+<MudTabs @bind-ActivePanelIndex="_activeTab">
+    <MudTabPanel Text="Overview" />
+    <MudTabPanel Text="Details" />
+</MudTabs>
+
+@code {
+    private int _activeTab;
+}
+```

--- a/.github/skills/mudblazor/references/LAYOUT-NAVIGATION.md
+++ b/.github/skills/mudblazor/references/LAYOUT-NAVIGATION.md
@@ -1,0 +1,39 @@
+# MudBlazor Layout and Navigation
+
+Use this reference when structuring pages, shell layout, and navigation affordances.
+
+## Layout Components
+
+| Component | When to use it. | Notes. |
+|-----------|-----------------|--------|
+| `MudAppBar` | Top-level application bar and command strip. | Commonly paired with drawer toggles and page-level actions. |
+| `MudContainer` | Width-constrained page content area. | Helps maintain readable line lengths and consistent margins. |
+| `MudDrawer` | Side navigation or secondary panel content. | Bind `@bind-Open` for predictable state handling. |
+| `MudGrid` + `MudItem` | Responsive column-based layouts. | Prefer over bespoke CSS grid for standard responsive layouts. |
+| `MudHidden` | Breakpoint-based conditional visibility. | Prefer over custom media-query show/hide CSS. |
+| `MudPaper` | Surface container with elevation and padding support. | Use for sections and panels requiring visual separation. |
+| `MudDivider` | Visual separation between content groups. | Prefer over raw `<hr>` elements. |
+| `MudStack` | One-dimensional spacing and alignment layout. | Usually the quickest layout primitive for forms and card internals. |
+| `MudToolBar` | Inline command toolbar in sections or cards. | Useful for local action groups and filter bars. |
+
+## Navigation Components
+
+| Component | When to use it. | Notes. |
+|-----------|-----------------|--------|
+| `MudBreadcrumbs` | Hierarchical page context and location path. | Useful for deep configuration flows. |
+| `MudLink` | Styled navigation links aligned with theme typography and colours. | Use for inline links in copy and helper text. |
+| `MudMenu` | Contextual menu actions anchored to a trigger. | Good for overflow actions in dense UIs. |
+| `MudNavMenu` + `MudNavLink` + `MudNavGroup` | Persistent app navigation structures. | Preferred for sidebar and grouped navigation. |
+
+## Decision Guidance
+
+- Start page structure with `MudContainer`, `MudStack`, and `MudPaper`.
+- Add `MudGrid` only when true responsive columns are needed.
+- Use `MudDrawer` and `MudNavMenu` for app shell navigation, not ad hoc link lists.
+- Use `MudMenu` for condensed action sets before introducing custom popovers.
+
+## Related References
+
+- For action components in bars and menus, see `BUTTONS.md`.
+- For overlays and transient surfaces, see `FEEDBACK-OVERLAYS.md`.
+- For full page shell setup, see `../SKILL.md`.


### PR DESCRIPTION
This pull request adds a comprehensive set of reference documentation files for MudBlazor component usage, organized by component family and UI theme. The changes enhance discoverability and clarify decision guidance for SoloDevBoard developers, providing quick lookup tables, usage notes, and troubleshooting advice for inputs, buttons, layout/navigation, data display, feedback/overlays, and known pitfalls. The most important changes are grouped below:

**Reference Documentation Expansion**

* Added new reference files covering MudBlazor component families: `INPUTS.md`, `BUTTONS.md`, `LAYOUT-NAVIGATION.md`, `DATA-DISPLAY.md`, `FEEDBACK-OVERLAYS.md`, and `DATAGRID.md`. Each file includes decision guidance, component tables, and usage notes for its theme. (.github/skills/mudblazor/references/INPUTS.md [[1]](diffhunk://#diff-f4dfc11b9b26e4e5c814cfbc8a3ad97bbb4ad9e5b403fdbf297e2c11e7218bfbR1-R41) BUTTONS.md [[2]](diffhunk://#diff-989cb9d8a6d8b3db22494c51eb78e11c8fef57e58bd3419f1563fdbfa339162cR1-R28) LAYOUT-NAVIGATION.md [[3]](diffhunk://#diff-fc4bbdc1cbb22162e6ccafce9020b015fcf5fcbfd0fba4832d8a980223a231abR1-R39) DATA-DISPLAY.md [[4]](diffhunk://#diff-1daacc00d1707a4e2d53e48ef5c506304a1d73d54973858111bd0637f8e14dddR1-R39) FEEDBACK-OVERLAYS.md [[5]](diffhunk://#diff-07c3922b6498c1a7a2ca75368f3384a92a66a0833e8300ca9f03da3d36d55d43R1-R28) DATAGRID.md [[6]](diffhunk://#diff-02227c654194a41e374d250f95156f0024ee7ac5d31eb73bbce53ba5591d468cR7-R18)

* Expanded the component chooser mapping in `COMPONENT-CHOOSER.md` to include additional official MudBlazor components, with cross-links to new reference files for grouped guidance. (.github/skills/mudblazor/references/COMPONENT-CHOOSER.md [.github/skills/mudblazor/references/COMPONENT-CHOOSER.mdR71-R107](diffhunk://#diff-36e1f2e2272f5387834e0bcda4ae319251208c3943524fddd26bbb6b53b99bc7R71-R107))

**Troubleshooting and Pitfall Guidance**

* Added new troubleshooting sections for common MudBlazor pitfalls in `KNOWN-PITFALLS.md`, including menu/popover clipping, form validation, file upload guardrails, and tab selection issues, with code samples and explicit fixes. (.github/skills/mudblazor/references/KNOWN-PITFALLS.md [.github/skills/mudblazor/references/KNOWN-PITFALLS.mdR129-R208](diffhunk://#diff-602505c315a962c0fab756da8029e3404e9d09a15926a12646b05136b1912e68R129-R208))

**Navigation and Cross-Referencing Improvements**

* Introduced a "Reference Map" section in `SKILL.md` to guide users to the appropriate reference files after using the component chooser, improving lookup speed and clarity. (.github/skills/mudblazor/SKILL.md [.github/skills/mudblazor/SKILL.mdR118-R131](diffhunk://#diff-0b56a03ebf8c28ed4e0d7b5ee017b56cebb7fbf4ba6a7a7920862f0c3e0c59a8R118-R131))

**Component-Specific Guidance**

* Provided clear guidance in each reference on when to use specific MudBlazor components, including tables for quick comparison and notes on provider setup, accessibility, and common mistakes. (All new reference files above)

These changes collectively make the MudBlazor skill documentation more modular, actionable, and easier to navigate for both new and experienced SoloDevBoard developers.