### PR TITLE
[story] Triage session progress, skip, markdown rendering, and single-select repository scope

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
 
   <!-- UI -->
   <ItemGroup>
+    <PackageVersion Include="Markdig" Version="0.37.0" />
     <PackageVersion Include="MudBlazor" Version="9.1.0" />
   </ItemGroup>
 

--- a/adr/README.md
+++ b/adr/README.md
@@ -31,7 +31,7 @@ Each ADR follows this format:
 | [ADR-0006](0006-moq-mocking-library.md) | Switch Mocking Library from NSubstitute to Moq | Accepted (assertion library aspect superseded by ADR-0008) |
 | [ADR-0007](0007-multi-tenancy-authentication-phased-approach.md) | Multi-Tenancy Authentication — Phased Approach | Accepted |
 | [ADR-0008](0008-remove-fluentassertions.md) | Remove FluentAssertions — Use xUnit Built-in Assertions Only | Accepted |
-| [ADR-0009](0009-fluent-ui-blazor-component-library.md) | Use Microsoft Fluent UI Blazor Component Library | Accepted |
+| [ADR-0009](0009-fluent-ui-blazor-component-library.md) | Use Microsoft Fluent UI Blazor Component Library | Superseded by ADR-0012 |
 | [ADR-0010](0010-bunit-component-testing.md) | Use bUnit for Blazor Component Testing | Accepted |
 | [ADR-0011](0011-boundary-data-shapes.md) | Boundary Data Shapes — DTOs at the Application→App Boundary | Accepted |
 | [ADR-0012](0012-switch-to-mudblazor-component-library.md) | Switch UI Component Library from Fluent UI Blazor to MudBlazor | Accepted — supersedes ADR-0009 |

--- a/docs/user-guide/triage-ui.md
+++ b/docs/user-guide/triage-ui.md
@@ -5,38 +5,28 @@ parent: User Guide
 nav_order: 5
 ---
 
-> ⚠️ **Under Development** — This feature is planned for Phase 3. This page will be updated as the feature progresses.
-
----
 
 ## Overview
 
-The Triage UI provides a focused, keyboard-friendly interface for working through incoming GitHub issues. It presents one issue at a time and allows you to quickly apply labels, assign milestones, add to a project board, or close duplicates — without leaving the triage view.
+The Triage UI enables you to work through untriaged GitHub issues for a single selected repository in a focused, step-by-step session. Issues without any labels are queued and presented one at a time, allowing you to triage efficiently and track your progress throughout the session.
 
-Key goals of the Triage UI:
-- Reduce the friction of issue triage so that it becomes a quick, routine task.
-- Provide keyboard shortcuts for common actions.
-- Support bulk triage sessions with a clear progress indicator.
-
----
+Key features:
+- You can start a triage session for one repository at a time.
+- Only unlabelled issues are included in the triage queue.
+- The interface shows your current position (e.g., Item 3 of 10), remaining count, skipped count, and a progress indicator.
+- You can move to the next item or skip the current item, optionally providing a reason for skipping.
+- Skipped items can be revisited within the same session.
+- Progress and session context are always visible, so you know how much work remains.
 
 ## How to Use
 
-*Coming soon — this section will describe the Triage UI interface and keyboard shortcuts once the feature is complete.*
+1. Select a repository to start a triage session.
+2. The Triage UI queues all unlabelled issues for that repository.
+3. Review each item in turn, then choose **Next** to continue or **Skip** to defer the current item with an optional reason.
+4. After reaching the end of the queue, choose the revisit action to process skipped items within the same session.
+5. Use the progress indicator and session context to track your position, remaining items, and skipped count.
 
-Planned interactions include:
-- Starting a triage session for one or more repositories.
-- Viewing issues one at a time with full context (body, comments, timeline).
-- Applying labels, milestones, and project board assignments without opening GitHub.
-- Marking an issue as a duplicate and closing it with a reference.
-- Skipping issues and returning to them later.
-- Ending a triage session with a summary of actions taken.
-
----
-
-## Configuration
-
-*Coming soon — this section will describe configuration options for the Triage UI.*
+**Note:** The Triage UI currently supports one-repository sessions and progress visibility. Additional triage actions (such as label assignment, milestone selection, and project board placement) are planned for future releases and are not yet available.
 
 Planned configuration options include:
 - Filtering which issues appear in a triage session (e.g. unlabelled only, no milestone, created within the last 7 days).

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -158,7 +158,7 @@ Labels: `type/epic`, `area/triage`
 
 > **Next up:** Triage UI work is now formally planned and remains the current delivery priority for Phase 3. All items below are tracked via the new issue hierarchy and are open/planned for milestone v0.3.0.
 
