### PR TITLE
[type/story] Refresh Audit Dashboard with wireframe-aligned layout and KPI summary cards

### DIFF
--- a/docs/user-guide/audit-dashboard.md
+++ b/docs/user-guide/audit-dashboard.md
@@ -7,7 +7,7 @@ nav_order: 2
 
 # Audit Dashboard
 
-The Audit Dashboard provides a summary of open issues, open pull requests, and repository health indicators across all your GitHub repositories in SoloDevBoard.
+The Audit Dashboard provides a summary of open issues, open pull requests, repository health indicators, and now features a wireframe-aligned repository selector, KPI summary cards, grouped health indicators, and a consistent feedback region across all your GitHub repositories in SoloDevBoard.
 
 ## Accessing the Audit Dashboard
 
@@ -19,9 +19,11 @@ The Audit Dashboard provides a summary of open issues, open pull requests, and r
 - A repository selector lets you choose one or more of your active GitHub repositories before loading any data.
 - Each repository is shown as a row in a sortable MudBlazor grid.
 - Columns include repository full name (linked to GitHub), open issue count, and open pull request count.
-- Total summary cards display aggregate open issues and open pull requests across all repositories.
-- A loading skeleton is shown while repository options are loading, and again while audit data is being fetched.
-- An empty state is displayed if no repositories are returned.
+- The repository selector at the top of the page provides clear access to repository selection and audit actions.
+- KPI summary cards display total open issues, total open pull requests, unlabelled issues, and failing workflows across all selected repositories.
+- Health indicator sections are grouped in a dedicated container below the KPI summary, making it easier to scan repository health at a glance.
+- Feedback states (loading, empty, error, and prompt) are surfaced through a consistent feedback region, ensuring users always understand the current state of the dashboard.
+- All UI elements follow the wireframe-aligned layout for improved clarity and usability.
 - The browser page title is set to 'Audit Dashboard — SoloDevBoard'.
 - The Unlabelled Issues section shows issues without any labels, including repository, issue number, title, and age.
 - The Stale Pull Requests section lists pull requests with no activity in the last 14 days, including repository, pull request number, title, author, and days since update.
@@ -38,9 +40,11 @@ The Audit Dashboard provides a summary of open issues, open pull requests, and r
 5. Review the summary grid to see open issues and pull requests per repository.
 6. Click a repository name to open it directly in GitHub.
 7. Use the summary cards to view total open issues and pull requests.
-8. Expand the health indicator panels to review unlabelled issues, stale pull requests, and failing workflows.
-9. Click links in health sections to open items in GitHub (in a new tab).
-10. To change the repository set, adjust the selector and click **Load selected repositories** again.
+8. Review the KPI summary cards for a quick overview of repository health.
+9. Expand grouped health indicator sections to see details about unlabelled issues, stale pull requests, and failing workflows.
+10. Observe feedback states in the feedback region for loading, empty, error, or prompt messages.
+11. Click links in health sections to open items in GitHub (in a new tab).
+12. To change the repository set, adjust the selector and click **Load selected repositories** again.
 
 ## Notes
 
@@ -48,5 +52,6 @@ Zero-state messages are shown when no items are found in a health indicator sect
 - "No unlabelled issues — great."
 - "No stale pull requests — great."
 - "No failing workflows — great."
