### PR TITLE
[story] Triage UI: assign milestone and add to project board from triage view

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,6 +28,7 @@ SoloDevBoard supports two authentication modes:
   - `repo` (full control of private repositories)
   - `read:org` (read-only access to organisation data, if applicable)
   - `workflow` (to manage GitHub Actions workflows)
+  - `read:project` (read-only access to GitHub Projects; required for the Triage UI project board feature)
 
 - **GitHub App:** Recommended for production deployments. Provides fine-grained permissions and does not expire. See the [GitHub Apps documentation](https://docs.github.com/en/apps) for setup instructions.
 

--- a/docs/user-guide/triage-ui.md
+++ b/docs/user-guide/triage-ui.md
@@ -40,3 +40,27 @@ You can apply labels to issues directly from the Triage UI without leaving the t
 - Primary success and failure feedback appears inline in the triage view via the operation alert, with additional snackbar notifications used for selected error conditions.
 
 The two-action model keeps the triage rhythm straightforward: every item is either labelled and advanced, or advanced without changes.
+
+## Assigning Milestones from the Triage UI
+
+You can assign a milestone to an issue directly within the Triage UI, without leaving your triage session.
+
+- In the **Planning Actions** section, use the milestone dropdown to select the desired milestone for the current issue.
+- Click the **Assign milestone** button to apply your selection.
+- A feedback message will confirm whether the milestone was assigned successfully or if an error occurred.
+- You can continue triaging without interruption after assigning a milestone.
+
+Milestone assignment is available for all issues where you have permission to edit milestones. If the operation fails, an error message will be shown with guidance to retry or check your permissions.
+
+## Adding Issues to Project Boards from the Triage UI
+
+The Triage UI allows you to add issues to a GitHub project board and set their status column in context.
+
+- In the **Planning Actions** section, select a project board from the available list.
+- Choose the desired project status (column) for the issue.
+- Click the **Add to project board** button to place the issue in the selected board and status.
+- Success or failure feedback will appear in the user feedback region, confirming the result of the operation.
+
+If the issue is already on the selected board, you can update its status column directly. Any errors encountered during project board placement will be surfaced with actionable feedback.
+
+All planning actions use MudBlazor controls for a consistent and accessible experience, and the workflow aligns with the [triage wireframe](../../plan/wireframes/triage-ui-wireframe.md).

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -166,7 +166,7 @@ Labels: `type/epic`, `area/triage`
 
 - [x] As a solo developer, I want to start a triage session that presents unlabelled issues one at a time, supports progress tracking, and allows skipping and returning later so that I can work through them efficiently. _(Issue #145 — implemented 2026-03-18.)_
 - [x] As a solo developer, I want to apply labels to an issue with a single click or keyboard shortcut so that triage is fast. _(Issue #146 — implemented 2026-03-26.)_
-- [ ] As a solo developer, I want to assign a milestone to an issue and add it to a GitHub project board column without leaving the triage view so that I can organise my work and plan in context. _(Issue #147)_
+- [x] As a solo developer, I want to assign a milestone to an issue and add it to a GitHub project board column without leaving the triage view so that I can organise my work and plan in context. _(Issue #147 — implemented 2026-05-05.)_
 - [ ] As a solo developer, I want to mark an issue as a duplicate and close it with a reference so that duplicate tracking is clean. _(Issue #148)_
 - [ ] As a solo developer, I want to see a summary at the end of a triage session showing all actions taken, and have the option to skip and return to issues later, so that I have a record of what was done and am not blocked by difficult triage decisions. _(Issue #149)_
 - [ ] As a solo developer, I want to triage unlabelled pull requests alongside issues so that my entire GitHub workload, including open PRs, is managed in one place. _(Issue #150)_

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
@@ -199,6 +199,85 @@
                     <MudText Typo="Typo.caption" data-testid="triage-keyboard-shortcuts-legend">
                         Keyboard shortcuts (when the action buttons are focused): L applies selected label and advances, and N moves to the next item without changes.
                     </MudText>
+
+                    <MudDivider />
+
+                    <MudText Typo="Typo.subtitle2">Planning actions</MudText>
+                    <MudText Typo="Typo.body2" data-testid="triage-planning-help">
+                        Assign a milestone or place this item on a project board without leaving the current triage context.
+                    </MudText>
+
+                    <MudGrid Spacing="2" data-testid="triage-planning-actions-region">
+                        <MudItem xs="12" md="6">
+                            <MudStack Spacing="1" data-testid="triage-milestone-action-region">
+                                <MudSelect T="int?"
+                                           Value="selectedMilestoneNumber"
+                                           ValueChanged="OnSelectedMilestoneChangedAsync"
+                                           Label="Milestone"
+                                           Variant="Variant.Outlined"
+                                           Disabled="isApplyingSessionAction || isLoadingPlanningOptions"
+                                           data-testid="triage-milestone-select">
+                                    <MudSelectItem T="int?" Value="@((int?)null)">No milestone</MudSelectItem>
+
+                                    @if (availableMilestoneOptions.Count == 0)
+                                    {
+                                        <MudSelectItem T="int?" Value="@((int?)null)" Disabled="true">No milestones found in this repository</MudSelectItem>
+                                    }
+
+                                    @foreach (var milestoneOption in availableMilestoneOptions)
+                                    {
+                                        <MudSelectItem T="int?" Value="@((int?)milestoneOption.Number)">@milestoneOption.Title</MudSelectItem>
+                                    }
+                                </MudSelect>
+
+                                <MudButton Variant="Variant.Outlined"
+                                           Color="Color.Primary"
+                                           Disabled="!CanAssignMilestone"
+                                           OnClick="AssignSelectedMilestoneAsync"
+                                           data-testid="triage-assign-milestone-button">
+                                    Assign milestone
+                                </MudButton>
+                            </MudStack>
+                        </MudItem>
+
+                        <MudItem xs="12" md="6">
+                            <MudStack Spacing="1" data-testid="triage-project-board-action-region">
+                                <MudSelect T="string"
+                                           Value="selectedProjectBoardId"
+                                           ValueChanged="OnSelectedProjectBoardChangedAsync"
+                                           Label="Project board"
+                                           Variant="Variant.Outlined"
+                                           Disabled="isApplyingSessionAction || isLoadingPlanningOptions || availableProjectBoardOptions.Count == 0"
+                                           data-testid="triage-project-board-select">
+                                    @foreach (var projectBoardOption in availableProjectBoardOptions)
+                                    {
+                                        <MudSelectItem T="string" Value="@projectBoardOption.Id">@projectBoardOption.Title</MudSelectItem>
+                                    }
+                                </MudSelect>
+
+                                <MudSelect T="string"
+                                           Value="selectedProjectBoardStatusOptionId"
+                                           ValueChanged="OnSelectedProjectBoardStatusOptionChangedAsync"
+                                           Label="Project status"
+                                           Variant="Variant.Outlined"
+                                           Disabled="isApplyingSessionAction || isLoadingPlanningOptions || ActiveProjectBoardStatusOptions.Count == 0"
+                                           data-testid="triage-project-status-select">
+                                    @foreach (var statusOption in ActiveProjectBoardStatusOptions)
+                                    {
+                                        <MudSelectItem T="string" Value="@statusOption.Id">@statusOption.Name</MudSelectItem>
+                                    }
+                                </MudSelect>
+
+                                <MudButton Variant="Variant.Outlined"
+                                           Color="Color.Secondary"
+                                           Disabled="!CanAddToProjectBoard"
+                                           OnClick="AddCurrentItemToProjectBoardAsync"
+                                           data-testid="triage-add-to-project-board-button">
+                                    Add to project board
+                                </MudButton>
+                            </MudStack>
+                        </MudItem>
+                    </MudGrid>
                 </MudStack>
             </MudPaper>
         }

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
@@ -49,9 +49,15 @@ public partial class Triage : ComponentBase
     private bool isApplyingSessionAction;
     private TriageSessionDto? currentSession;
     private IReadOnlyList<string> availableLabelNames = [];
+    private IReadOnlyList<TriageMilestoneOptionDto> availableMilestoneOptions = [];
+    private IReadOnlyList<TriageProjectBoardOptionDto> availableProjectBoardOptions = [];
     private string selectedQuickActionLabelName = string.Empty;
+    private int? selectedMilestoneNumber;
+    private string selectedProjectBoardId = string.Empty;
+    private string selectedProjectBoardStatusOptionId = string.Empty;
     private string? operationMessage;
     private Severity operationSeverity = Severity.Info;
+    private bool isLoadingPlanningOptions;
 
     private bool CanStartSession
         => !isLoadingRepositories
@@ -69,6 +75,27 @@ public partial class Triage : ComponentBase
         => !isApplyingSessionAction
             && CurrentItem is not null
             && LabelExists(selectedQuickActionLabelName);
+
+    private bool CanAssignMilestone
+        => !isApplyingSessionAction
+            && CurrentItem is not null
+            && !isLoadingPlanningOptions
+            && (selectedMilestoneNumber.HasValue || CurrentItem.MilestoneNumber.HasValue);
+
+    private bool CanAddToProjectBoard
+        => !isApplyingSessionAction
+            && CurrentItem is not null
+            && !isLoadingPlanningOptions
+            && !string.IsNullOrWhiteSpace(selectedProjectBoardId)
+            && !string.IsNullOrWhiteSpace(selectedProjectBoardStatusOptionId)
+            && ActiveProjectBoard is not null;
+
+    private TriageProjectBoardOptionDto? ActiveProjectBoard
+        => availableProjectBoardOptions.FirstOrDefault(option =>
+            option.Id.Equals(selectedProjectBoardId, StringComparison.Ordinal));
+
+    private IReadOnlyList<TriageProjectBoardStatusOptionDto> ActiveProjectBoardStatusOptions
+        => ActiveProjectBoard?.StatusOptions ?? [];
 
     private MarkupString CurrentItemBodyMarkup
         => string.IsNullOrWhiteSpace(CurrentItem?.Body)
@@ -191,7 +218,12 @@ public partial class Triage : ComponentBase
         {
             currentSession = null;
             availableLabelNames = [];
+            availableMilestoneOptions = [];
+            availableProjectBoardOptions = [];
             selectedQuickActionLabelName = string.Empty;
+            selectedMilestoneNumber = null;
+            selectedProjectBoardId = string.Empty;
+            selectedProjectBoardStatusOptionId = string.Empty;
             operationSeverity = Severity.Info;
             operationMessage = string.IsNullOrWhiteSpace(selectedRepositoryFullName)
                 ? null
@@ -229,6 +261,8 @@ public partial class Triage : ComponentBase
         {
             currentSession = await TriageService.StartSessionAsync(owner, repo, includePullRequests);
             await LoadQuickActionLabelsAsync(owner, repo);
+            await LoadPlanningOptionsAsync(currentSession);
+            SyncPlanningSelectionFromCurrentItem();
 
             operationSeverity = Severity.Success;
             operationMessage = currentSession.Progress.TotalItems == 0
@@ -355,6 +389,7 @@ public partial class Triage : ComponentBase
 
             var labelledSession = await TriageService.ApplyLabelToCurrentItemAsync(currentSession, labelName);
             currentSession = await TriageService.AdvanceSessionAsync(labelledSession);
+            SyncPlanningSelectionFromCurrentItem();
 
             operationSeverity = Severity.Success;
             operationMessage = currentSession.CurrentItem is null
@@ -394,6 +429,7 @@ public partial class Triage : ComponentBase
         {
             var completedItemNumber = currentSession.CurrentItem.Number;
             currentSession = await TriageService.AdvanceSessionAsync(currentSession);
+            SyncPlanningSelectionFromCurrentItem();
             operationSeverity = Severity.Info;
             operationMessage = currentSession.CurrentItem is null
                 ? $"Moved past item #{completedItemNumber} without changes. Reached the end of the current queue."
@@ -405,6 +441,134 @@ public partial class Triage : ComponentBase
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while moving to the next item without changes.";
             Snackbar.Add("Could not move to the next item without changes.", Severity.Error);
+        }
+        finally
+        {
+            isApplyingSessionAction = false;
+        }
+    }
+
+    private Task OnSelectedMilestoneChangedAsync(int? milestoneNumber)
+    {
+        selectedMilestoneNumber = milestoneNumber;
+        return Task.CompletedTask;
+    }
+
+    private Task OnSelectedProjectBoardChangedAsync(string projectBoardId)
+    {
+        selectedProjectBoardId = projectBoardId ?? string.Empty;
+
+        if (ActiveProjectBoardStatusOptions.Count == 0)
+        {
+            selectedProjectBoardStatusOptionId = string.Empty;
+            return Task.CompletedTask;
+        }
+
+        if (!ActiveProjectBoardStatusOptions.Any(option => option.Id.Equals(selectedProjectBoardStatusOptionId, StringComparison.Ordinal)))
+        {
+            selectedProjectBoardStatusOptionId = ActiveProjectBoardStatusOptions[0].Id;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private Task OnSelectedProjectBoardStatusOptionChangedAsync(string statusOptionId)
+    {
+        selectedProjectBoardStatusOptionId = statusOptionId ?? string.Empty;
+        return Task.CompletedTask;
+    }
+
+    private async Task AssignSelectedMilestoneAsync()
+    {
+        if (currentSession is null || CurrentItem is null || !CanAssignMilestone)
+        {
+            return;
+        }
+
+        isApplyingSessionAction = true;
+
+        try
+        {
+            var selectedMilestoneTitle = availableMilestoneOptions
+                .FirstOrDefault(option => option.Number == selectedMilestoneNumber)
+                ?.Title;
+
+            currentSession = await TriageService.AssignMilestoneToCurrentItemAsync(
+                currentSession,
+                selectedMilestoneNumber,
+                selectedMilestoneTitle);
+
+            SyncPlanningSelectionFromCurrentItem();
+
+            operationSeverity = Severity.Success;
+            operationMessage = selectedMilestoneNumber is null
+                ? $"Cleared milestone assignment for item #{CurrentItem.Number}."
+                : $"Assigned milestone '{selectedMilestoneTitle}' to item #{CurrentItem.Number}.";
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while assigning milestone to triage item.");
+            operationSeverity = Severity.Error;
+            operationMessage = $"GitHub API request failed while assigning milestone. {ex.Message}";
+            Snackbar.Add("Could not assign the selected milestone due to a GitHub API error.", Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to assign milestone to the current triage item.");
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while assigning the selected milestone.";
+            Snackbar.Add("Could not assign the selected milestone.", Severity.Error);
+        }
+        finally
+        {
+            isApplyingSessionAction = false;
+        }
+    }
+
+    private async Task AddCurrentItemToProjectBoardAsync()
+    {
+        if (currentSession is null || CurrentItem is null || !CanAddToProjectBoard || ActiveProjectBoard is null)
+        {
+            return;
+        }
+
+        var selectedStatusOption = ActiveProjectBoardStatusOptions
+            .FirstOrDefault(option => option.Id.Equals(selectedProjectBoardStatusOptionId, StringComparison.Ordinal));
+
+        if (selectedStatusOption is null)
+        {
+            return;
+        }
+
+        isApplyingSessionAction = true;
+
+        try
+        {
+            var currentItemNumber = CurrentItem.Number;
+            currentSession = await TriageService.AddCurrentItemToProjectBoardAsync(
+                currentSession,
+                ActiveProjectBoard.Id,
+                ActiveProjectBoard.Title,
+                ActiveProjectBoard.StatusFieldId,
+                selectedStatusOption.Id,
+                selectedStatusOption.Name);
+
+            operationSeverity = Severity.Success;
+            operationMessage = $"Added item #{currentItemNumber} to '{ActiveProjectBoard.Title}' with status '{selectedStatusOption.Name}'.";
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while adding triage item to project board.");
+            operationSeverity = Severity.Error;
+            operationMessage = $"GitHub API request failed while adding to project board. {ex.Message}";
+            Snackbar.Add("Could not add the item to the selected project board due to a GitHub API error.", Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to add the current triage item to a project board.");
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while adding this item to a project board.";
+            Snackbar.Add("Could not add the item to the selected project board.", Severity.Error);
         }
         finally
         {
@@ -424,6 +588,7 @@ public partial class Triage : ComponentBase
         try
         {
             currentSession = await TriageService.RevisitSkippedItemsAsync(currentSession);
+            SyncPlanningSelectionFromCurrentItem();
             operationSeverity = Severity.Info;
             operationMessage = "Skipped items were appended to the queue for review.";
         }
@@ -437,6 +602,111 @@ public partial class Triage : ComponentBase
         finally
         {
             isApplyingSessionAction = false;
+        }
+    }
+
+    private async Task LoadPlanningOptionsAsync(TriageSessionDto session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        isLoadingPlanningOptions = true;
+
+        var milestoneLoadFailed = false;
+
+        try
+        {
+            availableMilestoneOptions = await TriageService.GetMilestoneOptionsAsync(session);
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while loading milestone options for triage.");
+            availableMilestoneOptions = [];
+            milestoneLoadFailed = true;
+            operationSeverity = Severity.Error;
+            operationMessage = $"GitHub API request failed while loading milestone options. {ex.Message}";
+            Snackbar.Add("Failed to load milestone options for triage.", Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load milestone options for triage.");
+            availableMilestoneOptions = [];
+            milestoneLoadFailed = true;
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while loading milestone options.";
+            Snackbar.Add("An unexpected error occurred while loading milestone options.", Severity.Error);
+        }
+
+        try
+        {
+            availableProjectBoardOptions = await TriageService.GetProjectBoardOptionsAsync(session);
+
+            if (!availableProjectBoardOptions.Any(option => option.Id.Equals(selectedProjectBoardId, StringComparison.Ordinal)))
+            {
+                selectedProjectBoardId = availableProjectBoardOptions.FirstOrDefault()?.Id ?? string.Empty;
+            }
+
+            if (ActiveProjectBoardStatusOptions.Count == 0)
+            {
+                selectedProjectBoardStatusOptionId = string.Empty;
+                return;
+            }
+
+            if (!ActiveProjectBoardStatusOptions.Any(option => option.Id.Equals(selectedProjectBoardStatusOptionId, StringComparison.Ordinal)))
+            {
+                selectedProjectBoardStatusOptionId = ActiveProjectBoardStatusOptions[0].Id;
+            }
+
+            if (milestoneLoadFailed)
+            {
+                return;
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while loading project-board options for triage.");
+            availableProjectBoardOptions = [];
+            selectedProjectBoardId = string.Empty;
+            selectedProjectBoardStatusOptionId = string.Empty;
+
+            if (!milestoneLoadFailed)
+            {
+                operationSeverity = Severity.Warning;
+                operationMessage = $"Milestones loaded, but project-board options could not be loaded. {ex.Message}";
+                Snackbar.Add("Failed to load project-board options for triage.", Severity.Warning);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load project-board options for triage.");
+            availableProjectBoardOptions = [];
+            selectedProjectBoardId = string.Empty;
+            selectedProjectBoardStatusOptionId = string.Empty;
+
+            if (!milestoneLoadFailed)
+            {
+                operationSeverity = Severity.Warning;
+                operationMessage = "Milestones loaded, but an unexpected error occurred while loading project-board options.";
+                Snackbar.Add("An unexpected error occurred while loading project-board options.", Severity.Warning);
+            }
+        }
+        finally
+        {
+            isLoadingPlanningOptions = false;
+        }
+    }
+
+    private void SyncPlanningSelectionFromCurrentItem()
+    {
+        selectedMilestoneNumber = CurrentItem?.MilestoneNumber;
+
+        if (!availableProjectBoardOptions.Any(option => option.Id.Equals(selectedProjectBoardId, StringComparison.Ordinal)))
+        {
+            selectedProjectBoardId = availableProjectBoardOptions.FirstOrDefault()?.Id ?? string.Empty;
+        }
+
+        if (!ActiveProjectBoardStatusOptions.Any(option => option.Id.Equals(selectedProjectBoardStatusOptionId, StringComparison.Ordinal)))
+        {
+            selectedProjectBoardStatusOptionId = ActiveProjectBoardStatusOptions.FirstOrDefault()?.Id ?? string.Empty;
         }
     }
 

--- a/src/Application/SoloDevBoard.Application/Services/GitHub/IGitHubService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/GitHub/IGitHubService.cs
@@ -118,6 +118,27 @@ public interface IGitHubService
     /// <returns>The created project-item node identifier.</returns>
     Task<string> AddTriageItemToProjectBoardAsync(string owner, string repo, int itemNumber, string projectId, CancellationToken cancellationToken = default);
 
+    /// <summary>Retrieves GitHub Project v2 boards available for a repository with status options.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A read-only list of project boards that expose a status field.</returns>
+    Task<IReadOnlyList<TriageProjectBoard>> GetProjectBoardsForRepositoryAsync(string owner, string repo, CancellationToken cancellationToken = default);
+
+    /// <summary>Updates the status field for a project board item.</summary>
+    /// <param name="projectId">The project-board node identifier.</param>
+    /// <param name="projectItemId">The project-item node identifier.</param>
+    /// <param name="statusFieldId">The project status-field node identifier.</param>
+    /// <param name="statusOptionId">The selected status-option node identifier.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous status update operation.</returns>
+    Task UpdateProjectBoardItemStatusAsync(
+        string projectId,
+        string projectItemId,
+        string statusFieldId,
+        string statusOptionId,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Closes a triage item as duplicate and records a duplicate reference comment.</summary>
     /// <param name="owner">The GitHub account owner login.</param>
     /// <param name="repo">The repository name.</param>

--- a/src/Application/SoloDevBoard.Application/Services/Triage/ITriageService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/ITriageService.cs
@@ -37,6 +37,44 @@ public interface ITriageService
     /// <returns>The updated triage session DTO.</returns>
     Task<TriageSessionDto> ApplyLabelToCurrentItemAsync(TriageSessionDto session, string labelName, CancellationToken cancellationToken = default);
 
+    /// <summary>Retrieves milestone options for the repository in the active triage session.</summary>
+    /// <param name="session">The current session state.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A read-only list of milestone options sorted by title.</returns>
+    Task<IReadOnlyList<TriageMilestoneOptionDto>> GetMilestoneOptionsAsync(TriageSessionDto session, CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves project-board options for the repository in the active triage session.</summary>
+    /// <param name="session">The current session state.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A read-only list of project-board options sorted by title.</returns>
+    Task<IReadOnlyList<TriageProjectBoardOptionDto>> GetProjectBoardOptionsAsync(TriageSessionDto session, CancellationToken cancellationToken = default);
+
+    /// <summary>Assigns or clears a milestone on the current session item.</summary>
+    /// <param name="session">The current session state.</param>
+    /// <param name="milestoneNumber">The milestone number to assign, or <see langword="null"/> to clear.</param>
+    /// <param name="milestoneTitle">The milestone title associated with <paramref name="milestoneNumber"/>.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The updated triage session DTO.</returns>
+    Task<TriageSessionDto> AssignMilestoneToCurrentItemAsync(TriageSessionDto session, int? milestoneNumber, string? milestoneTitle, CancellationToken cancellationToken = default);
+
+    /// <summary>Adds the current session item to a project board and sets its status.</summary>
+    /// <param name="session">The current session state.</param>
+    /// <param name="projectId">The project-board node identifier.</param>
+    /// <param name="projectTitle">The project-board display title.</param>
+    /// <param name="statusFieldId">The project status-field node identifier.</param>
+    /// <param name="statusOptionId">The selected project status-option node identifier.</param>
+    /// <param name="statusOptionName">The selected project status-option display name.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The updated triage session DTO.</returns>
+    Task<TriageSessionDto> AddCurrentItemToProjectBoardAsync(
+        TriageSessionDto session,
+        string projectId,
+        string projectTitle,
+        string statusFieldId,
+        string statusOptionId,
+        string statusOptionName,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Builds the latest triage session summary from current session state.</summary>
     /// <param name="session">The current session state.</param>
     /// <returns>The computed triage session summary DTO.</returns>

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageMilestoneOptionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageMilestoneOptionDto.cs
@@ -1,0 +1,6 @@
+namespace SoloDevBoard.Application.Services.Triage;
+
+/// <summary>Represents a milestone option available for triage assignment.</summary>
+/// <param name="Number">The repository-scoped milestone number.</param>
+/// <param name="Title">The milestone title.</param>
+public sealed record TriageMilestoneOptionDto(int Number, string Title);

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageProjectBoardOptionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageProjectBoardOptionDto.cs
@@ -1,0 +1,14 @@
+namespace SoloDevBoard.Application.Services.Triage;
+
+/// <summary>Represents a project-board option available for triage placement.</summary>
+/// <param name="Id">The GitHub node identifier for the project board.</param>
+/// <param name="Title">The project board title.</param>
+/// <param name="OwnerLogin">The login of the project owner.</param>
+/// <param name="StatusFieldId">The project status-field node identifier.</param>
+/// <param name="StatusOptions">The selectable project status options.</param>
+public sealed record TriageProjectBoardOptionDto(
+    string Id,
+    string Title,
+    string OwnerLogin,
+    string StatusFieldId,
+    IReadOnlyList<TriageProjectBoardStatusOptionDto> StatusOptions);

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageProjectBoardStatusOptionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageProjectBoardStatusOptionDto.cs
@@ -1,0 +1,6 @@
+namespace SoloDevBoard.Application.Services.Triage;
+
+/// <summary>Represents a project-board status option at the Application→App boundary.</summary>
+/// <param name="Id">The GitHub node identifier for the status option.</param>
+/// <param name="Name">The display name for the status option.</param>
+public sealed record TriageProjectBoardStatusOptionDto(string Id, string Name);

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
@@ -218,6 +218,180 @@ public sealed class TriageService : ITriageService
     }
 
     /// <inheritdoc/>
+    public async Task<IReadOnlyList<TriageMilestoneOptionDto>> GetMilestoneOptionsAsync(TriageSessionDto session, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(session);
+
+        var milestones = await _gitHubService
+            .GetMilestonesAsync(session.OwnerLogin, session.RepositoryName, cancellationToken)
+            .ConfigureAwait(false);
+
+        return milestones
+            .Where(milestone => milestone.Number > 0)
+            .Select(milestone => new TriageMilestoneOptionDto(milestone.Number, milestone.Title))
+            .OrderBy(option => option.Title, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<TriageProjectBoardOptionDto>> GetProjectBoardOptionsAsync(TriageSessionDto session, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(session);
+
+        var projectBoards = await _gitHubService
+            .GetProjectBoardsForRepositoryAsync(session.OwnerLogin, session.RepositoryName, cancellationToken)
+            .ConfigureAwait(false);
+
+        return projectBoards
+            .Select(projectBoard => new TriageProjectBoardOptionDto(
+                projectBoard.Id,
+                projectBoard.Title,
+                projectBoard.OwnerLogin,
+                projectBoard.StatusFieldId,
+                projectBoard.StatusOptions
+                    .Select(status => new TriageProjectBoardStatusOptionDto(status.Id, status.Name))
+                    .OrderBy(option => option.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToArray()))
+            .OrderBy(projectBoard => projectBoard.Title, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    /// <inheritdoc/>
+    public async Task<TriageSessionDto> AssignMilestoneToCurrentItemAsync(TriageSessionDto session, int? milestoneNumber, string? milestoneTitle, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(session);
+
+        if (milestoneNumber is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(milestoneNumber), "Milestone number must be greater than zero when provided.");
+        }
+
+        var domainSession = ToDomain(session);
+        if (domainSession.CurrentIndex >= domainSession.Queue.Count)
+        {
+            return ToDto(domainSession);
+        }
+
+        var currentItem = domainSession.Queue[domainSession.CurrentIndex];
+        if (!TryParseRepositoryScope(currentItem.RepositoryFullName, out var owner, out var repo))
+        {
+            throw new ArgumentException(
+                $"Repository scope '{currentItem.RepositoryFullName}' must be in owner/repository format.",
+                nameof(session));
+        }
+
+        await _gitHubService
+            .AssignMilestoneToTriageItemAsync(owner, repo, currentItem.Number, milestoneNumber, cancellationToken)
+            .ConfigureAwait(false);
+
+        var normalisedMilestoneTitle = milestoneNumber is null
+            ? string.Empty
+            : milestoneTitle?.Trim() ?? string.Empty;
+
+        var updatedCurrentItem = currentItem with
+        {
+            Milestone = milestoneNumber is null
+                ? null
+                : new SoloDevBoard.Domain.Entities.Milestones.Milestone
+                {
+                    Number = milestoneNumber.Value,
+                    Title = normalisedMilestoneTitle,
+                },
+        };
+
+        var updatedQueue = domainSession.Queue
+            .Select((item, index) => index == domainSession.CurrentIndex ? updatedCurrentItem : item)
+            .ToArray();
+
+        var detail = milestoneNumber is null
+            ? "Cleared milestone assignment."
+            : $"Assigned milestone '{normalisedMilestoneTitle}'.";
+
+        var action = new TriageAction
+        {
+            ActionType = TriageActionType.MilestoneAssigned,
+            ItemType = currentItem.ItemType,
+            ItemNumber = currentItem.Number,
+            RepositoryFullName = currentItem.RepositoryFullName,
+            Detail = detail,
+            OccurredAt = DateTimeOffset.UtcNow,
+        };
+
+        var updatedActionHistory = domainSession.ActionHistory
+            .Concat([action])
+            .ToArray();
+
+        return UpdateSessionState(domainSession with
+        {
+            Queue = updatedQueue,
+            ActionHistory = updatedActionHistory,
+        });
+    }
+
+    /// <inheritdoc/>
+    public async Task<TriageSessionDto> AddCurrentItemToProjectBoardAsync(
+        TriageSessionDto session,
+        string projectId,
+        string projectTitle,
+        string statusFieldId,
+        string statusOptionId,
+        string statusOptionName,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectTitle);
+        ArgumentException.ThrowIfNullOrWhiteSpace(statusFieldId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(statusOptionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(statusOptionName);
+
+        var domainSession = ToDomain(session);
+        if (domainSession.CurrentIndex >= domainSession.Queue.Count)
+        {
+            return ToDto(domainSession);
+        }
+
+        var currentItem = domainSession.Queue[domainSession.CurrentIndex];
+        if (!TryParseRepositoryScope(currentItem.RepositoryFullName, out var owner, out var repo))
+        {
+            throw new ArgumentException(
+                $"Repository scope '{currentItem.RepositoryFullName}' must be in owner/repository format.",
+                nameof(session));
+        }
+
+        var projectItemId = await _gitHubService
+            .AddTriageItemToProjectBoardAsync(owner, repo, currentItem.Number, projectId, cancellationToken)
+            .ConfigureAwait(false);
+
+        await _gitHubService
+            .UpdateProjectBoardItemStatusAsync(projectId, projectItemId, statusFieldId, statusOptionId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var action = new TriageAction
+        {
+            ActionType = TriageActionType.ProjectBoardAssigned,
+            ItemType = currentItem.ItemType,
+            ItemNumber = currentItem.Number,
+            RepositoryFullName = currentItem.RepositoryFullName,
+            Detail = $"Added to project board '{projectTitle.Trim()}' with status '{statusOptionName.Trim()}'.",
+            OccurredAt = DateTimeOffset.UtcNow,
+        };
+
+        var updatedActionHistory = domainSession.ActionHistory
+            .Concat([action])
+            .ToArray();
+
+        return UpdateSessionState(domainSession with
+        {
+            ActionHistory = updatedActionHistory,
+        });
+    }
+
+    /// <inheritdoc/>
     public TriageSessionSummaryDto BuildSessionSummary(TriageSessionDto session)
     {
         ArgumentNullException.ThrowIfNull(session);

--- a/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageProjectBoard.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageProjectBoard.cs
@@ -1,0 +1,20 @@
+namespace SoloDevBoard.Domain.Entities.Triage;
+
+/// <summary>Represents a GitHub Project v2 board available for triage placement.</summary>
+public sealed record TriageProjectBoard
+{
+    /// <summary>Gets the GitHub node identifier for the project board.</summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Gets the project board title.</summary>
+    public string Title { get; init; } = string.Empty;
+
+    /// <summary>Gets the login of the project owner.</summary>
+    public string OwnerLogin { get; init; } = string.Empty;
+
+    /// <summary>Gets the status field node identifier for the board.</summary>
+    public string StatusFieldId { get; init; } = string.Empty;
+
+    /// <summary>Gets the available status options for the board.</summary>
+    public IReadOnlyList<TriageProjectBoardStatusOption> StatusOptions { get; init; } = [];
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageProjectBoardStatusOption.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageProjectBoardStatusOption.cs
@@ -1,0 +1,11 @@
+namespace SoloDevBoard.Domain.Entities.Triage;
+
+/// <summary>Represents a selectable status option within a GitHub Project v2 status field.</summary>
+public sealed record TriageProjectBoardStatusOption
+{
+    /// <summary>Gets the GitHub node identifier for the status option.</summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Gets the display name of the status option.</summary>
+    public string Name { get; init; } = string.Empty;
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
@@ -348,6 +348,90 @@ public sealed class GitHubService : IGitHubService
     }
 
     /// <inheritdoc/>
+    public async Task<IReadOnlyList<TriageProjectBoard>> GetProjectBoardsForRepositoryAsync(string owner, string repo, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        const string query = "query TriageProjectBoards($owner: String!, $repo: String!) { repository(owner: $owner, name: $repo) { projectsV2(first: 50) { nodes { id title owner { ... on User { login } ... on Organization { login } } fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } } }";
+
+        var client = CreateAuthenticatedClient();
+        var requestBody = new GraphQlRequestDto(
+            query,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["owner"] = owner,
+                ["repo"] = repo,
+            });
+
+        using var response = await client.PostAsJsonAsync("/graphql", requestBody, JsonOptions, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var payload = await response.Content.ReadFromJsonAsync<GetProjectBoardsResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw CreateInvalidResponseException("GraphQL response body was empty.", "/graphql");
+
+        if (payload.Errors.Count > 0)
+        {
+            var combinedErrors = string.Join("; ", payload.Errors.Select(static error => error.Message));
+            throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
+        }
+
+        var nodes = payload.Data?.Repository?.ProjectsV2?.Nodes ?? [];
+
+        return nodes
+            .Select(ToProjectBoardDomain)
+            .Where(static projectBoard => projectBoard is not null)
+            .Select(static projectBoard => projectBoard!)
+            .OrderBy(projectBoard => projectBoard.Title, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    /// <inheritdoc/>
+    public async Task UpdateProjectBoardItemStatusAsync(
+        string projectId,
+        string projectItemId,
+        string statusFieldId,
+        string statusOptionId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectItemId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(statusFieldId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(statusOptionId);
+
+        const string mutation = "mutation SetProjectV2Status($projectId: ID!, $itemId: ID!, $fieldId: ID!, $statusOptionId: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { singleSelectOptionId: $statusOptionId } }) { projectV2Item { id } } }";
+
+        var client = CreateAuthenticatedClient();
+        var requestBody = new GraphQlRequestDto(
+            mutation,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["projectId"] = projectId,
+                ["itemId"] = projectItemId,
+                ["fieldId"] = statusFieldId,
+                ["statusOptionId"] = statusOptionId,
+            });
+
+        using var response = await client.PostAsJsonAsync("/graphql", requestBody, JsonOptions, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var payload = await response.Content.ReadFromJsonAsync<UpdateProjectBoardItemStatusResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw CreateInvalidResponseException("GraphQL response body was empty.", "/graphql");
+
+        if (payload.Errors.Count > 0)
+        {
+            var combinedErrors = string.Join("; ", payload.Errors.Select(static error => error.Message));
+            throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
+        }
+
+        var updatedItemId = payload.Data?.UpdateProjectV2ItemFieldValue?.ProjectV2Item?.Id;
+        if (string.IsNullOrWhiteSpace(updatedItemId))
+        {
+            throw CreateInvalidResponseException("GraphQL response did not contain the updated project item identifier.", "/graphql");
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task CloseTriageItemAsDuplicateAsync(string owner, string repo, GitHubTriageItemType itemType, int itemNumber, string duplicateReference, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
@@ -428,6 +512,47 @@ public sealed class GitHubService : IGitHubService
             $"GitHub API request failed with status code {(int)response.StatusCode} ({response.StatusCode}). Response body: {responseBody}",
             null,
             response.StatusCode);
+    }
+
+    private static TriageProjectBoard? ToProjectBoardDomain(ProjectBoardNodeDto node)
+    {
+        if (string.IsNullOrWhiteSpace(node.Id) || string.IsNullOrWhiteSpace(node.Title))
+        {
+            return null;
+        }
+
+        var statusField = node.Fields?.Nodes
+            .FirstOrDefault(field =>
+                !string.IsNullOrWhiteSpace(field.Id)
+                && field.Name.Equals("Status", StringComparison.OrdinalIgnoreCase));
+
+        if (statusField is null || string.IsNullOrWhiteSpace(statusField.Id))
+        {
+            return null;
+        }
+
+        var statusOptions = statusField.Options
+            .Where(option => !string.IsNullOrWhiteSpace(option.Id) && !string.IsNullOrWhiteSpace(option.Name))
+            .Select(option => new TriageProjectBoardStatusOption
+            {
+                Id = option.Id,
+                Name = option.Name,
+            })
+            .ToArray();
+
+        if (statusOptions.Length == 0)
+        {
+            return null;
+        }
+
+        return new TriageProjectBoard
+        {
+            Id = node.Id,
+            Title = node.Title,
+            OwnerLogin = node.Owner?.Login ?? string.Empty,
+            StatusFieldId = statusField.Id,
+            StatusOptions = statusOptions,
+        };
     }
 
     /// <summary>Creates an <see cref="HttpRequestException"/> describing an unexpected or empty API response body.</summary>
@@ -963,6 +1088,121 @@ public sealed class GitHubService : IGitHubService
 
     /// <summary>DTO for GraphQL mutation item payload.</summary>
     private sealed record AddProjectV2ItemPayloadItemDto
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = string.Empty;
+    }
+
+    /// <summary>DTO wrapper for GraphQL get-project-board responses.</summary>
+    private sealed record GetProjectBoardsResponseDto
+    {
+        [JsonPropertyName("data")]
+        public GetProjectBoardsDataDto? Data { get; init; }
+
+        [JsonPropertyName("errors")]
+        public IReadOnlyList<GraphQlErrorDto> Errors { get; init; } = [];
+    }
+
+    /// <summary>DTO for GraphQL project-board data payload.</summary>
+    private sealed record GetProjectBoardsDataDto
+    {
+        [JsonPropertyName("repository")]
+        public RepositoryProjectBoardsDto? Repository { get; init; }
+    }
+
+    /// <summary>DTO for repository project-board data.</summary>
+    private sealed record RepositoryProjectBoardsDto
+    {
+        [JsonPropertyName("projectsV2")]
+        public ProjectBoardConnectionDto? ProjectsV2 { get; init; }
+    }
+
+    /// <summary>DTO for project-board GraphQL connections.</summary>
+    private sealed record ProjectBoardConnectionDto
+    {
+        [JsonPropertyName("nodes")]
+        public IReadOnlyList<ProjectBoardNodeDto> Nodes { get; init; } = [];
+    }
+
+    /// <summary>DTO for project-board nodes.</summary>
+    private sealed record ProjectBoardNodeDto
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = string.Empty;
+
+        [JsonPropertyName("title")]
+        public string Title { get; init; } = string.Empty;
+
+        [JsonPropertyName("owner")]
+        public GraphQlOwnerDto? Owner { get; init; }
+
+        [JsonPropertyName("fields")]
+        public ProjectBoardFieldConnectionDto? Fields { get; init; }
+    }
+
+    /// <summary>DTO for GraphQL owner payloads.</summary>
+    private sealed record GraphQlOwnerDto
+    {
+        [JsonPropertyName("login")]
+        public string Login { get; init; } = string.Empty;
+    }
+
+    /// <summary>DTO for project-board field connections.</summary>
+    private sealed record ProjectBoardFieldConnectionDto
+    {
+        [JsonPropertyName("nodes")]
+        public IReadOnlyList<ProjectBoardSingleSelectFieldDto> Nodes { get; init; } = [];
+    }
+
+    /// <summary>DTO for project-board single-select status fields.</summary>
+    private sealed record ProjectBoardSingleSelectFieldDto
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = string.Empty;
+
+        [JsonPropertyName("options")]
+        public IReadOnlyList<ProjectBoardSingleSelectOptionDto> Options { get; init; } = [];
+    }
+
+    /// <summary>DTO for project-board single-select status options.</summary>
+    private sealed record ProjectBoardSingleSelectOptionDto
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = string.Empty;
+    }
+
+    /// <summary>DTO wrapper for GraphQL update-project-item-status responses.</summary>
+    private sealed record UpdateProjectBoardItemStatusResponseDto
+    {
+        [JsonPropertyName("data")]
+        public UpdateProjectBoardItemStatusDataDto? Data { get; init; }
+
+        [JsonPropertyName("errors")]
+        public IReadOnlyList<GraphQlErrorDto> Errors { get; init; } = [];
+    }
+
+    /// <summary>DTO for update-project-item-status GraphQL data payload.</summary>
+    private sealed record UpdateProjectBoardItemStatusDataDto
+    {
+        [JsonPropertyName("updateProjectV2ItemFieldValue")]
+        public UpdateProjectBoardItemStatusPayloadDto? UpdateProjectV2ItemFieldValue { get; init; }
+    }
+
+    /// <summary>DTO for update-project-item-status GraphQL payload.</summary>
+    private sealed record UpdateProjectBoardItemStatusPayloadDto
+    {
+        [JsonPropertyName("projectV2Item")]
+        public UpdateProjectBoardItemStatusItemDto? ProjectV2Item { get; init; }
+    }
+
+    /// <summary>DTO for update-project-item-status GraphQL item payload.</summary>
+    private sealed record UpdateProjectBoardItemStatusItemDto
     {
         [JsonPropertyName("id")]
         public string Id { get; init; } = string.Empty;

--- a/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
@@ -530,6 +530,173 @@ public sealed class TriageTests
             Times.Never);
     }
 
+    [Fact]
+    public async Task Triage_AssignMilestoneClicked_AssignsMilestoneAndShowsSuccessMessage()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [CreateItem(501, "Issue 501", "owner/repo")],
+            currentIndex: 0,
+            skippedItems: []);
+
+        var milestoneAssignedSession = startedSession with
+        {
+            Queue =
+            [
+                startedSession.Queue[0] with
+                {
+                    MilestoneNumber = 7,
+                    MilestoneTitle = "v0.7.0",
+                },
+            ],
+            ActionHistory =
+            [
+                new TriageActionDto(TriageActionTypeDto.MilestoneAssigned, TriageItemTypeDto.Issue, 501, "owner/repo", "Assigned milestone 'v0.7.0'.", DateTimeOffset.UtcNow),
+            ],
+            Summary = new TriageSessionSummaryDto(1, 0, 1, 0, 0, 1, 0, 0),
+        };
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.GetMilestoneOptionsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new TriageMilestoneOptionDto(7, "v0.7.0")]);
+
+        _triageServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _triageServiceMock
+            .Setup(service => service.AssignMilestoneToCurrentItemAsync(It.IsAny<TriageSessionDto>(), 7, "v0.7.0", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(milestoneAssignedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+        cut.WaitForAssertion(() => Assert.Contains("Issue 501", cut.Markup));
+
+        var milestoneSelect = cut
+            .FindComponents<MudSelect<int?>>()
+            .Single(component => string.Equals(component.Instance.Label, "Milestone", StringComparison.Ordinal));
+
+        await cut.InvokeAsync(() => milestoneSelect.Instance.ValueChanged.InvokeAsync(7));
+        cut.Find("[data-testid='triage-assign-milestone-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Assigned milestone 'v0.7.0' to item #501", cut.Markup, StringComparison.Ordinal);
+        });
+
+        _triageServiceMock.Verify(
+            service => service.AssignMilestoneToCurrentItemAsync(It.IsAny<TriageSessionDto>(), 7, "v0.7.0", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Triage_AddToProjectBoardClicked_AddsItemAndShowsSuccessMessage()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [CreateItem(601, "Issue 601", "owner/repo")],
+            currentIndex: 0,
+            skippedItems: []);
+
+        var updatedSession = startedSession with
+        {
+            ActionHistory =
+            [
+                new TriageActionDto(TriageActionTypeDto.ProjectBoardAssigned, TriageItemTypeDto.Issue, 601, "owner/repo", "Added to project board 'Roadmap' with status 'In Progress'.", DateTimeOffset.UtcNow),
+            ],
+            Summary = new TriageSessionSummaryDto(1, 0, 1, 0, 0, 0, 1, 0),
+        };
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.GetMilestoneOptionsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _triageServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new TriageProjectBoardOptionDto(
+                    "project-id",
+                    "Roadmap",
+                    "owner",
+                    "status-field-id",
+                    [
+                        new TriageProjectBoardStatusOptionDto("in-progress", "In Progress"),
+                        new TriageProjectBoardStatusOptionDto("done", "Done"),
+                    ]),
+            ]);
+
+        _triageServiceMock
+            .Setup(service => service.AddCurrentItemToProjectBoardAsync(
+                It.IsAny<TriageSessionDto>(),
+                "project-id",
+                "Roadmap",
+                "status-field-id",
+                "in-progress",
+                "In Progress",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updatedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+        cut.WaitForAssertion(() => Assert.Contains("Issue 601", cut.Markup));
+
+        cut.Find("[data-testid='triage-add-to-project-board-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Added item #601 to 'Roadmap' with status 'In Progress'", cut.Markup, StringComparison.Ordinal);
+        });
+
+        _triageServiceMock.Verify(
+            service => service.AddCurrentItemToProjectBoardAsync(
+                It.IsAny<TriageSessionDto>(),
+                "project-id",
+                "Roadmap",
+                "status-field-id",
+                "in-progress",
+                "In Progress",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private static async Task SelectQuickLabelAsync(IRenderedComponent<Triage> cut, string labelName)
     {
         ArgumentNullException.ThrowIfNull(cut);
@@ -692,6 +859,12 @@ public sealed class TriageTests
 
         var ctx = new BunitContext();
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        _triageServiceMock
+            .SetReturnsDefault(Task.FromResult<IReadOnlyList<TriageMilestoneOptionDto>>(Array.Empty<TriageMilestoneOptionDto>()));
+        _triageServiceMock
+            .SetReturnsDefault(Task.FromResult<IReadOnlyList<TriageProjectBoardOptionDto>>(Array.Empty<TriageProjectBoardOptionDto>()));
+
         ctx.Services.AddMudServices();
         ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
         ctx.Services.AddScoped(_ => _triageServiceMock.Object);

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
@@ -276,6 +276,133 @@ public sealed class TriageServiceTests
     }
 
     [Fact]
+    public async Task GetMilestoneOptionsAsync_MilestonesReturned_ReturnsSortedOptions()
+    {
+        // Arrange
+        _gitHubServiceMock
+            .Setup(service => service.GetMilestonesAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new SoloDevBoard.Domain.Entities.Milestones.Milestone { Number = 3, Title = "v0.3.0" },
+                new SoloDevBoard.Domain.Entities.Milestones.Milestone { Number = 1, Title = "v0.1.0" },
+            ]);
+
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var session = CreateSession(queueCount: 1, currentIndex: 0);
+
+        // Act
+        var result = await sut.GetMilestoneOptionsAsync(session);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, result[0].Number);
+        Assert.Equal("v0.1.0", result[0].Title);
+        Assert.Equal(3, result[1].Number);
+    }
+
+    [Fact]
+    public async Task GetProjectBoardOptionsAsync_ProjectBoardsReturned_ReturnsSortedOptions()
+    {
+        // Arrange
+        _gitHubServiceMock
+            .Setup(service => service.GetProjectBoardsForRepositoryAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new TriageProjectBoard
+                {
+                    Id = "project-two",
+                    Title = "Roadmap",
+                    OwnerLogin = "owner",
+                    StatusFieldId = "status-two",
+                    StatusOptions =
+                    [
+                        new TriageProjectBoardStatusOption { Id = "done", Name = "Done" },
+                        new TriageProjectBoardStatusOption { Id = "in-progress", Name = "In Progress" },
+                    ],
+                },
+                new TriageProjectBoard
+                {
+                    Id = "project-one",
+                    Title = "Backlog",
+                    OwnerLogin = "owner",
+                    StatusFieldId = "status-one",
+                    StatusOptions =
+                    [
+                        new TriageProjectBoardStatusOption { Id = "todo", Name = "Todo" },
+                    ],
+                },
+            ]);
+
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var session = CreateSession(queueCount: 1, currentIndex: 0);
+
+        // Act
+        var result = await sut.GetProjectBoardOptionsAsync(session);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Backlog", result[0].Title);
+        Assert.Equal("Roadmap", result[1].Title);
+        Assert.Equal("Done", result[1].StatusOptions[0].Name);
+        Assert.Equal("In Progress", result[1].StatusOptions[1].Name);
+    }
+
+    [Fact]
+    public async Task AssignMilestoneToCurrentItemAsync_ValidMilestone_AssignsMilestoneAndRecordsAction()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var session = CreateSession(queueCount: 1, currentIndex: 0);
+
+        // Act
+        var result = await sut.AssignMilestoneToCurrentItemAsync(session, 12, "v1.2.0");
+
+        // Assert
+        Assert.Equal(12, result.Queue[0].MilestoneNumber);
+        Assert.Equal("v1.2.0", result.Queue[0].MilestoneTitle);
+        Assert.Single(result.ActionHistory);
+        Assert.Equal(TriageActionTypeDto.MilestoneAssigned, result.ActionHistory[0].ActionType);
+        Assert.Equal(1, result.Summary.MilestonesAssignedCount);
+
+        _gitHubServiceMock.Verify(
+            service => service.AssignMilestoneToTriageItemAsync("owner", "repo", 1, 12, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AddCurrentItemToProjectBoardAsync_ValidInput_AddsItemAndUpdatesStatusAndRecordsAction()
+    {
+        // Arrange
+        _gitHubServiceMock
+            .Setup(service => service.AddTriageItemToProjectBoardAsync("owner", "repo", 1, "project-id", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("project-item-id");
+
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var session = CreateSession(queueCount: 1, currentIndex: 0);
+
+        // Act
+        var result = await sut.AddCurrentItemToProjectBoardAsync(
+            session,
+            "project-id",
+            "Roadmap",
+            "status-field-id",
+            "in-progress",
+            "In Progress");
+
+        // Assert
+        Assert.Single(result.ActionHistory);
+        Assert.Equal(TriageActionTypeDto.ProjectBoardAssigned, result.ActionHistory[0].ActionType);
+        Assert.Contains("Roadmap", result.ActionHistory[0].Detail, StringComparison.Ordinal);
+        Assert.Contains("In Progress", result.ActionHistory[0].Detail, StringComparison.Ordinal);
+        Assert.Equal(1, result.Summary.ProjectAssignmentsCount);
+
+        _gitHubServiceMock.Verify(
+            service => service.AddTriageItemToProjectBoardAsync("owner", "repo", 1, "project-id", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _gitHubServiceMock.Verify(
+            service => service.UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public void BuildSessionSummary_ActionHistoryIncludesAllActionTypes_ReturnsComputedCounts()
     {
         // Arrange

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -748,96 +748,96 @@ public sealed class GitHubServiceTests
         Assert.Equal("https://api.github.com/graphql", handler.Requests[1].RequestUri!.ToString());
     }
 
-        [Fact]
-        public async Task GetProjectBoardsForRepositoryAsync_StatusFieldPresent_ReturnsProjectBoardOptions()
-        {
-                // Arrange
-                var handler = new QueueMessageHandler(
-                [
-                        CreateJsonResponse(HttpStatusCode.OK, """
-                        {
-                            "data": {
-                                "repository": {
-                                    "projectsV2": {
+    [Fact]
+    public async Task GetProjectBoardsForRepositoryAsync_StatusFieldPresent_ReturnsProjectBoardOptions()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "projectsV2": {
+                            "nodes": [
+                                {
+                                    "id": "PVT_kwHOAJefG84BQ6bh",
+                                    "title": "Roadmap",
+                                    "owner": { "login": "owner" },
+                                    "fields": {
                                         "nodes": [
                                             {
-                                                "id": "PVT_kwHOAJefG84BQ6bh",
-                                                "title": "Roadmap",
-                                                "owner": { "login": "owner" },
-                                                "fields": {
-                                                    "nodes": [
-                                                        {
-                                                            "id": "PVTF_status",
-                                                            "name": "Status",
-                                                            "options": [
-                                                                { "id": "option-one", "name": "In Progress" },
-                                                                { "id": "option-two", "name": "Done" }
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
+                                                "id": "PVTF_status",
+                                                "name": "Status",
+                                                "options": [
+                                                    { "id": "option-one", "name": "In Progress" },
+                                                    { "id": "option-two", "name": "Done" }
+                                                ]
                                             }
                                         ]
                                     }
                                 }
-                            },
-                            "errors": []
+                            ]
                         }
-                        """),
-                ]);
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
 
-                var sut = CreateSubject(handler);
+        var sut = CreateSubject(handler);
 
-                // Act
-                var result = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo");
+        // Act
+        var result = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo");
 
-                // Assert
-                Assert.Single(result);
-                Assert.Equal("Roadmap", result[0].Title);
-                Assert.Equal("PVTF_status", result[0].StatusFieldId);
-                Assert.Equal(2, result[0].StatusOptions.Count);
-                Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
-                Assert.Equal("https://api.github.com/graphql", handler.Requests[0].RequestUri!.ToString());
-        }
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("Roadmap", result[0].Title);
+        Assert.Equal("PVTF_status", result[0].StatusFieldId);
+        Assert.Equal(2, result[0].StatusOptions.Count);
+        Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+        Assert.Equal("https://api.github.com/graphql", handler.Requests[0].RequestUri!.ToString());
+    }
 
-        [Fact]
-        public async Task UpdateProjectBoardItemStatusAsync_ValidResponse_PostsGraphQlMutation()
-        {
-                // Arrange
-                var handler = new QueueMessageHandler(
-                [
-                        CreateJsonResponse(HttpStatusCode.OK, """
-                        {
-                            "data": {
-                                "updateProjectV2ItemFieldValue": {
-                                    "projectV2Item": {
-                                        "id": "PVTI_lAHOAJefG84BQ6bhzgnrX1A"
-                                    }
-                                }
-                            },
-                            "errors": []
+    [Fact]
+    public async Task UpdateProjectBoardItemStatusAsync_ValidResponse_PostsGraphQlMutation()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "updateProjectV2ItemFieldValue": {
+                        "projectV2Item": {
+                            "id": "PVTI_lAHOAJefG84BQ6bhzgnrX1A"
                         }
-                        """),
-                ]);
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
 
-                var sut = CreateSubject(handler);
+        var sut = CreateSubject(handler);
 
-                // Act
-                await sut.UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress");
+        // Act
+        await sut.UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress");
 
-                // Assert
-                Assert.Single(handler.Requests);
-                Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
-                Assert.Equal("https://api.github.com/graphql", handler.Requests[0].RequestUri!.ToString());
+        // Assert
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+        Assert.Equal("https://api.github.com/graphql", handler.Requests[0].RequestUri!.ToString());
 
-                var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
-                using var document = JsonDocument.Parse(payload);
-                var variables = document.RootElement.GetProperty("variables");
-                Assert.Equal("project-id", variables.GetProperty("projectId").GetString());
-                Assert.Equal("project-item-id", variables.GetProperty("itemId").GetString());
-                Assert.Equal("status-field-id", variables.GetProperty("fieldId").GetString());
-                Assert.Equal("in-progress", variables.GetProperty("statusOptionId").GetString());
-        }
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        var variables = document.RootElement.GetProperty("variables");
+        Assert.Equal("project-id", variables.GetProperty("projectId").GetString());
+        Assert.Equal("project-item-id", variables.GetProperty("itemId").GetString());
+        Assert.Equal("status-field-id", variables.GetProperty("fieldId").GetString());
+        Assert.Equal("in-progress", variables.GetProperty("statusOptionId").GetString());
+    }
 
     [Fact]
     public async Task CloseTriageItemAsDuplicateAsync_Issue_PostsCommentAndClosesIssue()

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -748,6 +748,97 @@ public sealed class GitHubServiceTests
         Assert.Equal("https://api.github.com/graphql", handler.Requests[1].RequestUri!.ToString());
     }
 
+        [Fact]
+        public async Task GetProjectBoardsForRepositoryAsync_StatusFieldPresent_ReturnsProjectBoardOptions()
+        {
+                // Arrange
+                var handler = new QueueMessageHandler(
+                [
+                        CreateJsonResponse(HttpStatusCode.OK, """
+                        {
+                            "data": {
+                                "repository": {
+                                    "projectsV2": {
+                                        "nodes": [
+                                            {
+                                                "id": "PVT_kwHOAJefG84BQ6bh",
+                                                "title": "Roadmap",
+                                                "owner": { "login": "owner" },
+                                                "fields": {
+                                                    "nodes": [
+                                                        {
+                                                            "id": "PVTF_status",
+                                                            "name": "Status",
+                                                            "options": [
+                                                                { "id": "option-one", "name": "In Progress" },
+                                                                { "id": "option-two", "name": "Done" }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "errors": []
+                        }
+                        """),
+                ]);
+
+                var sut = CreateSubject(handler);
+
+                // Act
+                var result = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo");
+
+                // Assert
+                Assert.Single(result);
+                Assert.Equal("Roadmap", result[0].Title);
+                Assert.Equal("PVTF_status", result[0].StatusFieldId);
+                Assert.Equal(2, result[0].StatusOptions.Count);
+                Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+                Assert.Equal("https://api.github.com/graphql", handler.Requests[0].RequestUri!.ToString());
+        }
+
+        [Fact]
+        public async Task UpdateProjectBoardItemStatusAsync_ValidResponse_PostsGraphQlMutation()
+        {
+                // Arrange
+                var handler = new QueueMessageHandler(
+                [
+                        CreateJsonResponse(HttpStatusCode.OK, """
+                        {
+                            "data": {
+                                "updateProjectV2ItemFieldValue": {
+                                    "projectV2Item": {
+                                        "id": "PVTI_lAHOAJefG84BQ6bhzgnrX1A"
+                                    }
+                                }
+                            },
+                            "errors": []
+                        }
+                        """),
+                ]);
+
+                var sut = CreateSubject(handler);
+
+                // Act
+                await sut.UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress");
+
+                // Assert
+                Assert.Single(handler.Requests);
+                Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+                Assert.Equal("https://api.github.com/graphql", handler.Requests[0].RequestUri!.ToString());
+
+                var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+                using var document = JsonDocument.Parse(payload);
+                var variables = document.RootElement.GetProperty("variables");
+                Assert.Equal("project-id", variables.GetProperty("projectId").GetString());
+                Assert.Equal("project-item-id", variables.GetProperty("itemId").GetString());
+                Assert.Equal("status-field-id", variables.GetProperty("fieldId").GetString());
+                Assert.Equal("in-progress", variables.GetProperty("statusOptionId").GetString());
+        }
+
     [Fact]
     public async Task CloseTriageItemAsDuplicateAsync_Issue_PostsCommentAndClosesIssue()
     {


### PR DESCRIPTION
## Summary of Changes

Adds a planning actions panel to the Triage page, allowing the developer to assign a milestone and add the current issue to a GitHub project board column without leaving the triage view.

**New capabilities:**
- Milestone dropdown (loads available milestones for the triaged repository) with a single-click assign action.
- Project board dropdown (loads project boards linked to the repository via GraphQL) with a status selector and add action.
- Milestone and project board options load independently — a boards API failure does not clear milestone data.
- Milestone dropdown shows a descriptive empty-state item when the repository has no milestones, rather than appearing broken.

**Layers changed:**
- **Domain:** `TriageProjectBoard`, `TriageProjectBoardStatusOption` entities.
- **Application:** `TriageMilestoneOptionDto`, `TriageProjectBoardOptionDto`, `TriageProjectBoardStatusOptionDto` DTOs; four new methods on `ITriageService` / `TriageService`.
- **Infrastructure:** `GetProjectBoardsForRepositoryAsync` (GraphQL query) and `UpdateProjectBoardItemStatusAsync` (GraphQL mutation) on `IGitHubService` / `GitHubService`.
- **App:** Planning actions panel in `Triage.razor` / `Triage.razor.cs` using MudBlazor `MudSelect` and `MudButton`.

## Related Issue(s)

Closes #147

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

UI confirmed working via live test in Aspire-hosted environment: milestone list populates correctly, empty-state message shown when no milestones exist, milestone assigned successfully, issue updated as expected.

## Additional Notes

PAT scope `read:project` is required for the GraphQL `projectsV2` query. See `docs/getting-started.md` for local dev setup.