### PR TITLE
[type/story] Refresh One-Click Migration page workflow layout and bUnit coverage

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,6 +49,40 @@
         "${workspaceFolder}/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj",
         "run"
       ],
+      "problemMatcher": [
+        {
+          "pattern": [
+            {
+              "regexp": ".",
+              "file": 1,
+              "location": 2,
+              "message": 3
+            }
+          ],
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": "^.*Build started.*",
+            "endsPattern": "^.*Now listening on:\\s+(https?://\\S+)"
+          }
+        }
+      ],
+      "isBackground": true,
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      }
+    },
+    {
+      "label": "watch (wsl)",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "--project",
+        "${workspaceFolder}/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj",
+        "run"
+      ],
       "options": {
         "env": {
           "DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER": "1"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,6 +49,11 @@
         "${workspaceFolder}/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj",
         "run"
       ],
+      "options": {
+        "env": {
+          "DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER": "1"
+        }
+      },
       "problemMatcher": [
         {
           "pattern": [

--- a/docs/user-guide/one-click-migration.md
+++ b/docs/user-guide/one-click-migration.md
@@ -64,7 +64,7 @@ Select how existing artefacts in each target repository are handled when a match
 | **Merge** | Conflicting items are replaced with source values; items that exist only in the target are preserved. |
 
 
-### Step 4 — Review the preview and feedback region
+### Step 4 — Review the preview and status guidance
 
 Click **Preview** to generate a read-only diff for each target repository. No changes are made at this stage.
 
@@ -75,7 +75,7 @@ The preview card for each target shows:
 
 If the preview shows no actionable changes for a target repository, an information notice is displayed instead and the **Apply** button is not shown.
 
-The feedback region provides immediate status updates, error messages, and post-migration summaries, so you are always informed about the outcome of your actions.
+The status and guidance region provides immediate status updates, warnings, and error messages while you work through preview and apply actions.
 
 ### Step 5 — Apply the migration
 
@@ -87,7 +87,7 @@ Partial failures are reported per target repository — a failure for one target
 
 ### Step 6 — Review the post-migration summary
 
-After migration completes, a summary view is shown for each target repository in the feedback region.
+After migration completes, a summary view is shown for each target repository in the post-migration summary region.
 
 - **Labels** and **Milestones** rows display the number of items created, updated, deleted, and skipped for each artefact type.
 - Partial failures are reported per target repository, with error messages shown inline for any unsuccessful operations.

--- a/docs/user-guide/one-click-migration.md
+++ b/docs/user-guide/one-click-migration.md
@@ -11,7 +11,7 @@ nav_order: 2
 
 ## Overview
 
-One-Click Migration allows you to copy label taxonomies, milestones, and project board configurations from one GitHub repository to another in a single action. This is particularly useful when bootstrapping a new repository to match the conventions of an existing project.
+One-Click Migration allows you to copy label taxonomies and milestones from one GitHub repository to another in a single action. This is particularly useful when bootstrapping a new repository to match the conventions of an existing project.
 
 Key goals of One-Click Migration:
 - Eliminate the repetitive manual work of recreating labels and milestones in new repositories.
@@ -63,7 +63,8 @@ Select how existing artefacts in each target repository are handled when a match
 | **Overwrite** | Conflicting items are replaced with those from the source. A warning is shown before you confirm. |
 | **Merge** | Conflicting items are replaced with source values; items that exist only in the target are preserved. |
 
-### Step 4 — Preview changes
+
+### Step 4 — Review the preview and feedback region
 
 Click **Preview** to generate a read-only diff for each target repository. No changes are made at this stage.
 
@@ -72,27 +73,27 @@ The preview card for each target shows:
 - **Labels** — tables listing labels to create, update, and delete, with colour, name, and description for each row.
 - **Milestones** — tables listing milestones to create, update, and delete, with title, state, due date, and description for each row.
 
-If the preview shows no actionable changes for a target repository, an information notice is displayed instead and the **Confirm and apply** button is not shown.
+If the preview shows no actionable changes for a target repository, an information notice is displayed instead and the **Apply** button is not shown.
+
+The feedback region provides immediate status updates, error messages, and post-migration summaries, so you are always informed about the outcome of your actions.
 
 ### Step 5 — Apply the migration
 
-Once you are satisfied with the preview, click **Confirm and apply**. This button only appears when there is at least one actionable change across all target repositories.
+Once you are satisfied with the preview, click **Apply**. This button only appears when there is at least one actionable change across all target repositories.
 
 If you selected the **Overwrite** strategy, an on-page warning is shown before destructive changes are applied.
 
 Partial failures are reported per target repository — a failure for one target does not abort the remaining targets.
 
-### Step 6 — Review the summary
+### Step 6 — Review the post-migration summary
 
-
-
-After migration completes, a summary view is shown for each target repository.
+After migration completes, a summary view is shown for each target repository in the feedback region.
 
 - **Labels** and **Milestones** rows display the number of items created, updated, deleted, and skipped for each artefact type.
 - Partial failures are reported per target repository, with error messages shown inline for any unsuccessful operations.
 - If a target has no operations for an enabled artefact type, the summary still displays that artefact row with zero counts.
 
-Project board configuration migration remains planned for a later slice and is not yet available.
+**Note:** Project board configuration migration is not included in the current delivery. Only labels and milestones are supported at this time.
 
 ---
 

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -122,11 +122,12 @@ Labels: `type/epic`, `area/migration`
 - [x] Test: Infrastructure tests for GitHub milestone migration support. _(Completed as #97 for v0.3.0. Coverage added for response mapping, create/update request behaviour, non-success responses, and guard clauses.)_
 - [x] Test: bUnit tests for the Migration page workflow. _(Completed as #98 for v0.3.0. Coverage added for empty state, selection and preview gating, duplicate apply prevention, and post-migration summary error rendering.)_
 
+
 ### Wireframe-First Refresh Planning (Retroactive)
 
 - [x] As a solo developer, I want an approved wireframe artefact for the One-Click Migration page refresh so that implementation and test work can align on workflow-first layout, MudBlazor-first planning, and accessibility requirements. _(Wireframe created on 2026-03-17: plan/wireframes/one-click-migration-wireframe.md.)_
-- [ ] As a solo developer, I want the One-Click Migration page refreshed against the approved wireframe so that repository selection, migration scope, conflict strategy, preview review, apply action, post-migration summary, and feedback states are clearer to scan and operate. _(Issue #139; wireframe reference: plan/wireframes/one-click-migration-wireframe.md.)_
-- [ ] Test: bUnit coverage for the One-Click Migration page refresh should reference the approved wireframe so that the planned layout, state variants, and workflow gating are protected against regression. _(Issue #140; wireframe reference: plan/wireframes/one-click-migration-wireframe.md.)_
+- [x] As a solo developer, I want the One-Click Migration page refreshed against the approved wireframe so that repository selection, migration scope, conflict strategy, preview review, apply action, post-migration summary, and feedback states are clearer to scan and operate. _(Issue #139 implemented 2026-03-18. The page now uses a workflow-first layout with a dedicated feedback region, fully aligned to the wireframe. No project-board migration scope was added.)_
+- [x] Test: bUnit coverage for the One-Click Migration page refresh should reference the approved wireframe so that the planned layout, state variants, and workflow gating are protected against regression. _(Issue #140 implemented 2026-03-18. Coverage expanded for workflow controls, preview region/empty state, post-migration summary, feedback region, and workflow gating.)_
 
 - [ ] As a solo developer, I want to migrate project board column configurations so that new repositories start with the same board structure. _(Deferred follow-on slice; requires GitHub Projects v2 support and is captured in ADR-0013.)_
 

--- a/plan/wireframes/one-click-migration-wireframe.md
+++ b/plan/wireframes/one-click-migration-wireframe.md
@@ -17,12 +17,12 @@
 | Page Header: One-Click Migration                                      |
 | Intro copy: labels and milestones only for the current delivery slice |
 +-----------------------------------------------------------------------+
-| Workflow Controls                                                     |
+| Migration Setup                                                       |
 | [Source Repository Select] [Target Repository Multi-Select]           |
 | [Scope: Labels] [Scope: Milestones] [Conflict Strategy Select]        |
 | [Preview Changes]                                    [Apply Migration]|
 +-----------------------------------------------------------------------+
-| Preview Region                                                        |
+| Preview                                                               |
 | +-------------------------------------------------------------------+ |
 | | Target Repository A                                                | |
 | |  - Labels: create 2, update 1, skip 3                             | |
@@ -37,7 +37,7 @@
 | [Success / partial failure / error alert]                            |
 | [Created | Updated | Deleted | Skipped counts by target]             |
 +-----------------------------------------------------------------------+
-| Feedback Region                                                       |
+| Status and Guidance                                                   |
 | [Status messages, warnings, validation, and next-step guidance]       |
 +-----------------------------------------------------------------------+
 ```
@@ -52,12 +52,12 @@
 
 ## State Variants
 - Empty state: Explain that a source repository, one or more target repositories, and at least one migration scope are required before preview can run.
-- Loading state: Keep the workflow controls visible while preview or apply work is in progress, with the active region showing a busy state.
+- Loading state: Keep the migration setup controls visible while preview or apply work is in progress, with the active region showing a busy state.
 - Warning state: Surface conflicts, validation issues, or partial failures in a clear feedback region without hiding previously generated preview data.
 - Success state: Show a concise result summary with created, updated, deleted, and skipped counts for each target repository.
 
 ## Accessibility Notes
-- Focus order should move from workflow controls to preview, then to the post-migration summary and feedback region.
+- Focus order should move from migration setup to preview, then to the post-migration summary and status and guidance.
 - All selectors, buttons, and alerts should expose accessible labels and descriptive helper text where needed.
 - Status and validation messaging should use an `aria-live` polite region so workflow feedback is announced without being disruptive.
 - Preview tables and summary counts should remain understandable when read linearly by assistive technologies.

--- a/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor
@@ -4,10 +4,13 @@
 
 <MudStack Spacing="3">
     <MudText Typo="Typo.h4">One-Click Migration</MudText>
-    <MudText Typo="Typo.body1">Preview and apply label and milestone migration from one source repository to multiple target repositories.</MudText>
+    <MudText Typo="Typo.body1">Run labels and milestones migration from one source repository to one or more target repositories.</MudText>
+    <MudText Typo="Typo.body2">This workflow covers the current delivery slice for labels and milestones only.</MudText>
 
-    <MudPaper Class="pa-4" Elevation="1">
+    <MudPaper Class="pa-4" Elevation="1" data-testid="migration-workflow-controls-card">
         <MudStack Spacing="2">
+            <MudText Typo="Typo.h6" data-testid="migration-workflow-controls-heading">Migration setup</MudText>
+
             @if (isLoadingRepositories)
             {
                 <MudStack AlignItems="AlignItems.Center" Spacing="1" aria-live="polite" role="status">
@@ -17,99 +20,124 @@
             }
             else
             {
-                <RepositorySelector
-                    Title="Repositories"
-                    Label="Repositories"
-                    Placeholder="Search repositories and select"
-                    EmptyStateText="No active repositories are available for migration."
-                    AvailableRepositories="availableRepositoryFullNames"
-                    SelectedRepositories="selectedRepositoryFullNames"
-                    SelectedRepositoriesChanged="OnSelectedRepositoriesChangedAsync"
-                    SummaryText="@RepositorySelectorSummary"
-                    ShowSelectedChips="true"
-                    ShowSelectionActions="true"
-                    Disabled="IsBusy"
-                    AutocompleteTestId="migration-repository-autocomplete"
-                    SummaryTestId="migration-repository-selector-summary" />
+                <MudGrid Spacing="2">
+                    <MudItem xs="12" md="6">
+                        <RepositorySelector
+                            Title="Repositories"
+                            Label="Repositories"
+                            Placeholder="Search repositories and select"
+                            EmptyStateText="No active repositories are available for migration."
+                            AvailableRepositories="availableRepositoryFullNames"
+                            SelectedRepositories="selectedRepositoryFullNames"
+                            SelectedRepositoriesChanged="OnSelectedRepositoriesChangedAsync"
+                            SummaryText="@RepositorySelectorSummary"
+                            ShowSelectedChips="true"
+                            ShowSelectionActions="true"
+                            Disabled="IsBusy"
+                            AutocompleteTestId="migration-repository-autocomplete"
+                            SummaryTestId="migration-repository-selector-summary" />
+                    </MudItem>
 
-                <MudSelect T="string"
-                           Label="Source repository"
-                           Value="sourceRepositoryFullName"
-                           ValueChanged="OnSourceRepositoryChangedAsync"
-                           Variant="Variant.Outlined"
-                           Disabled="@(IsBusy || selectedRepositories.Count < 2)"
-                           data-testid="migration-source-select">
-                    @foreach (var repository in selectedRepositories.OrderBy(repository => repository.FullName, StringComparer.OrdinalIgnoreCase))
-                    {
-                        <MudSelectItem T="string" Value="@repository.FullName">@repository.FullName</MudSelectItem>
-                    }
-                </MudSelect>
+                    <MudItem xs="12" md="6">
+                        <MudPaper Class="pa-3" Outlined="true">
+                            <MudStack Spacing="1">
+                                <MudText Typo="Typo.subtitle2">Source repository</MudText>
+                                <MudText Typo="Typo.body2">Choose the source repository used to generate preview and apply actions.</MudText>
 
-                <MudText Typo="Typo.subtitle2">Target repositories</MudText>
-                <MudStack Spacing="1" data-testid="migration-target-list">
-                    @foreach (var repository in selectedRepositories.OrderBy(repository => repository.FullName, StringComparer.OrdinalIgnoreCase))
-                    {
-                        var isSourceRepository = repository.FullName.Equals(sourceRepositoryFullName, StringComparison.OrdinalIgnoreCase);
-                        <MudCheckBox T="bool"
-                                     Value="targetRepositoryFullNames.Contains(repository.FullName)"
-                                     ValueChanged="isChecked => OnTargetRepositoryChangedAsync(repository.FullName, isChecked)"
-                                     Disabled="@(IsBusy || isSourceRepository)"
-                                     Label="@repository.FullName"
-                                     data-testid="migration-target-checkbox" />
-                    }
-                </MudStack>
+                                <MudSelect T="string"
+                                           Label="Source repository"
+                                           Value="sourceRepositoryFullName"
+                                           ValueChanged="OnSourceRepositoryChangedAsync"
+                                           Variant="Variant.Outlined"
+                                           Disabled="@(IsBusy || selectedRepositories.Count < 2)"
+                                           data-testid="migration-source-select">
+                                    @foreach (var repository in selectedRepositories.OrderBy(repository => repository.FullName, StringComparer.OrdinalIgnoreCase))
+                                    {
+                                        <MudSelectItem T="string" Value="@repository.FullName">@repository.FullName</MudSelectItem>
+                                    }
+                                </MudSelect>
+                            </MudStack>
+                        </MudPaper>
+                    </MudItem>
 
-                <MudSelect T="MigrationConflictStrategy"
-                           Label="Conflict strategy"
-                           Value="conflictStrategy"
-                           ValueChanged="OnConflictStrategyChangedAsync"
-                           Variant="Variant.Outlined"
-                           Disabled="IsBusy"
-                           data-testid="migration-conflict-strategy-select">
-                    @foreach (var option in conflictOptions)
-                    {
-                        <MudSelectItem T="MigrationConflictStrategy" Value="@option.Value">@option.Label</MudSelectItem>
-                    }
-                </MudSelect>
+                    <MudItem xs="12" md="6">
+                        <MudPaper Class="pa-3" Outlined="true">
+                            <MudStack Spacing="1">
+                                <MudText Typo="Typo.subtitle2">Target repositories</MudText>
+                                <MudText Typo="Typo.body2">Select one or more targets. The source repository cannot be selected as a target.</MudText>
 
-                <MudPaper Class="pa-3" Outlined="true" data-testid="migration-conflict-strategy-help">
-                    <MudStack Spacing="1">
-                        <MudText Typo="Typo.subtitle2">Conflict behaviour</MudText>
-                        @foreach (var option in conflictOptions)
-                        {
-                            <MudText Typo="Typo.body2"><strong>@option.Label:</strong> @option.Description</MudText>
-                        }
-                    </MudStack>
-                </MudPaper>
+                                <MudStack Spacing="1" data-testid="migration-target-list">
+                                    @foreach (var repository in selectedRepositories.OrderBy(repository => repository.FullName, StringComparer.OrdinalIgnoreCase))
+                                    {
+                                        var isSourceRepository = repository.FullName.Equals(sourceRepositoryFullName, StringComparison.OrdinalIgnoreCase);
+                                        <MudCheckBox T="bool"
+                                                     Value="targetRepositoryFullNames.Contains(repository.FullName)"
+                                                     ValueChanged="isChecked => OnTargetRepositoryChangedAsync(repository.FullName, isChecked)"
+                                                     Disabled="@(IsBusy || isSourceRepository)"
+                                                     Label="@repository.FullName"
+                                                     data-testid="migration-target-checkbox" />
+                                    }
+                                </MudStack>
+                            </MudStack>
+                        </MudPaper>
+                    </MudItem>
 
-                <MudPaper Class="pa-3" Outlined="true" data-testid="migration-scope-card">
-                    <MudStack Spacing="1">
-                        <MudText Typo="Typo.subtitle2">Items to migrate</MudText>
-                        <MudSwitch T="bool"
-                                   Value="migrateLabels"
-                                   ValueChanged="OnMigrateLabelsChangedAsync"
-                                   Label="Labels"
-                                   Disabled="IsBusy"
-                                   Color="Color.Primary"
-                                   data-testid="migration-scope-labels-switch" />
-                        <MudSwitch T="bool"
-                                   Value="migrateMilestones"
-                                   ValueChanged="OnMigrateMilestonesChangedAsync"
-                                   Label="Milestones"
-                                   Disabled="IsBusy"
-                                   Color="Color.Primary"
-                                   data-testid="migration-scope-milestones-switch" />
-                    </MudStack>
-                </MudPaper>
+                    <MudItem xs="12" md="6">
+                        <MudStack Spacing="2">
+                            <MudSelect T="MigrationConflictStrategy"
+                                       Label="Conflict strategy"
+                                       Value="conflictStrategy"
+                                       ValueChanged="OnConflictStrategyChangedAsync"
+                                       Variant="Variant.Outlined"
+                                       Disabled="IsBusy"
+                                       data-testid="migration-conflict-strategy-select">
+                                @foreach (var option in conflictOptions)
+                                {
+                                    <MudSelectItem T="MigrationConflictStrategy" Value="@option.Value">@option.Label</MudSelectItem>
+                                }
+                            </MudSelect>
 
-                @if (conflictStrategy == MigrationConflictStrategy.Overwrite)
-                {
-                    <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined" data-testid="migration-overwrite-warning">
-                        Overwrite can remove target labels and milestones that do not exist in the source repository.
-                    </MudAlert>
-                }
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="migration-conflict-strategy-help">
+                                <MudStack Spacing="1">
+                                    <MudText Typo="Typo.subtitle2">Conflict behaviour</MudText>
+                                    @foreach (var option in conflictOptions)
+                                    {
+                                        <MudText Typo="Typo.body2"><strong>@option.Label:</strong> @option.Description</MudText>
+                                    }
+                                </MudStack>
+                            </MudPaper>
 
-                <MudStack Row="true" Spacing="1">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="migration-scope-card">
+                                <MudStack Spacing="1">
+                                    <MudText Typo="Typo.subtitle2">Migration scope</MudText>
+                                    <MudSwitch T="bool"
+                                               Value="migrateLabels"
+                                               ValueChanged="OnMigrateLabelsChangedAsync"
+                                               Label="Labels"
+                                               Disabled="IsBusy"
+                                               Color="Color.Primary"
+                                               data-testid="migration-scope-labels-switch" />
+                                    <MudSwitch T="bool"
+                                               Value="migrateMilestones"
+                                               ValueChanged="OnMigrateMilestonesChangedAsync"
+                                               Label="Milestones"
+                                               Disabled="IsBusy"
+                                               Color="Color.Primary"
+                                               data-testid="migration-scope-milestones-switch" />
+                                </MudStack>
+                            </MudPaper>
+
+                            @if (conflictStrategy == MigrationConflictStrategy.Overwrite)
+                            {
+                                <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined" data-testid="migration-overwrite-warning">
+                                    Overwrite can remove target labels and milestones that do not exist in the source repository.
+                                </MudAlert>
+                            }
+                        </MudStack>
+                    </MudItem>
+                </MudGrid>
+
+                <MudStack Row="true" Spacing="1" Class="justify-end" data-testid="migration-workflow-actions">
                     <MudButton Variant="Variant.Outlined"
                                Color="Color.Secondary"
                                Disabled="@(!CanPreview)"
@@ -130,7 +158,6 @@
                                 Confirm apply migration
                             </MudButton>
                         }
-
                         <MudButton Variant="Variant.Text"
                                    Color="Color.Default"
                                    OnClick="CancelPreview"
@@ -145,13 +172,6 @@
                 {
                     <MudProgressLinear Indeterminate="true" Color="Color.Primary" data-testid="migration-progress-indicator" />
                 }
-
-                @if (!string.IsNullOrWhiteSpace(operationMessage))
-                {
-                    <MudAlert Severity="@operationSeverity" Dense="true" Variant="Variant.Outlined" data-testid="migration-operation-message">
-                        @operationMessage
-                    </MudAlert>
-                }
             }
         </MudStack>
     </MudPaper>
@@ -160,13 +180,15 @@
     {
         <MudPaper Class="pa-4" Elevation="1" data-testid="migration-preview-card">
             <MudStack Spacing="2">
-                <MudText Typo="Typo.h6">Migration preview (@previewResult.ConflictStrategy)</MudText>
+                <MudText Typo="Typo.h6">Preview</MudText>
+                <MudText Typo="Typo.body2">Review create, update, delete, and skip actions by target repository before applying migration.</MudText>
+                <MudText Typo="Typo.subtitle1">Migration preview (@previewResult.ConflictStrategy)</MudText>
                 @foreach (var repository in orderedPreviewRepositories)
                 {
                     var labelPreview = GetLabelPreview(repository);
                     var milestonePreview = GetMilestonePreview(repository);
 
-                    <MudPaper Class="pa-3" Outlined="true">
+                    <MudPaper Class="pa-3" Outlined="true" data-testid="migration-preview-repository-card">
                         <MudText Typo="Typo.subtitle1">@repository</MudText>
 
                         @if (migrateLabels)
@@ -220,11 +242,20 @@
             </MudStack>
         </MudPaper>
     }
+    else
+    {
+        <MudPaper Class="pa-4" Elevation="1" data-testid="migration-preview-empty-state">
+            <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Outlined">
+                Select one source repository, one or more target repositories, and at least one migration scope to generate a preview.
+            </MudAlert>
+        </MudPaper>
+    }
 
     @if (applyResult.LabelResults.Count > 0 || applyResult.MilestoneResults.Count > 0)
     {
         <MudPaper Class="pa-4" Elevation="1" data-testid="migration-summary-card">
             <MudStack Spacing="2">
+                <MudText Typo="Typo.h6">Post-migration summary</MudText>
                 <MudText Typo="Typo.h6">Migration summary (@applyResult.ConflictStrategy)</MudText>
                 @foreach (var repository in orderedApplyRepositories)
                 {
@@ -265,4 +296,35 @@
             </MudStack>
         </MudPaper>
     }
+
+    <MudPaper Class="pa-4" Elevation="1" data-testid="migration-feedback-region" aria-live="polite">
+        <MudStack Spacing="1">
+            <MudText Typo="Typo.h6">Status and guidance</MudText>
+
+            @if (!string.IsNullOrWhiteSpace(operationMessage))
+            {
+                <MudAlert Severity="@operationSeverity" Dense="true" Variant="Variant.Outlined" data-testid="migration-operation-message">
+                    @operationMessage
+                </MudAlert>
+            }
+            else if (!CanPreview)
+            {
+                <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Outlined" data-testid="migration-requirements-info">
+                    Select repositories and migration scope to unlock preview.
+                </MudAlert>
+            }
+            else if (showPreview && !HasActionablePreviewChanges)
+            {
+                <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined" data-testid="migration-no-action-warning">
+                    The current preview has no actionable create, update, or delete changes.
+                </MudAlert>
+            }
+            else if (showPreview && HasActionablePreviewChanges)
+            {
+                <MudAlert Severity="Severity.Success" Dense="true" Variant="Variant.Outlined" data-testid="migration-ready-to-apply-info">
+                    Review the preview and apply migration when you are ready.
+                </MudAlert>
+            }
+        </MudStack>
+    </MudPaper>
 </MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor
@@ -155,7 +155,7 @@
                                        Disabled="@(!CanApply)"
                                        OnClick="ApplyMigrationAsync"
                                        data-testid="migration-apply-button">
-                                Confirm apply migration
+                                Apply migration
                             </MudButton>
                         }
                         <MudButton Variant="Variant.Text"
@@ -256,7 +256,7 @@
         <MudPaper Class="pa-4" Elevation="1" data-testid="migration-summary-card">
             <MudStack Spacing="2">
                 <MudText Typo="Typo.h6">Post-migration summary</MudText>
-                <MudText Typo="Typo.h6">Migration summary (@applyResult.ConflictStrategy)</MudText>
+                <MudText Typo="Typo.body2">Conflict strategy used: @applyResult.ConflictStrategy</MudText>
                 @foreach (var repository in orderedApplyRepositories)
                 {
                     var labelResult = GetLabelResult(repository);

--- a/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
@@ -456,7 +456,7 @@ public sealed class MigrationTests
         // Assert
         cut.WaitForAssertion(() =>
         {
-            Assert.Contains("Migration summary (Merge)", cut.Markup);
+            Assert.Contains("Conflict strategy used: Merge", cut.Markup);
             Assert.Contains("Label migration failed.", cut.Markup);
             Assert.Contains("GitHub label API rate limit reached", cut.Markup);
         });

--- a/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
@@ -44,6 +44,32 @@ public sealed class MigrationTests
     }
 
     [Fact]
+    public async Task Migration_PageLoaded_RendersWorkflowAndFeedbackRegions()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                CreateRepository("owner", "repo-a"),
+                CreateRepository("owner", "repo-b"),
+            ]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Migration>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotNull(cut.Find("[data-testid='migration-workflow-controls-card']"));
+            Assert.NotNull(cut.Find("[data-testid='migration-preview-empty-state']"));
+            Assert.NotNull(cut.Find("[data-testid='migration-feedback-region']"));
+            Assert.NotNull(cut.Find("[data-testid='migration-requirements-info']"));
+        });
+    }
+
+    [Fact]
     public async Task Migration_PreviewClicked_UsesSelectedConflictStrategy()
     {
         // Arrange
@@ -137,8 +163,63 @@ public sealed class MigrationTests
         cut.Find("[data-testid='migration-preview-button']").Click();
 
         // Assert
-        cut.WaitForAssertion(() => Assert.Contains("Migration preview (Skip)", cut.Markup));
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Migration preview (Skip)", cut.Markup);
+            Assert.NotNull(cut.Find("[data-testid='migration-no-action-warning']"));
+        });
+
         Assert.Empty(cut.FindAll("[data-testid='migration-apply-button']"));
+    }
+
+    [Fact]
+    public async Task Migration_ActionablePreviewGenerated_ShowsReadyToApplyFeedbackMessage()
+    {
+        // Arrange
+        var sourceRepository = CreateRepository("owner", "repo-a");
+        var targetRepository = CreateRepository("owner", "repo-b");
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([sourceRepository, targetRepository]);
+
+        _migrationServiceMock
+            .Setup(service => service.PreviewMigrationAsync(
+                "owner/repo-a",
+                It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
+                It.IsAny<MigrationScopeDto>(),
+                MigrationConflictStrategy.Skip,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MigrationPreviewDto(
+                MigrationConflictStrategy.Skip,
+                [new LabelSyncRepositoryPreviewDto(
+                    "owner/repo-b",
+                    [new LabelDto("priority/high", "d93f0b", "High priority", "owner/repo-b")],
+                    [],
+                    [],
+                    [])],
+                [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])]));
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Migration>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='migration-repository-autocomplete']"));
+
+        await SelectRepositoriesAsync(cut, sourceRepository, targetRepository);
+
+        var targetCheckboxes = cut.FindAll("[data-testid='migration-target-checkbox']");
+        Assert.Equal(2, targetCheckboxes.Count);
+        targetCheckboxes[1].Change(true);
+
+        cut.Find("[data-testid='migration-preview-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotNull(cut.Find("[data-testid='migration-apply-button']"));
+            Assert.NotNull(cut.Find("[data-testid='migration-ready-to-apply-info']"));
+        });
     }
 
     [Fact]


### PR DESCRIPTION
## Summary of Changes

This PR refreshes the One-Click Migration page to align with the approved wireframe and newer MudBlazor-first page patterns, while preserving the existing labels-and-milestones migration behaviour.

The page layout now uses four clear regions:
- Migration setup.
- Preview.
- Post-migration summary.
- Status and guidance.

It also expands and updates bUnit coverage for the refreshed layout and workflow gating states.

Follow-up review feedback has now been addressed on this same branch:
- Guide wording now matches the actual page regions.
- The apply button label is now Apply migration.
- The summary region heading hierarchy is simplified.
- The watch task behaviour is split into default watch and dedicated watch (wsl) variants.

Closes #139
Closes #140

## Type of Change

- [x] Feature (non-breaking change that adds functionality).
- [x] Chore / maintenance (tooling and task configuration).
- [x] Documentation (user guide wording corrections).

## Checklist

- [x] I have performed a self-review of my own code.
- [x] My changes follow the coding conventions in .github/copilot-instructions.md.
- [x] All new and existing tests pass (dotnet test).
- [x] I have added or updated tests to cover my changes.
- [x] I have updated relevant documentation in docs/ or plan/.
- [x] No new compiler warnings have been introduced.
- [x] All text in comments, strings, and docs is written in UK English.
- [x] If this adds a new feature, plan/BACKLOG.md and docs/index.md have been updated where required.

## Additional Notes

- No scope expansion was introduced beyond the current Phase 3 labels-and-milestones migration slice.
- The branch now includes the signed-commit state and follow-up review fixes.
