### PR TITLE
[type/story] Triage: searchable quick-label autocomplete with apply-and-advance actions

### DIFF
--- a/docs/user-guide/triage-ui.md
+++ b/docs/user-guide/triage-ui.md
@@ -13,21 +13,30 @@ The Triage UI enables you to work through untriaged GitHub issues for a single s
 Key features:
 - You can start a triage session for one repository at a time.
 - Only unlabelled issues are included in the triage queue.
-- The interface shows your current position (e.g., Item 3 of 10), remaining count, skipped count, and a progress indicator.
-- You can move to the next item or skip the current item, optionally providing a reason for skipping.
-- Skipped items can be revisited within the same session.
+- The interface shows your current position (e.g., Item 3 of 10), a remaining count, and a progress indicator.
+- Use the **Quick Label** field to search and select a label, then click **Apply + next** to apply it and move on.
+- Click **Next** to advance without making any change to the current item.
 - Progress and session context are always visible, so you know how much work remains.
 
 ## How to Use
 
 1. Select a repository to start a triage session.
 2. The Triage UI queues all unlabelled issues for that repository.
-3. Review each item in turn, then choose **Next** to continue or **Skip** to defer the current item with an optional reason.
-4. After reaching the end of the queue, choose the revisit action to process skipped items within the same session.
-5. Use the progress indicator and session context to track your position, remaining items, and skipped count.
+3. Review each item in turn, then either:
+   - Search for a label in the **Quick Label** field and click **Apply + next** to label the issue and advance, or
+   - Click **Next** to advance to the next item without applying a label.
+4. The session completes once all queued items have been processed.
+5. Use the progress indicator and session context to track your position and the number of remaining items.
 
-**Note:** The Triage UI currently supports one-repository sessions and progress visibility. Additional triage actions (such as label assignment, milestone selection, and project board placement) are planned for future releases and are not yet available.
 
-Planned configuration options include:
-- Filtering which issues appear in a triage session (e.g. unlabelled only, no milestone, created within the last 7 days).
-- Customising available quick-action buttons for frequently used labels or milestones.
+## Quick Label Actions and Keyboard Shortcuts
+
+You can apply labels to issues directly from the Triage UI without leaving the triage view.
+
+- Use the **Quick Label** search field to find and select a repository label. The field accepts free-text search so you can type any part of a label name.
+- Click **Apply + next** (or press **L**) to apply the selected label and immediately advance to the next item.
+- Click **Next** (or press **N**) to move to the next item without applying a label.
+- Keyboard shortcuts work when the action button row is focused. Typing in the Quick Label field does not trigger shortcuts.
+- Success and failure feedback appears immediately via a snackbar notification.
+
+The two-action model keeps the triage rhythm straightforward: every item is either labelled and advanced, or advanced without changes.

--- a/docs/user-guide/triage-ui.md
+++ b/docs/user-guide/triage-ui.md
@@ -8,11 +8,11 @@ nav_order: 5
 
 ## Overview
 
-The Triage UI enables you to work through untriaged GitHub issues for a single selected repository in a focused, step-by-step session. Issues without any labels are queued and presented one at a time, allowing you to triage efficiently and track your progress throughout the session.
+The Triage UI enables you to work through untriaged GitHub items for a single selected repository in a focused, step-by-step session. Unlabelled issues are always included, and you can optionally include pull requests in the same queue.
 
 Key features:
 - You can start a triage session for one repository at a time.
-- Only unlabelled issues are included in the triage queue.
+- The queue includes unlabelled issues, with an option to include pull requests.
 - The interface shows your current position (e.g., Item 3 of 10), a remaining count, and a progress indicator.
 - Use the **Quick Label** field to search and select a label, then click **Apply + next** to apply it and move on.
 - Click **Next** to advance without making any change to the current item.
@@ -37,6 +37,6 @@ You can apply labels to issues directly from the Triage UI without leaving the t
 - Click **Apply + next** (or press **L**) to apply the selected label and immediately advance to the next item.
 - Click **Next** (or press **N**) to move to the next item without applying a label.
 - Keyboard shortcuts work when the action button row is focused. Typing in the Quick Label field does not trigger shortcuts.