+Feedback region also displays loading, error, and prompt messages to guide the user through dashboard states.
 
 For more information about upcoming features, see the [BACKLOG](../../plan/BACKLOG.md).

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -43,7 +43,8 @@ Labels: `type/epic`, `area/infrastructure`
 - [x] As a solo developer, I want the Repositories page refreshed to use a clearer command-strip, data-grid, and feedback layout so that repository management scales cleanly as SoloDevBoard grows. _(Issue #131 implemented on 2026-03-17; paired bUnit coverage issue #132 also complete; wireframe-aligned follow-on to #67.)_
   - Implementation note: Completed 2026-03-17. The new Repositories page layout, command strip, responsive actions, search, data grid, and feedback region are now live. Paired bUnit test coverage (#132) is also complete.
 - [x] As a solo developer, I want the Label Manager page refreshed into tabbed workflows for Labels, Recommended Taxonomy, and Synchronise so that label-management modes have a clearer mental model. _(Issue #133 implemented on 2026-03-17; paired test issue #134 also complete; wireframe-aligned follow-on to #68.)_
-- [ ] As a solo developer, I want the Audit Dashboard refreshed with a clearer command surface, KPI summary cards, and grouped health indicators so that repository health is easier to scan and act on. _(Issue #135 planned for v0.2.0; paired test issue #136; wireframe-aligned follow-on to #40 and #48.)_
+- [x] As a solo developer, I want the Audit Dashboard refreshed with a clearer command surface, KPI summary cards, grouped health indicators, and consistent feedback region so that repository health is easier to scan and act on. _(Issue #135 implemented on 2026-03-17; paired test issue #136 also complete; wireframe-aligned follow-on to #40 and #48.)_
+  - Implementation note: Completed 2026-03-17. The Audit Dashboard now features a wireframe-aligned command surface, KPI summary cards, grouped health indicators, and a consistent feedback region. Paired bUnit test coverage (#136) validates command surface, KPI summary, health indicator, and zero-state rendering paths.
 
 ---
 
@@ -250,4 +251,4 @@ Labels: `type/chore`, `area/infrastructure`
 - [ ] Configure logging with structured output (Azure Application Insights integration). _(#107)_
 - [x] Set up Dependabot for automated dependency updates. _(done — `dependabot.yml` and auto-merge workflow added previously; see issue #109.)_
 
- 
+

--- a/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor
@@ -9,7 +9,7 @@
 
     @if (isLoadingRepositories)
     {
-        <MudPaper Class="pa-4" Outlined="true" aria-live="polite" role="status" data-testid="audit-command-surface-loading">
+        <MudPaper Class="pa-4" Outlined="true" aria-live="polite" role="status" data-testid="audit-feedback-region">
             <MudStack Spacing="2">
                 <MudText Typo="Typo.h6">Repository selector</MudText>
                 <MudSkeleton Height="56px" Animation="Animation.Wave" />
@@ -130,7 +130,7 @@
                         <MudItem xs="12" sm="6" md="3">
                             <MudPaper Class="pa-3" Outlined="true" data-testid="audit-failing-workflows-kpi-card">
                                 <MudText Typo="Typo.caption">Failing workflows</MudText>
-                                <MudText Typo="Typo.h5">@totalFailingWorkflowRuns</MudText>
+                                <MudText Typo="Typo.h5">@totalFailingWorkflows</MudText>
                             </MudPaper>
                         </MudItem>
                     </MudGrid>

--- a/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor
@@ -9,9 +9,9 @@
 
     @if (isLoadingRepositories)
     {
-        <MudPaper Class="pa-3" Outlined="true" aria-live="polite" role="status" data-testid="audit-repository-filter-loading">
+        <MudPaper Class="pa-4" Outlined="true" aria-live="polite" role="status" data-testid="audit-command-surface-loading">
             <MudStack Spacing="2">
-                <MudText Typo="Typo.subtitle2">Repository filter</MudText>
+                <MudText Typo="Typo.h6">Repository selector</MudText>
                 <MudSkeleton Height="56px" Animation="Animation.Wave" />
                 <MudSkeleton Height="36px" Width="220px" Animation="Animation.Wave" />
                 <MudSkeleton Height="20px" Width="340px" Animation="Animation.Wave" />
@@ -29,7 +29,7 @@
     }
     else if (!string.IsNullOrWhiteSpace(repositoryLoadErrorMessage))
     {
-        <MudPaper Class="pa-4" Elevation="1" aria-live="assertive" role="alert" data-testid="audit-error-state">
+        <MudPaper Class="pa-4" Elevation="1" aria-live="assertive" role="alert" data-testid="audit-feedback-region">
             <MudStack Spacing="2">
                 <MudText Typo="Typo.h6">Unable to load repositories</MudText>
                 <MudText Typo="Typo.body2">@repositoryLoadErrorMessage</MudText>
@@ -38,7 +38,7 @@
     }
     else if (repositoryOptions.Count == 0)
     {
-        <MudPaper Class="pa-4" Elevation="1" aria-live="polite" data-testid="audit-empty-state">
+        <MudPaper Class="pa-4" Elevation="1" aria-live="polite" data-testid="audit-feedback-region">
             <MudStack Spacing="1">
                 <MudText Typo="Typo.h6">No repositories found</MudText>
                 <MudText Typo="Typo.body2">No active repositories were returned for this account.</MudText>
@@ -47,9 +47,10 @@
     }
     else
     {
-        <MudPaper Class="pa-3" Outlined="true" data-testid="audit-repository-filter">
+        <MudPaper Class="pa-4" Outlined="true" data-testid="audit-command-surface">
             <MudStack Spacing="2">
-                <MudText Typo="Typo.subtitle2">Repository filter</MudText>
+                <MudText Typo="Typo.h6">Repository selector</MudText>
+                <MudText Typo="Typo.body2">Select the repositories to include, then load the latest dashboard snapshot.</MudText>
                 <RepositorySelector
                     Title=""
                     Label="Repositories"
@@ -65,19 +66,21 @@
                     AutocompleteTestId="audit-repository-autocomplete"
                     SummaryTestId="audit-repository-summary" />
 
-                <MudButton Variant="Variant.Outlined"
-                           Color="Color.Secondary"
-                           Disabled="@(isLoadingRepositories || isLoadingAuditData || selectedRepositoryNames.Count == 0)"
-                           OnClick="LoadSelectedRepositoriesAsync"
-                           data-testid="audit-load-selected-button">
-                    Load selected repositories
-                </MudButton>
+                <MudStack Row="true" Justify="Justify.FlexEnd">
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               Disabled="@(isLoadingRepositories || isLoadingAuditData || selectedRepositoryNames.Count == 0)"
+                               OnClick="LoadSelectedRepositoriesAsync"
+                               data-testid="audit-load-selected-button">
+                        Load selected repositories
+                    </MudButton>
+                </MudStack>
             </MudStack>
         </MudPaper>
 
         @if (isLoadingAuditData)
         {
-            <MudPaper Class="pa-4" Elevation="1" aria-live="polite" role="status" data-testid="audit-loading-state">
+            <MudPaper Class="pa-4" Elevation="1" aria-live="polite" role="status" data-testid="audit-feedback-region">
                 <MudStack Spacing="2">
                     <MudSkeleton Height="86px" Animation="Animation.Wave" />
                     <MudSkeleton Height="240px" Animation="Animation.Wave" />
@@ -87,7 +90,7 @@
         }
         else if (!string.IsNullOrWhiteSpace(auditLoadErrorMessage))
         {
-            <MudPaper Class="pa-4" Elevation="1" aria-live="assertive" role="alert" data-testid="audit-summary-error-state">
+            <MudPaper Class="pa-4" Elevation="1" aria-live="assertive" role="alert" data-testid="audit-feedback-region">
                 <MudStack Spacing="2">
                     <MudText Typo="Typo.h6">Unable to load audit summary</MudText>
                     <MudText Typo="Typo.body2">@auditLoadErrorMessage</MudText>
@@ -96,26 +99,43 @@
         }
         else if (!hasLoadedAuditSummary)
         {
-            <MudPaper Class="pa-4" Elevation="1" data-testid="audit-selection-prompt">
+            <MudPaper Class="pa-4" Elevation="1" data-testid="audit-feedback-region">
                 <MudText Typo="Typo.body2">Select one or more repositories, then load the audit summary.</MudText>
             </MudPaper>
         }
         else
         {
-            <MudGrid>
-                <MudItem xs="12" sm="6">
-                    <MudPaper Class="pa-3" Outlined="true" data-testid="audit-total-issues-card">
-                        <MudText Typo="Typo.caption">Total open issues</MudText>
-                        <MudText Typo="Typo.h5">@totalOpenIssues</MudText>
-                    </MudPaper>
-                </MudItem>
-                <MudItem xs="12" sm="6">
-                    <MudPaper Class="pa-3" Outlined="true" data-testid="audit-total-prs-card">
-                        <MudText Typo="Typo.caption">Total open pull requests</MudText>
-                        <MudText Typo="Typo.h5">@totalOpenPullRequests</MudText>
-                    </MudPaper>
-                </MudItem>
-            </MudGrid>
+            <MudPaper Class="pa-4" Outlined="true" data-testid="audit-kpi-summary-cards">
+                <MudStack Spacing="2">
+                    <MudText Typo="Typo.h6">KPI summary</MudText>
+                    <MudGrid>
+                        <MudItem xs="12" sm="6" md="3">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="audit-total-issues-card">
+                                <MudText Typo="Typo.caption">Total open issues</MudText>
+                                <MudText Typo="Typo.h5">@totalOpenIssues</MudText>
+                            </MudPaper>
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="3">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="audit-total-prs-card">
+                                <MudText Typo="Typo.caption">Total open pull requests</MudText>
+                                <MudText Typo="Typo.h5">@totalOpenPullRequests</MudText>
+                            </MudPaper>
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="3">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="audit-unlabelled-kpi-card">
+                                <MudText Typo="Typo.caption">Unlabelled issues</MudText>
+                                <MudText Typo="Typo.h5">@totalUnlabelledIssues</MudText>
+                            </MudPaper>
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="3">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="audit-failing-workflows-kpi-card">
+                                <MudText Typo="Typo.caption">Failing workflows</MudText>
+                                <MudText Typo="Typo.h5">@totalFailingWorkflowRuns</MudText>
+                            </MudPaper>
+                        </MudItem>
+                    </MudGrid>
+                </MudStack>
+            </MudPaper>
 
             <MudPaper Class="pa-2" Elevation="1" data-testid="audit-summary-table">
                 <MudDataGrid T="RepositoryAuditSummaryDto"
@@ -143,117 +163,122 @@
                 </MudDataGrid>
             </MudPaper>
 
-            <MudExpansionPanels MultiExpansion="true" Class="mt-2" data-testid="audit-health-indicator-sections">
-            <MudExpansionPanel Expanded="true" data-testid="audit-unlabelled-issues-section">
-                <TitleContent>
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                        <MudText Typo="Typo.subtitle1">Unlabelled Issues</MudText>
-                        <MudBadge Color="Color.Warning" Content="@unlabelledIssues.Count" />
-                    </MudStack>
-                </TitleContent>
-                <ChildContent>
-                    @if (unlabelledIssues.Count == 0)
-                    {
-                        <MudText Typo="Typo.body2" data-testid="audit-unlabelled-empty">No unlabelled issues — great!</MudText>
-                    }
-                    else
-                    {
-                        <MudTable T="IssueDto" Items="unlabelledIssues" Dense="true" Hover="true" data-testid="audit-unlabelled-table">
-                            <HeaderContent>
-                                <MudTh>Repository</MudTh>
-                                <MudTh>Issue</MudTh>
-                                <MudTh>Title</MudTh>
-                                <MudTh>Age (days)</MudTh>
-                            </HeaderContent>
-                            <RowTemplate>
-                                <MudTd DataLabel="Repository">@context.RepositoryFullName</MudTd>
-                                <MudTd DataLabel="Issue">
-                                    <MudLink Href="@context.HtmlUrl" Target="_blank" rel="noopener noreferrer">
-                                        #@context.Number
-                                    </MudLink>
-                                </MudTd>
-                                <MudTd DataLabel="Title">@context.Title</MudTd>
-                                <MudTd DataLabel="Age (days)">@GetDaysBetween(context.CreatedAt)</MudTd>
-                            </RowTemplate>
-                        </MudTable>
-                    }
-                </ChildContent>
-            </MudExpansionPanel>
+            <MudPaper Class="pa-3" Outlined="true" data-testid="audit-health-indicators-group">
+                <MudStack Spacing="2">
+                    <MudText Typo="Typo.h6">Health indicators</MudText>
+                    <MudExpansionPanels MultiExpansion="true" data-testid="audit-health-indicator-sections">
+                        <MudExpansionPanel Expanded="true" data-testid="audit-unlabelled-issues-section">
+                            <TitleContent>
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                    <MudText Typo="Typo.subtitle1">Unlabelled Issues</MudText>
+                                    <MudBadge Color="Color.Warning" Content="@unlabelledIssues.Count" />
+                                </MudStack>
+                            </TitleContent>
+                            <ChildContent>
+                                @if (unlabelledIssues.Count == 0)
+                                {
+                                    <MudText Typo="Typo.body2" data-testid="audit-unlabelled-empty">No unlabelled issues — great!</MudText>
+                                }
+                                else
+                                {
+                                    <MudTable T="IssueDto" Items="unlabelledIssues" Dense="true" Hover="true" data-testid="audit-unlabelled-table">
+                                        <HeaderContent>
+                                            <MudTh>Repository</MudTh>
+                                            <MudTh>Issue</MudTh>
+                                            <MudTh>Title</MudTh>
+                                            <MudTh>Age (days)</MudTh>
+                                        </HeaderContent>
+                                        <RowTemplate>
+                                            <MudTd DataLabel="Repository">@context.RepositoryFullName</MudTd>
+                                            <MudTd DataLabel="Issue">
+                                                <MudLink Href="@context.HtmlUrl" Target="_blank" rel="noopener noreferrer">
+                                                    #@context.Number
+                                                </MudLink>
+                                            </MudTd>
+                                            <MudTd DataLabel="Title">@context.Title</MudTd>
+                                            <MudTd DataLabel="Age (days)">@GetDaysBetween(context.CreatedAt)</MudTd>
+                                        </RowTemplate>
+                                    </MudTable>
+                                }
+                            </ChildContent>
+                        </MudExpansionPanel>
 
-            <MudExpansionPanel Expanded="true" data-testid="audit-stale-prs-section">
-                <TitleContent>
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                        <MudText Typo="Typo.subtitle1">Stale Pull Requests</MudText>
-                        <MudBadge Color="Color.Warning" Content="@stalePullRequests.Count" />
-                    </MudStack>
-                </TitleContent>
-                <ChildContent>
-                    @if (stalePullRequests.Count == 0)
-                    {
-                        <MudText Typo="Typo.body2" data-testid="audit-stale-empty">No stale pull requests — great!</MudText>
-                    }
-                    else
-                    {
-                        <MudTable T="PullRequestDto" Items="stalePullRequests" Dense="true" Hover="true" data-testid="audit-stale-table">
-                            <HeaderContent>
-                                <MudTh>Repository</MudTh>
-                                <MudTh>Pull request</MudTh>
-                                <MudTh>Title</MudTh>
-                                <MudTh>Author</MudTh>
-                                <MudTh>Days since update</MudTh>
-                            </HeaderContent>
-                            <RowTemplate>
-                                <MudTd DataLabel="Repository">@context.RepositoryFullName</MudTd>
-                                <MudTd DataLabel="Pull request">
-                                    <MudLink Href="@context.HtmlUrl" Target="_blank" rel="noopener noreferrer">
-                                        #@context.Number
-                                    </MudLink>
-                                </MudTd>
-                                <MudTd DataLabel="Title">@context.Title</MudTd>
-                                <MudTd DataLabel="Author">@context.AuthorLogin</MudTd>
-                                <MudTd DataLabel="Days since update">@GetDaysBetween(context.UpdatedAt)</MudTd>
-                            </RowTemplate>
-                        </MudTable>
-                    }
-                </ChildContent>
-            </MudExpansionPanel>
+                        <MudExpansionPanel Expanded="true" data-testid="audit-stale-prs-section">
+                            <TitleContent>
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                    <MudText Typo="Typo.subtitle1">Stale Pull Requests</MudText>
+                                    <MudBadge Color="Color.Warning" Content="@stalePullRequests.Count" />
+                                </MudStack>
+                            </TitleContent>
+                            <ChildContent>
+                                @if (stalePullRequests.Count == 0)
+                                {
+                                    <MudText Typo="Typo.body2" data-testid="audit-stale-empty">No stale pull requests — great!</MudText>
+                                }
+                                else
+                                {
+                                    <MudTable T="PullRequestDto" Items="stalePullRequests" Dense="true" Hover="true" data-testid="audit-stale-table">
+                                        <HeaderContent>
+                                            <MudTh>Repository</MudTh>
+                                            <MudTh>Pull request</MudTh>
+                                            <MudTh>Title</MudTh>
+                                            <MudTh>Author</MudTh>
+                                            <MudTh>Days since update</MudTh>
+                                        </HeaderContent>
+                                        <RowTemplate>
+                                            <MudTd DataLabel="Repository">@context.RepositoryFullName</MudTd>
+                                            <MudTd DataLabel="Pull request">
+                                                <MudLink Href="@context.HtmlUrl" Target="_blank" rel="noopener noreferrer">
+                                                    #@context.Number
+                                                </MudLink>
+                                            </MudTd>
+                                            <MudTd DataLabel="Title">@context.Title</MudTd>
+                                            <MudTd DataLabel="Author">@context.AuthorLogin</MudTd>
+                                            <MudTd DataLabel="Days since update">@GetDaysBetween(context.UpdatedAt)</MudTd>
+                                        </RowTemplate>
+                                    </MudTable>
+                                }
+                            </ChildContent>
+                        </MudExpansionPanel>
 
-            <MudExpansionPanel Expanded="true" data-testid="audit-failing-workflows-section">
-                <TitleContent>
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                        <MudText Typo="Typo.subtitle1">Failing Workflows</MudText>
-                        <MudBadge Color="Color.Error" Content="@failingWorkflowRuns.Count" />
-                    </MudStack>
-                </TitleContent>
-                <ChildContent>
-                    @if (failingWorkflowRuns.Count == 0)
-                    {
-                        <MudText Typo="Typo.body2" data-testid="audit-workflows-empty">No failing workflows — great!</MudText>
-                    }
-                    else
-                    {
-                        <MudTable T="WorkflowRunDto" Items="failingWorkflowRuns" Dense="true" Hover="true" data-testid="audit-workflows-table">
-                            <HeaderContent>
-                                <MudTh>Repository</MudTh>
-                                <MudTh>Workflow</MudTh>
-                                <MudTh>Branch</MudTh>
-                                <MudTh>Run</MudTh>
-                            </HeaderContent>
-                            <RowTemplate>
-                                <MudTd DataLabel="Repository">@context.RepositoryFullName</MudTd>
-                                <MudTd DataLabel="Workflow">@context.WorkflowName</MudTd>
-                                <MudTd DataLabel="Branch">@context.HeadBranch</MudTd>
-                                <MudTd DataLabel="Run">
-                                    <MudLink Href="@context.HtmlUrl" Target="_blank" rel="noopener noreferrer">
-                                        Open run
-                                    </MudLink>
-                                </MudTd>
-                            </RowTemplate>
-                        </MudTable>
-                    }
-                </ChildContent>
-            </MudExpansionPanel>
-            </MudExpansionPanels>
+                        <MudExpansionPanel Expanded="true" data-testid="audit-failing-workflows-section">
+                            <TitleContent>
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                    <MudText Typo="Typo.subtitle1">Failing Workflows</MudText>
+                                    <MudBadge Color="Color.Error" Content="@failingWorkflowRuns.Count" />
+                                </MudStack>
+                            </TitleContent>
+                            <ChildContent>
+                                @if (failingWorkflowRuns.Count == 0)
+                                {
+                                    <MudText Typo="Typo.body2" data-testid="audit-workflows-empty">No failing workflows — great!</MudText>
+                                }
+                                else
+                                {
+                                    <MudTable T="WorkflowRunDto" Items="failingWorkflowRuns" Dense="true" Hover="true" data-testid="audit-workflows-table">
+                                        <HeaderContent>
+                                            <MudTh>Repository</MudTh>
+                                            <MudTh>Workflow</MudTh>
+                                            <MudTh>Branch</MudTh>
+                                            <MudTh>Run</MudTh>
+                                        </HeaderContent>
+                                        <RowTemplate>
+                                            <MudTd DataLabel="Repository">@context.RepositoryFullName</MudTd>
+                                            <MudTd DataLabel="Workflow">@context.WorkflowName</MudTd>
+                                            <MudTd DataLabel="Branch">@context.HeadBranch</MudTd>
+                                            <MudTd DataLabel="Run">
+                                                <MudLink Href="@context.HtmlUrl" Target="_blank" rel="noopener noreferrer">
+                                                    Open run
+                                                </MudLink>
+                                            </MudTd>
+                                        </RowTemplate>
+                                    </MudTable>
+                                }
+                            </ChildContent>
+                        </MudExpansionPanel>
+                    </MudExpansionPanels>
+                </MudStack>
+            </MudPaper>
         }
     }
 </MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor.cs
@@ -29,6 +29,8 @@ public partial class Audit : ComponentBase
     private HashSet<string> selectedRepositories = new(StringComparer.OrdinalIgnoreCase);
     private int totalOpenIssues;
     private int totalOpenPullRequests;
+    private int totalUnlabelledIssues;
+    private int totalFailingWorkflowRuns;
     private bool isLoadingRepositories = true;
     private bool isLoadingAuditData;
     private bool hasLoadedAuditSummary;
@@ -182,6 +184,8 @@ public partial class Audit : ComponentBase
 
         totalOpenIssues = repositorySummaries.Sum(result => result.OpenIssueCount);
         totalOpenPullRequests = repositorySummaries.Sum(result => result.OpenPullRequestCount);
+        totalUnlabelledIssues = repositorySummaries.Sum(result => result.UnlabelledIssueCount);
+        totalFailingWorkflowRuns = repositorySummaries.Sum(result => result.FailingWorkflowCount);
     }
 
     private void ResetDashboardData()
@@ -192,6 +196,8 @@ public partial class Audit : ComponentBase
         failingWorkflowRuns = [];
         totalOpenIssues = 0;
         totalOpenPullRequests = 0;
+        totalUnlabelledIssues = 0;
+        totalFailingWorkflowRuns = 0;
     }
 
     private static int GetDaysBetween(DateTimeOffset value)

--- a/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor.cs
@@ -30,7 +30,7 @@ public partial class Audit : ComponentBase
     private int totalOpenIssues;
     private int totalOpenPullRequests;
     private int totalUnlabelledIssues;
-    private int totalFailingWorkflowRuns;
+    private int totalFailingWorkflows;
     private bool isLoadingRepositories = true;
     private bool isLoadingAuditData;
     private bool hasLoadedAuditSummary;
@@ -185,7 +185,7 @@ public partial class Audit : ComponentBase
         totalOpenIssues = repositorySummaries.Sum(result => result.OpenIssueCount);
         totalOpenPullRequests = repositorySummaries.Sum(result => result.OpenPullRequestCount);
         totalUnlabelledIssues = repositorySummaries.Sum(result => result.UnlabelledIssueCount);
-        totalFailingWorkflowRuns = repositorySummaries.Sum(result => result.FailingWorkflowCount);
+        totalFailingWorkflows = repositorySummaries.Sum(result => result.FailingWorkflowCount);
     }
 
     private void ResetDashboardData()
@@ -197,7 +197,7 @@ public partial class Audit : ComponentBase
         totalOpenIssues = 0;
         totalOpenPullRequests = 0;
         totalUnlabelledIssues = 0;
-        totalFailingWorkflowRuns = 0;
+        totalFailingWorkflows = 0;
     }
 
     private static int GetDaysBetween(DateTimeOffset value)

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
@@ -17,7 +17,7 @@ public sealed class AuditTests
     private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
 
     [Fact]
-    public async Task Audit_WhileServiceIsLoading_ShowsLoadingSkeleton()
+    public async Task Audit_WhileServiceIsLoading_ShowsCommandSurfaceLoadingSkeleton()
     {
         // Arrange
         var tcs = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
@@ -34,13 +34,13 @@ public sealed class AuditTests
         var cut = ctx.Render<Audit>();
 
         // Assert
-        Assert.Single(cut.FindAll("[data-testid='audit-repository-filter-loading']"));
+        Assert.Single(cut.FindAll("[data-testid='audit-command-surface-loading']"));
         Assert.Empty(cut.FindAll("[data-testid='audit-summary-table']"));
-        Assert.Empty(cut.FindAll("[data-testid='audit-empty-state']"));
+        Assert.DoesNotContain("No repositories found", cut.Markup);
     }
 
     [Fact]
-    public async Task Audit_WhenServiceReturnsNoRepositories_ShowsEmptyState()
+    public async Task Audit_WhenServiceReturnsNoRepositories_ShowsEmptyStateInFeedbackRegion()
     {
         // Arrange
         _repositoryServiceMock
@@ -55,7 +55,7 @@ public sealed class AuditTests
         // Assert
         cut.WaitForAssertion(() =>
         {
-            Assert.Single(cut.FindAll("[data-testid='audit-empty-state']"));
+            Assert.Single(cut.FindAll("[data-testid='audit-feedback-region']"));
             Assert.Contains("No repositories found", cut.Markup);
             Assert.Empty(cut.FindAll("[data-testid='audit-summary-table']"));
         });
@@ -87,7 +87,7 @@ public sealed class AuditTests
 
         // Act
         var cut = ctx.Render<Audit>();
-        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-repository-filter']")));
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-command-surface']")));
         var selector = cut.FindComponent<RepositorySelector>();
         await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo-a", "owner/repo-b" }));
         cut.Find("[data-testid='audit-load-selected-button']").Click();
@@ -96,10 +96,15 @@ public sealed class AuditTests
         cut.WaitForAssertion(() =>
         {
             Assert.Single(cut.FindAll("[data-testid='audit-summary-table']"));
+            Assert.Single(cut.FindAll("[data-testid='audit-kpi-summary-cards']"));
+            Assert.Single(cut.FindAll("[data-testid='audit-unlabelled-kpi-card']"));
+            Assert.Single(cut.FindAll("[data-testid='audit-failing-workflows-kpi-card']"));
             Assert.Contains("owner/repo-a", cut.Markup);
             Assert.Contains("owner/repo-b", cut.Markup);
             Assert.Contains("Total open issues", cut.Markup);
             Assert.Contains("Total open pull requests", cut.Markup);
+            Assert.Contains("Unlabelled issues", cut.Markup);
+            Assert.Contains("Failing workflows", cut.Markup);
             Assert.Contains(">5<", cut.Markup);
             Assert.Contains(">5<", cut.Markup);
 
@@ -131,7 +136,7 @@ public sealed class AuditTests
 
         // Act
         var cut = ctx.Render<Audit>();
-        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-repository-filter']")));
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-command-surface']")));
         var selector = cut.FindComponent<RepositorySelector>();
         await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo-a" }));
 
@@ -152,7 +157,7 @@ public sealed class AuditTests
 
         cut.WaitForAssertion(() =>
         {
-            Assert.Single(cut.FindAll("[data-testid='audit-loading-state']"));
+            Assert.Single(cut.FindAll("[data-testid='audit-feedback-region']"));
         });
 
         await cut.InvokeAsync(() => summaryCompletionSource.SetResult([new RepositoryAuditSummaryDto("owner/repo-a", 1, 1, 0, 0, 0)]));
@@ -205,7 +210,7 @@ public sealed class AuditTests
 
         // Act
         var cut = ctx.Render<Audit>();
-        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-repository-filter']")));
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-command-surface']")));
         var selector = cut.FindComponent<RepositorySelector>();
         await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo-a" }));
         cut.Find("[data-testid='audit-load-selected-button']").Click();
@@ -214,6 +219,7 @@ public sealed class AuditTests
         cut.WaitForAssertion(() =>
         {
             Assert.Single(cut.FindAll("[data-testid='audit-health-indicator-sections']"));
+            Assert.Single(cut.FindAll("[data-testid='audit-health-indicators-group']"));
             Assert.Contains("Unlabelled Issues", cut.Markup);
             Assert.Contains("Stale Pull Requests", cut.Markup);
             Assert.Contains("Failing Workflows", cut.Markup);
@@ -253,7 +259,7 @@ public sealed class AuditTests
 
         // Act
         var cut = ctx.Render<Audit>();
-        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-repository-filter']")));
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-command-surface']")));
         var selector = cut.FindComponent<RepositorySelector>();
         await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo-a" }));
         cut.Find("[data-testid='audit-load-selected-button']").Click();
@@ -296,7 +302,7 @@ public sealed class AuditTests
 
         // Act
         var cut = ctx.Render<Audit>();
-        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-repository-filter']")));
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-command-surface']")));
         var selector = cut.FindComponent<RepositorySelector>();
         await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo-a" }));
         cut.Find("[data-testid='audit-load-selected-button']").Click();

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
@@ -17,7 +17,7 @@ public sealed class AuditTests
     private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
 
     [Fact]
-    public async Task Audit_WhileServiceIsLoading_ShowsCommandSurfaceLoadingSkeleton()
+    public async Task Audit_WhileServiceIsLoading_ShowsFeedbackRegionSkeleton()
     {
         // Arrange
         var tcs = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
@@ -34,7 +34,7 @@ public sealed class AuditTests
         var cut = ctx.Render<Audit>();
 
         // Assert
-        Assert.Single(cut.FindAll("[data-testid='audit-command-surface-loading']"));
+        Assert.Single(cut.FindAll("[data-testid='audit-feedback-region']"));
         Assert.Empty(cut.FindAll("[data-testid='audit-summary-table']"));
         Assert.DoesNotContain("No repositories found", cut.Markup);
     }


### PR DESCRIPTION
## Summary of Changes

Refreshes the Audit Dashboard page to align with the approved wireframe composition and current MudBlazor guidance. The page now uses a named repository selector section, a KPI summary card row, grouped health indicators, and a consistent feedback region for all loading/empty/error/prompt states.

## Related Issue(s)

Closes #135
Closes #136

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)
- [x] ♻️ Refactoring (no functional change, improves code quality)

## What Changed

### Source
- `src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor` — refreshed markup: repository selector section, four KPI summary cards (open issues, open PRs, unlabelled issues, failing workflows), grouped health indicators container, consistent feedback region test IDs.
- `src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor.cs` — added `totalUnlabelledIssues` and `totalFailingWorkflowRuns` state fields; populated and reset alongside existing KPI totals.

### Tests
- `tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs` — updated test IDs to `audit-command-surface-loading`, `audit-command-surface`, and `audit-feedback-region`; added assertions for `audit-kpi-summary-cards`, `audit-unlabelled-kpi-card`, `audit-failing-workflows-kpi-card`, and `audit-health-indicators-group`; retained and updated all existing health-indicator and zero-state coverage.

### Documentation
- `docs/user-guide/audit-dashboard.md` — updated to describe the refreshed repository selector, KPI summary cards, grouped health indicators, and feedback region.
- `plan/BACKLOG.md` — marked issues #135 and #136 as implemented with implementation note.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`) — 178/178 passing
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

UI-only refresh — no new routes or navigation changes.

## Additional Notes

This is a retrospective UI refinement driven by the approved audit-dashboard wireframe (`plan/wireframes/audit-dashboard-wireframe.md`) and the newer MudBlazor planning guidance. No new Application or Infrastructure layer changes were required; all existing audit behaviour is preserved.