-- [ ] As a solo developer, I want to start a triage session that presents unlabelled issues one at a time, supports progress tracking, and allows skipping and returning later so that I can work through them efficiently. _(Issue #145)_
+- [x] As a solo developer, I want to start a triage session that presents unlabelled issues one at a time, supports progress tracking, and allows skipping and returning later so that I can work through them efficiently. _(Issue #145 — implemented 2026-03-18)_
 - [ ] As a solo developer, I want to apply labels to an issue with a single click or keyboard shortcut so that triage is fast. _(Issue #146)_
 - [ ] As a solo developer, I want to assign a milestone to an issue and add it to a GitHub project board column without leaving the triage view so that I can organise my work and plan in context. _(Issue #147)_
 - [ ] As a solo developer, I want to mark an issue as a duplicate and close it with a reference so that duplicate tracking is clean. _(Issue #148)_

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -158,7 +158,7 @@ Labels: `type/epic`, `area/triage`
 
 > **Next up:** Triage UI work is now formally planned and remains the current delivery priority for Phase 3. All items below are tracked via the new issue hierarchy and are open/planned for milestone v0.3.0.
 
-- [x] As a solo developer, I want to start a triage session that presents unlabelled issues one at a time, supports progress tracking, and allows skipping and returning later so that I can work through them efficiently. _(Issue #145 — implemented 2026-03-18)_
+- [x] As a solo developer, I want to start a triage session that presents unlabelled issues one at a time, supports progress tracking, and allows skipping and returning later so that I can work through them efficiently. _(Issue #145 — implemented 2026-03-18.)_
 - [ ] As a solo developer, I want to apply labels to an issue with a single click or keyboard shortcut so that triage is fast. _(Issue #146)_
 - [ ] As a solo developer, I want to assign a milestone to an issue and add it to a GitHub project board column without leaving the triage view so that I can organise my work and plan in context. _(Issue #147)_
 - [ ] As a solo developer, I want to mark an issue as a duplicate and close it with a reference so that duplicate tracking is clean. _(Issue #148)_

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
@@ -39,7 +39,7 @@
                     SingleSelectionOnly="true"
                     Disabled="isStartingSession"
                     AutocompleteTestId="triage-repository-autocomplete"
-                    SummaryTestId="triage-scope-summary" />
+                    SummaryTestId="triage-repository-scope-summary" />
 
                 <MudSwitch T="bool"
                            Value="includePullRequests"
@@ -133,9 +133,13 @@
                         <div class="mud-typography mud-typography-body2 triage-markdown" data-testid="triage-item-body">@CurrentItemBodyMarkup</div>
                     }
 
-                    <MudLink Href="@CurrentItem.HtmlUrl" Target="_blank" Typo="Typo.body2" data-testid="triage-item-link">
+                    <a href="@CurrentItem.HtmlUrl"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="mud-link mud-typography mud-typography-body2"
+                       data-testid="triage-item-link">
                         Open item #@CurrentItem.Number on GitHub
-                    </MudLink>
+                    </a>
                 </MudStack>
             </MudPaper>
 

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
@@ -2,9 +2,193 @@
 
 <PageTitle>Triage UI</PageTitle>
 
-<MudStack Spacing="2">
+<MudStack Spacing="3">
     <MudText Typo="Typo.h4">Triage UI</MudText>
-    <MudPaper Class="pa-4" Elevation="1">
-        <MudText Typo="Typo.body1">This feature is coming soon.</MudText>
+    <MudText Typo="Typo.body1">Start a focused triage session and work through one untriaged item at a time with clear queue context.</MudText>
+
+    <MudPaper Class="pa-4" Elevation="1" data-testid="triage-session-start-region">
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.h6">Session scope</MudText>
+
+            @if (isLoadingRepositories)
+            {
+                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" role="status" aria-live="polite" data-testid="triage-loading-repositories">
+                    <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading repositories" />
+                    <MudText Typo="Typo.body2">Loading repositories...</MudText>
+                </MudStack>
+            }
+            else if (availableRepositories.Count == 0)
+            {
+                <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Dense="true" data-testid="triage-no-repositories-alert">
+                    No active repositories are available for triage.
+                </MudAlert>
+            }
+            else
+            {
+                <RepositorySelector
+                    Title=""
+                    Label="Repository"
+                    Placeholder="Search repositories and select"
+                    EmptyStateText="No active repositories are available for triage."
+                    AvailableRepositories="availableRepositories.Select(repository => repository.FullName).ToArray()"
+                    SelectedRepositories="SelectedRepositoryFullNames"
+                    SelectedRepositoriesChanged="OnSelectedRepositoryChangedAsync"
+                    SummaryText="@ScopeSummaryText"
+                    ShowSelectedChips="true"
+                    ShowSelectionActions="true"
+                    SingleSelectionOnly="true"
+                    Disabled="isStartingSession"
+                    AutocompleteTestId="triage-repository-autocomplete"
+                    SummaryTestId="triage-scope-summary" />
+
+                <MudSwitch T="bool"
+                           Value="includePullRequests"
+                           ValueChanged="OnIncludePullRequestsChangedAsync"
+                           Label="Include pull requests"
+                           Disabled="isStartingSession"
+                           Color="Color.Primary"
+                           data-testid="triage-include-pull-requests-switch" />
+
+                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" data-testid="triage-session-controls">
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               Disabled="!CanStartSession"
+                               OnClick="StartSessionAsync"
+                               data-testid="triage-start-session-button">
+                        Start triage session
+                    </MudButton>
+
+                    <MudText Typo="Typo.body2" data-testid="triage-scope-summary">@ScopeSummaryText</MudText>
+                </MudStack>
+            }
+        </MudStack>
     </MudPaper>
+
+    @if (!string.IsNullOrWhiteSpace(operationMessage))
+    {
+        <MudAlert Severity="operationSeverity" Dense="true" Variant="Variant.Outlined" data-testid="triage-operation-alert">
+            @operationMessage
+        </MudAlert>
+    }
+
+    @if (currentSession is null)
+    {
+        <MudPaper Class="pa-4" Elevation="1" data-testid="triage-not-started-region">
+            <MudText Typo="Typo.body1">Select a repository scope and start a session to begin triage.</MudText>
+        </MudPaper>
+    }
+    else
+    {
+        <MudPaper Class="pa-4" Elevation="1" data-testid="triage-session-header-region">
+            <MudStack Spacing="1">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                    <MudText Typo="Typo.h6">Session progress</MudText>
+                    <MudChip T="string" Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small" data-testid="triage-current-position-chip">@CurrentPositionText</MudChip>
+                </MudStack>
+
+                <MudProgressLinear Value="SessionProgressPercent"
+                                   Color="Color.Primary"
+                                   Rounded="true"
+                                   Striped="true"
+                                   data-testid="triage-progress-indicator" />
+
+                <MudText Typo="Typo.body2" data-testid="triage-remaining-count">@RemainingCountText</MudText>
+                <MudText Typo="Typo.body2" data-testid="triage-skipped-count">@SkippedCountText</MudText>
+            </MudStack>
+        </MudPaper>
+
+        @if (CurrentItem is not null)
+        {
+            <MudPaper Class="pa-4" Elevation="1" data-testid="triage-item-detail-region">
+                <MudStack Spacing="2">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                        <MudText Typo="Typo.h6">Item details</MudText>
+                        <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" data-testid="triage-item-type-chip">@CurrentItemTypeText</MudChip>
+                    </MudStack>
+
+                    <MudText Typo="Typo.h5" data-testid="triage-item-title">@CurrentItem.Title</MudText>
+
+                    <MudStack Row="true" Spacing="2" data-testid="triage-item-metadata-row">
+                        <MudText Typo="Typo.body2">Repository: @CurrentItem.RepositoryFullName</MudText>
+                        <MudText Typo="Typo.body2">Author: @CurrentItem.AuthorLogin</MudText>
+                        <MudText Typo="Typo.body2">Updated: @CurrentItem.UpdatedAt.ToString("u")</MudText>
+                    </MudStack>
+
+                    @if (CurrentItem.Labels.Count == 0)
+                    {
+                        <MudText Typo="Typo.body2" data-testid="triage-item-labels-empty">No labels assigned.</MudText>
+                    }
+                    else
+                    {
+                        <MudStack Row="true" Spacing="1" data-testid="triage-item-labels-list">
+                            @foreach (var label in CurrentItem.Labels)
+                            {
+                                <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small">@label</MudChip>
+                            }
+                        </MudStack>
+                    }
+
+                    @if (!string.IsNullOrWhiteSpace(CurrentItem.Body))
+                    {
+                        <div class="mud-typography mud-typography-body2 triage-markdown" data-testid="triage-item-body">@CurrentItemBodyMarkup</div>
+                    }
+
+                    <MudLink Href="@CurrentItem.HtmlUrl" Target="_blank" Typo="Typo.body2" data-testid="triage-item-link">
+                        Open item #@CurrentItem.Number on GitHub
+                    </MudLink>
+                </MudStack>
+            </MudPaper>
+
+            <MudPaper Class="pa-4" Elevation="1" data-testid="triage-action-surface-region">
+                <MudStack Spacing="2">
+                    <MudText Typo="Typo.h6">Actions</MudText>
+
+                    <MudStack Row="true" Spacing="1" data-testid="triage-action-buttons-row">
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   Disabled="isApplyingSessionAction"
+                                   OnClick="AdvanceSessionAsync"
+                                   data-testid="triage-next-item-button">
+                            Next item
+                        </MudButton>
+
+                        <MudButton Variant="Variant.Outlined"
+                                   Color="Color.Secondary"
+                                   Disabled="isApplyingSessionAction"
+                                   OnClick="SkipCurrentItemAsync"
+                                   data-testid="triage-skip-item-button">
+                            Skip for later
+                        </MudButton>
+                    </MudStack>
+
+                    <MudTextField @bind-Value="skipReason"
+                                  Label="Skip reason (optional)"
+                                  Variant="Variant.Outlined"
+                                  Immediate="true"
+                                  Disabled="isApplyingSessionAction"
+                                  data-testid="triage-skip-reason-input" />
+                </MudStack>
+            </MudPaper>
+        }
+        else
+        {
+            <MudPaper Class="pa-4" Elevation="1" data-testid="triage-session-complete-region">
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.h6">Session complete</MudText>
+                    <MudText Typo="Typo.body2">@SessionCompleteSummaryText</MudText>
+
+                    @if (currentSession.SkippedItems.Count > 0)
+                    {
+                        <MudButton Variant="Variant.Outlined"
+                                   Color="Color.Secondary"
+                                   Disabled="isApplyingSessionAction"
+                                   OnClick="RevisitSkippedItemsAsync"
+                                   data-testid="triage-revisit-skipped-button">
+                            Revisit skipped items
+                        </MudButton>
+                    }
+                </MudStack>
+            </MudPaper>
+        }
+    }
 </MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
@@ -1,0 +1,396 @@
+using Microsoft.AspNetCore.Components;
+using Markdig;
+using MudBlazor;
+using SoloDevBoard.Application.Services.Repositories;
+using SoloDevBoard.Application.Services.Triage;
+using System.Text.RegularExpressions;
+
+namespace SoloDevBoard.App.Components.Features.Triage.Pages;
+
+/// <summary>Provides the one-at-a-time triage session workflow UI.</summary>
+public partial class Triage : ComponentBase
+{
+    private static readonly MarkdownPipeline markdownPipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .DisableHtml()
+        .Build();
+
+    private static readonly Regex hrefRegex = new("href=\"(?<url>[^\"]+)\"", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+    private static readonly Regex imageRegex = new("<img[^>]*>", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+
+    /// <summary>Gets or sets the repository service used to load available repository scope options.</summary>
+    [Inject]
+    public IRepositoryService RepositoryService { get; set; } = default!;
+
+    /// <summary>Gets or sets the triage service used to start and progress sessions.</summary>
+    [Inject]
+    public ITriageService TriageService { get; set; } = default!;
+
+    /// <summary>Gets or sets the logger for triage diagnostics.</summary>
+    [Inject]
+    public ILogger<Triage> Logger { get; set; } = default!;
+
+    /// <summary>Gets or sets the snackbar service used for non-blocking notifications.</summary>
+    [Inject]
+    public ISnackbar Snackbar { get; set; } = default!;
+
+    private IReadOnlyList<RepositoryDto> availableRepositories = [];
+    private string selectedRepositoryFullName = string.Empty;
+    private bool includePullRequests = true;
+    private bool isLoadingRepositories = true;
+    private bool isStartingSession;
+    private bool isApplyingSessionAction;
+    private string skipReason = string.Empty;
+    private TriageSessionDto? currentSession;
+    private string? operationMessage;
+    private Severity operationSeverity = Severity.Info;
+
+    private bool CanStartSession
+        => !isLoadingRepositories
+            && !isStartingSession
+            && !string.IsNullOrWhiteSpace(selectedRepositoryFullName);
+
+    private IReadOnlyList<string> SelectedRepositoryFullNames
+        => string.IsNullOrWhiteSpace(selectedRepositoryFullName)
+            ? []
+            : [selectedRepositoryFullName];
+
+    private TriageItemDto? CurrentItem => currentSession?.CurrentItem;
+
+    private MarkupString CurrentItemBodyMarkup
+        => string.IsNullOrWhiteSpace(CurrentItem?.Body)
+            ? new MarkupString(string.Empty)
+            : new MarkupString(RenderMarkdownForDisplay(CurrentItem.Body));
+
+    private string ScopeSummaryText
+        => string.IsNullOrWhiteSpace(selectedRepositoryFullName)
+            ? "Select one repository to scope this triage session."
+            : $"Scope: {selectedRepositoryFullName}";
+
+    private string CurrentPositionText
+    {
+        get
+        {
+            if (currentSession is null)
+            {
+                return "Session not started";
+            }
+
+            if (currentSession.Progress.TotalItems == 0)
+            {
+                return "No items in queue";
+            }
+
+            var position = Math.Min(currentSession.CurrentIndex + 1, currentSession.Progress.TotalItems);
+            return $"Item {position} of {currentSession.Progress.TotalItems}";
+        }
+    }
+
+    private double SessionProgressPercent
+    {
+        get
+        {
+            if (currentSession is null || currentSession.Progress.TotalItems == 0)
+            {
+                return 0;
+            }
+
+            return Math.Clamp(
+                (currentSession.Progress.ProcessedItems / (double)currentSession.Progress.TotalItems) * 100d,
+                0d,
+                100d);
+        }
+    }
+
+    private string RemainingCountText
+        => currentSession is null
+            ? "Remaining: 0 items"
+            : $"Remaining: {currentSession.Progress.RemainingItems} items";
+
+    private string SkippedCountText
+        => currentSession is null
+            ? "Skipped: 0 items"
+            : $"Skipped: {currentSession.Progress.SkippedItems} items";
+
+    private string CurrentItemTypeText
+        => CurrentItem?.ItemType == TriageItemTypeDto.PullRequest
+            ? "Pull request"
+            : "Issue";
+
+    private string SessionCompleteSummaryText
+        => currentSession is null
+            ? string.Empty
+            : $"Processed {currentSession.Summary.ProcessedItems} of {currentSession.Summary.TotalItems} items. {currentSession.Summary.SkippedItems} skipped item(s) are available to revisit.";
+
+    /// <inheritdoc/>
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadRepositoriesAsync();
+    }
+
+    private async Task LoadRepositoriesAsync()
+    {
+        isLoadingRepositories = true;
+        operationMessage = null;
+
+        try
+        {
+            availableRepositories = (await RepositoryService.GetActiveRepositoriesAsync())
+                .OrderBy(repository => repository.FullName, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (!availableRepositories.Any(repository => repository.FullName.Equals(selectedRepositoryFullName, StringComparison.OrdinalIgnoreCase)))
+            {
+                selectedRepositoryFullName = string.Empty;
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while loading triage repositories.");
+            operationSeverity = Severity.Error;
+            operationMessage = $"GitHub API request failed while loading repositories. {ex.Message}";
+            Snackbar.Add("Failed to load repositories for triage session scope.", Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load triage repositories.");
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while loading repositories.";
+            Snackbar.Add("An unexpected error occurred while loading triage repositories.", Severity.Error);
+        }
+        finally
+        {
+            isLoadingRepositories = false;
+        }
+    }
+
+    private Task OnSelectedRepositoryChangedAsync(IReadOnlyList<string> repositoryFullNames)
+    {
+        ArgumentNullException.ThrowIfNull(repositoryFullNames);
+
+        var previousRepositoryFullName = selectedRepositoryFullName;
+
+        selectedRepositoryFullName = repositoryFullNames
+            .FirstOrDefault(static fullName => !string.IsNullOrWhiteSpace(fullName))
+            ?? string.Empty;
+
+        if (!string.Equals(previousRepositoryFullName, selectedRepositoryFullName, StringComparison.OrdinalIgnoreCase))
+        {
+            currentSession = null;
+            skipReason = string.Empty;
+            operationSeverity = Severity.Info;
+            operationMessage = string.IsNullOrWhiteSpace(selectedRepositoryFullName)
+                ? null
+                : "Repository scope changed. Start a new triage session to load items.";
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private Task OnIncludePullRequestsChangedAsync(bool value)
+    {
+        includePullRequests = value;
+        return Task.CompletedTask;
+    }
+
+    private async Task StartSessionAsync()
+    {
+        if (!CanStartSession)
+        {
+            return;
+        }
+
+        if (!TryParseRepositoryScope(selectedRepositoryFullName, out var owner, out var repo))
+        {
+            operationSeverity = Severity.Warning;
+            operationMessage = "Repository scope must be in owner/repository format.";
+            Snackbar.Add("Select a valid repository scope before starting triage.", Severity.Warning);
+            return;
+        }
+
+        isStartingSession = true;
+        operationMessage = null;
+
+        try
+        {
+            currentSession = await TriageService.StartSessionAsync(owner, repo, includePullRequests);
+            skipReason = string.Empty;
+
+            operationSeverity = Severity.Success;
+            operationMessage = currentSession.Progress.TotalItems == 0
+                ? $"No untriaged items were found in {selectedRepositoryFullName}."
+                : $"Started triage session for {selectedRepositoryFullName}.";
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while starting triage session for {RepositoryScope}.", selectedRepositoryFullName);
+            operationSeverity = Severity.Error;
+            operationMessage = $"GitHub API request failed while starting triage session. {ex.Message}";
+            Snackbar.Add("Failed to start triage session due to a GitHub API error.", Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to start triage session for {RepositoryScope}.", selectedRepositoryFullName);
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while starting triage session.";
+            Snackbar.Add("An unexpected error occurred while starting triage session.", Severity.Error);
+        }
+        finally
+        {
+            isStartingSession = false;
+        }
+    }
+
+    private async Task AdvanceSessionAsync()
+    {
+        if (currentSession is null || currentSession.CurrentItem is null || isApplyingSessionAction)
+        {
+            return;
+        }
+
+        isApplyingSessionAction = true;
+
+        try
+        {
+            currentSession = await TriageService.AdvanceSessionAsync(currentSession);
+            operationSeverity = Severity.Info;
+            operationMessage = currentSession.CurrentItem is null
+                ? "Reached the end of the current queue."
+                : $"Moved to {CurrentPositionText}.";
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to move to the next triage item.");
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while moving to the next item.";
+            Snackbar.Add("Could not move to the next triage item.", Severity.Error);
+        }
+        finally
+        {
+            isApplyingSessionAction = false;
+        }
+    }
+
+    private async Task SkipCurrentItemAsync()
+    {
+        if (currentSession is null || currentSession.CurrentItem is null || isApplyingSessionAction)
+        {
+            return;
+        }
+
+        isApplyingSessionAction = true;
+
+        try
+        {
+            currentSession = await TriageService.SkipCurrentItemAsync(currentSession, skipReason);
+            skipReason = string.Empty;
+            operationSeverity = Severity.Info;
+            operationMessage = "Skipped current item and deferred it for later review.";
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to skip the current triage item.");
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while skipping the item.";
+            Snackbar.Add("Could not skip the current triage item.", Severity.Error);
+        }
+        finally
+        {
+            isApplyingSessionAction = false;
+        }
+    }
+
+    private async Task RevisitSkippedItemsAsync()
+    {
+        if (currentSession is null || currentSession.SkippedItems.Count == 0 || isApplyingSessionAction)
+        {
+            return;
+        }
+
+        isApplyingSessionAction = true;
+
+        try
+        {
+            currentSession = await TriageService.RevisitSkippedItemsAsync(currentSession);
+            operationSeverity = Severity.Info;
+            operationMessage = "Skipped items were appended to the queue for review.";
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to revisit skipped triage items.");
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while revisiting skipped items.";
+            Snackbar.Add("Could not revisit skipped triage items.", Severity.Error);
+        }
+        finally
+        {
+            isApplyingSessionAction = false;
+        }
+    }
+
+    private static bool TryParseRepositoryScope(string repositoryFullName, out string owner, out string repo)
+    {
+        owner = string.Empty;
+        repo = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(repositoryFullName))
+        {
+            return false;
+        }
+
+        var segments = repositoryFullName.Split('/', 2, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length != 2)
+        {
+            return false;
+        }
+
+        owner = segments[0];
+        repo = segments[1];
+        return true;
+    }
+
+    /// <summary>Converts markdown body content into HTML suitable for safe display in the triage UI.</summary>
+    /// <param name="body">The original issue or pull-request body content.</param>
+    /// <returns>Rendered HTML with unsafe protocols and image tags removed.</returns>
+    private static string RenderMarkdownForDisplay(string body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+
+        var html = Markdown.ToHtml(body, markdownPipeline);
+        html = imageRegex.Replace(html, string.Empty);
+
+        // Keep rendered links clickable while preventing unsafe protocols.
+        html = hrefRegex.Replace(
+            html,
+            static match =>
+            {
+                var url = match.Groups["url"].Value;
+                return IsAllowedLink(url)
+                    ? match.Value
+                    : "href=\"#\"";
+            });
+
+        return html;
+    }
+
+    private static bool IsAllowedLink(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return false;
+        }
+
+        if (url.StartsWith("#", StringComparison.Ordinal) || url.StartsWith("/", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        return uri.Scheme is "http" or "https" or "mailto";
+    }
+
+}

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
@@ -3,6 +3,7 @@ using Markdig;
 using MudBlazor;
 using SoloDevBoard.Application.Services.Repositories;
 using SoloDevBoard.Application.Services.Triage;
+using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
 
 namespace SoloDevBoard.App.Components.Features.Triage.Pages;
@@ -105,12 +106,12 @@ public partial class Triage : ComponentBase
     private string RemainingCountText
         => currentSession is null
             ? "Remaining: 0 items"
-            : $"Remaining: {currentSession.Progress.RemainingItems} items";
+            : $"Remaining: {currentSession.Progress.RemainingItems} {GetItemCountLabel(currentSession.Progress.RemainingItems)}";
 
     private string SkippedCountText
         => currentSession is null
             ? "Skipped: 0 items"
-            : $"Skipped: {currentSession.Progress.SkippedItems} items";
+            : $"Skipped: {currentSession.Progress.SkippedItems} {GetItemCountLabel(currentSession.Progress.SkippedItems)}";
 
     private string CurrentItemTypeText
         => CurrentItem?.ItemType == TriageItemTypeDto.PullRequest
@@ -357,18 +358,27 @@ public partial class Triage : ComponentBase
         ArgumentNullException.ThrowIfNull(body);
 
         var html = Markdown.ToHtml(body, markdownPipeline);
-        html = imageRegex.Replace(html, string.Empty);
 
-        // Keep rendered links clickable while preventing unsafe protocols.
-        html = hrefRegex.Replace(
-            html,
-            static match =>
-            {
-                var url = match.Groups["url"].Value;
-                return IsAllowedLink(url)
-                    ? match.Value
-                    : "href=\"#\"";
-            });
+        try
+        {
+            html = imageRegex.Replace(html, string.Empty);
+
+            // Keep rendered links clickable while preventing unsafe protocols.
+            html = hrefRegex.Replace(
+                html,
+                static match =>
+                {
+                    var url = match.Groups["url"].Value;
+                    return IsAllowedLink(url)
+                        ? match.Value
+                        : "href=\"#\"";
+                });
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            // Fall back to escaped plain text if regex replacement times out.
+            return $"<p>{HtmlEncoder.Default.Encode(body)}</p>";
+        }
 
         return html;
     }
@@ -380,17 +390,31 @@ public partial class Triage : ComponentBase
             return false;
         }
 
-        if (url.StartsWith("#", StringComparison.Ordinal) || url.StartsWith("/", StringComparison.Ordinal))
+        if (url.StartsWith("#", StringComparison.Ordinal))
         {
             return true;
         }
 
-        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        if (url.StartsWith("/", StringComparison.Ordinal))
+        {
+            return !url.StartsWith("//", StringComparison.Ordinal);
+        }
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var absoluteUri))
+        {
+            return absoluteUri.Scheme is "http" or "https" or "mailto";
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Relative, out _))
         {
             return false;
         }
 
-        return uri.Scheme is "http" or "https" or "mailto";
+        // Block scheme-like values masquerading as relative URLs.
+        var schemeSeparatorIndex = url.IndexOf(':', StringComparison.Ordinal);
+        return schemeSeparatorIndex <= 0;
     }
+
+    private static string GetItemCountLabel(int count) => count == 1 ? "item" : "items";
 
 }

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.css
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.css
@@ -1,0 +1,67 @@
+.triage-markdown {
+    line-height: 1.55;
+}
+
+.triage-markdown > :first-child {
+    margin-top: 0;
+}
+
+.triage-markdown > :last-child {
+    margin-bottom: 0;
+}
+
+.triage-markdown ::deep p {
+    margin: 0.5rem 0;
+}
+
+.triage-markdown ::deep ul,
+.triage-markdown ::deep ol {
+    margin: 0.5rem 0 0.75rem;
+    padding-left: 1.25rem;
+}
+
+.triage-markdown ::deep li + li {
+    margin-top: 0.2rem;
+}
+
+.triage-markdown ::deep h1,
+.triage-markdown ::deep h2,
+.triage-markdown ::deep h3,
+.triage-markdown ::deep h4,
+.triage-markdown ::deep h5,
+.triage-markdown ::deep h6 {
+    margin: 0.75rem 0 0.35rem;
+    line-height: 1.35;
+    font-weight: 600;
+}
+
+.triage-markdown ::deep h1 {
+    font-size: 1.45rem;
+}
+
+.triage-markdown ::deep h2 {
+    font-size: 1.3rem;
+}
+
+.triage-markdown ::deep h3 {
+    font-size: 1.2rem;
+}
+
+.triage-markdown ::deep h4,
+.triage-markdown ::deep h5,
+.triage-markdown ::deep h6 {
+    font-size: 1.05rem;
+}
+
+.triage-markdown ::deep pre {
+    margin: 0.6rem 0;
+    padding: 0.65rem 0.8rem;
+    border-radius: 4px;
+    overflow-x: auto;
+    background-color: var(--mud-palette-background-grey);
+}
+
+.triage-markdown ::deep code {
+    font-family: var(--mud-typography-default-family);
+    font-size: 0.92em;
+}

--- a/src/App/SoloDevBoard.App/Components/Shared/Components/RepositorySelector.razor
+++ b/src/App/SoloDevBoard.App/Components/Shared/Components/RepositorySelector.razor
@@ -21,10 +21,17 @@
                          MinCharacters="0"
                          Clearable="true"
                          Immediate="true"
-                         Disabled="Disabled"
+                         Disabled="@(Disabled || (SingleSelectionOnly && SelectedRepositories.Count > 0))"
                          Adornment="Adornment.Start"
                          AdornmentIcon="@Icons.Material.Filled.Search"
                          data-testid="@AutocompleteTestId" />
+
+        @if (SingleSelectionOnly && SelectedRepositories.Count > 0)
+        {
+            <MudText Typo="Typo.caption" data-testid="repository-selector-single-selection-lock-message">
+                One repository can be selected at a time. Remove the current selection to choose another repository.
+            </MudText>
+        }
 
         @if (ShowSelectedChips && SelectedRepositories.Count > 0)
         {
@@ -41,7 +48,7 @@
             </MudStack>
         }
 
-        @if (ShowSelectionActions)
+        @if (ShowSelectionActions && !SingleSelectionOnly)
         {
             <MudStack Row="true" Spacing="1">
                 <MudButton Variant="Variant.Text"

--- a/src/App/SoloDevBoard.App/Components/Shared/Components/RepositorySelector.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Shared/Components/RepositorySelector.razor.cs
@@ -43,6 +43,10 @@ public partial class RepositorySelector : ComponentBase
     [Parameter]
     public bool ShowSelectedChips { get; set; } = true;
 
+    /// <summary>Gets or sets a value indicating whether the selector should allow only one selected repository.</summary>
+    [Parameter]
+    public bool SingleSelectionOnly { get; set; }
+
     /// <summary>Gets or sets a value indicating whether select-all and clear actions are shown.</summary>
     [Parameter]
     public bool ShowSelectionActions { get; set; } = true;
@@ -69,11 +73,14 @@ public partial class RepositorySelector : ComponentBase
             matches = matches.Where(repository => repository.Contains(filter, StringComparison.OrdinalIgnoreCase));
         }
 
-        var selectedNames = SelectedRepositories
-            .Where(repository => !string.IsNullOrWhiteSpace(repository))
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (!SingleSelectionOnly)
+        {
+            var selectedNames = SelectedRepositories
+                .Where(repository => !string.IsNullOrWhiteSpace(repository))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        matches = matches.Where(repository => !selectedNames.Contains(repository));
+            matches = matches.Where(repository => !selectedNames.Contains(repository));
+        }
 
         return Task.FromResult(matches);
     }
@@ -90,13 +97,19 @@ public partial class RepositorySelector : ComponentBase
             return;
         }
 
+        repositoryAutocompleteValue = null;
+
+        if (SingleSelectionOnly)
+        {
+            await SelectedRepositoriesChanged.InvokeAsync([repository]);
+            return;
+        }
+
         var selected = SelectedRepositories
             .Where(item => !string.IsNullOrWhiteSpace(item))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         _ = selected.Add(repository);
-
-        repositoryAutocompleteValue = null;
 
         await SelectedRepositoriesChanged.InvokeAsync(
             selected

--- a/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj
+++ b/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj
@@ -9,6 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Markdig" />
 		<PackageReference Include="MudBlazor" />
 	</ItemGroup>
 

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
@@ -21,7 +21,9 @@ public sealed class TriageService : ITriageService
 
         var issues = await _gitHubService.GetIssuesAsync(owner, repo, cancellationToken).ConfigureAwait(false);
         var queue = new List<TriageItem>(issues.Count + 16);
-        queue.AddRange(issues.Select(issue => ToDomainIssueItem(owner, repo, issue)));
+        queue.AddRange(issues
+            .Where(issue => issue.Labels.Count == 0)
+            .Select(issue => ToDomainIssueItem(owner, repo, issue)));
 
         if (includePullRequests)
         {

--- a/tests/App.Tests/SoloDevBoard.App.Tests/RepositorySelectorTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/RepositorySelectorTests.cs
@@ -1,0 +1,59 @@
+using Bunit;
+using MudBlazor;
+using MudBlazor.Services;
+using SoloDevBoard.App.Components.Shared.Components;
+
+namespace SoloDevBoard.App.Tests;
+
+/// <summary>Component tests for <see cref="RepositorySelector"/> single-selection behaviour.</summary>
+public sealed class RepositorySelectorTests
+{
+    [Fact]
+    public async Task RepositorySelector_SingleSelectionOnly_SelectedRepositoryExists_DisablesAutocomplete()
+    {
+        // Arrange
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<RepositorySelector>(parameters => parameters
+            .Add(selector => selector.SingleSelectionOnly, true)
+            .Add(selector => selector.AvailableRepositories, new[] { "owner/repo-a", "owner/repo-b" })
+            .Add(selector => selector.SelectedRepositories, new[] { "owner/repo-a" }));
+
+        // Assert
+        var autocomplete = cut.FindComponent<MudAutocomplete<string>>();
+        Assert.True(autocomplete.Instance.Disabled);
+        Assert.NotNull(cut.Find("[data-testid='repository-selector-single-selection-lock-message']"));
+    }
+
+    [Fact]
+    public async Task RepositorySelector_SingleSelectionOnly_NoSelectedRepository_EnablesAutocomplete()
+    {
+        // Arrange
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<RepositorySelector>(parameters => parameters
+            .Add(selector => selector.SingleSelectionOnly, true)
+            .Add(selector => selector.AvailableRepositories, new[] { "owner/repo-a", "owner/repo-b" })
+            .Add(selector => selector.SelectedRepositories, Array.Empty<string>()));
+
+        // Assert
+        var autocomplete = cut.FindComponent<MudAutocomplete<string>>();
+        Assert.False(autocomplete.Instance.Disabled);
+        Assert.Empty(cut.FindAll("[data-testid='repository-selector-single-selection-lock-message']"));
+    }
+
+    private static BunitContext CreateContext()
+    {
+        var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddMudServices();
+
+        ctx.Render<MudPopoverProvider>();
+        ctx.Render<MudDialogProvider>();
+        ctx.Render<MudSnackbarProvider>();
+
+        return ctx;
+    }
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
@@ -1,0 +1,352 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MudBlazor;
+using MudBlazor.Services;
+using SoloDevBoard.App.Components.Features.Triage.Pages;
+using SoloDevBoard.App.Components.Shared.Components;
+using SoloDevBoard.Application.Services.Repositories;
+using SoloDevBoard.Application.Services.Triage;
+
+namespace SoloDevBoard.App.Tests;
+
+/// <summary>Component tests for the <see cref="Triage"/> page.</summary>
+public sealed class TriageTests
+{
+    private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
+    private readonly Mock<ITriageService> _triageServiceMock = new();
+
+    [Fact]
+    public async Task Triage_StartSessionClicked_LoadsFirstItemAndShowsRemainingCount()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [
+                CreateItem(101, "Issue 101", "owner/repo"),
+                CreateItem(102, "Issue 102", "owner/repo"),
+            ],
+            currentIndex: 0,
+            skippedItems: []);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Issue 101", cut.Markup);
+            Assert.Contains("Item 1 of 2", cut.Markup);
+            Assert.Contains("Remaining: 2 items", cut.Markup);
+        });
+
+        _triageServiceMock.Verify(
+            service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Triage_NextItemClicked_MovesToNextQueueItemAndUpdatesContext()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [
+                CreateItem(101, "Issue 101", "owner/repo"),
+                CreateItem(102, "Issue 102", "owner/repo"),
+            ],
+            currentIndex: 0,
+            skippedItems: []);
+
+        var advancedSession = startedSession with
+        {
+            CurrentIndex = 1,
+            Progress = new TriageSessionProgressDto(2, 1, 1, 0),
+            Summary = new TriageSessionSummaryDto(2, 1, 1, 0, 0, 0, 0, 0),
+        };
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(advancedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+        cut.WaitForAssertion(() => Assert.Contains("Issue 101", cut.Markup));
+
+        cut.Find("[data-testid='triage-next-item-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Issue 102", cut.Markup);
+            Assert.Contains("Item 2 of 2", cut.Markup);
+            Assert.Contains("Remaining: 1 items", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task Triage_SkipThenRevisitClicked_DefersItemAndRequeuesItForLater()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var activeItem = CreateItem(101, "Issue 101", "owner/repo");
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [activeItem],
+            currentIndex: 0,
+            skippedItems: []);
+
+        var skippedSession = CreateSession(
+            "owner",
+            "repo",
+            [],
+            currentIndex: 0,
+            skippedItems: [activeItem]);
+
+        var revisitedSession = CreateSession(
+            "owner",
+            "repo",
+            [activeItem],
+            currentIndex: 0,
+            skippedItems: []);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.SkipCurrentItemAsync(It.IsAny<TriageSessionDto>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(skippedSession);
+
+        _triageServiceMock
+            .Setup(service => service.RevisitSkippedItemsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(revisitedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+        cut.WaitForAssertion(() => Assert.Contains("Issue 101", cut.Markup));
+
+        cut.Find("[data-testid='triage-skip-item-button']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Session complete", cut.Markup);
+            Assert.Contains("Skipped: 1 items", cut.Markup);
+            Assert.NotNull(cut.Find("[data-testid='triage-revisit-skipped-button']"));
+        });
+
+        cut.Find("[data-testid='triage-revisit-skipped-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Issue 101", cut.Markup);
+            Assert.Contains("Skipped: 0 items", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task Triage_CurrentItemBodyContainsMarkdown_RendersFormattedBodyContent()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var markdownItem = new TriageItemDto(
+            TriageItemTypeDto.Issue,
+            201,
+            201,
+            "owner/repo",
+            "Markdown issue",
+            "https://github.com/owner/repo/issues/201",
+            "# Heading\n\n- One\n- Two\n\n[Link](https://example.com)",
+            "open",
+            "markheydon",
+            [],
+            null,
+            string.Empty,
+            DateTimeOffset.UtcNow.AddDays(-2),
+            DateTimeOffset.UtcNow.AddDays(-1));
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSession("owner", "repo", [markdownItem], 0, []));
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            var body = cut.Find("[data-testid='triage-item-body']");
+            Assert.Contains("<h1", body.InnerHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<li", body.InnerHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("href=\"https://example.com\"", body.InnerHtml, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    [Fact]
+    public async Task Triage_RepositorySelectionClearedAfterSessionStarted_HidesActiveSessionDetails()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo-a"), CreateRepository("owner", "repo-b")]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo-a",
+            [CreateItem(301, "Issue 301", "owner/repo-a")],
+            currentIndex: 0,
+            skippedItems: []);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo-a", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo-a" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+        cut.WaitForAssertion(() => Assert.Contains("Issue 301", cut.Markup));
+
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(Array.Empty<string>()));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotNull(cut.Find("[data-testid='triage-not-started-region']"));
+            Assert.DoesNotContain("Issue 301", cut.Markup);
+            Assert.Empty(cut.FindAll("[data-testid='triage-item-detail-region']"));
+        });
+    }
+
+    private static RepositoryDto CreateRepository(string owner, string name)
+        => new(
+            Id: Math.Abs(HashCode.Combine(owner, name)),
+            Name: name,
+            FullName: $"{owner}/{name}",
+            Description: $"Repository {name}",
+            Url: $"https://github.com/{owner}/{name}",
+            IsPrivate: false,
+            IsArchived: false,
+            CreatedAt: DateTimeOffset.UtcNow.AddDays(-30),
+            UpdatedAt: DateTimeOffset.UtcNow.AddDays(-1));
+
+    private static TriageItemDto CreateItem(int number, string title, string repositoryFullName)
+        => new(
+            TriageItemTypeDto.Issue,
+            number,
+            number,
+            repositoryFullName,
+            title,
+            $"https://github.com/{repositoryFullName}/issues/{number}",
+            $"Body for {title}",
+            "open",
+            "markheydon",
+            [],
+            null,
+            string.Empty,
+            DateTimeOffset.UtcNow.AddDays(-5),
+            DateTimeOffset.UtcNow.AddDays(-1));
+
+    private static TriageSessionDto CreateSession(
+        string owner,
+        string repo,
+        IReadOnlyList<TriageItemDto> queue,
+        int currentIndex,
+        IReadOnlyList<TriageItemDto> skippedItems)
+    {
+        var processed = Math.Min(Math.Max(currentIndex, 0), queue.Count);
+        var remaining = Math.Max(queue.Count - processed, 0);
+
+        return new TriageSessionDto(
+            Guid.NewGuid(),
+            owner,
+            repo,
+            false,
+            queue,
+            currentIndex,
+            skippedItems,
+            [],
+            new TriageSessionProgressDto(queue.Count, processed, remaining, skippedItems.Count),
+            new TriageSessionSummaryDto(queue.Count, processed, remaining, skippedItems.Count, 0, 0, 0, 0),
+            DateTimeOffset.UtcNow);
+    }
+
+    private BunitContext CreateContext()
+    {
+        var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddMudServices();
+        ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
+        ctx.Services.AddScoped(_ => _triageServiceMock.Object);
+
+        ctx.Render<MudPopoverProvider>();
+        ctx.Render<MudDialogProvider>();
+        ctx.Render<MudSnackbarProvider>();
+
+        return ctx;
+    }
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
@@ -114,7 +114,7 @@ public sealed class TriageTests
         {
             Assert.Contains("Issue 102", cut.Markup);
             Assert.Contains("Item 2 of 2", cut.Markup);
-            Assert.Contains("Remaining: 1 items", cut.Markup);
+            Assert.Contains("Remaining: 1 item", cut.Markup);
         });
     }
 
@@ -178,7 +178,7 @@ public sealed class TriageTests
         cut.WaitForAssertion(() =>
         {
             Assert.Contains("Session complete", cut.Markup);
-            Assert.Contains("Skipped: 1 items", cut.Markup);
+            Assert.Contains("Skipped: 1 item", cut.Markup);
             Assert.NotNull(cut.Find("[data-testid='triage-revisit-skipped-button']"));
         });
 
@@ -237,6 +237,55 @@ public sealed class TriageTests
             Assert.Contains("<h1", body.InnerHtml, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("<li", body.InnerHtml, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("href=\"https://example.com\"", body.InnerHtml, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    [Fact]
+    public async Task Triage_CurrentItemBodyContainsRelativeAndUnsafeLinks_PreservesRelativeAndNeutralisesUnsafeHref()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var markdownItem = new TriageItemDto(
+            TriageItemTypeDto.Issue,
+            202,
+            202,
+            "owner/repo",
+            "Link safety issue",
+            "https://github.com/owner/repo/issues/202",
+            "[Relative](./docs/page.md) [Query](?view=compact) [Unsafe](javascript:alert('x'))",
+            "open",
+            "markheydon",
+            [],
+            null,
+            string.Empty,
+            DateTimeOffset.UtcNow.AddDays(-2),
+            DateTimeOffset.UtcNow.AddDays(-1));
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSession("owner", "repo", [markdownItem], 0, []));
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            var body = cut.Find("[data-testid='triage-item-body']");
+            Assert.Contains("href=\"./docs/page.md\"", body.InnerHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("href=\"?view=compact\"", body.InnerHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("href=\"#\"", body.InnerHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("href=\"javascript:alert", body.InnerHtml, StringComparison.OrdinalIgnoreCase);
         });
     }
 

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
@@ -1,6 +1,7 @@
 using Moq;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Application.Services.Triage;
+using SoloDevBoard.Domain.Entities.Labels;
 using SoloDevBoard.Domain.Entities.Triage;
 
 namespace SoloDevBoard.Application.Tests;
@@ -79,6 +80,27 @@ public sealed class TriageServiceTests
         Assert.Equal(2, result.Queue.Count);
         Assert.Contains(result.Queue, item => item.ItemType == TriageItemTypeDto.Issue);
         Assert.Contains(result.Queue, item => item.ItemType == TriageItemTypeDto.PullRequest);
+    }
+
+    [Fact]
+    public async Task StartSessionAsync_LabelledIssuePresent_ExcludesLabelledIssueFromQueue()
+    {
+        // Arrange
+        _gitHubServiceMock
+            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new Issue { Id = 1, Number = 11, Title = "Unlabelled", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2), Labels = [] },
+                new Issue { Id = 2, Number = 12, Title = "Labelled", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1), Labels = [new Label { Name = "priority/high" }] },
+            ]);
+
+        var sut = new TriageService(_gitHubServiceMock.Object);
+
+        // Act
+        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: false);
+
+        // Assert
+        Assert.Single(result.Queue);
+        Assert.Equal(11, result.Queue[0].Number);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary of Changes

Implements the full triage session workflow for issue #145, covering one-at-a-time item presentation, progress tracking, skip support, markdown-rendered item bodies, and a locked single-select repository scope.

Key changes:

- **Triage session orchestration:** The Triage page now presents one unlabelled item at a time, shows current position (e.g. "Item 3 of 10"), remaining count, skipped count, and a progress bar. Users can move to the next item or skip with an optional reason. Skipped items can be revisited within the same session.
- **Single-select repository scope:** The page uses the shared `RepositorySelector` component in `SingleSelectionOnly` mode. The autocomplete locks once a repository is chosen; removing the chip unlocks it. Stale session details are cleared immediately when the scope changes.
- **Markdown rendering:** Issue/PR body text is rendered as formatted markdown using Markdig 0.37.0 (open-source). HTML is disabled in the Markdig pipeline; unsafe `href` schemes and `<img>` tags are stripped as a defence-in-depth measure.
- **Scoped CSS with `::deep`:** A new `Triage.razor.css` stylesheet applies visual formatting to the markdown content. `::deep` selectors are used because Blazor CSS isolation does not apply scoped attributes to HTML emitted via `MarkupString`.
- **`RepositorySelector` enhancement:** New `SingleSelectionOnly` parameter added to the shared component with a lock-state hint message and short-circuit logic in `OnRepositorySelectedAsync`.
- **Include pull requests default on:** The "Include pull requests" switch now defaults to `true`.

## Related Issue(s)

Closes #145
Relates to #142 (Feature: Triage UI), #87 (Epic: Triage)

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

N/A — UI changes reflect the triage-ui wireframe already reviewed.

## Additional Notes

- Markdig 0.37.0 is an open-source MIT-licensed package; no commercial licence required.
- The `::deep` CSS selector pattern is the standard Blazor approach for styling HTML injected via `MarkupString`; this is the correct escape hatch, not a CSS isolation bypass.
- 201 tests pass (0 failed) following all changes.
