### PR TITLE
[type/story] Label Manager tabbed wireframe refresh and bUnit coverage update

### DIFF
--- a/docs/user-guide/label-manager.md
+++ b/docs/user-guide/label-manager.md
@@ -37,15 +37,13 @@ The current plan is that One-Click Migration will provide a broader preview-firs
 
 ## How to Use
 
-The consolidated label view and bulk CRUD operations are available on the `Labels` page.
+The Label Manager page now uses a tabbed layout to organise label management workflows. The repository selector is positioned above the tabs, allowing you to choose one or more repositories before switching between workflows.
 
-Current interactions:
+The three available tabs are:
 
-1. Select one or more active repositories in the repository selector.
-2. Select `Load selected repositories` to build a consolidated label view.
-3. Use the `Filter` input to narrow results by label name.
-4. Use `New label` to create labels for selected repositories.
-5. Use row-level `Edit` and `Delete` actions to modify existing labels.
+1. **Labels** — View, create, edit, and delete labels across the selected repositories. Use the consolidated label view and bulk CRUD operations here. Filter by label name, and use the `New label` button to add labels. Row-level actions allow editing and deleting existing labels.
+2. **Recommended taxonomy** — Apply a recommended label taxonomy to the selected repositories. Preview proposed changes, confirm before applying, and review a per-repository summary after completion.
+3. **Synchronise** — Synchronise labels from a source repository to one or more target repositories. Preview all changes before applying, and receive a summary of the synchronisation outcome for each target repository.
 
 The create and edit dialogs include:
 

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -42,7 +42,7 @@ Labels: `type/epic`, `area/infrastructure`
 - [x] As a solo developer, I want the application switched from Fluent UI Blazor to MudBlazor so that UI delivery by AI agents is more reliable and requires fewer workarounds. _(ADR-0012, Epic #63 — done, 2026-03-09)_
 - [x] As a solo developer, I want the Repositories page refreshed to use a clearer command-strip, data-grid, and feedback layout so that repository management scales cleanly as SoloDevBoard grows. _(Issue #131 implemented on 2026-03-17; paired bUnit coverage issue #132 also complete; wireframe-aligned follow-on to #67.)_
   - Implementation note: Completed 2026-03-17. The new Repositories page layout, command strip, responsive actions, search, data grid, and feedback region are now live. Paired bUnit test coverage (#132) is also complete.
-- [ ] As a solo developer, I want the Label Manager page refreshed into tabbed workflows for Labels, Recommended Taxonomy, and Synchronise so that label-management modes have a clearer mental model. _(Issue #133 planned for v0.2.0; paired test issue #134; wireframe-aligned follow-on to #68.)_
+- [x] As a solo developer, I want the Label Manager page refreshed into tabbed workflows for Labels, Recommended Taxonomy, and Synchronise so that label-management modes have a clearer mental model. _(Issue #133 implemented on 2026-03-17; paired test issue #134 also complete; wireframe-aligned follow-on to #68.)_
 - [ ] As a solo developer, I want the Audit Dashboard refreshed with a clearer command surface, KPI summary cards, and grouped health indicators so that repository health is easier to scan and act on. _(Issue #135 planned for v0.2.0; paired test issue #136; wireframe-aligned follow-on to #40 and #48.)_
 
 ---

--- a/plan/wireframes/label-manager-wireframe.md
+++ b/plan/wireframes/label-manager-wireframe.md
@@ -12,9 +12,9 @@
 ## Layout
 ```
 +-------------------------------------------------------------+
-| Tab Strip: [Labels] [Recommended Taxonomy] [Synchronise]    |
+| Repository Selector: [Repository dropdown]                  |
 +-------------------------------------------------------------+
-| Scope Selector: [Repository dropdown]                       |
+| Tab Strip: [Labels] [Recommended Taxonomy] [Synchronise]    |
 +-------------------------------------------------------------+
 | Action Strip: [Create] [Edit] [Delete] [Bulk Actions]       |
 +-------------------------------------------------------------+
@@ -33,7 +33,7 @@
 - Each tab presents relevant actions and feedback, minimising context switching.
 
 ## Interaction Notes
-- Scope selector filters results and actions by repository.
+- Repository selector sets page-level context and filters all tabs.
 - Action strip adapts to selected tab (e.g., synchronise actions only in Synchronise tab).
 - Feedback region provides real-time status and error messages.
 
@@ -43,10 +43,10 @@
 - Error state: Show error in feedback region.
 
 ## Accessibility Notes
-- Focus order: Tab strip → scope selector → action strip → results region → feedback region.
+- Focus order: Repository selector → tab strip → action strip → results region → feedback region.
 - ARIA: Tabs use `role="tablist"`, results region uses `aria-label`.
 - Live region: Feedback region uses `aria-live="polite"`.
 
 ## Responsive Behaviour
-- Desktop: Tabs and action strip remain visible, results region adapts to width.
-- Mobile: Tabs collapse into dropdown, action strip moves to bottom, results region stacks vertically.
+- Desktop: Repository selector remains above tabs, with tabs and action strip visible and results region adapting to width.
+- Mobile: Repository selector stays first, tabs collapse into dropdown, action strip moves to bottom, and results region stacks vertically.

--- a/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor
@@ -401,21 +401,29 @@
                     </MudStack>
                 }
             }
-            else if (!string.IsNullOrWhiteSpace(taxonomyOperationMessage))
-            {
-                <MudAlert Severity="@taxonomyOperationSeverity" Dense="true" Variant="Variant.Outlined" data-testid="taxonomy-operation-message">
-                    @taxonomyOperationMessage
-                </MudAlert>
-            }
-            else if (!string.IsNullOrWhiteSpace(syncOperationMessage))
-            {
-                <MudAlert Severity="@syncOperationSeverity" Dense="true" Variant="Variant.Outlined" data-testid="sync-operation-message">
-                    @syncOperationMessage
-                </MudAlert>
-            }
             else
             {
-                <MudText Typo="Typo.body2">No active status messages.</MudText>
+                var hasTaxonomyMessage = !string.IsNullOrWhiteSpace(taxonomyOperationMessage);
+                var hasSyncMessage = !string.IsNullOrWhiteSpace(syncOperationMessage);
+
+                if (hasTaxonomyMessage)
+                {
+                    <MudAlert Severity="@taxonomyOperationSeverity" Dense="true" Variant="Variant.Outlined" data-testid="taxonomy-operation-message">
+                        @taxonomyOperationMessage
+                    </MudAlert>
+                }
+
+                if (hasSyncMessage)
+                {
+                    <MudAlert Severity="@syncOperationSeverity" Dense="true" Variant="Variant.Outlined" data-testid="sync-operation-message">
+                        @syncOperationMessage
+                    </MudAlert>
+                }
+
+                if (!hasTaxonomyMessage && !hasSyncMessage)
+                {
+                    <MudText Typo="Typo.body2">No active status messages.</MudText>
+                }
             }
         </MudStack>
     </MudPaper>

--- a/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor
@@ -4,9 +4,9 @@
 
 <MudStack Spacing="3">
     <MudText Typo="Typo.h4">Label Manager</MudText>
-    <MudText Typo="Typo.body1">View labels across selected repositories and identify missing labels quickly.</MudText>
+    <MudText Typo="Typo.body1">View labels across selected repositories and organise taxonomy and synchronisation workflows by mode.</MudText>
 
-    <MudPaper Class="pa-4" Elevation="1">
+    <MudPaper Class="pa-4" Elevation="1" data-testid="repository-selector-region">
         <MudStack Spacing="2">
             <MudText Typo="Typo.h6">Repository selector</MudText>
 
@@ -16,23 +16,32 @@
             }
             else
             {
-                <MudStack Spacing="2">
-                    <RepositorySelector
-                        Title=""
-                        Label="Repositories"
-                        Placeholder="Search repositories and select"
-                        EmptyStateText="No active repositories are available for label analysis."
-                        AvailableRepositories="availableRepositoryFullNames"
-                        SelectedRepositories="selectedRepositoryFullNames"
-                        SelectedRepositoriesChanged="OnSelectedRepositoriesChangedAsync"
-                        SummaryText="@RepositorySelectorSummary"
-                        ShowSelectedChips="true"
-                        ShowSelectionActions="true"
-                        Disabled="ShowLoadingState"
-                        AutocompleteTestId="repository-autocomplete"
-                        SummaryTestId="repository-selector-summary" />
+                <RepositorySelector
+                    Title=""
+                    Label="Repositories"
+                    Placeholder="Search repositories and select"
+                    EmptyStateText="No active repositories are available for label analysis."
+                    AvailableRepositories="availableRepositoryFullNames"
+                    SelectedRepositories="selectedRepositoryFullNames"
+                    SelectedRepositoriesChanged="OnSelectedRepositoriesChangedAsync"
+                    SummaryText="@RepositorySelectorSummary"
+                    ShowSelectedChips="true"
+                    ShowSelectionActions="true"
+                    Disabled="ShowLoadingState"
+                    AutocompleteTestId="repository-autocomplete"
+                    SummaryTestId="repository-selector-summary" />
+            }
+        </MudStack>
+    </MudPaper>
 
-                    <MudStack Row="true" Spacing="1">
+    <MudPaper Elevation="1" data-testid="label-manager-tab-strip">
+        <MudTabs Rounded="true"
+                 ActivePanelIndex="activeTabIndex"
+                 ActivePanelIndexChanged="OnActiveTabIndexChanged"
+                 data-testid="label-manager-tabs">
+            <MudTabPanel Text="Labels">
+                <MudStack Spacing="2" Class="pt-3">
+                    <MudStack Row="true" Spacing="1" data-testid="labels-action-strip">
                         <MudButton Variant="Variant.Filled"
                                    Color="Color.Primary"
                                    data-testid="new-label-button"
@@ -50,30 +59,105 @@
                         </MudButton>
                     </MudStack>
 
-                    <MudDivider />
+                    @if (ShowLabelFilter)
+                    {
+                        <MudTextField @bind-Value="SearchText"
+                                      Placeholder="Filter by label name"
+                                      Variant="Variant.Outlined"
+                                      Adornment="Adornment.Start"
+                                      AdornmentIcon="@Icons.Material.Filled.FilterAlt"
+                                      Immediate="true"
+                                      InputType="InputType.Search"
+                                      data-testid="label-filter" />
+                    }
 
+                    <MudPaper Class="pa-4" Outlined="true" aria-label="Labels results" data-testid="labels-results-region">
+                        @if (ShowLoadingState)
+                        {
+                            <MudStack AlignItems="AlignItems.Center" Spacing="1" aria-live="polite" role="status" data-testid="labels-loading-state">
+                                <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading labels" />
+                                <MudText Typo="Typo.body2">@(isLoadingRepositories ? "Loading repositories..." : "Loading labels...")</MudText>
+                            </MudStack>
+                        }
+                        else if (hasLoadedLabels && filteredRows.Count == 0)
+                        {
+                            <MudStack Spacing="1" aria-live="polite" data-testid="labels-empty-state">
+                                <MudText Typo="Typo.h6">No labels found</MudText>
+                                <MudText Typo="Typo.body2">No labels were returned for the selected repositories.</MudText>
+                            </MudStack>
+                        }
+                        else if (hasLoadedLabels)
+                        {
+                            <MudDataGrid T="Labels.LabelRow"
+                                         Items="filteredRows"
+                                         Hover="true"
+                                         Dense="true"
+                                         SortMode="SortMode.Multiple"
+                                         data-testid="labels-grid">
+                                <Columns>
+                                    <PropertyColumn Property="row => row.Name" Title="Label" Sortable="true" />
+                                    <TemplateColumn T="Labels.LabelRow" Title="Colour">
+                                        <CellTemplate>
+                                            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                                                <MudChip Variant="Variant.Outlined"
+                                                         Size="Size.Small"
+                                                         Style="@GetColourChipStyle(context.Item.Colour)">@($"#{context.Item.Colour}")</MudChip>
+                                            </MudStack>
+                                        </CellTemplate>
+                                    </TemplateColumn>
+                                    <PropertyColumn Property="row => row.Description" Title="Description" />
+                                    <PropertyColumn Property="row => row.RepositoriesWithLabelText" Title="Repositories" />
+                                    <PropertyColumn Property="row => row.MissingRepositoriesText" Title="Missing in" />
+                                    <TemplateColumn T="Labels.LabelRow" Title="Actions">
+                                        <CellTemplate>
+                                            <MudStack Row="true" Spacing="1">
+                                                <MudButton Variant="Variant.Outlined"
+                                                           Color="Color.Default"
+                                                           Size="Size.Small"
+                                                           data-testid="edit-label-button"
+                                                           OnClick="() => ShowEditDialogAsync(context.Item)">
+                                                    Edit
+                                                </MudButton>
+                                                <MudButton Variant="Variant.Text"
+                                                           Color="Color.Error"
+                                                           Size="Size.Small"
+                                                           data-testid="delete-label-button"
+                                                           OnClick="() => ShowDeleteDialogAsync(context.Item)">
+                                                    Delete
+                                                </MudButton>
+                                            </MudStack>
+                                        </CellTemplate>
+                                    </TemplateColumn>
+                                </Columns>
+                            </MudDataGrid>
+                        }
+                        else
+                        {
+                            <MudText Typo="Typo.body2">Select one or more repositories, then load labels to see the consolidated grid.</MudText>
+                        }
+                    </MudPaper>
+                </MudStack>
+            </MudTabPanel>
+
+            <MudTabPanel Text="Recommended taxonomy">
+                <MudStack Spacing="2" Class="pt-3">
                     <MudText Typo="Typo.h6">Apply recommended taxonomy</MudText>
                     <MudText Typo="Typo.body2">Choose a strategy, preview changes, then confirm to apply labels across selected repositories.</MudText>
 
-                    <MudSelect T="string"
-                               Label="Recommended strategy"
-                               Value="selectedStrategyId"
-                               ValueChanged="OnStrategySelectedAsync"
-                               Variant="Variant.Outlined"
-                               Disabled="@(ShowLoadingState || !selectedRepositories.Any() || recommendedStrategies.Count == 0)"
-                               data-testid="taxonomy-strategy-select">
-                        @foreach (var strategy in recommendedStrategies)
-                        {
-                            <MudSelectItem T="string" Value="@strategy.Id">@strategy.Name</MudSelectItem>
-                        }
-                    </MudSelect>
+                    <MudStack Row="true" Spacing="1" data-testid="taxonomy-action-strip">
+                        <MudSelect T="string"
+                                   Label="Recommended label set"
+                                   Value="selectedStrategyId"
+                                   ValueChanged="OnStrategySelectedAsync"
+                                   Variant="Variant.Outlined"
+                                   Disabled="@(ShowLoadingState || !selectedRepositories.Any() || recommendedStrategies.Count == 0)"
+                                   data-testid="taxonomy-strategy-select">
+                            @foreach (var strategy in recommendedStrategies)
+                            {
+                                <MudSelectItem T="string" Value="@strategy.Id">@strategy.Name</MudSelectItem>
+                            }
+                        </MudSelect>
 
-                    @if (!string.IsNullOrWhiteSpace(SelectedStrategyDescription))
-                    {
-                        <MudText Typo="Typo.body2">@SelectedStrategyDescription</MudText>
-                    }
-
-                    <MudStack Row="true" Spacing="1">
                         <MudButton Variant="Variant.Outlined"
                                    Color="Color.Secondary"
                                    Disabled="@(!CanPreviewRecommendedTaxonomy)"
@@ -101,73 +185,127 @@
                         }
                     </MudStack>
 
-                    @if (!string.IsNullOrWhiteSpace(taxonomyOperationMessage))
+                    @if (!string.IsNullOrWhiteSpace(SelectedStrategyDescription))
                     {
-                        <MudAlert Severity="@taxonomyOperationSeverity" Dense="true" Variant="Variant.Outlined" data-testid="taxonomy-operation-message">
-                            @taxonomyOperationMessage
-                        </MudAlert>
+                        <MudText Typo="Typo.body2">@SelectedStrategyDescription</MudText>
                     }
 
-                    <MudDivider />
+                    <MudText Typo="Typo.caption">This selects the taxonomy template to apply. Conflict strategies such as Skip, Overwrite, and Merge are available in the Migrate workflow.</MudText>
 
+                    <MudPaper Class="pa-4" Outlined="true" aria-label="Recommended taxonomy results" data-testid="taxonomy-results-region">
+                        @if (showRecommendedPreview)
+                        {
+                            <MudStack Spacing="2" data-testid="taxonomy-preview-card">
+                                <MudText Typo="Typo.h6">Taxonomy preview</MudText>
+                                @foreach (var preview in recommendedPreview)
+                                {
+                                    <MudPaper Class="pa-3" Outlined="true">
+                                        <MudText Typo="Typo.subtitle1">@preview.RepositoryFullName</MudText>
+                                        <MudText Typo="Typo.body2">Create: @preview.ToCreate.Count, Update: @preview.ToUpdate.Count, Skip: @preview.Skipped.Count</MudText>
+
+                                        @if (preview.ToCreate.Count > 0)
+                                        {
+                                            <LabelPreviewTable Heading="Labels to create" Labels="preview.ToCreate" />
+                                        }
+
+                                        @if (preview.ToUpdate.Count > 0)
+                                        {
+                                            <LabelPreviewTable Heading="Labels to update" Labels="preview.ToUpdate" />
+                                        }
+                                    </MudPaper>
+                                }
+                            </MudStack>
+                        }
+                        else if (recommendedApplyResults.Count > 0)
+                        {
+                            <MudStack Spacing="2" data-testid="taxonomy-summary-card">
+                                <MudText Typo="Typo.h6">Apply summary</MudText>
+                                @foreach (var result in recommendedApplyResults)
+                                {
+                                    <MudPaper Class="pa-3" Outlined="true">
+                                        <MudText Typo="Typo.subtitle1">@result.RepositoryFullName</MudText>
+                                        @if (result.HasError)
+                                        {
+                                            <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Outlined">@result.ErrorMessage</MudAlert>
+                                        }
+                                        else
+                                        {
+                                            <MudText Typo="Typo.body2">Created: @result.CreatedCount, Updated: @result.UpdatedCount, Skipped: @result.SkippedCount</MudText>
+                                        }
+                                    </MudPaper>
+                                }
+                            </MudStack>
+                        }
+                        else
+                        {
+                            <MudText Typo="Typo.body2">Preview recommended taxonomy to see pending label changes by repository.</MudText>
+                        }
+                    </MudPaper>
+                </MudStack>
+            </MudTabPanel>
+
+            <MudTabPanel Text="Synchronise">
+                <MudStack Spacing="2" Class="pt-3">
                     <MudText Typo="Typo.h6">Synchronise labels</MudText>
                     <MudText Typo="Typo.body2">Choose one source repository and one or more target repositories, preview the exact changes, then confirm before applying.</MudText>
 
-                    <MudSelect T="string"
-                               Label="Source repository"
-                               Value="syncSourceRepositoryFullName"
-                               ValueChanged="OnSyncSourceRepositoryChangedAsync"
-                               Variant="Variant.Outlined"
-                               Disabled="@(ShowLoadingState || selectedRepositories.Count < 2)"
-                               data-testid="sync-source-select">
-                        @foreach (var repository in selectedRepositories.OrderBy(repository => repository.FullName, StringComparer.OrdinalIgnoreCase))
-                        {
-                            <MudSelectItem T="string" Value="@repository.FullName">@repository.FullName</MudSelectItem>
-                        }
-                    </MudSelect>
+                    <MudStack Spacing="1" data-testid="sync-action-strip">
+                        <MudSelect T="string"
+                                   Label="Source repository"
+                                   Value="syncSourceRepositoryFullName"
+                                   ValueChanged="OnSyncSourceRepositoryChangedAsync"
+                                   Variant="Variant.Outlined"
+                                   Disabled="@(ShowLoadingState || selectedRepositories.Count < 2)"
+                                   data-testid="sync-source-select">
+                            @foreach (var repository in selectedRepositories.OrderBy(repository => repository.FullName, StringComparer.OrdinalIgnoreCase))
+                            {
+                                <MudSelectItem T="string" Value="@repository.FullName">@repository.FullName</MudSelectItem>
+                            }
+                        </MudSelect>
 
-                    <MudText Typo="Typo.subtitle2">Target repositories</MudText>
-                    <MudText Typo="Typo.caption">Targets will be aligned to the source for label name, colour, and description.</MudText>
+                        <MudText Typo="Typo.subtitle2">Target repositories</MudText>
+                        <MudText Typo="Typo.caption">Targets will be aligned to the source for label name, colour, and description.</MudText>
 
-                    <MudStack Spacing="1" data-testid="sync-target-list">
-                        @foreach (var repository in selectedRepositories.OrderBy(repository => repository.FullName, StringComparer.OrdinalIgnoreCase))
-                        {
-                            var isSourceRepository = repository.FullName.Equals(syncSourceRepositoryFullName, StringComparison.OrdinalIgnoreCase);
-                            <MudCheckBox T="bool"
-                                         Value="syncTargetRepositoryFullNames.Contains(repository.FullName)"
-                                         ValueChanged="isChecked => OnSyncTargetRepositoryChangedAsync(repository.FullName, isChecked)"
-                                         Disabled="@isSourceRepository"
-                                         Label="@repository.FullName"
-                                         data-testid="sync-target-checkbox" />
-                        }
-                    </MudStack>
+                        <MudStack Spacing="1" data-testid="sync-target-list">
+                            @foreach (var repository in selectedRepositories.OrderBy(repository => repository.FullName, StringComparer.OrdinalIgnoreCase))
+                            {
+                                var isSourceRepository = repository.FullName.Equals(syncSourceRepositoryFullName, StringComparison.OrdinalIgnoreCase);
+                                <MudCheckBox T="bool"
+                                             Value="syncTargetRepositoryFullNames.Contains(repository.FullName)"
+                                             ValueChanged="isChecked => OnSyncTargetRepositoryChangedAsync(repository.FullName, isChecked)"
+                                             Disabled="@isSourceRepository"
+                                             Label="@repository.FullName"
+                                             data-testid="sync-target-checkbox" />
+                            }
+                        </MudStack>
 
-                    <MudStack Row="true" Spacing="1">
-                        <MudButton Variant="Variant.Outlined"
-                                   Color="Color.Secondary"
-                                   Disabled="@(!CanPreviewLabelSynchronisation)"
-                                   OnClick="PreviewLabelSynchronisationAsync"
-                                   data-testid="preview-sync-button">
-                            Preview synchronisation
-                        </MudButton>
-
-                        @if (showSyncPreview)
-                        {
-                            <MudButton Variant="Variant.Filled"
-                                       Color="Color.Primary"
-                                       Disabled="@(!CanApplyLabelSynchronisation)"
-                                       OnClick="ApplyLabelSynchronisationAsync"
-                                       data-testid="confirm-sync-button">
-                                Confirm synchronisation
+                        <MudStack Row="true" Spacing="1">
+                            <MudButton Variant="Variant.Outlined"
+                                       Color="Color.Secondary"
+                                       Disabled="@(!CanPreviewLabelSynchronisation)"
+                                       OnClick="PreviewLabelSynchronisationAsync"
+                                       data-testid="preview-sync-button">
+                                Preview synchronisation
                             </MudButton>
 
-                            <MudButton Variant="Variant.Text"
-                                       Color="Color.Default"
-                                       OnClick="CancelLabelSynchronisationPreview"
-                                       data-testid="cancel-sync-button">
-                                Cancel
-                            </MudButton>
-                        }
+                            @if (showSyncPreview)
+                            {
+                                <MudButton Variant="Variant.Filled"
+                                           Color="Color.Primary"
+                                           Disabled="@(!CanApplyLabelSynchronisation)"
+                                           OnClick="ApplyLabelSynchronisationAsync"
+                                           data-testid="confirm-sync-button">
+                                    Confirm synchronisation
+                                </MudButton>
+
+                                <MudButton Variant="Variant.Text"
+                                           Color="Color.Default"
+                                           OnClick="CancelLabelSynchronisationPreview"
+                                           data-testid="cancel-sync-button">
+                                    Cancel
+                                </MudButton>
+                            }
+                        </MudStack>
                     </MudStack>
 
                     @if (isPreviewingSync || isApplyingSync)
@@ -176,222 +314,109 @@
                         <MudText Typo="Typo.body2">Synchronisation is in progress. Duplicate submissions are disabled.</MudText>
                     }
 
-                    @if (!string.IsNullOrWhiteSpace(syncOperationMessage))
-                    {
-                        <MudAlert Severity="@syncOperationSeverity" Dense="true" Variant="Variant.Outlined" data-testid="sync-operation-message">
-                            @syncOperationMessage
-                        </MudAlert>
-                    }
+                    <MudPaper Class="pa-4" Outlined="true" aria-label="Synchronisation results" data-testid="sync-results-region">
+                        @if (showSyncPreview)
+                        {
+                            <MudStack Spacing="2" data-testid="sync-preview-card">
+                                <MudText Typo="Typo.h6">Synchronisation preview</MudText>
+                                @foreach (var preview in syncPreviewResults)
+                                {
+                                    <MudPaper Class="pa-3" Outlined="true">
+                                        <MudText Typo="Typo.subtitle1">@preview.RepositoryFullName</MudText>
+                                        <MudText Typo="Typo.body2">Create: @preview.ToCreate.Count, Update: @preview.ToUpdate.Count, Delete: @preview.ToDelete.Count, Skip: @preview.Skipped.Count</MudText>
+
+                                        @if (preview.ToCreate.Count > 0)
+                                        {
+                                            <LabelPreviewTable Heading="Labels to create" Labels="preview.ToCreate" />
+                                        }
+
+                                        @if (preview.ToUpdate.Count > 0)
+                                        {
+                                            <LabelPreviewTable Heading="Labels to update" Labels="preview.ToUpdate" />
+                                        }
+
+                                        @if (preview.ToDelete.Count > 0)
+                                        {
+                                            <LabelPreviewTable Heading="Labels to delete" Labels="preview.ToDelete" />
+                                        }
+
+                                        @if (preview.Skipped.Count > 0)
+                                        {
+                                            <LabelPreviewTable Heading="Labels to skip" Labels="preview.Skipped" />
+                                        }
+                                    </MudPaper>
+                                }
+                            </MudStack>
+                        }
+                        else if (syncApplyResults.Count > 0)
+                        {
+                            <MudStack Spacing="2" data-testid="sync-summary-card">
+                                <MudText Typo="Typo.h6">Synchronisation summary</MudText>
+                                @foreach (var result in syncApplyResults)
+                                {
+                                    <MudPaper Class="pa-3" Outlined="true">
+                                        <MudText Typo="Typo.subtitle1">@result.RepositoryFullName</MudText>
+                                        @if (result.HasError)
+                                        {
+                                            <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Outlined">@result.ErrorMessage</MudAlert>
+                                        }
+                                        else
+                                        {
+                                            <MudText Typo="Typo.body2">Created: @result.CreatedCount, Updated: @result.UpdatedCount, Deleted: @result.DeletedCount, Skipped: @result.SkippedCount</MudText>
+                                        }
+                                    </MudPaper>
+                                }
+                            </MudStack>
+                        }
+                        else
+                        {
+                            <MudText Typo="Typo.body2">Preview synchronisation to compare source and target repositories before applying changes.</MudText>
+                        }
+                    </MudPaper>
                 </MudStack>
-            }
-        </MudStack>
+            </MudTabPanel>
+        </MudTabs>
     </MudPaper>
 
-@if (showRecommendedPreview)
-{
-    <MudPaper Class="pa-4" Elevation="1" data-testid="taxonomy-preview-card">
-        <MudStack Spacing="2">
-            <MudText Typo="Typo.h6">Taxonomy preview</MudText>
-            @foreach (var preview in recommendedPreview)
-            {
-                <MudPaper Class="pa-3" Outlined="true">
-                    <MudText Typo="Typo.subtitle1">@preview.RepositoryFullName</MudText>
-                    <MudText Typo="Typo.body2">Create: @preview.ToCreate.Count, Update: @preview.ToUpdate.Count, Skip: @preview.Skipped.Count</MudText>
-
-                    @if (preview.ToCreate.Count > 0)
-                    {
-                        <LabelPreviewTable Heading="Labels to create" Labels="preview.ToCreate" />
-                    }
-
-                    @if (preview.ToUpdate.Count > 0)
-                    {
-                        <LabelPreviewTable Heading="Labels to update" Labels="preview.ToUpdate" />
-                    }
-                </MudPaper>
-            }
-        </MudStack>
-    </MudPaper>
-}
-
-@if (recommendedApplyResults.Count > 0)
-{
-    <MudPaper Class="pa-4" Elevation="1" data-testid="taxonomy-summary-card">
-        <MudStack Spacing="2">
-            <MudText Typo="Typo.h6">Apply summary</MudText>
-            @foreach (var result in recommendedApplyResults)
-            {
-                <MudPaper Class="pa-3" Outlined="true">
-                    <MudText Typo="Typo.subtitle1">@result.RepositoryFullName</MudText>
-                    @if (result.HasError)
-                    {
-                        <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Outlined">@result.ErrorMessage</MudAlert>
-                    }
-                    else
-                    {
-                        <MudText Typo="Typo.body2">Created: @result.CreatedCount, Updated: @result.UpdatedCount, Skipped: @result.SkippedCount</MudText>
-                    }
-                </MudPaper>
-            }
-        </MudStack>
-    </MudPaper>
-}
-
-@if (showSyncPreview)
-{
-    <MudPaper Class="pa-4" Elevation="1" data-testid="sync-preview-card">
-        <MudStack Spacing="2">
-            <MudText Typo="Typo.h6">Synchronisation preview</MudText>
-            @foreach (var preview in syncPreviewResults)
-            {
-                <MudPaper Class="pa-3" Outlined="true">
-                    <MudText Typo="Typo.subtitle1">@preview.RepositoryFullName</MudText>
-                    <MudText Typo="Typo.body2">Create: @preview.ToCreate.Count, Update: @preview.ToUpdate.Count, Delete: @preview.ToDelete.Count, Skip: @preview.Skipped.Count</MudText>
-
-                    @if (preview.ToCreate.Count > 0)
-                    {
-                        <LabelPreviewTable Heading="Labels to create" Labels="preview.ToCreate" />
-                    }
-
-                    @if (preview.ToUpdate.Count > 0)
-                    {
-                        <LabelPreviewTable Heading="Labels to update" Labels="preview.ToUpdate" />
-                    }
-
-                    @if (preview.ToDelete.Count > 0)
-                    {
-                        <LabelPreviewTable Heading="Labels to delete" Labels="preview.ToDelete" />
-                    }
-
-                    @if (preview.Skipped.Count > 0)
-                    {
-                        <LabelPreviewTable Heading="Labels to skip" Labels="preview.Skipped" />
-                    }
-                </MudPaper>
-            }
-        </MudStack>
-    </MudPaper>
-}
-
-@if (syncApplyResults.Count > 0)
-{
-    <MudPaper Class="pa-4" Elevation="1" data-testid="sync-summary-card">
-        <MudStack Spacing="2">
-            <MudText Typo="Typo.h6">Synchronisation summary</MudText>
-            @foreach (var result in syncApplyResults)
-            {
-                <MudPaper Class="pa-3" Outlined="true">
-                    <MudText Typo="Typo.subtitle1">@result.RepositoryFullName</MudText>
-                    @if (result.HasError)
-                    {
-                        <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Outlined">@result.ErrorMessage</MudAlert>
-                    }
-                    else
-                    {
-                        <MudText Typo="Typo.body2">Created: @result.CreatedCount, Updated: @result.UpdatedCount, Deleted: @result.DeletedCount, Skipped: @result.SkippedCount</MudText>
-                    }
-                </MudPaper>
-            }
-        </MudStack>
-    </MudPaper>
-}
-
-@if (ShowLabelFilter)
-{
-    <MudPaper Class="pa-4" Elevation="1">
+    <MudPaper Class="pa-4" Elevation="1" aria-live="polite" data-testid="label-manager-feedback-region">
         <MudStack Spacing="1">
-            <MudText Typo="Typo.h6">Filter</MudText>
-            <MudTextField @bind-Value="SearchText"
-                          Placeholder="Filter by label name"
-                          Variant="Variant.Outlined"
-                          Adornment="Adornment.Start"
-                          AdornmentIcon="@Icons.Material.Filled.FilterAlt"
-                          Immediate="true"
-                          InputType="InputType.Search"
-                          data-testid="label-filter" />
-        </MudStack>
-    </MudPaper>
-}
+            <MudText Typo="Typo.h6">Status</MudText>
 
-@if (ShowLoadingState)
-{
-    <MudPaper Class="pa-4" Elevation="1" aria-live="polite" role="status" data-testid="labels-loading-state">
-        <MudStack AlignItems="AlignItems.Center" Spacing="1">
-            <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading labels" />
-            <MudText Typo="Typo.body2">@(isLoadingRepositories ? "Loading repositories..." : "Loading labels...")</MudText>
-        </MudStack>
-    </MudPaper>
-}
-else if (!string.IsNullOrWhiteSpace(errorMessage))
-{
-    <MudPaper Class="pa-4" Elevation="1" aria-live="assertive" role="alert">
-        <MudStack Spacing="1">
-            <MudText Typo="Typo.h6">@ErrorTitle</MudText>
-            <MudText Typo="Typo.body2">@errorMessage</MudText>
-        </MudStack>
-        @if (availableRepositories.Count == 0)
-        {
-            <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="ReloadRepositoriesAsync">Try loading repositories again</MudButton>
-        }
-        else
-        {
-            <MudStack Row="true" Spacing="1" Class="mt-2">
-                <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="ReloadRepositoriesAsync">Reload repositories</MudButton>
-                <MudButton Variant="Variant.Outlined" Color="Color.Secondary" OnClick="LoadLabelsForSelectionAsync">Try loading labels again</MudButton>
-            </MudStack>
-        }
-    </MudPaper>
-}
-else if (hasLoadedLabels && filteredRows.Count == 0)
-{
-    <MudPaper Class="pa-4" Elevation="1" aria-live="polite" data-testid="labels-empty-state">
-        <MudText Typo="Typo.h6">No labels found</MudText>
-        <MudText Typo="Typo.body2">No labels were returned for the selected repositories.</MudText>
-    </MudPaper>
-}
-else if (hasLoadedLabels)
-{
-    <MudDataGrid T="Labels.LabelRow"
-                     Items="filteredRows"
-                     Hover="true"
-                     Dense="true"
-                     SortMode="SortMode.Multiple"
-                     data-testid="labels-grid">
-            <Columns>
-                <PropertyColumn Property="row => row.Name" Title="Label" Sortable="true" />
-                <TemplateColumn T="Labels.LabelRow" Title="Colour">
-                    <CellTemplate>
-                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-                            <MudChip Variant="Variant.Outlined"
-                                     Size="Size.Small"
-                                     Style="@GetColourChipStyle(context.Item.Colour)">@($"#{context.Item.Colour}")</MudChip>
-                        </MudStack>
-                    </CellTemplate>
-                </TemplateColumn>
-                <PropertyColumn Property="row => row.Description" Title="Description" />
-                <PropertyColumn Property="row => row.RepositoriesWithLabelText" Title="Repositories" />
-                <PropertyColumn Property="row => row.MissingRepositoriesText" Title="Missing in" />
-                <TemplateColumn T="Labels.LabelRow" Title="Actions">
-                    <CellTemplate>
-                        <MudStack Row="true" Spacing="1">
-                            <MudButton Variant="Variant.Outlined"
-                                       Color="Color.Default"
-                                       Size="Size.Small"
-                                       data-testid="edit-label-button"
-                                       OnClick="() => ShowEditDialogAsync(context.Item)">
-                                Edit
-                            </MudButton>
-                            <MudButton Variant="Variant.Text"
-                                       Color="Color.Error"
-                                       Size="Size.Small"
-                                       data-testid="delete-label-button"
-                                       OnClick="() => ShowDeleteDialogAsync(context.Item)">
-                                Delete
-                            </MudButton>
-                        </MudStack>
-                    </CellTemplate>
-                </TemplateColumn>
-            </Columns>
-        </MudDataGrid>
-}
+            @if (!string.IsNullOrWhiteSpace(errorMessage))
+            {
+                <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Outlined">
+                    <MudText Typo="Typo.subtitle2">@ErrorTitle</MudText>
+                    <MudText Typo="Typo.body2">@errorMessage</MudText>
+                </MudAlert>
 
+                @if (availableRepositories.Count == 0)
+                {
+                    <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="ReloadRepositoriesAsync">Try loading repositories again</MudButton>
+                }
+                else
+                {
+                    <MudStack Row="true" Spacing="1" Class="mt-2">
+                        <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="ReloadRepositoriesAsync">Reload repositories</MudButton>
+                        <MudButton Variant="Variant.Outlined" Color="Color.Secondary" OnClick="LoadLabelsForSelectionAsync">Try loading labels again</MudButton>
+                    </MudStack>
+                }
+            }
+            else if (!string.IsNullOrWhiteSpace(taxonomyOperationMessage))
+            {
+                <MudAlert Severity="@taxonomyOperationSeverity" Dense="true" Variant="Variant.Outlined" data-testid="taxonomy-operation-message">
+                    @taxonomyOperationMessage
+                </MudAlert>
+            }
+            else if (!string.IsNullOrWhiteSpace(syncOperationMessage))
+            {
+                <MudAlert Severity="@syncOperationSeverity" Dense="true" Variant="Variant.Outlined" data-testid="sync-operation-message">
+                    @syncOperationMessage
+                </MudAlert>
+            }
+            else
+            {
+                <MudText Typo="Typo.body2">No active status messages.</MudText>
+            }
+        </MudStack>
+    </MudPaper>
 </MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor.cs
@@ -10,6 +10,8 @@ namespace SoloDevBoard.App.Components.Features.Labels.Pages;
 /// <summary>Displays a consolidated view of labels across selected repositories.</summary>
 public partial class Labels : ComponentBase
 {
+    private const int LabelsTabIndex = 0;
+
     /// <summary>Gets or sets the application service used to retrieve repositories.</summary>
     [Inject]
     public IRepositoryService RepositoryService { get; set; } = default!;
@@ -57,6 +59,7 @@ public partial class Labels : ComponentBase
     private bool isApplyingSync;
     private string? syncOperationMessage;
     private Severity syncOperationSeverity = Severity.Info;
+    private int activeTabIndex = LabelsTabIndex;
 
     protected override async Task OnInitializedAsync()
     {
@@ -90,6 +93,12 @@ public partial class Labels : ComponentBase
     private async Task ReloadRepositoriesAsync()
     {
         await LoadRepositoriesAsync();
+    }
+
+    private Task OnActiveTabIndexChanged(int tabIndex)
+    {
+        activeTabIndex = tabIndex;
+        return Task.CompletedTask;
     }
 
     private Task OnStrategySelectedAsync(string strategyId)

--- a/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
@@ -65,6 +65,60 @@ public sealed class LabelsTests
     }
 
     [Fact]
+    public async Task Labels_PageLayout_RendersRepositorySelectorBeforeTabStrip()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                CreateRepository("owner", "repo-a"),
+            ]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Labels>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='repository-selector-region']"));
+            Assert.Single(cut.FindAll("[data-testid='label-manager-tab-strip']"));
+
+            var markup = cut.Markup;
+            var selectorPosition = markup.IndexOf("repository-selector-region", StringComparison.Ordinal);
+            var tabStripPosition = markup.IndexOf("label-manager-tab-strip", StringComparison.Ordinal);
+            Assert.True(selectorPosition >= 0);
+            Assert.True(tabStripPosition > selectorPosition);
+        });
+    }
+
+    [Fact]
+    public async Task Labels_WhenSwitchingToRecommendedTaxonomyTab_ShowsTaxonomyActionStrip()
+    {
+        // Arrange
+        var repoA = CreateRepository("owner", "repo-a");
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repoA]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Labels>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
+        await ActivateTabAsync(cut, "Recommended taxonomy");
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='taxonomy-action-strip']"));
+            Assert.Empty(cut.FindAll("[data-testid='sync-action-strip']"));
+        });
+    }
+
+    [Fact]
     public async Task Labels_RepositoriesLoaded_ArchivedRepositoriesAreHiddenByDefault()
     {
         // Arrange
@@ -266,6 +320,7 @@ public sealed class LabelsTests
         cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
 
         await SelectRepositoriesAsync(cut, repoA);
+        await ActivateTabAsync(cut, "Recommended taxonomy");
         cut.Find("[data-testid='preview-taxonomy-button']").Click();
 
         // Assert
@@ -316,6 +371,7 @@ public sealed class LabelsTests
         cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
 
         await SelectRepositoriesAsync(cut, repoA);
+        await ActivateTabAsync(cut, "Recommended taxonomy");
         cut.Find("[data-testid='preview-taxonomy-button']").Click();
         cut.WaitForAssertion(() => _ = cut.Find("[data-testid='confirm-apply-taxonomy-button']"));
 
@@ -356,6 +412,7 @@ public sealed class LabelsTests
         var cut = ctx.Render<Labels>();
         cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
         await SelectRepositoriesAsync(cut, repoA);
+        await ActivateTabAsync(cut, "Recommended taxonomy");
         cut.Find("[data-testid='preview-taxonomy-button']").Click();
 
         // Assert
@@ -385,6 +442,7 @@ public sealed class LabelsTests
         var cut = ctx.Render<Labels>();
         cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
         await SelectRepositoriesAsync(cut, repoA);
+        await ActivateTabAsync(cut, "Recommended taxonomy");
 
         var previewButton = cut.Find("[data-testid='preview-taxonomy-button']");
         previewButton.Click();
@@ -419,6 +477,7 @@ public sealed class LabelsTests
         var cut = ctx.Render<Labels>();
         cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
         await SelectRepositoriesAsync(cut, repoA, repoB);
+        await ActivateTabAsync(cut, "Synchronise");
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -462,6 +521,7 @@ public sealed class LabelsTests
         var cut = ctx.Render<Labels>();
         cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
         await SelectRepositoriesAsync(cut, repoA, repoB);
+        await ActivateTabAsync(cut, "Synchronise");
         cut.Find("[data-testid='preview-sync-button']").Click();
         cut.WaitForAssertion(() => _ = cut.Find("[data-testid='confirm-sync-button']"));
         cut.Find("[data-testid='confirm-sync-button']").Click();
@@ -503,6 +563,7 @@ public sealed class LabelsTests
         var cut = ctx.Render<Labels>();
         cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
         await SelectRepositoriesAsync(cut, repoA, repoB);
+        await ActivateTabAsync(cut, "Synchronise");
 
         cut.Find("[data-testid='preview-sync-button']").Click();
 
@@ -546,6 +607,15 @@ public sealed class LabelsTests
         var selectedFullNames = repositories.Select(repository => repository.FullName).ToArray();
 
         await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(selectedFullNames));
+    }
+
+    private static async Task ActivateTabAsync(IRenderedComponent<Labels> cut, string tabText)
+    {
+        var tabButton = cut
+            .FindAll("[role='tab']")
+            .First(button => button.TextContent.Trim().Equals(tabText, StringComparison.OrdinalIgnoreCase));
+
+        await cut.InvokeAsync(() => tabButton.Click());
     }
 
     private static RepositoryDto CreateRepository(string owner, string name, bool isPrivate = false, bool isArchived = false)


### PR DESCRIPTION
## Summary of Changes

Refreshes the Label Manager page from a single-scroll layout into a repository-first tabbed layout aligned with the approved wireframe. The repository selector sits above the tab strip, and three dedicated tabs — Labels, Recommended taxonomy, and Synchronise — give each workflow mode its own focused content area.

A shared feedback region at the bottom of the page consolidates error, taxonomy result, sync result, and empty-state banners. All existing create, edit, delete, and synchronisation capabilities are preserved.

Testing-phase fixes applied after initial browser validation:
- Added `Class="pt-3"` (MudBlazor utility) to all three tab panels to increase spacing between the tab strip and the first heading.
- Renamed the taxonomy selector label from `Recommended strategy` to `Recommended label set` and added a caption directing users to the Migrate workflow for conflict strategies (Skip, Overwrite, Merge).

bUnit coverage updated in line with the structural changes: two new layout tests added (`Labels_PageLayout_RendersRepositorySelectorBeforeTabStrip`, `Labels_WhenSwitchingToRecommendedTaxonomyTab_ShowsTaxonomyActionStrip`), six existing tests updated to activate the relevant tab before interacting with tab-specific controls, and a shared `ActivateTabAsync` helper extracted.

## Related Issue(s)

Closes #133
Closes #134

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

Browser testing confirmed:
- Labels tab: repository selector above tabs, label grid with filter, action buttons.
- Recommended taxonomy tab: taxonomy template selector, preview/confirm/cancel strip.
- Synchronise tab: source/target selectors, preview/confirm/cancel strip.

## Additional Notes

No breaking changes. No migration required. No new infrastructure. MudBlazor utility classes used throughout; no new `.razor.css` introduced.