-- Success and failure feedback appears immediately via a snackbar notification.
+- Primary success and failure feedback appears inline in the triage view via the operation alert, with additional snackbar notifications used for selected error conditions.
 
 The two-action model keeps the triage rhythm straightforward: every item is either labelled and advanced, or advanced without changes.

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -159,7 +159,7 @@ Labels: `type/epic`, `area/triage`
 > **Next up:** Triage UI work is now formally planned and remains the current delivery priority for Phase 3. All items below are tracked via the new issue hierarchy and are open/planned for milestone v0.3.0.
 
 - [x] As a solo developer, I want to start a triage session that presents unlabelled issues one at a time, supports progress tracking, and allows skipping and returning later so that I can work through them efficiently. _(Issue #145 — implemented 2026-03-18.)_
-- [ ] As a solo developer, I want to apply labels to an issue with a single click or keyboard shortcut so that triage is fast. _(Issue #146)_
+- [x] As a solo developer, I want to apply labels to an issue with a single click or keyboard shortcut so that triage is fast. _(Issue #146 — implemented 2026-03-26.)_
 - [ ] As a solo developer, I want to assign a milestone to an issue and add it to a GitHub project board column without leaving the triage view so that I can organise my work and plan in context. _(Issue #147)_
 - [ ] As a solo developer, I want to mark an issue as a duplicate and close it with a reference so that duplicate tracking is clean. _(Issue #148)_
 - [ ] As a solo developer, I want to see a summary at the end of a triage session showing all actions taken, and have the option to skip and return to issues later, so that I have a record of what was done and am not blocked by difficult triage decisions. _(Issue #149)_

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
@@ -79,26 +79,26 @@
     }
     else
     {
-        <MudPaper Class="pa-4" Elevation="1" data-testid="triage-session-header-region">
-            <MudStack Spacing="1">
-                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
-                    <MudText Typo="Typo.h6">Session progress</MudText>
-                    <MudChip T="string" Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small" data-testid="triage-current-position-chip">@CurrentPositionText</MudChip>
-                </MudStack>
-
-                <MudProgressLinear Value="SessionProgressPercent"
-                                   Color="Color.Primary"
-                                   Rounded="true"
-                                   Striped="true"
-                                   data-testid="triage-progress-indicator" />
-
-                <MudText Typo="Typo.body2" data-testid="triage-remaining-count">@RemainingCountText</MudText>
-                <MudText Typo="Typo.body2" data-testid="triage-skipped-count">@SkippedCountText</MudText>
-            </MudStack>
-        </MudPaper>
-
         @if (CurrentItem is not null)
         {
+            <MudPaper Class="pa-4" Elevation="1" data-testid="triage-session-header-region">
+                <MudStack Spacing="1">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                        <MudText Typo="Typo.h6">Session progress</MudText>
+                        <MudChip T="string" Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small" data-testid="triage-current-position-chip">@CurrentPositionText</MudChip>
+                    </MudStack>
+
+                    <MudProgressLinear Value="SessionProgressPercent"
+                                       Color="Color.Primary"
+                                       Rounded="true"
+                                       Striped="true"
+                                       data-testid="triage-progress-indicator" />
+
+                    <MudText Typo="Typo.body2" data-testid="triage-remaining-count">@RemainingCountText</MudText>
+                    <MudText Typo="Typo.body2" data-testid="triage-skipped-count">@SkippedCountText</MudText>
+                </MudStack>
+            </MudPaper>
+
             <MudPaper Class="pa-4" Elevation="1" data-testid="triage-item-detail-region">
                 <MudStack Spacing="2">
                     <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
@@ -143,34 +143,64 @@
                 </MudStack>
             </MudPaper>
 
-            <MudPaper Class="pa-4" Elevation="1" data-testid="triage-action-surface-region">
+            <MudPaper Class="pa-4"
+                      Elevation="1"
+                      data-testid="triage-action-surface-region">
                 <MudStack Spacing="2">
                     <MudText Typo="Typo.h6">Actions</MudText>
 
-                    <MudStack Row="true" Spacing="1" data-testid="triage-action-buttons-row">
-                        <MudButton Variant="Variant.Filled"
-                                   Color="Color.Primary"
-                                   Disabled="isApplyingSessionAction"
-                                   OnClick="AdvanceSessionAsync"
-                                   data-testid="triage-next-item-button">
-                            Next item
-                        </MudButton>
+                    <MudText Typo="Typo.body2" data-testid="triage-action-semantics-help">
+                        Apply + next saves the selected label and advances. Next advances without making any change to the current item.
+                    </MudText>
 
-                        <MudButton Variant="Variant.Outlined"
-                                   Color="Color.Secondary"
-                                   Disabled="isApplyingSessionAction"
-                                   OnClick="SkipCurrentItemAsync"
-                                   data-testid="triage-skip-item-button">
-                            Skip for later
-                        </MudButton>
+                    <MudStack Spacing="1" data-testid="triage-label-quick-action-row">
+                        <MudAutocomplete T="string"
+                                         Value="selectedQuickActionLabelName"
+                                         ValueChanged="OnSelectedQuickActionLabelChangedAsync"
+                                         SearchFunc="SearchQuickActionLabelsAsync"
+                                         ToStringFunc="labelName => labelName ?? string.Empty"
+                                         Label="Quick label"
+                                         Placeholder="Search labels and select"
+                                         Variant="Variant.Outlined"
+                                         MinCharacters="0"
+                                         Clearable="true"
+                                         Immediate="true"
+                                         Strict="false"
+                                         ResetValueOnEmptyText="true"
+                                         Disabled="isApplyingSessionAction || availableLabelNames.Count == 0"
+                                         Adornment="Adornment.Start"
+                                         AdornmentIcon="@Icons.Material.Filled.Search"
+                                         Class="flex-grow-1"
+                                         data-testid="triage-quick-label-autocomplete" />
+
+                        <MudStack Row="true"
+                                  Spacing="1"
+                                  tabindex="0"
+                                  @onkeydown="HandleActionSurfaceKeyDownAsync"
+                                  data-testid="triage-action-buttons-row">
+                            <MudButton Variant="Variant.Filled"
+                                       Color="Color.Primary"
+                                       Disabled="!CanApplySelectedLabel"
+                                       OnClick="ApplySelectedLabelAsync"
+                                       Class="triage-action-button"
+                                       data-testid="triage-apply-label-button">
+                                Apply + next
+                            </MudButton>
+
+                            <MudButton Variant="Variant.Filled"
+                                       Color="Color.Secondary"
+                                       Disabled="isApplyingSessionAction"
+                                       OnClick="CompleteWithoutChangesAsync"
+                                       Class="triage-action-button"
+                                       data-testid="triage-next-item-button">
+                                Next
+                            </MudButton>
+                        </MudStack>
                     </MudStack>
 
-                    <MudTextField @bind-Value="skipReason"
-                                  Label="Skip reason (optional)"
-                                  Variant="Variant.Outlined"
-                                  Immediate="true"
-                                  Disabled="isApplyingSessionAction"
-                                  data-testid="triage-skip-reason-input" />
+                    <MudText Typo="Typo.caption" data-testid="triage-keyboard-shortcuts-legend">
+                        Keyboard shortcuts (when the action buttons are focused): L applies selected label and advances, and N moves to the next item without changes.
+                    </MudText>
                 </MudStack>
             </MudPaper>
         }

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
@@ -182,7 +182,6 @@
                                        Color="Color.Primary"
                                        Disabled="!CanApplySelectedLabel"
                                        OnClick="ApplySelectedLabelAsync"
-                                       Class="triage-action-button"
                                        data-testid="triage-apply-label-button">
                                 Apply + next
                             </MudButton>
@@ -191,7 +190,6 @@
                                        Color="Color.Secondary"
                                        Disabled="isApplyingSessionAction"
                                        OnClick="CompleteWithoutChangesAsync"
-                                       Class="triage-action-button"
                                        data-testid="triage-next-item-button">
                                 Next
                             </MudButton>

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Markdig;
 using MudBlazor;
+using SoloDevBoard.Application.Services.Labels;
 using SoloDevBoard.Application.Services.Repositories;
 using SoloDevBoard.Application.Services.Triage;
 using System.Text.Encodings.Web;
@@ -27,6 +29,10 @@ public partial class Triage : ComponentBase
     [Inject]
     public ITriageService TriageService { get; set; } = default!;
 
+    /// <summary>Gets or sets the label service used to retrieve repository label options.</summary>
+    [Inject]
+    public ILabelManagerService LabelManagerService { get; set; } = default!;
+
     /// <summary>Gets or sets the logger for triage diagnostics.</summary>
     [Inject]
     public ILogger<Triage> Logger { get; set; } = default!;
@@ -41,8 +47,9 @@ public partial class Triage : ComponentBase
     private bool isLoadingRepositories = true;
     private bool isStartingSession;
     private bool isApplyingSessionAction;
-    private string skipReason = string.Empty;
     private TriageSessionDto? currentSession;
+    private IReadOnlyList<string> availableLabelNames = [];
+    private string selectedQuickActionLabelName = string.Empty;
     private string? operationMessage;
     private Severity operationSeverity = Severity.Info;
 
@@ -57,6 +64,11 @@ public partial class Triage : ComponentBase
             : [selectedRepositoryFullName];
 
     private TriageItemDto? CurrentItem => currentSession?.CurrentItem;
+
+    private bool CanApplySelectedLabel
+        => !isApplyingSessionAction
+            && CurrentItem is not null
+            && !string.IsNullOrWhiteSpace(selectedQuickActionLabelName);
 
     private MarkupString CurrentItemBodyMarkup
         => string.IsNullOrWhiteSpace(CurrentItem?.Body)
@@ -178,7 +190,8 @@ public partial class Triage : ComponentBase
         if (!string.Equals(previousRepositoryFullName, selectedRepositoryFullName, StringComparison.OrdinalIgnoreCase))
         {
             currentSession = null;
-            skipReason = string.Empty;
+            availableLabelNames = [];
+            selectedQuickActionLabelName = string.Empty;
             operationSeverity = Severity.Info;
             operationMessage = string.IsNullOrWhiteSpace(selectedRepositoryFullName)
                 ? null
@@ -215,7 +228,7 @@ public partial class Triage : ComponentBase
         try
         {
             currentSession = await TriageService.StartSessionAsync(owner, repo, includePullRequests);
-            skipReason = string.Empty;
+            await LoadQuickActionLabelsAsync(owner, repo);
 
             operationSeverity = Severity.Success;
             operationMessage = currentSession.Progress.TotalItems == 0
@@ -242,9 +255,76 @@ public partial class Triage : ComponentBase
         }
     }
 
-    private async Task AdvanceSessionAsync()
+    private async Task LoadQuickActionLabelsAsync(string owner, string repo)
     {
-        if (currentSession is null || currentSession.CurrentItem is null || isApplyingSessionAction)
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        try
+        {
+            var labelNames = await LabelManagerService.GetLabelsAsync(owner, repo);
+
+            availableLabelNames = labelNames
+                .Select(label => label.Name)
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (availableLabelNames.Count > 0)
+            {
+                selectedQuickActionLabelName = availableLabelNames[0];
+            }
+            else
+            {
+                selectedQuickActionLabelName = string.Empty;
+                operationSeverity = Severity.Warning;
+                operationMessage = "No repository labels are available to apply as quick actions.";
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while loading quick-action labels for {RepositoryScope}.", $"{owner}/{repo}");
+            availableLabelNames = [];
+            selectedQuickActionLabelName = string.Empty;
+            operationSeverity = Severity.Error;
+            operationMessage = $"GitHub API request failed while loading labels. {ex.Message}";
+            Snackbar.Add("Failed to load quick-action labels for triage.", Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load quick-action labels for {RepositoryScope}.", $"{owner}/{repo}");
+            availableLabelNames = [];
+            selectedQuickActionLabelName = string.Empty;
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while loading labels for quick actions.";
+            Snackbar.Add("An unexpected error occurred while loading quick-action labels.", Severity.Error);
+        }
+    }
+
+    private Task OnSelectedQuickActionLabelChangedAsync(string labelName)
+    {
+        selectedQuickActionLabelName = labelName ?? string.Empty;
+        return Task.CompletedTask;
+    }
+
+    private Task<IEnumerable<string>> SearchQuickActionLabelsAsync(string? value, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        IEnumerable<string> matches = availableLabelNames;
+
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            var filter = value.Trim();
+            matches = matches.Where(labelName => labelName.Contains(filter, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return Task.FromResult(matches);
+    }
+
+    private async Task ApplySelectedLabelAsync()
+    {
+        if (currentSession is null || CurrentItem is null || !CanApplySelectedLabel)
         {
             return;
         }
@@ -253,18 +333,30 @@ public partial class Triage : ComponentBase
 
         try
         {
-            currentSession = await TriageService.AdvanceSessionAsync(currentSession);
-            operationSeverity = Severity.Info;
+            var appliedItemNumber = CurrentItem.Number;
+            var labelName = selectedQuickActionLabelName.Trim();
+
+            var labelledSession = await TriageService.ApplyLabelToCurrentItemAsync(currentSession, labelName);
+            currentSession = await TriageService.AdvanceSessionAsync(labelledSession);
+
+            operationSeverity = Severity.Success;
             operationMessage = currentSession.CurrentItem is null
-                ? "Reached the end of the current queue."
-                : $"Moved to {CurrentPositionText}.";
+                ? $"Applied label '{labelName}' to item #{appliedItemNumber}. Reached the end of the current queue."
+                : $"Applied label '{labelName}' to item #{appliedItemNumber} and moved to {CurrentPositionText}.";
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while applying label to triage item.");
+            operationSeverity = Severity.Error;
+            operationMessage = $"GitHub API request failed while applying the label. {ex.Message}";
+            Snackbar.Add("Could not apply the selected label due to a GitHub API error.", Severity.Error);
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Failed to move to the next triage item.");
+            Logger.LogError(ex, "Failed to apply label to the current triage item.");
             operationSeverity = Severity.Error;
-            operationMessage = "An unexpected error occurred while moving to the next item.";
-            Snackbar.Add("Could not move to the next triage item.", Severity.Error);
+            operationMessage = "An unexpected error occurred while applying the selected label.";
+            Snackbar.Add("Could not apply the selected label.", Severity.Error);
         }
         finally
         {
@@ -272,7 +364,7 @@ public partial class Triage : ComponentBase
         }
     }
 
-    private async Task SkipCurrentItemAsync()
+    private async Task CompleteWithoutChangesAsync()
     {
         if (currentSession is null || currentSession.CurrentItem is null || isApplyingSessionAction)
         {
@@ -283,17 +375,19 @@ public partial class Triage : ComponentBase
 
         try
         {
-            currentSession = await TriageService.SkipCurrentItemAsync(currentSession, skipReason);
-            skipReason = string.Empty;
+            var completedItemNumber = currentSession.CurrentItem.Number;
+            currentSession = await TriageService.AdvanceSessionAsync(currentSession);
             operationSeverity = Severity.Info;
-            operationMessage = "Skipped current item and deferred it for later review.";
+            operationMessage = currentSession.CurrentItem is null
+                ? $"Moved past item #{completedItemNumber} without changes. Reached the end of the current queue."
+                : $"Moved past item #{completedItemNumber} without changes and moved to {CurrentPositionText}.";
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Failed to skip the current triage item.");
+            Logger.LogError(ex, "Failed to move to the next triage item without changes.");
             operationSeverity = Severity.Error;
-            operationMessage = "An unexpected error occurred while skipping the item.";
-            Snackbar.Add("Could not skip the current triage item.", Severity.Error);
+            operationMessage = "An unexpected error occurred while moving to the next item without changes.";
+            Snackbar.Add("Could not move to the next item without changes.", Severity.Error);
         }
         finally
         {
@@ -326,6 +420,30 @@ public partial class Triage : ComponentBase
         finally
         {
             isApplyingSessionAction = false;
+        }
+    }
+
+    private async Task HandleActionSurfaceKeyDownAsync(KeyboardEventArgs args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (isApplyingSessionAction)
+        {
+            return;
+        }
+
+        switch (args.Key)
+        {
+            case "l":
+            case "L":
+                await ApplySelectedLabelAsync();
+                break;
+            case "n":
+            case "N":
+                await CompleteWithoutChangesAsync();
+                break;
+            default:
+                break;
         }
     }
 

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
@@ -68,7 +68,7 @@ public partial class Triage : ComponentBase
     private bool CanApplySelectedLabel
         => !isApplyingSessionAction
             && CurrentItem is not null
-            && !string.IsNullOrWhiteSpace(selectedQuickActionLabelName);
+            && LabelExists(selectedQuickActionLabelName);
 
     private MarkupString CurrentItemBodyMarkup
         => string.IsNullOrWhiteSpace(CurrentItem?.Body)
@@ -270,13 +270,10 @@ public partial class Triage : ComponentBase
                 .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
                 .ToArray();
 
-            if (availableLabelNames.Count > 0)
+            selectedQuickActionLabelName = string.Empty;
+
+            if (availableLabelNames.Count == 0)
             {
-                selectedQuickActionLabelName = availableLabelNames[0];
-            }
-            else
-            {
-                selectedQuickActionLabelName = string.Empty;
                 operationSeverity = Severity.Warning;
                 operationMessage = "No repository labels are available to apply as quick actions.";
             }
@@ -320,6 +317,26 @@ public partial class Triage : ComponentBase
         }
 
         return Task.FromResult(matches);
+    }
+
+    private bool LabelExists(string? labelName)
+    {
+        if (string.IsNullOrWhiteSpace(labelName))
+        {
+            return false;
+        }
+
+        var candidate = labelName.Trim();
+
+        foreach (var availableLabelName in availableLabelNames)
+        {
+            if (string.Equals(availableLabelName, candidate, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private async Task ApplySelectedLabelAsync()

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.css
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.css
@@ -65,7 +65,3 @@
     font-family: var(--mud-typography-default-family);
     font-size: 0.92em;
 }
-
-.triage-action-button {
-    height: 56px;
-}

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.css
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.css
@@ -65,3 +65,7 @@
     font-family: var(--mud-typography-default-family);
     font-size: 0.92em;
 }
+
+.triage-action-button {
+    height: 56px;
+}

--- a/src/Application/SoloDevBoard.Application/Services/Triage/ITriageService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/ITriageService.cs
@@ -30,6 +30,13 @@ public interface ITriageService
     /// <returns>The updated triage session DTO.</returns>
     Task<TriageSessionDto> RevisitSkippedItemsAsync(TriageSessionDto session, CancellationToken cancellationToken = default);
 
+    /// <summary>Applies a label to the currently active session item.</summary>
+    /// <param name="session">The current session state.</param>
+    /// <param name="labelName">The label name to apply.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The updated triage session DTO.</returns>
+    Task<TriageSessionDto> ApplyLabelToCurrentItemAsync(TriageSessionDto session, string labelName, CancellationToken cancellationToken = default);
+
     /// <summary>Builds the latest triage session summary from current session state.</summary>
     /// <param name="session">The current session state.</param>
     /// <returns>The computed triage session summary DTO.</returns>

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
@@ -8,6 +8,8 @@ public sealed class TriageService : ITriageService
 {
     private readonly IGitHubService _gitHubService;
 
+    /// <summary>Initialises a new instance of the <see cref="TriageService"/> class.</summary>
+    /// <param name="gitHubService">The GitHub service used to retrieve and apply triage actions.</param>
     public TriageService(IGitHubService gitHubService)
     {
         _gitHubService = gitHubService ?? throw new ArgumentNullException(nameof(gitHubService));
@@ -152,10 +154,95 @@ public sealed class TriageService : ITriageService
     }
 
     /// <inheritdoc/>
+    public async Task<TriageSessionDto> ApplyLabelToCurrentItemAsync(TriageSessionDto session, string labelName, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentException.ThrowIfNullOrWhiteSpace(labelName);
+
+        var domainSession = ToDomain(session);
+        if (domainSession.CurrentIndex >= domainSession.Queue.Count)
+        {
+            return ToDto(domainSession);
+        }
+
+        var currentItem = domainSession.Queue[domainSession.CurrentIndex];
+        if (!TryParseRepositoryScope(currentItem.RepositoryFullName, out var owner, out var repo))
+        {
+            throw new ArgumentException(
+                $"Repository scope '{currentItem.RepositoryFullName}' must be in owner/repository format.",
+                nameof(session));
+        }
+
+        var trimmedLabelName = labelName.Trim();
+        var updatedLabels = currentItem.Labels
+            .Select(label => label.Name)
+            .Concat([trimmedLabelName])
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Select(static name => name.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        await _gitHubService
+            .ApplyLabelsToTriageItemAsync(owner, repo, currentItem.Number, updatedLabels, cancellationToken)
+            .ConfigureAwait(false);
+
+        var updatedCurrentItem = currentItem with
+        {
+            Labels = updatedLabels.Select(name => new SoloDevBoard.Domain.Entities.Labels.Label { Name = name }).ToArray(),
+        };
+
+        var updatedQueue = domainSession.Queue
+            .Select((item, index) => index == domainSession.CurrentIndex ? updatedCurrentItem : item)
+            .ToArray();
+
+        var action = new TriageAction
+        {
+            ActionType = TriageActionType.LabelApplied,
+            ItemType = currentItem.ItemType,
+            ItemNumber = currentItem.Number,
+            RepositoryFullName = currentItem.RepositoryFullName,
+            Detail = $"Applied label '{trimmedLabelName}'.",
+            OccurredAt = DateTimeOffset.UtcNow,
+        };
+
+        var updatedActionHistory = domainSession.ActionHistory
+            .Concat([action])
+            .ToArray();
+
+        return UpdateSessionState(domainSession with
+        {
+            Queue = updatedQueue,
+            ActionHistory = updatedActionHistory,
+        });
+    }
+
+    /// <inheritdoc/>
     public TriageSessionSummaryDto BuildSessionSummary(TriageSessionDto session)
     {
         ArgumentNullException.ThrowIfNull(session);
         return UpdateSessionState(ToDomain(session)).Summary;
+    }
+
+    private static bool TryParseRepositoryScope(string repositoryFullName, out string owner, out string repo)
+    {
+        owner = string.Empty;
+        repo = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(repositoryFullName))
+        {
+            return false;
+        }
+
+        var segments = repositoryFullName.Split('/', 2, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length != 2)
+        {
+            return false;
+        }
+
+        owner = segments[0];
+        repo = segments[1];
+        return true;
     }
 
     private static TriageSessionDto UpdateSessionState(TriageSession session)

--- a/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
@@ -404,6 +404,8 @@ public sealed class TriageTests
         cut.Find("[data-testid='triage-start-session-button']").Click();
         cut.WaitForAssertion(() => Assert.Contains("Issue 401", cut.Markup));
 
+        await SelectQuickLabelAsync(cut, "type/bug");
+
         cut.Find("[data-testid='triage-apply-label-button']").Click();
 
         // Assert
@@ -466,6 +468,8 @@ public sealed class TriageTests
         cut.Find("[data-testid='triage-start-session-button']").Click();
         cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("[data-testid='triage-action-surface-region']")));
 
+        await SelectQuickLabelAsync(cut, "priority/high");
+
         cut.Find("[data-testid='triage-action-buttons-row']").KeyDown("l");
 
         // Assert
@@ -475,6 +479,67 @@ public sealed class TriageTests
         _triageServiceMock.Verify(
             service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task Triage_SessionStartsWithAvailableLabels_QuickLabelDefaultsToEmptyAndApplyDisabled()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        _labelManagerServiceMock
+            .Setup(service => service.GetLabelsAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new LabelDto("priority/high", "d93f0b", "Should be addressed in the current sprint or release", "repo"),
+                new LabelDto("type/bug", "d73a4a", "A bug or unexpected behaviour", "repo"),
+            ]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [CreateItem(450, "Issue 450", "owner/repo")],
+            currentIndex: 0,
+            skippedItems: []);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(string.IsNullOrEmpty(cut.Find("[data-testid='triage-quick-label-autocomplete']").GetAttribute("value")));
+            Assert.True(cut.Find("[data-testid='triage-apply-label-button']").HasAttribute("disabled"));
+        });
+
+        _triageServiceMock.Verify(
+            service => service.ApplyLabelToCurrentItemAsync(It.IsAny<TriageSessionDto>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static async Task SelectQuickLabelAsync(IRenderedComponent<Triage> cut, string labelName)
+    {
+        ArgumentNullException.ThrowIfNull(cut);
+        ArgumentException.ThrowIfNullOrWhiteSpace(labelName);
+
+        var quickLabelAutocomplete = cut
+            .FindComponents<MudAutocomplete<string>>()
+            .Single(component => string.Equals(component.Instance.Label, "Quick label", StringComparison.Ordinal));
+
+        await cut.InvokeAsync(() => quickLabelAutocomplete.Instance.ValueChanged.InvokeAsync(labelName));
     }
 
     [Fact]

--- a/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
@@ -5,6 +5,7 @@ using MudBlazor;
 using MudBlazor.Services;
 using SoloDevBoard.App.Components.Features.Triage.Pages;
 using SoloDevBoard.App.Components.Shared.Components;
+using SoloDevBoard.Application.Services.Labels;
 using SoloDevBoard.Application.Services.Repositories;
 using SoloDevBoard.Application.Services.Triage;
 
@@ -15,6 +16,7 @@ public sealed class TriageTests
 {
     private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
     private readonly Mock<ITriageService> _triageServiceMock = new();
+    private readonly Mock<ILabelManagerService> _labelManagerServiceMock = new();
 
     [Fact]
     public async Task Triage_StartSessionClicked_LoadsFirstItemAndShowsRemainingCount()
@@ -119,34 +121,31 @@ public sealed class TriageTests
     }
 
     [Fact]
-    public async Task Triage_SkipThenRevisitClicked_DefersItemAndRequeuesItForLater()
+    public async Task Triage_NextClicked_MovesToNextItemWithoutApplyingChanges()
     {
         // Arrange
         _repositoryServiceMock
             .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([CreateRepository("owner", "repo")]);
 
-        var activeItem = CreateItem(101, "Issue 101", "owner/repo");
-
         var startedSession = CreateSession(
             "owner",
             "repo",
-            [activeItem],
+            [
+                CreateItem(101, "Issue 101", "owner/repo"),
+                CreateItem(102, "Issue 102", "owner/repo"),
+            ],
             currentIndex: 0,
             skippedItems: []);
 
-        var skippedSession = CreateSession(
+        var advancedSession = CreateSession(
             "owner",
             "repo",
-            [],
-            currentIndex: 0,
-            skippedItems: [activeItem]);
-
-        var revisitedSession = CreateSession(
-            "owner",
-            "repo",
-            [activeItem],
-            currentIndex: 0,
+            [
+                CreateItem(101, "Issue 101", "owner/repo"),
+                CreateItem(102, "Issue 102", "owner/repo"),
+            ],
+            currentIndex: 1,
             skippedItems: []);
 
         _triageServiceMock
@@ -154,12 +153,8 @@ public sealed class TriageTests
             .ReturnsAsync(startedSession);
 
         _triageServiceMock
-            .Setup(service => service.SkipCurrentItemAsync(It.IsAny<TriageSessionDto>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(skippedSession);
-
-        _triageServiceMock
-            .Setup(service => service.RevisitSkippedItemsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(revisitedSession);
+            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(advancedSession);
 
         await using var ctx = CreateContext();
 
@@ -173,22 +168,70 @@ public sealed class TriageTests
         cut.Find("[data-testid='triage-start-session-button']").Click();
         cut.WaitForAssertion(() => Assert.Contains("Issue 101", cut.Markup));
 
-        cut.Find("[data-testid='triage-skip-item-button']").Click();
-
-        cut.WaitForAssertion(() =>
-        {
-            Assert.Contains("Session complete", cut.Markup);
-            Assert.Contains("Skipped: 1 item", cut.Markup);
-            Assert.NotNull(cut.Find("[data-testid='triage-revisit-skipped-button']"));
-        });
-
-        cut.Find("[data-testid='triage-revisit-skipped-button']").Click();
+        cut.Find("[data-testid='triage-next-item-button']").Click();
 
         // Assert
         cut.WaitForAssertion(() =>
         {
-            Assert.Contains("Issue 101", cut.Markup);
+            Assert.Contains("Issue 102", cut.Markup);
             Assert.Contains("Skipped: 0 items", cut.Markup);
+        });
+
+        _triageServiceMock.Verify(
+            service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Triage_NextClickedOnFinalItem_ShowsSessionCompleteWithoutProgressHeader()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [CreateItem(103, "Issue 103", "owner/repo")],
+            currentIndex: 0,
+            skippedItems: []);
+
+        var completedSession = CreateSession(
+            "owner",
+            "repo",
+            [CreateItem(103, "Issue 103", "owner/repo")],
+            currentIndex: 1,
+            skippedItems: []);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(completedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+        cut.WaitForAssertion(() => Assert.Contains("Issue 103", cut.Markup));
+
+        cut.Find("[data-testid='triage-next-item-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotEmpty(cut.FindAll("[data-testid='triage-session-complete-region']"));
+            Assert.Empty(cut.FindAll("[data-testid='triage-session-header-region']"));
+            Assert.Empty(cut.FindAll("[data-testid='triage-progress-indicator']"));
         });
     }
 
@@ -290,6 +333,196 @@ public sealed class TriageTests
     }
 
     [Fact]
+    public async Task Triage_ApplyLabelClicked_InvokesTriageServiceAndShowsUpdatedLabels()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        _labelManagerServiceMock
+            .Setup(service => service.GetLabelsAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new LabelDto("type/bug", "d73a4a", "A bug or unexpected behaviour", "repo"),
+            ]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [
+                CreateItem(401, "Issue 401", "owner/repo"),
+                CreateItem(402, "Issue 402", "owner/repo"),
+            ],
+            currentIndex: 0,
+            skippedItems: []);
+
+        var labelledSession = startedSession with
+        {
+            Queue =
+            [
+                startedSession.Queue[0] with
+                {
+                    Labels = ["type/bug"],
+                },
+                startedSession.Queue[1],
+            ],
+            ActionHistory =
+            [
+                new TriageActionDto(TriageActionTypeDto.LabelApplied, TriageItemTypeDto.Issue, 401, "owner/repo", "Applied label 'type/bug'.", DateTimeOffset.UtcNow),
+            ],
+            Summary = new TriageSessionSummaryDto(2, 0, 2, 0, 1, 0, 0, 0),
+        };
+
+        var advancedSession = labelledSession with
+        {
+            CurrentIndex = 1,
+            Progress = new TriageSessionProgressDto(2, 1, 1, 0),
+            Summary = new TriageSessionSummaryDto(2, 1, 1, 0, 1, 0, 0, 0),
+        };
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.ApplyLabelToCurrentItemAsync(It.IsAny<TriageSessionDto>(), "type/bug", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(labelledSession);
+
+        _triageServiceMock
+            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(advancedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+        cut.WaitForAssertion(() => Assert.Contains("Issue 401", cut.Markup));
+
+        cut.Find("[data-testid='triage-apply-label-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Issue 402", cut.Markup);
+            Assert.Contains("Applied label 'type/bug' to item #401 and moved to Item 2 of 2", cut.Markup, StringComparison.Ordinal);
+        });
+
+        _triageServiceMock.Verify(
+            service => service.ApplyLabelToCurrentItemAsync(It.IsAny<TriageSessionDto>(), "type/bug", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _triageServiceMock.Verify(
+            service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Triage_ActionSurfaceShortcutL_PressedAppliesSelectedLabel()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        _labelManagerServiceMock
+            .Setup(service => service.GetLabelsAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new LabelDto("priority/high", "d93f0b", "Should be addressed in the current sprint or release", "repo"),
+            ]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [CreateItem(402, "Issue 402", "owner/repo")],
+            currentIndex: 0,
+            skippedItems: []);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.ApplyLabelToCurrentItemAsync(It.IsAny<TriageSessionDto>(), "priority/high", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("[data-testid='triage-action-surface-region']")));
+
+        cut.Find("[data-testid='triage-action-buttons-row']").KeyDown("l");
+
+        // Assert
+        _triageServiceMock.Verify(
+            service => service.ApplyLabelToCurrentItemAsync(It.IsAny<TriageSessionDto>(), "priority/high", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _triageServiceMock.Verify(
+            service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Triage_QuickLabelInputShortcutL_Pressed_DoesNotApplySelectedLabel()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        _labelManagerServiceMock
+            .Setup(service => service.GetLabelsAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new LabelDto("priority/high", "d93f0b", "Should be addressed in the current sprint or release", "repo"),
+            ]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [CreateItem(403, "Issue 403", "owner/repo")],
+            currentIndex: 0,
+            skippedItems: []);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-quick-label-autocomplete']"));
+
+        cut.Find("[data-testid='triage-quick-label-autocomplete']").KeyDown("l");
+
+        // Assert
+        _triageServiceMock.Verify(
+            service => service.ApplyLabelToCurrentItemAsync(It.IsAny<TriageSessionDto>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task Triage_RepositorySelectionClearedAfterSessionStarted_HidesActiveSessionDetails()
     {
         // Arrange
@@ -386,11 +619,18 @@ public sealed class TriageTests
 
     private BunitContext CreateContext()
     {
+        _labelManagerServiceMock
+            .SetReturnsDefault(Task.FromResult<IReadOnlyList<LabelDto>>(
+            [
+                new LabelDto("type/story", "1d76db", "A user-facing Story delivering a discrete piece of value", "repo"),
+            ]));
+
         var ctx = new BunitContext();
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
         ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
         ctx.Services.AddScoped(_ => _triageServiceMock.Object);
+        ctx.Services.AddScoped(_ => _labelManagerServiceMock.Object);
 
         ctx.Render<MudPopoverProvider>();
         ctx.Render<MudDialogProvider>();

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
@@ -207,6 +207,75 @@ public sealed class TriageServiceTests
     }
 
     [Fact]
+    public async Task ApplyLabelToCurrentItemAsync_ActiveItemExists_AppliesLabelAndRecordsAction()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var session = CreateSession(queueCount: 1, currentIndex: 0);
+
+        // Act
+        var result = await sut.ApplyLabelToCurrentItemAsync(session, "type/story");
+
+        // Assert
+        Assert.Single(result.Queue[0].Labels);
+        Assert.Equal("type/story", result.Queue[0].Labels[0]);
+        Assert.Single(result.ActionHistory);
+        Assert.Equal(TriageActionTypeDto.LabelApplied, result.ActionHistory[0].ActionType);
+        Assert.Contains("type/story", result.ActionHistory[0].Detail, StringComparison.Ordinal);
+        Assert.Equal(1, result.Summary.LabelsAppliedCount);
+
+        _gitHubServiceMock.Verify(
+            service => service.ApplyLabelsToTriageItemAsync("owner", "repo", 1, It.Is<IReadOnlyList<string>>(labels => labels.Count == 1 && labels[0] == "type/story"), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ApplyLabelToCurrentItemAsync_LabelAlreadyAssigned_DoesNotDuplicateAssignedLabel()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var existingLabelItem = new TriageItemDto(
+            TriageItemTypeDto.Issue,
+            1,
+            99,
+            "owner/repo",
+            "Item 99",
+            string.Empty,
+            string.Empty,
+            "open",
+            "mark",
+            ["priority/high"],
+            null,
+            string.Empty,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+
+        var session = new TriageSessionDto(
+            Guid.NewGuid(),
+            "owner",
+            "repo",
+            false,
+            [existingLabelItem],
+            0,
+            [],
+            [],
+            new TriageSessionProgressDto(1, 0, 1, 0),
+            new TriageSessionSummaryDto(1, 0, 1, 0, 0, 0, 0, 0),
+            DateTimeOffset.UtcNow);
+
+        // Act
+        var result = await sut.ApplyLabelToCurrentItemAsync(session, "priority/high");
+
+        // Assert
+        Assert.Single(result.Queue[0].Labels);
+        Assert.Equal("priority/high", result.Queue[0].Labels[0]);
+
+        _gitHubServiceMock.Verify(
+            service => service.ApplyLabelsToTriageItemAsync("owner", "repo", 99, It.Is<IReadOnlyList<string>>(labels => labels.Count == 1 && labels[0] == "priority/high"), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public void BuildSessionSummary_ActionHistoryIncludesAllActionTypes_ReturnsComputedCounts()
     {
         // Arrange


### PR DESCRIPTION
## Summary of Changes

Implements keyboard-first quick label actions in the Triage UI. Replaces the previous `MudSelect` with a searchable `MudAutocomplete`, simplifies the action surface to two focused buttons (**Apply + next** and **Next**), and fixes a session-completion display regression where the progress header was shown after the queue was exhausted.

Follow-up review fixes are included:
- Quick Label now defaults to empty when the session starts.
- **Apply + next** is enabled only when the selected label exists in the available repository labels (case-insensitive).
- User guide wording now reflects optional pull-request inclusion and inline alert feedback semantics.

## Related Issue(s)

Closes #146

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Additional Notes

The skip/defer action surface remains out of scope for this story. The session data model still tracks skipped items for compatibility with follow-on end-of-session work.
