### PR TITLE
[type/enabler] Triage session orchestration and GitHub write operations

### DIFF
--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -166,23 +166,14 @@ Labels: `type/epic`, `area/triage`
 - [ ] As a solo developer, I want to triage unlabelled pull requests alongside issues so that my entire GitHub workload, including open PRs, is managed in one place. _(Issue #150)_
 
 **Enablers:**
-- [ ] Triage session orchestration. _(Issue #143)_
-- [ ] Triage UI state management. _(Issue #144)_
+- [x] Triage session orchestration implemented on branch feature/issue-143-144-triage-session-and-github-actions. _(Issue #143; domain model and Application DTO/service orchestration complete; tests passing.)_
+- [x] Triage UI state management implemented on branch feature/issue-143-144-triage-session-and-github-actions. _(Issue #144; GitHub triage write operations and project-board assignment GraphQL support in IGitHubService and GitHubService complete; tests passing.)_
 
 **Tests:**
 - [ ] Triage session orchestration unit tests. _(Issue #151)_
 - [ ] Triage UI state management unit tests. _(Issue #152)_
 - [ ] Triage UI bUnit tests. _(Issue #153)_
 
----
-
-## Epic 6: Workflow Templates
-
-Labels: `type/epic`, `area/workflows`
-
-- [ ] As a solo developer, I want to browse a library of GitHub Actions workflow templates so that I can find one suitable for my project.
-- [ ] As a solo developer, I want to customise a template's parameters before applying it so that it is configured correctly for my repository.
-- [ ] As a solo developer, I want to apply a workflow template to one or more repositories at once so that I can roll out CI/CD configurations efficiently.
 - [ ] As a solo developer, I want to see which repositories already have a particular workflow template applied so that I have a clear overview of my CI/CD coverage.
 - [ ] As a solo developer, I want to be alerted when a repository's workflow file differs from the canonical template so that I can update it.
 - [ ] As a solo developer, I want built-in templates for .NET CI, Azure CD, and Dependabot so that I have useful starting points out of the box.

--- a/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using SoloDevBoard.Application.Services.Audit;
 using SoloDevBoard.Application.Services.Labels;
 using SoloDevBoard.Application.Services.Migration;
 using SoloDevBoard.Application.Services.Repositories;
+using SoloDevBoard.Application.Services.Triage;
 
 namespace SoloDevBoard.Application.Services.Common;
 
@@ -21,6 +22,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<ILabelManagerService, LabelService>();
         services.AddScoped<IMigrationService, MigrationService>();
         services.AddScoped<IAuditDashboardService, AuditDashboardService>();
+        services.AddScoped<ITriageService, TriageService>();
 
         return services;
     }

--- a/src/Application/SoloDevBoard.Application/Services/GitHub/GitHubTriageItemType.cs
+++ b/src/Application/SoloDevBoard.Application/Services/GitHub/GitHubTriageItemType.cs
@@ -1,0 +1,11 @@
+namespace SoloDevBoard.Application.Services.GitHub;
+
+/// <summary>Defines triage item types used by GitHub write operations.</summary>
+public enum GitHubTriageItemType
+{
+    /// <summary>Represents a GitHub issue.</summary>
+    Issue = 0,
+
+    /// <summary>Represents a GitHub pull request.</summary>
+    PullRequest = 1,
+}

--- a/src/Application/SoloDevBoard.Application/Services/GitHub/IGitHubService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/GitHub/IGitHubService.cs
@@ -90,4 +90,41 @@ public interface IGitHubService
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous delete operation.</returns>
     Task DeleteLabelAsync(string owner, string repo, string labelName, CancellationToken cancellationToken = default);
+
+    /// <summary>Replaces all labels on a triage item with the specified set.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="itemNumber">The repository-scoped item number.</param>
+    /// <param name="labelNames">The label names to set on the item.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous label assignment operation.</returns>
+    Task ApplyLabelsToTriageItemAsync(string owner, string repo, int itemNumber, IReadOnlyList<string> labelNames, CancellationToken cancellationToken = default);
+
+    /// <summary>Assigns or clears a milestone on a triage item.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="itemNumber">The repository-scoped item number.</param>
+    /// <param name="milestoneNumber">The milestone number to assign, or <see langword="null"/> to clear.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous milestone assignment operation.</returns>
+    Task AssignMilestoneToTriageItemAsync(string owner, string repo, int itemNumber, int? milestoneNumber, CancellationToken cancellationToken = default);
+
+    /// <summary>Adds a triage item to a GitHub Project v2 board.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="itemNumber">The repository-scoped item number.</param>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The created project-item node identifier.</returns>
+    Task<string> AddTriageItemToProjectBoardAsync(string owner, string repo, int itemNumber, string projectId, CancellationToken cancellationToken = default);
+
+    /// <summary>Closes a triage item as duplicate and records a duplicate reference comment.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="itemType">The triage item type.</param>
+    /// <param name="itemNumber">The repository-scoped item number.</param>
+    /// <param name="duplicateReference">The canonical issue or pull-request reference.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous duplicate closure operation.</returns>
+    Task CloseTriageItemAsDuplicateAsync(string owner, string repo, GitHubTriageItemType itemType, int itemNumber, string duplicateReference, CancellationToken cancellationToken = default);
 }

--- a/src/Application/SoloDevBoard.Application/Services/Triage/ITriageService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/ITriageService.cs
@@ -1,23 +1,37 @@
-using SoloDevBoard.Domain.Entities.Triage;
-
 namespace SoloDevBoard.Application.Services.Triage;
 
-/// <summary>Provides issue triage operations.</summary>
+/// <summary>Provides one-at-a-time triage session orchestration operations.</summary>
 public interface ITriageService
 {
-    /// <summary>Retrieves issues that still require triage in the specified repository.</summary>
+    /// <summary>Starts a triage session for a repository.</summary>
     /// <param name="owner">The GitHub account owner login.</param>
     /// <param name="repo">The repository name.</param>
+    /// <param name="includePullRequests"><see langword="true"/> to include pull requests in the triage queue; otherwise, <see langword="false"/>.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    /// <returns>A read-only list of issues that require triage.</returns>
-    Task<IReadOnlyList<Issue>> GetUntriagedIssuesAsync(string owner, string repo, CancellationToken cancellationToken = default);
+    /// <returns>The initialised triage session DTO.</returns>
+    Task<TriageSessionDto> StartSessionAsync(string owner, string repo, bool includePullRequests = false, CancellationToken cancellationToken = default);
 
-    /// <summary>Applies a triage label to an issue.</summary>
-    /// <param name="owner">The GitHub account owner login.</param>
-    /// <param name="repo">The repository name.</param>
-    /// <param name="issueNumber">The repository-scoped issue number.</param>
-    /// <param name="labelName">The label name to apply.</param>
+    /// <summary>Advances the session to the next queue item.</summary>
+    /// <param name="session">The current session state.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    /// <returns>A task that represents the asynchronous label application operation.</returns>
-    Task ApplyTriageLabelAsync(string owner, string repo, int issueNumber, string labelName, CancellationToken cancellationToken = default);
+    /// <returns>The updated triage session DTO.</returns>
+    Task<TriageSessionDto> AdvanceSessionAsync(TriageSessionDto session, CancellationToken cancellationToken = default);
+
+    /// <summary>Skips the currently active item and records a skip action.</summary>
+    /// <param name="session">The current session state.</param>
+    /// <param name="reason">An optional user-provided skip reason.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The updated triage session DTO.</returns>
+    Task<TriageSessionDto> SkipCurrentItemAsync(TriageSessionDto session, string reason, CancellationToken cancellationToken = default);
+
+    /// <summary>Appends skipped items to the end of the queue for revisit.</summary>
+    /// <param name="session">The current session state.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The updated triage session DTO.</returns>
+    Task<TriageSessionDto> RevisitSkippedItemsAsync(TriageSessionDto session, CancellationToken cancellationToken = default);
+
+    /// <summary>Builds the latest triage session summary from current session state.</summary>
+    /// <param name="session">The current session state.</param>
+    /// <returns>The computed triage session summary DTO.</returns>
+    TriageSessionSummaryDto BuildSessionSummary(TriageSessionDto session);
 }

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageActionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageActionDto.cs
@@ -1,0 +1,10 @@
+namespace SoloDevBoard.Application.Services.Triage;
+
+/// <summary>Represents a recorded action in a triage session.</summary>
+public sealed record TriageActionDto(
+    TriageActionTypeDto ActionType,
+    TriageItemTypeDto ItemType,
+    int ItemNumber,
+    string RepositoryFullName,
+    string Detail,
+    DateTimeOffset OccurredAt);

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageActionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageActionDto.cs
@@ -1,6 +1,12 @@
 namespace SoloDevBoard.Application.Services.Triage;
 
 /// <summary>Represents a recorded action in a triage session.</summary>
+/// <param name="ActionType">The type of action that was performed.</param>
+/// <param name="ItemType">The triage item type for the affected item.</param>
+/// <param name="ItemNumber">The repository-scoped number of the affected issue or pull request.</param>
+/// <param name="RepositoryFullName">The full repository name in <c>owner/repo</c> format.</param>
+/// <param name="Detail">Additional detail describing the action.</param>
+/// <param name="OccurredAt">The UTC timestamp when the action occurred.</param>
 public sealed record TriageActionDto(
     TriageActionTypeDto ActionType,
     TriageItemTypeDto ItemType,

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageActionTypeDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageActionTypeDto.cs
@@ -1,0 +1,20 @@
+namespace SoloDevBoard.Application.Services.Triage;
+
+/// <summary>Defines supported triage action types for Application-layer DTOs.</summary>
+public enum TriageActionTypeDto
+{
+    /// <summary>Represents a label assignment action.</summary>
+    LabelApplied = 0,
+
+    /// <summary>Represents a milestone assignment action.</summary>
+    MilestoneAssigned = 1,
+
+    /// <summary>Represents assigning an item to a project board.</summary>
+    ProjectBoardAssigned = 2,
+
+    /// <summary>Represents duplicate closure action.</summary>
+    ClosedAsDuplicate = 3,
+
+    /// <summary>Represents skipping an item for later review.</summary>
+    Skipped = 4,
+}

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageItemDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageItemDto.cs
@@ -1,6 +1,20 @@
 namespace SoloDevBoard.Application.Services.Triage;
 
 /// <summary>Represents a triage queue item at the Application→App boundary.</summary>
+/// <param name="ItemType">The triage item type.</param>
+/// <param name="Id">The GitHub node identifier represented as an integer ID.</param>
+/// <param name="Number">The repository-scoped number of the issue or pull request.</param>
+/// <param name="RepositoryFullName">The full repository name in <c>owner/repo</c> format.</param>
+/// <param name="Title">The issue or pull request title.</param>
+/// <param name="HtmlUrl">The browser URL for the item.</param>
+/// <param name="Body">The body content for the item.</param>
+/// <param name="State">The current GitHub state value.</param>
+/// <param name="AuthorLogin">The login of the item author.</param>
+/// <param name="Labels">The current labels on the item.</param>
+/// <param name="MilestoneNumber">The assigned milestone number, when present.</param>
+/// <param name="MilestoneTitle">The assigned milestone title, or an empty string when no milestone is assigned.</param>
+/// <param name="CreatedAt">The UTC timestamp when the item was created.</param>
+/// <param name="UpdatedAt">The UTC timestamp when the item was last updated.</param>
 public sealed record TriageItemDto(
     TriageItemTypeDto ItemType,
     int Id,

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageItemDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageItemDto.cs
@@ -1,0 +1,18 @@
+namespace SoloDevBoard.Application.Services.Triage;
+
+/// <summary>Represents a triage queue item at the Application→App boundary.</summary>
+public sealed record TriageItemDto(
+    TriageItemTypeDto ItemType,
+    int Id,
+    int Number,
+    string RepositoryFullName,
+    string Title,
+    string HtmlUrl,
+    string Body,
+    string State,
+    string AuthorLogin,
+    IReadOnlyList<string> Labels,
+    int? MilestoneNumber,
+    string MilestoneTitle,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt);

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageItemTypeDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageItemTypeDto.cs
@@ -1,0 +1,11 @@
+namespace SoloDevBoard.Application.Services.Triage;
+
+/// <summary>Defines the supported triage item types for Application-layer DTOs.</summary>
+public enum TriageItemTypeDto
+{
+    /// <summary>Represents a GitHub issue.</summary>
+    Issue = 0,
+
+    /// <summary>Represents a GitHub pull request.</summary>
+    PullRequest = 1,
+}

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
@@ -3,24 +3,398 @@ using SoloDevBoard.Domain.Entities.Triage;
 
 namespace SoloDevBoard.Application.Services.Triage;
 
-/// <summary>Stub implementation of <see cref="ITriageService"/>.</summary>
+/// <summary>Application-layer orchestration for one-at-a-time triage sessions.</summary>
 public sealed class TriageService : ITriageService
 {
     private readonly IGitHubService _gitHubService;
 
     public TriageService(IGitHubService gitHubService)
     {
-        _gitHubService = gitHubService;
+        _gitHubService = gitHubService ?? throw new ArgumentNullException(nameof(gitHubService));
     }
 
     /// <inheritdoc/>
-    public Task<IReadOnlyList<Issue>> GetUntriagedIssuesAsync(string owner, string repo, CancellationToken cancellationToken = default)
-        => _gitHubService.GetIssuesAsync(owner, repo, cancellationToken);
-
-    /// <inheritdoc/>
-    public Task ApplyTriageLabelAsync(string owner, string repo, int issueNumber, string labelName, CancellationToken cancellationToken = default)
+    public async Task<TriageSessionDto> StartSessionAsync(string owner, string repo, bool includePullRequests = false, CancellationToken cancellationToken = default)
     {
-        // TODO: Implement applying a triage label to a specific issue.
-        return Task.CompletedTask;
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var issues = await _gitHubService.GetIssuesAsync(owner, repo, cancellationToken).ConfigureAwait(false);
+        var queue = new List<TriageItem>(issues.Count + 16);
+        queue.AddRange(issues.Select(issue => ToDomainIssueItem(owner, repo, issue)));
+
+        if (includePullRequests)
+        {
+            var pullRequests = await _gitHubService.GetPullRequestsAsync(owner, repo, cancellationToken).ConfigureAwait(false);
+            queue.AddRange(pullRequests.Select(pullRequest => ToDomainPullRequestItem(owner, repo, pullRequest)));
+        }
+
+        var orderedQueue = queue
+            .OrderBy(item => item.UpdatedAt)
+            .ToArray();
+
+        var session = new TriageSession
+        {
+            SessionId = Guid.NewGuid(),
+            OwnerLogin = owner,
+            RepositoryName = repo,
+            IncludePullRequests = includePullRequests,
+            Queue = orderedQueue,
+            CurrentIndex = 0,
+            SkippedItems = [],
+            ActionHistory = [],
+            Progress = BuildProgress(orderedQueue.Length, 0, 0),
+            Summary = BuildSummary(orderedQueue.Length, 0, 0, []),
+            StartedAt = DateTimeOffset.UtcNow,
+        };
+
+        return ToDto(session);
     }
+
+    /// <inheritdoc/>
+    public Task<TriageSessionDto> AdvanceSessionAsync(TriageSessionDto session, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(session);
+
+        var domainSession = ToDomain(session);
+        var nextIndex = domainSession.Queue.Count == 0
+            ? 0
+            : Math.Min(domainSession.CurrentIndex + 1, domainSession.Queue.Count);
+
+        return Task.FromResult(UpdateSessionState(domainSession with { CurrentIndex = nextIndex }));
+    }
+
+    /// <inheritdoc/>
+    public Task<TriageSessionDto> SkipCurrentItemAsync(TriageSessionDto session, string reason, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(session);
+
+        var domainSession = ToDomain(session);
+        if (domainSession.CurrentIndex >= domainSession.Queue.Count)
+        {
+            return Task.FromResult(ToDto(domainSession));
+        }
+
+        var currentItem = domainSession.Queue[domainSession.CurrentIndex];
+        var updatedSkippedItems = domainSession.SkippedItems
+            .Concat([currentItem])
+            .DistinctBy(item => (item.ItemType, item.Number, item.RepositoryFullName))
+            .ToArray();
+
+        var detail = string.IsNullOrWhiteSpace(reason)
+            ? "Skipped for later review."
+            : $"Skipped for later review. Reason: {reason.Trim()}";
+
+        var action = new TriageAction
+        {
+            ActionType = TriageActionType.Skipped,
+            ItemType = currentItem.ItemType,
+            ItemNumber = currentItem.Number,
+            RepositoryFullName = currentItem.RepositoryFullName,
+            Detail = detail,
+            OccurredAt = DateTimeOffset.UtcNow,
+        };
+
+        var updatedActionHistory = domainSession.ActionHistory
+            .Concat([action])
+            .ToArray();
+
+        var nextIndex = Math.Min(domainSession.CurrentIndex + 1, domainSession.Queue.Count);
+
+        return Task.FromResult(UpdateSessionState(domainSession with
+        {
+            CurrentIndex = nextIndex,
+            SkippedItems = updatedSkippedItems,
+            ActionHistory = updatedActionHistory,
+        }));
+    }
+
+    /// <inheritdoc/>
+    public Task<TriageSessionDto> RevisitSkippedItemsAsync(TriageSessionDto session, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(session);
+
+        var domainSession = ToDomain(session);
+        if (domainSession.SkippedItems.Count == 0)
+        {
+            return Task.FromResult(ToDto(domainSession));
+        }
+
+        var existingKeys = domainSession.Queue
+            .Select(item => (item.ItemType, item.Number, item.RepositoryFullName))
+            .ToHashSet();
+
+        var appendItems = domainSession.SkippedItems
+            .Where(item => !existingKeys.Contains((item.ItemType, item.Number, item.RepositoryFullName)))
+            .ToArray();
+
+        var updatedQueue = domainSession.Queue
+            .Concat(appendItems)
+            .ToArray();
+
+        return Task.FromResult(UpdateSessionState(domainSession with
+        {
+            Queue = updatedQueue,
+            SkippedItems = [],
+        }));
+    }
+
+    /// <inheritdoc/>
+    public TriageSessionSummaryDto BuildSessionSummary(TriageSessionDto session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        return UpdateSessionState(ToDomain(session)).Summary;
+    }
+
+    private static TriageSessionDto UpdateSessionState(TriageSession session)
+    {
+        var progress = BuildProgress(session.Queue.Count, session.CurrentIndex, session.SkippedItems.Count);
+        var summary = BuildSummary(session.Queue.Count, session.CurrentIndex, session.SkippedItems.Count, session.ActionHistory);
+
+        var updated = session with
+        {
+            Progress = progress,
+            Summary = summary,
+        };
+
+        return ToDto(updated);
+    }
+
+    private static TriageSessionProgress BuildProgress(int totalItems, int currentIndex, int skippedItems)
+    {
+        var processed = Math.Min(Math.Max(currentIndex, 0), totalItems);
+        var remaining = Math.Max(totalItems - processed, 0);
+
+        return new TriageSessionProgress
+        {
+            TotalItems = totalItems,
+            ProcessedItems = processed,
+            RemainingItems = remaining,
+            SkippedItems = skippedItems,
+        };
+    }
+
+    private static TriageSessionSummary BuildSummary(int totalItems, int currentIndex, int skippedItems, IReadOnlyList<TriageAction> actionHistory)
+    {
+        var processed = Math.Min(Math.Max(currentIndex, 0), totalItems);
+        var remaining = Math.Max(totalItems - processed, 0);
+
+        return new TriageSessionSummary
+        {
+            TotalItems = totalItems,
+            ProcessedItems = processed,
+            RemainingItems = remaining,
+            SkippedItems = skippedItems,
+            LabelsAppliedCount = actionHistory.Count(action => action.ActionType == TriageActionType.LabelApplied),
+            MilestonesAssignedCount = actionHistory.Count(action => action.ActionType == TriageActionType.MilestoneAssigned),
+            ProjectAssignmentsCount = actionHistory.Count(action => action.ActionType == TriageActionType.ProjectBoardAssigned),
+            DuplicateClosuresCount = actionHistory.Count(action => action.ActionType == TriageActionType.ClosedAsDuplicate),
+        };
+    }
+
+    private static TriageItem ToDomainIssueItem(string owner, string repo, Issue issue)
+    {
+        ArgumentNullException.ThrowIfNull(issue);
+
+        return new TriageItem
+        {
+            ItemType = TriageItemType.Issue,
+            Id = issue.Id,
+            Number = issue.Number,
+            RepositoryFullName = $"{owner}/{repo}",
+            Title = issue.Title,
+            HtmlUrl = issue.HtmlUrl,
+            Body = issue.Body,
+            State = issue.State,
+            AuthorLogin = issue.AuthorLogin,
+            Labels = issue.Labels,
+            Milestone = issue.Milestone,
+            CreatedAt = issue.CreatedAt,
+            UpdatedAt = issue.UpdatedAt,
+        };
+    }
+
+    private static TriageItem ToDomainPullRequestItem(string owner, string repo, PullRequest pullRequest)
+    {
+        ArgumentNullException.ThrowIfNull(pullRequest);
+
+        return new TriageItem
+        {
+            ItemType = TriageItemType.PullRequest,
+            Id = pullRequest.Id,
+            Number = pullRequest.Number,
+            RepositoryFullName = $"{owner}/{repo}",
+            Title = pullRequest.Title,
+            HtmlUrl = pullRequest.HtmlUrl,
+            Body = pullRequest.Body,
+            State = pullRequest.State,
+            AuthorLogin = pullRequest.AuthorLogin,
+            Labels = [],
+            Milestone = null,
+            CreatedAt = pullRequest.CreatedAt,
+            UpdatedAt = pullRequest.UpdatedAt,
+        };
+    }
+
+    private static TriageSessionDto ToDto(TriageSession session)
+    {
+        return new TriageSessionDto(
+            session.SessionId,
+            session.OwnerLogin,
+            session.RepositoryName,
+            session.IncludePullRequests,
+            session.Queue.Select(ToDto).ToArray(),
+            session.CurrentIndex,
+            session.SkippedItems.Select(ToDto).ToArray(),
+            session.ActionHistory.Select(ToDto).ToArray(),
+            ToDto(session.Progress),
+            ToDto(session.Summary),
+            session.StartedAt);
+    }
+
+    private static TriageSession ToDomain(TriageSessionDto session)
+    {
+        return new TriageSession
+        {
+            SessionId = session.SessionId,
+            OwnerLogin = session.OwnerLogin,
+            RepositoryName = session.RepositoryName,
+            IncludePullRequests = session.IncludePullRequests,
+            Queue = session.Queue.Select(ToDomain).ToArray(),
+            CurrentIndex = session.CurrentIndex,
+            SkippedItems = session.SkippedItems.Select(ToDomain).ToArray(),
+            ActionHistory = session.ActionHistory.Select(ToDomain).ToArray(),
+            Progress = ToDomain(session.Progress),
+            Summary = ToDomain(session.Summary),
+            StartedAt = session.StartedAt,
+        };
+    }
+
+    private static TriageItemDto ToDto(TriageItem item)
+    {
+        return new TriageItemDto(
+            item.ItemType == TriageItemType.PullRequest ? TriageItemTypeDto.PullRequest : TriageItemTypeDto.Issue,
+            item.Id,
+            item.Number,
+            item.RepositoryFullName,
+            item.Title,
+            item.HtmlUrl,
+            item.Body,
+            item.State,
+            item.AuthorLogin,
+            item.Labels.Select(label => label.Name).ToArray(),
+            item.Milestone?.Number,
+            item.Milestone?.Title ?? string.Empty,
+            item.CreatedAt,
+            item.UpdatedAt);
+    }
+
+    private static TriageItem ToDomain(TriageItemDto item)
+    {
+        return new TriageItem
+        {
+            ItemType = item.ItemType == TriageItemTypeDto.PullRequest ? TriageItemType.PullRequest : TriageItemType.Issue,
+            Id = item.Id,
+            Number = item.Number,
+            RepositoryFullName = item.RepositoryFullName,
+            Title = item.Title,
+            HtmlUrl = item.HtmlUrl,
+            Body = item.Body,
+            State = item.State,
+            AuthorLogin = item.AuthorLogin,
+            Labels = item.Labels.Select(labelName => new SoloDevBoard.Domain.Entities.Labels.Label { Name = labelName }).ToArray(),
+            Milestone = item.MilestoneNumber is null
+                ? null
+                : new SoloDevBoard.Domain.Entities.Milestones.Milestone { Number = item.MilestoneNumber.Value, Title = item.MilestoneTitle },
+            CreatedAt = item.CreatedAt,
+            UpdatedAt = item.UpdatedAt,
+        };
+    }
+
+    private static TriageActionDto ToDto(TriageAction action)
+    {
+        return new TriageActionDto(
+            ToDto(action.ActionType),
+            action.ItemType == TriageItemType.PullRequest ? TriageItemTypeDto.PullRequest : TriageItemTypeDto.Issue,
+            action.ItemNumber,
+            action.RepositoryFullName,
+            action.Detail,
+            action.OccurredAt);
+    }
+
+    private static TriageAction ToDomain(TriageActionDto action)
+    {
+        return new TriageAction
+        {
+            ActionType = ToDomain(action.ActionType),
+            ItemType = action.ItemType == TriageItemTypeDto.PullRequest ? TriageItemType.PullRequest : TriageItemType.Issue,
+            ItemNumber = action.ItemNumber,
+            RepositoryFullName = action.RepositoryFullName,
+            Detail = action.Detail,
+            OccurredAt = action.OccurredAt,
+        };
+    }
+
+    private static TriageSessionProgressDto ToDto(TriageSessionProgress progress)
+        => new(progress.TotalItems, progress.ProcessedItems, progress.RemainingItems, progress.SkippedItems);
+
+    private static TriageSessionSummaryDto ToDto(TriageSessionSummary summary)
+        => new(
+            summary.TotalItems,
+            summary.ProcessedItems,
+            summary.RemainingItems,
+            summary.SkippedItems,
+            summary.LabelsAppliedCount,
+            summary.MilestonesAssignedCount,
+            summary.ProjectAssignmentsCount,
+            summary.DuplicateClosuresCount);
+
+    private static TriageSessionProgress ToDomain(TriageSessionProgressDto progress)
+    {
+        return new TriageSessionProgress
+        {
+            TotalItems = progress.TotalItems,
+            ProcessedItems = progress.ProcessedItems,
+            RemainingItems = progress.RemainingItems,
+            SkippedItems = progress.SkippedItems,
+        };
+    }
+
+    private static TriageSessionSummary ToDomain(TriageSessionSummaryDto summary)
+    {
+        return new TriageSessionSummary
+        {
+            TotalItems = summary.TotalItems,
+            ProcessedItems = summary.ProcessedItems,
+            RemainingItems = summary.RemainingItems,
+            SkippedItems = summary.SkippedItems,
+            LabelsAppliedCount = summary.LabelsAppliedCount,
+            MilestonesAssignedCount = summary.MilestonesAssignedCount,
+            ProjectAssignmentsCount = summary.ProjectAssignmentsCount,
+            DuplicateClosuresCount = summary.DuplicateClosuresCount,
+        };
+    }
+
+    private static TriageActionTypeDto ToDto(TriageActionType actionType)
+        => actionType switch
+        {
+            TriageActionType.LabelApplied => TriageActionTypeDto.LabelApplied,
+            TriageActionType.MilestoneAssigned => TriageActionTypeDto.MilestoneAssigned,
+            TriageActionType.ProjectBoardAssigned => TriageActionTypeDto.ProjectBoardAssigned,
+            TriageActionType.ClosedAsDuplicate => TriageActionTypeDto.ClosedAsDuplicate,
+            _ => TriageActionTypeDto.Skipped,
+        };
+
+    private static TriageActionType ToDomain(TriageActionTypeDto actionType)
+        => actionType switch
+        {
+            TriageActionTypeDto.LabelApplied => TriageActionType.LabelApplied,
+            TriageActionTypeDto.MilestoneAssigned => TriageActionType.MilestoneAssigned,
+            TriageActionTypeDto.ProjectBoardAssigned => TriageActionType.ProjectBoardAssigned,
+            TriageActionTypeDto.ClosedAsDuplicate => TriageActionType.ClosedAsDuplicate,
+            _ => TriageActionType.Skipped,
+        };
 }

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
@@ -101,10 +101,16 @@ public sealed class TriageService : ITriageService
             .Concat([action])
             .ToArray();
 
-        var nextIndex = Math.Min(domainSession.CurrentIndex + 1, domainSession.Queue.Count);
+        // Remove the skipped item from the active queue so revisit can append it at the end.
+        var updatedQueue = domainSession.Queue
+            .Where((_, index) => index != domainSession.CurrentIndex)
+            .ToArray();
+
+        var nextIndex = Math.Min(domainSession.CurrentIndex, updatedQueue.Length);
 
         return Task.FromResult(UpdateSessionState(domainSession with
         {
+            Queue = updatedQueue,
             CurrentIndex = nextIndex,
             SkippedItems = updatedSkippedItems,
             ActionHistory = updatedActionHistory,
@@ -123,16 +129,17 @@ public sealed class TriageService : ITriageService
             return Task.FromResult(ToDto(domainSession));
         }
 
-        var existingKeys = domainSession.Queue
+        var skippedKeys = domainSession.SkippedItems
             .Select(item => (item.ItemType, item.Number, item.RepositoryFullName))
             .ToHashSet();
 
-        var appendItems = domainSession.SkippedItems
-            .Where(item => !existingKeys.Contains((item.ItemType, item.Number, item.RepositoryFullName)))
+        // Ensure skipped items are moved to the end even if they still exist in the queue.
+        var retainedQueue = domainSession.Queue
+            .Where(item => !skippedKeys.Contains((item.ItemType, item.Number, item.RepositoryFullName)))
             .ToArray();
 
-        var updatedQueue = domainSession.Queue
-            .Concat(appendItems)
+        var updatedQueue = retainedQueue
+            .Concat(domainSession.SkippedItems)
             .ToArray();
 
         return Task.FromResult(UpdateSessionState(domainSession with

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionDto.cs
@@ -1,6 +1,17 @@
 namespace SoloDevBoard.Application.Services.Triage;
 
 /// <summary>Represents session state shared between Application and App layers for triage workflow.</summary>
+/// <param name="SessionId">The unique identifier for the triage session.</param>
+/// <param name="OwnerLogin">The repository owner login.</param>
+/// <param name="RepositoryName">The repository name.</param>
+/// <param name="IncludePullRequests">Indicates whether pull requests were included when the session started.</param>
+/// <param name="Queue">The current triage queue.</param>
+/// <param name="CurrentIndex">The zero-based index of the active queue item.</param>
+/// <param name="SkippedItems">Items skipped for later review.</param>
+/// <param name="ActionHistory">Recorded actions taken during the session.</param>
+/// <param name="Progress">Computed progress information for the session.</param>
+/// <param name="Summary">Computed summary information for the session.</param>
+/// <param name="StartedAt">The UTC timestamp when the session started.</param>
 public sealed record TriageSessionDto(
     Guid SessionId,
     string OwnerLogin,

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionDto.cs
@@ -1,0 +1,19 @@
+namespace SoloDevBoard.Application.Services.Triage;
+
+/// <summary>Represents session state shared between Application and App layers for triage workflow.</summary>
+public sealed record TriageSessionDto(
+    Guid SessionId,
+    string OwnerLogin,
+    string RepositoryName,
+    bool IncludePullRequests,
+    IReadOnlyList<TriageItemDto> Queue,
+    int CurrentIndex,
+    IReadOnlyList<TriageItemDto> SkippedItems,
+    IReadOnlyList<TriageActionDto> ActionHistory,
+    TriageSessionProgressDto Progress,
+    TriageSessionSummaryDto Summary,
+    DateTimeOffset StartedAt)
+{
+    /// <summary>Gets the currently active queue item, or <see langword="null"/> when the queue is exhausted.</summary>
+    public TriageItemDto? CurrentItem => CurrentIndex >= 0 && CurrentIndex < Queue.Count ? Queue[CurrentIndex] : null;
+}

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionProgressDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionProgressDto.cs
@@ -1,0 +1,4 @@
+namespace SoloDevBoard.Application.Services.Triage;
+
+/// <summary>Represents computed progress information for a triage session.</summary>
+public sealed record TriageSessionProgressDto(int TotalItems, int ProcessedItems, int RemainingItems, int SkippedItems);

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionProgressDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionProgressDto.cs
@@ -1,4 +1,8 @@
 namespace SoloDevBoard.Application.Services.Triage;
 
 /// <summary>Represents computed progress information for a triage session.</summary>
+/// <param name="TotalItems">The total number of items currently in the active queue.</param>
+/// <param name="ProcessedItems">The number of items already processed in the active queue.</param>
+/// <param name="RemainingItems">The number of items remaining in the active queue.</param>
+/// <param name="SkippedItems">The number of items skipped for later review.</param>
 public sealed record TriageSessionProgressDto(int TotalItems, int ProcessedItems, int RemainingItems, int SkippedItems);

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionSummaryDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionSummaryDto.cs
@@ -1,6 +1,14 @@
 namespace SoloDevBoard.Application.Services.Triage;
 
 /// <summary>Represents summary data for a triage session.</summary>
+/// <param name="TotalItems">The total number of items currently in the active queue.</param>
+/// <param name="ProcessedItems">The number of items already processed in the active queue.</param>
+/// <param name="RemainingItems">The number of items remaining in the active queue.</param>
+/// <param name="SkippedItems">The number of items skipped for later review.</param>
+/// <param name="LabelsAppliedCount">The number of label assignment actions recorded.</param>
+/// <param name="MilestonesAssignedCount">The number of milestone assignment actions recorded.</param>
+/// <param name="ProjectAssignmentsCount">The number of project-board assignment actions recorded.</param>
+/// <param name="DuplicateClosuresCount">The number of duplicate closure actions recorded.</param>
 public sealed record TriageSessionSummaryDto(
     int TotalItems,
     int ProcessedItems,

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionSummaryDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionSummaryDto.cs
@@ -1,0 +1,12 @@
+namespace SoloDevBoard.Application.Services.Triage;
+
+/// <summary>Represents summary data for a triage session.</summary>
+public sealed record TriageSessionSummaryDto(
+    int TotalItems,
+    int ProcessedItems,
+    int RemainingItems,
+    int SkippedItems,
+    int LabelsAppliedCount,
+    int MilestonesAssignedCount,
+    int ProjectAssignmentsCount,
+    int DuplicateClosuresCount);

--- a/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageAction.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageAction.cs
@@ -1,0 +1,26 @@
+namespace SoloDevBoard.Domain.Entities.Triage;
+
+/// <summary>Represents a single action taken during a triage session.</summary>
+public sealed record TriageAction : IAggregate
+{
+    /// <summary>Gets the aggregate identifier for this triage action.</summary>
+    public int Id { get; init; }
+
+    /// <summary>Gets the action type.</summary>
+    public TriageActionType ActionType { get; init; }
+
+    /// <summary>Gets the type of item the action was applied to.</summary>
+    public TriageItemType ItemType { get; init; }
+
+    /// <summary>Gets the repository-scoped item number targeted by the action.</summary>
+    public int ItemNumber { get; init; }
+
+    /// <summary>Gets the repository full name in owner/repository format.</summary>
+    public string RepositoryFullName { get; init; } = string.Empty;
+
+    /// <summary>Gets optional action detail text used by the UI.</summary>
+    public string Detail { get; init; } = string.Empty;
+
+    /// <summary>Gets the timestamp when the action was recorded.</summary>
+    public DateTimeOffset OccurredAt { get; init; }
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageActionType.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageActionType.cs
@@ -1,0 +1,20 @@
+namespace SoloDevBoard.Domain.Entities.Triage;
+
+/// <summary>Defines the supported triage actions recorded in a session.</summary>
+public enum TriageActionType
+{
+    /// <summary>Represents a label assignment action.</summary>
+    LabelApplied = 0,
+
+    /// <summary>Represents a milestone assignment action.</summary>
+    MilestoneAssigned = 1,
+
+    /// <summary>Represents assigning an item to a project board.</summary>
+    ProjectBoardAssigned = 2,
+
+    /// <summary>Represents duplicate closure action.</summary>
+    ClosedAsDuplicate = 3,
+
+    /// <summary>Represents skipping an item for later review.</summary>
+    Skipped = 4,
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageItem.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageItem.cs
@@ -1,0 +1,47 @@
+using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Domain.Entities.Milestones;
+
+namespace SoloDevBoard.Domain.Entities.Triage;
+
+/// <summary>Represents a single triage queue item.</summary>
+public sealed record TriageItem : IAggregate
+{
+    /// <summary>Gets the triage item type.</summary>
+    public TriageItemType ItemType { get; init; }
+
+    /// <summary>Gets the unique GitHub identifier for the item.</summary>
+    public int Id { get; init; }
+
+    /// <summary>Gets the repository-scoped item number.</summary>
+    public int Number { get; init; }
+
+    /// <summary>Gets the repository full name in owner/repository format.</summary>
+    public string RepositoryFullName { get; init; } = string.Empty;
+
+    /// <summary>Gets the item title.</summary>
+    public string Title { get; init; } = string.Empty;
+
+    /// <summary>Gets the web URL for the item.</summary>
+    public string HtmlUrl { get; init; } = string.Empty;
+
+    /// <summary>Gets the item body content.</summary>
+    public string Body { get; init; } = string.Empty;
+
+    /// <summary>Gets the current state for the item.</summary>
+    public string State { get; init; } = string.Empty;
+
+    /// <summary>Gets the author login for the item.</summary>
+    public string AuthorLogin { get; init; } = string.Empty;
+
+    /// <summary>Gets the labels currently assigned to the item.</summary>
+    public IReadOnlyList<Label> Labels { get; init; } = [];
+
+    /// <summary>Gets the milestone currently assigned to the item, if present.</summary>
+    public Milestone? Milestone { get; init; }
+
+    /// <summary>Gets the item creation timestamp.</summary>
+    public DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>Gets the last update timestamp for the item.</summary>
+    public DateTimeOffset UpdatedAt { get; init; }
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageItemType.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageItemType.cs
@@ -1,0 +1,11 @@
+namespace SoloDevBoard.Domain.Entities.Triage;
+
+/// <summary>Defines the supported triage item types.</summary>
+public enum TriageItemType
+{
+    /// <summary>Represents a GitHub issue.</summary>
+    Issue = 0,
+
+    /// <summary>Represents a GitHub pull request.</summary>
+    PullRequest = 1,
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageSession.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageSession.cs
@@ -1,0 +1,41 @@
+namespace SoloDevBoard.Domain.Entities.Triage;
+
+/// <summary>Represents the state of a single one-at-a-time triage session.</summary>
+public sealed record TriageSession : IAggregate
+{
+    /// <summary>Gets the aggregate identifier for the session.</summary>
+    public int Id { get; init; }
+
+    /// <summary>Gets the session identifier.</summary>
+    public Guid SessionId { get; init; }
+
+    /// <summary>Gets the owner login for the session repository.</summary>
+    public string OwnerLogin { get; init; } = string.Empty;
+
+    /// <summary>Gets the repository name for this session.</summary>
+    public string RepositoryName { get; init; } = string.Empty;
+
+    /// <summary>Gets a value indicating whether pull requests are included in the session queue.</summary>
+    public bool IncludePullRequests { get; init; }
+
+    /// <summary>Gets the queue of triage items for this session.</summary>
+    public IReadOnlyList<TriageItem> Queue { get; init; } = [];
+
+    /// <summary>Gets the zero-based index of the active item in the queue.</summary>
+    public int CurrentIndex { get; init; }
+
+    /// <summary>Gets the items that were skipped and marked for revisit.</summary>
+    public IReadOnlyList<TriageItem> SkippedItems { get; init; } = [];
+
+    /// <summary>Gets the action history for this session.</summary>
+    public IReadOnlyList<TriageAction> ActionHistory { get; init; } = [];
+
+    /// <summary>Gets computed progress information for the current state.</summary>
+    public TriageSessionProgress Progress { get; init; } = new();
+
+    /// <summary>Gets summary information for the current state.</summary>
+    public TriageSessionSummary Summary { get; init; } = new();
+
+    /// <summary>Gets the timestamp when the session started.</summary>
+    public DateTimeOffset StartedAt { get; init; }
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageSessionProgress.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageSessionProgress.cs
@@ -1,0 +1,20 @@
+namespace SoloDevBoard.Domain.Entities.Triage;
+
+/// <summary>Represents computed session progress data for triage flow.</summary>
+public sealed record TriageSessionProgress : IAggregate
+{
+    /// <summary>Gets the aggregate identifier for this progress snapshot.</summary>
+    public int Id { get; init; }
+
+    /// <summary>Gets the total number of items in the session queue.</summary>
+    public int TotalItems { get; init; }
+
+    /// <summary>Gets the number of items already traversed in the queue.</summary>
+    public int ProcessedItems { get; init; }
+
+    /// <summary>Gets the number of items remaining in the queue.</summary>
+    public int RemainingItems { get; init; }
+
+    /// <summary>Gets the number of items currently marked as skipped.</summary>
+    public int SkippedItems { get; init; }
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageSessionSummary.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageSessionSummary.cs
@@ -1,0 +1,32 @@
+namespace SoloDevBoard.Domain.Entities.Triage;
+
+/// <summary>Represents summary data for a completed or in-flight triage session.</summary>
+public sealed record TriageSessionSummary : IAggregate
+{
+    /// <summary>Gets the aggregate identifier for this summary snapshot.</summary>
+    public int Id { get; init; }
+
+    /// <summary>Gets the total number of items in the session queue.</summary>
+    public int TotalItems { get; init; }
+
+    /// <summary>Gets the number of processed items.</summary>
+    public int ProcessedItems { get; init; }
+
+    /// <summary>Gets the number of remaining items.</summary>
+    public int RemainingItems { get; init; }
+
+    /// <summary>Gets the number of items that were skipped.</summary>
+    public int SkippedItems { get; init; }
+
+    /// <summary>Gets the number of label actions recorded.</summary>
+    public int LabelsAppliedCount { get; init; }
+
+    /// <summary>Gets the number of milestone assignment actions recorded.</summary>
+    public int MilestonesAssignedCount { get; init; }
+
+    /// <summary>Gets the number of project-board assignment actions recorded.</summary>
+    public int ProjectAssignmentsCount { get; init; }
+
+    /// <summary>Gets the number of duplicate closure actions recorded.</summary>
+    public int DuplicateClosuresCount { get; init; }
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
@@ -231,6 +231,174 @@ public sealed class GitHubService : IGitHubService
         await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
+    public async Task ApplyLabelsToTriageItemAsync(string owner, string repo, int itemNumber, IReadOnlyList<string> labelNames, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        if (itemNumber <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(itemNumber), "Item number must be greater than zero.");
+        }
+
+        ArgumentNullException.ThrowIfNull(labelNames);
+
+        var normalisedLabelNames = labelNames
+            .Where(label => !string.IsNullOrWhiteSpace(label))
+            .Select(label => label.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var client = CreateAuthenticatedClient();
+        var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/issues/{itemNumber}/labels";
+
+        using var response = await client.PutAsJsonAsync(
+                endpoint,
+                new TriageLabelsRequestDto(normalisedLabelNames),
+                JsonOptions,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task AssignMilestoneToTriageItemAsync(string owner, string repo, int itemNumber, int? milestoneNumber, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        if (itemNumber <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(itemNumber), "Item number must be greater than zero.");
+        }
+
+        if (milestoneNumber is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(milestoneNumber), "Milestone number must be greater than zero when provided.");
+        }
+
+        var client = CreateAuthenticatedClient();
+        var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/issues/{itemNumber}";
+
+        using var request = new HttpRequestMessage(HttpMethod.Patch, endpoint)
+        {
+            Content = JsonContent.Create(new TriageMilestoneRequestDto(milestoneNumber), options: JsonOptions),
+        };
+
+        using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> AddTriageItemToProjectBoardAsync(string owner, string repo, int itemNumber, string projectId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+
+        if (itemNumber <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(itemNumber), "Item number must be greater than zero.");
+        }
+
+        var client = CreateAuthenticatedClient();
+        var itemEndpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/issues/{itemNumber}";
+
+        using var itemResponse = await client.GetAsync(itemEndpoint, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStatusCodeAsync(itemResponse, cancellationToken).ConfigureAwait(false);
+
+        var itemNode = await itemResponse.Content.ReadFromJsonAsync<TriageItemNodeResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw CreateInvalidResponseException("Triage item response was empty.", itemEndpoint);
+
+        if (string.IsNullOrWhiteSpace(itemNode.NodeId))
+        {
+            throw CreateInvalidResponseException("Triage item did not include a node identifier.", itemEndpoint);
+        }
+
+        const string mutation = "mutation AddProjectV2Item($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) { item { id } } }";
+        var requestBody = new GraphQlRequestDto(
+            mutation,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["projectId"] = projectId,
+                ["contentId"] = itemNode.NodeId,
+            });
+
+        using var graphQlResponse = await client.PostAsJsonAsync("/graphql", requestBody, JsonOptions, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStatusCodeAsync(graphQlResponse, cancellationToken).ConfigureAwait(false);
+
+        var graphQlPayload = await graphQlResponse.Content.ReadFromJsonAsync<AddProjectV2ItemResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw CreateInvalidResponseException("GraphQL response body was empty.", "/graphql");
+
+        if (graphQlPayload.Errors.Count > 0)
+        {
+            var combinedErrors = string.Join("; ", graphQlPayload.Errors.Select(static error => error.Message));
+            throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
+        }
+
+        var addedItemId = graphQlPayload.Data?.AddProjectV2ItemById?.Item?.Id;
+        if (string.IsNullOrWhiteSpace(addedItemId))
+        {
+            throw CreateInvalidResponseException("GraphQL response did not contain the created project item identifier.", "/graphql");
+        }
+
+        return addedItemId;
+    }
+
+    /// <inheritdoc/>
+    public async Task CloseTriageItemAsDuplicateAsync(string owner, string repo, GitHubTriageItemType itemType, int itemNumber, string duplicateReference, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(duplicateReference);
+
+        if (itemNumber <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(itemNumber), "Item number must be greater than zero.");
+        }
+
+        var trimmedReference = duplicateReference.Trim();
+        var client = CreateAuthenticatedClient();
+
+        var commentEndpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/issues/{itemNumber}/comments";
+        var comment = new DuplicateCommentRequestDto($"Duplicate of {trimmedReference}");
+
+        using var commentResponse = await client.PostAsJsonAsync(commentEndpoint, comment, JsonOptions, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStatusCodeAsync(commentResponse, cancellationToken).ConfigureAwait(false);
+
+        switch (itemType)
+        {
+            case GitHubTriageItemType.Issue:
+            {
+                var issueEndpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/issues/{itemNumber}";
+                using var issueRequest = new HttpRequestMessage(HttpMethod.Patch, issueEndpoint)
+                {
+                    Content = JsonContent.Create(new IssueStateRequestDto("closed"), options: JsonOptions),
+                };
+
+                using var issueResponse = await client.SendAsync(issueRequest, cancellationToken).ConfigureAwait(false);
+                await EnsureSuccessStatusCodeAsync(issueResponse, cancellationToken).ConfigureAwait(false);
+                break;
+            }
+            case GitHubTriageItemType.PullRequest:
+            {
+                var pullRequestEndpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/pulls/{itemNumber}";
+                using var pullRequestRequest = new HttpRequestMessage(HttpMethod.Patch, pullRequestEndpoint)
+                {
+                    Content = JsonContent.Create(new PullRequestStateRequestDto("closed"), options: JsonOptions),
+                };
+
+                using var pullRequestResponse = await client.SendAsync(pullRequestRequest, cancellationToken).ConfigureAwait(false);
+                await EnsureSuccessStatusCodeAsync(pullRequestResponse, cancellationToken).ConfigureAwait(false);
+                break;
+            }
+            default:
+                throw new ArgumentOutOfRangeException(nameof(itemType), itemType, "Unsupported triage item type.");
+        }
+    }
+
     private HttpClient CreateAuthenticatedClient()
     {
         // Authentication is handled by the configured GitHubAuthHandler on the named HttpClient.
@@ -735,5 +903,75 @@ public sealed class GitHubService : IGitHubService
             Colour = label.Colour,
             Description = label.Description,
         };
+    }
+
+    /// <summary>Request body DTO for setting labels on a triage item.</summary>
+    private sealed record TriageLabelsRequestDto(
+        [property: JsonPropertyName("labels")] IReadOnlyList<string> Labels);
+
+    /// <summary>Request body DTO for assigning or clearing a milestone on a triage item.</summary>
+    private sealed record TriageMilestoneRequestDto(
+        [property: JsonPropertyName("milestone")] int? Milestone);
+
+    /// <summary>Request body DTO for posting duplicate-reference comments.</summary>
+    private sealed record DuplicateCommentRequestDto(
+        [property: JsonPropertyName("body")] string Body);
+
+    /// <summary>Request body DTO for issue state updates.</summary>
+    private sealed record IssueStateRequestDto(
+        [property: JsonPropertyName("state")] string State);
+
+    /// <summary>Request body DTO for pull request state updates.</summary>
+    private sealed record PullRequestStateRequestDto(
+        [property: JsonPropertyName("state")] string State);
+
+    /// <summary>Request body DTO for GitHub GraphQL requests.</summary>
+    private sealed record GraphQlRequestDto(
+        [property: JsonPropertyName("query")] string Query,
+        [property: JsonPropertyName("variables")] IReadOnlyDictionary<string, string> Variables);
+
+    /// <summary>DTO for resolving a triage item GraphQL node identifier from the issues REST endpoint.</summary>
+    private sealed record TriageItemNodeResponseDto
+    {
+        [JsonPropertyName("node_id")]
+        public string NodeId { get; init; } = string.Empty;
+    }
+
+    /// <summary>DTO wrapper for GraphQL add-project-item responses.</summary>
+    private sealed record AddProjectV2ItemResponseDto
+    {
+        [JsonPropertyName("data")]
+        public AddProjectV2ItemDataDto? Data { get; init; }
+
+        [JsonPropertyName("errors")]
+        public IReadOnlyList<GraphQlErrorDto> Errors { get; init; } = [];
+    }
+
+    /// <summary>DTO for GraphQL response data payload.</summary>
+    private sealed record AddProjectV2ItemDataDto
+    {
+        [JsonPropertyName("addProjectV2ItemById")]
+        public AddProjectV2ItemPayloadDto? AddProjectV2ItemById { get; init; }
+    }
+
+    /// <summary>DTO for GraphQL mutation payload.</summary>
+    private sealed record AddProjectV2ItemPayloadDto
+    {
+        [JsonPropertyName("item")]
+        public AddProjectV2ItemPayloadItemDto? Item { get; init; }
+    }
+
+    /// <summary>DTO for GraphQL mutation item payload.</summary>
+    private sealed record AddProjectV2ItemPayloadItemDto
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = string.Empty;
+    }
+
+    /// <summary>DTO for GraphQL error payloads.</summary>
+    private sealed record GraphQlErrorDto
+    {
+        [JsonPropertyName("message")]
+        public string Message { get; init; } = string.Empty;
     }
 }

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
@@ -108,7 +108,9 @@ public sealed class TriageServiceTests
         var result = await sut.SkipCurrentItemAsync(session, "Needs follow-up");
 
         // Assert
-        Assert.Equal(1, result.CurrentIndex);
+        Assert.Equal(0, result.CurrentIndex);
+        Assert.Single(result.Queue);
+        Assert.Equal(2, result.Queue[0].Number);
         Assert.Single(result.SkippedItems);
         Assert.Single(result.ActionHistory);
         Assert.Equal(TriageActionTypeDto.Skipped, result.ActionHistory[0].ActionType);
@@ -149,6 +151,37 @@ public sealed class TriageServiceTests
         // Assert
         Assert.Empty(result.SkippedItems);
         Assert.Equal(0, result.Progress.SkippedItems);
+    }
+
+    [Fact]
+    public async Task RevisitSkippedItemsAsync_SkippedItemStillPresentInQueue_MovesItemToQueueEnd()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var itemOne = new TriageItemDto(TriageItemTypeDto.Issue, 1, 11, "owner/repo", "Item 1", string.Empty, string.Empty, "open", "mark", [], null, string.Empty, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        var itemTwo = new TriageItemDto(TriageItemTypeDto.Issue, 2, 12, "owner/repo", "Item 2", string.Empty, string.Empty, "open", "mark", [], null, string.Empty, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+        var session = new TriageSessionDto(
+            Guid.NewGuid(),
+            "owner",
+            "repo",
+            false,
+            [itemOne, itemTwo],
+            1,
+            [itemOne],
+            [],
+            new TriageSessionProgressDto(2, 1, 1, 1),
+            new TriageSessionSummaryDto(2, 1, 1, 1, 0, 0, 0, 0),
+            DateTimeOffset.UtcNow);
+
+        // Act
+        var result = await sut.RevisitSkippedItemsAsync(session);
+
+        // Assert
+        Assert.Equal(2, result.Queue.Count);
+        Assert.Equal(12, result.Queue[0].Number);
+        Assert.Equal(11, result.Queue[1].Number);
+        Assert.Empty(result.SkippedItems);
     }
 
     [Fact]

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
@@ -1,0 +1,231 @@
+using Moq;
+using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Application.Services.Triage;
+using SoloDevBoard.Domain.Entities.Triage;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="TriageService"/>.</summary>
+public sealed class TriageServiceTests
+{
+    private readonly Mock<IGitHubService> _gitHubServiceMock = new();
+
+    [Fact]
+    public void Constructor_GitHubServiceIsNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        IGitHubService? gitHubService = null;
+
+        // Act
+        var action = () => _ = new TriageService(gitHubService!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(action);
+    }
+
+    [Fact]
+    public async Task StartSessionAsync_IssuesOnly_BuildsIssueQueueAndInitialProgress()
+    {
+        // Arrange
+        _gitHubServiceMock
+            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new Issue { Id = 1, Number = 11, Title = "Older", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2) },
+                new Issue { Id = 2, Number = 12, Title = "Newer", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1) },
+            ]);
+
+        var sut = new TriageService(_gitHubServiceMock.Object);
+
+        // Act
+        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: false);
+
+        // Assert
+        Assert.Equal("owner", result.OwnerLogin);
+        Assert.Equal("repo", result.RepositoryName);
+        Assert.False(result.IncludePullRequests);
+        Assert.Equal(2, result.Queue.Count);
+        Assert.Equal(TriageItemTypeDto.Issue, result.Queue[0].ItemType);
+        Assert.Equal(11, result.Queue[0].Number);
+        Assert.Equal(0, result.CurrentIndex);
+        Assert.Equal(2, result.Progress.TotalItems);
+        Assert.Equal(0, result.Progress.ProcessedItems);
+        Assert.Equal(2, result.Progress.RemainingItems);
+        _gitHubServiceMock.Verify(service => service.GetPullRequestsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StartSessionAsync_IncludePullRequests_CombinesIssuesAndPullRequests()
+    {
+        // Arrange
+        _gitHubServiceMock
+            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new Issue { Id = 1, Number = 11, Title = "Issue", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2) },
+            ]);
+
+        _gitHubServiceMock
+            .Setup(service => service.GetPullRequestsAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new PullRequest { Id = 2, Number = 21, Title = "Pull request", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1) },
+            ]);
+
+        var sut = new TriageService(_gitHubServiceMock.Object);
+
+        // Act
+        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true);
+
+        // Assert
+        Assert.Equal(2, result.Queue.Count);
+        Assert.Contains(result.Queue, item => item.ItemType == TriageItemTypeDto.Issue);
+        Assert.Contains(result.Queue, item => item.ItemType == TriageItemTypeDto.PullRequest);
+    }
+
+    [Fact]
+    public async Task AdvanceSessionAsync_QueueHasItems_IncrementsCurrentIndex()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var session = CreateSession(queueCount: 2, currentIndex: 0);
+
+        // Act
+        var result = await sut.AdvanceSessionAsync(session);
+
+        // Assert
+        Assert.Equal(1, result.CurrentIndex);
+        Assert.Equal(1, result.Progress.ProcessedItems);
+        Assert.Equal(1, result.Progress.RemainingItems);
+    }
+
+    [Fact]
+    public async Task SkipCurrentItemAsync_ActiveItemExists_AddsSkippedItemAndMovesForward()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var session = CreateSession(queueCount: 2, currentIndex: 0);
+
+        // Act
+        var result = await sut.SkipCurrentItemAsync(session, "Needs follow-up");
+
+        // Assert
+        Assert.Equal(1, result.CurrentIndex);
+        Assert.Single(result.SkippedItems);
+        Assert.Single(result.ActionHistory);
+        Assert.Equal(TriageActionTypeDto.Skipped, result.ActionHistory[0].ActionType);
+        Assert.Contains("Needs follow-up", result.ActionHistory[0].Detail, StringComparison.Ordinal);
+        Assert.Equal(1, result.Progress.SkippedItems);
+    }
+
+    [Fact]
+    public async Task RevisitSkippedItemsAsync_SkippedItemsExist_ClearsSkippedList()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var queue = new[]
+        {
+            new TriageItemDto(TriageItemTypeDto.Issue, 1, 11, "owner/repo", "Item 1", string.Empty, string.Empty, "open", "mark", [], null, string.Empty, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+        };
+        var skipped = new[]
+        {
+            new TriageItemDto(TriageItemTypeDto.Issue, 1, 11, "owner/repo", "Item 1", string.Empty, string.Empty, "open", "mark", [], null, string.Empty, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+        };
+
+        var session = new TriageSessionDto(
+            Guid.NewGuid(),
+            "owner",
+            "repo",
+            false,
+            queue,
+            1,
+            skipped,
+            [],
+            new TriageSessionProgressDto(1, 1, 0, 1),
+            new TriageSessionSummaryDto(1, 1, 0, 1, 0, 0, 0, 0),
+            DateTimeOffset.UtcNow);
+
+        // Act
+        var result = await sut.RevisitSkippedItemsAsync(session);
+
+        // Assert
+        Assert.Empty(result.SkippedItems);
+        Assert.Equal(0, result.Progress.SkippedItems);
+    }
+
+    [Fact]
+    public void BuildSessionSummary_ActionHistoryIncludesAllActionTypes_ReturnsComputedCounts()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var actions = new[]
+        {
+            new TriageActionDto(TriageActionTypeDto.LabelApplied, TriageItemTypeDto.Issue, 1, "owner/repo", string.Empty, DateTimeOffset.UtcNow),
+            new TriageActionDto(TriageActionTypeDto.LabelApplied, TriageItemTypeDto.Issue, 2, "owner/repo", string.Empty, DateTimeOffset.UtcNow),
+            new TriageActionDto(TriageActionTypeDto.MilestoneAssigned, TriageItemTypeDto.Issue, 3, "owner/repo", string.Empty, DateTimeOffset.UtcNow),
+            new TriageActionDto(TriageActionTypeDto.ProjectBoardAssigned, TriageItemTypeDto.Issue, 4, "owner/repo", string.Empty, DateTimeOffset.UtcNow),
+            new TriageActionDto(TriageActionTypeDto.ClosedAsDuplicate, TriageItemTypeDto.Issue, 5, "owner/repo", string.Empty, DateTimeOffset.UtcNow),
+        };
+
+        var session = new TriageSessionDto(
+            Guid.NewGuid(),
+            "owner",
+            "repo",
+            false,
+            CreateQueue(3),
+            2,
+            [],
+            actions,
+            new TriageSessionProgressDto(3, 2, 1, 0),
+            new TriageSessionSummaryDto(3, 2, 1, 0, 0, 0, 0, 0),
+            DateTimeOffset.UtcNow);
+
+        // Act
+        var result = sut.BuildSessionSummary(session);
+
+        // Assert
+        Assert.Equal(3, result.TotalItems);
+        Assert.Equal(2, result.ProcessedItems);
+        Assert.Equal(1, result.RemainingItems);
+        Assert.Equal(2, result.LabelsAppliedCount);
+        Assert.Equal(1, result.MilestonesAssignedCount);
+        Assert.Equal(1, result.ProjectAssignmentsCount);
+        Assert.Equal(1, result.DuplicateClosuresCount);
+    }
+
+    private static TriageSessionDto CreateSession(int queueCount, int currentIndex)
+    {
+        var queue = CreateQueue(queueCount);
+        return new TriageSessionDto(
+            Guid.NewGuid(),
+            "owner",
+            "repo",
+            false,
+            queue,
+            currentIndex,
+            [],
+            [],
+            new TriageSessionProgressDto(queueCount, currentIndex, Math.Max(queueCount - currentIndex, 0), 0),
+            new TriageSessionSummaryDto(queueCount, currentIndex, Math.Max(queueCount - currentIndex, 0), 0, 0, 0, 0, 0),
+            DateTimeOffset.UtcNow);
+    }
+
+    private static IReadOnlyList<TriageItemDto> CreateQueue(int count)
+    {
+        return Enumerable.Range(1, count)
+            .Select(index => new TriageItemDto(
+                TriageItemTypeDto.Issue,
+                index,
+                index,
+                "owner/repo",
+                $"Item {index}",
+                string.Empty,
+                string.Empty,
+                "open",
+                "mark",
+                [],
+                null,
+                string.Empty,
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow))
+            .ToArray();
+    }
+}

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -1,4 +1,5 @@
 using Moq;
+using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Domain.Entities.Labels;
 using SoloDevBoard.Infrastructure.GitHub;
 using System.Net;
@@ -652,6 +653,158 @@ public sealed class GitHubServiceTests
         Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
         Assert.Contains("GitHub API request failed", exception.Message, StringComparison.Ordinal);
     }
+
+      [Fact]
+      public async Task ApplyLabelsToTriageItemAsync_ValidLabels_PutsLabelsPayload()
+      {
+        // Arrange
+        var handler = new QueueMessageHandler([
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+            Content = new StringContent("[]", Encoding.UTF8, "application/json"),
+          },
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        await sut.ApplyLabelsToTriageItemAsync("owner", "repo", 42, ["type/story", "priority/high"]);
+
+        // Assert
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Put, handler.Requests[0].Method);
+        Assert.Equal("https://api.github.com/repos/owner/repo/issues/42/labels", handler.Requests[0].RequestUri!.ToString());
+
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        var labels = document.RootElement.GetProperty("labels");
+        Assert.Equal(2, labels.GetArrayLength());
+        Assert.Equal("type/story", labels[0].GetString());
+        Assert.Equal("priority/high", labels[1].GetString());
+      }
+
+      [Fact]
+      public async Task AssignMilestoneToTriageItemAsync_NullMilestone_SendsPatchWithNullMilestone()
+      {
+        // Arrange
+        var handler = new QueueMessageHandler([
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+          },
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        await sut.AssignMilestoneToTriageItemAsync("owner", "repo", 77, null);
+
+        // Assert
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Patch, handler.Requests[0].Method);
+        Assert.Equal("https://api.github.com/repos/owner/repo/issues/77", handler.Requests[0].RequestUri!.ToString());
+
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        Assert.Equal(JsonValueKind.Null, document.RootElement.GetProperty("milestone").ValueKind);
+      }
+
+      [Fact]
+      public async Task AddTriageItemToProjectBoardAsync_ValidResponses_ReturnsCreatedProjectItemId()
+      {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+          CreateJsonResponse(HttpStatusCode.OK, """
+            {
+              "node_id": "I_kwDOABCDE123"
+            }
+            """),
+          CreateJsonResponse(HttpStatusCode.OK, """
+            {
+              "data": {
+              "addProjectV2ItemById": {
+                "item": {
+                "id": "PVTI_lAHOAJefG84BQ6bhzgnrX1A"
+                }
+              }
+              },
+              "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        var result = await sut.AddTriageItemToProjectBoardAsync("owner", "repo", 55, "PVT_kwHOAJefG84BQ6bh");
+
+        // Assert
+        Assert.Equal("PVTI_lAHOAJefG84BQ6bhzgnrX1A", result);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+        Assert.Equal("https://api.github.com/repos/owner/repo/issues/55", handler.Requests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
+        Assert.Equal("https://api.github.com/graphql", handler.Requests[1].RequestUri!.ToString());
+      }
+
+      [Fact]
+      public async Task CloseTriageItemAsDuplicateAsync_Issue_PostsCommentAndClosesIssue()
+      {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+          new HttpResponseMessage(HttpStatusCode.Created)
+          {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+          },
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+          },
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        await sut.CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 99, "#12");
+
+        // Assert
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+        Assert.Equal("https://api.github.com/repos/owner/repo/issues/99/comments", handler.Requests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Patch, handler.Requests[1].Method);
+        Assert.Equal("https://api.github.com/repos/owner/repo/issues/99", handler.Requests[1].RequestUri!.ToString());
+      }
+
+      [Fact]
+      public async Task CloseTriageItemAsDuplicateAsync_PullRequest_PostsCommentAndClosesPullRequest()
+      {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+          new HttpResponseMessage(HttpStatusCode.Created)
+          {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+          },
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+          },
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        await sut.CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.PullRequest, 100, "#22");
+
+        // Assert
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+        Assert.Equal("https://api.github.com/repos/owner/repo/issues/100/comments", handler.Requests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Patch, handler.Requests[1].Method);
+        Assert.Equal("https://api.github.com/repos/owner/repo/pulls/100", handler.Requests[1].RequestUri!.ToString());
+      }
 
     private static GitHubService CreateSubject(HttpMessageHandler handler)
     {

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -654,15 +654,15 @@ public sealed class GitHubServiceTests
         Assert.Contains("GitHub API request failed", exception.Message, StringComparison.Ordinal);
     }
 
-      [Fact]
-      public async Task ApplyLabelsToTriageItemAsync_ValidLabels_PutsLabelsPayload()
-      {
+    [Fact]
+    public async Task ApplyLabelsToTriageItemAsync_ValidLabels_PutsLabelsPayload()
+    {
         // Arrange
         var handler = new QueueMessageHandler([
-          new HttpResponseMessage(HttpStatusCode.OK)
-          {
-            Content = new StringContent("[]", Encoding.UTF8, "application/json"),
-          },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]", Encoding.UTF8, "application/json"),
+            },
         ]);
 
         var sut = CreateSubject(handler);
@@ -681,17 +681,17 @@ public sealed class GitHubServiceTests
         Assert.Equal(2, labels.GetArrayLength());
         Assert.Equal("type/story", labels[0].GetString());
         Assert.Equal("priority/high", labels[1].GetString());
-      }
+    }
 
-      [Fact]
-      public async Task AssignMilestoneToTriageItemAsync_NullMilestone_SendsPatchWithNullMilestone()
-      {
+    [Fact]
+    public async Task AssignMilestoneToTriageItemAsync_NullMilestone_SendsPatchWithNullMilestone()
+    {
         // Arrange
         var handler = new QueueMessageHandler([
-          new HttpResponseMessage(HttpStatusCode.OK)
-          {
-            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
-          },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+            },
         ]);
 
         var sut = CreateSubject(handler);
@@ -707,20 +707,20 @@ public sealed class GitHubServiceTests
         var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
         using var document = JsonDocument.Parse(payload);
         Assert.Equal(JsonValueKind.Null, document.RootElement.GetProperty("milestone").ValueKind);
-      }
+    }
 
-      [Fact]
-      public async Task AddTriageItemToProjectBoardAsync_ValidResponses_ReturnsCreatedProjectItemId()
-      {
+    [Fact]
+    public async Task AddTriageItemToProjectBoardAsync_ValidResponses_ReturnsCreatedProjectItemId()
+    {
         // Arrange
         var handler = new QueueMessageHandler(
         [
-          CreateJsonResponse(HttpStatusCode.OK, """
+            CreateJsonResponse(HttpStatusCode.OK, """
             {
               "node_id": "I_kwDOABCDE123"
             }
             """),
-          CreateJsonResponse(HttpStatusCode.OK, """
+            CreateJsonResponse(HttpStatusCode.OK, """
             {
               "data": {
               "addProjectV2ItemById": {
@@ -746,22 +746,22 @@ public sealed class GitHubServiceTests
         Assert.Equal("https://api.github.com/repos/owner/repo/issues/55", handler.Requests[0].RequestUri!.ToString());
         Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
         Assert.Equal("https://api.github.com/graphql", handler.Requests[1].RequestUri!.ToString());
-      }
+    }
 
-      [Fact]
-      public async Task CloseTriageItemAsDuplicateAsync_Issue_PostsCommentAndClosesIssue()
-      {
+    [Fact]
+    public async Task CloseTriageItemAsDuplicateAsync_Issue_PostsCommentAndClosesIssue()
+    {
         // Arrange
         var handler = new QueueMessageHandler(
         [
-          new HttpResponseMessage(HttpStatusCode.Created)
-          {
-            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
-          },
-          new HttpResponseMessage(HttpStatusCode.OK)
-          {
-            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
-          },
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+            },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+            },
         ]);
 
         var sut = CreateSubject(handler);
@@ -775,22 +775,22 @@ public sealed class GitHubServiceTests
         Assert.Equal("https://api.github.com/repos/owner/repo/issues/99/comments", handler.Requests[0].RequestUri!.ToString());
         Assert.Equal(HttpMethod.Patch, handler.Requests[1].Method);
         Assert.Equal("https://api.github.com/repos/owner/repo/issues/99", handler.Requests[1].RequestUri!.ToString());
-      }
+    }
 
-      [Fact]
-      public async Task CloseTriageItemAsDuplicateAsync_PullRequest_PostsCommentAndClosesPullRequest()
-      {
+    [Fact]
+    public async Task CloseTriageItemAsDuplicateAsync_PullRequest_PostsCommentAndClosesPullRequest()
+    {
         // Arrange
         var handler = new QueueMessageHandler(
         [
-          new HttpResponseMessage(HttpStatusCode.Created)
-          {
-            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
-          },
-          new HttpResponseMessage(HttpStatusCode.OK)
-          {
-            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
-          },
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+            },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+            },
         ]);
 
         var sut = CreateSubject(handler);
@@ -804,7 +804,7 @@ public sealed class GitHubServiceTests
         Assert.Equal("https://api.github.com/repos/owner/repo/issues/100/comments", handler.Requests[0].RequestUri!.ToString());
         Assert.Equal(HttpMethod.Patch, handler.Requests[1].Method);
         Assert.Equal("https://api.github.com/repos/owner/repo/pulls/100", handler.Requests[1].RequestUri!.ToString());
-      }
+    }
 
     private static GitHubService CreateSubject(HttpMessageHandler handler)
     {


### PR DESCRIPTION
## Summary of Changes

Implements the triage session contract and GitHub write operations required for the Triage UI feature. This PR delivers two enablers:

- **#143 — Triage session orchestration:** Introduces domain records (`TriageItem`, `TriageAction`, `TriageSession`, `TriageSessionProgress`, `TriageSessionSummary`) and application-layer DTOs. Replaces the `ITriageService` stub with a full session contract supporting start, advance, skip, revisit-skipped, and build-summary operations. `TriageService` orchestrates queue ordering (oldest-updated-first), skip/revisit deduplication, and action history tracking.
- **#144 — GitHub write operations:** Extends `IGitHubService` and `GitHubService` with four triage write operations: apply labels (PUT), assign milestone (PATCH), assign to GitHub Projects v2 (GraphQL `addProjectV2ItemById`), and close as duplicate (POST comment + PATCH state).

All new components follow ADR-0011 (boundary data shapes) and ADR-0005 (GitHub API strategy). DI registration updated in `ApplicationServiceCollectionExtensions`.

## Related Issue(s)

Closes #143
Closes #144

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

N/A — no UI changes. These are backend enablers for the Triage UI.

## Additional Notes

12 new tests added (7 in `TriageServiceTests`, 5 in `GitHubServiceTests`). Total suite: 192 tests, 0 failures.

The `AddTriageItemToProjectBoardAsync` method uses a targeted GraphQL path (ADR-0005) — it first resolves the issue/PR `node_id` via REST, then calls the `addProjectV2ItemById` mutation with the project node ID.

Follow-on user stories (#145–#153) depend on these contracts and can now proceed to implementation.