### PR TITLE
feat(triage): close current item as duplicate with reference (#148)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
 		},
 		"ghcr.io/devcontainers/features/powershell:2": {
 			"version": "latest"
-		}
+		},
+		"ghcr.io/markheydon/devcontainer-features/copilot-likes:1": {}
 	},
 
 	"hostRequirements": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,8 +10,7 @@
 		},
 		"ghcr.io/devcontainers/features/powershell:2": {
 			"version": "latest"
-		},
-		"ghcr.io/markheydon/devcontainer-features/copilot-likes:1": {}
+		}
 	},
 
 	"hostRequirements": {

--- a/docs/user-guide/triage-ui.md
+++ b/docs/user-guide/triage-ui.md
@@ -32,13 +32,13 @@ Key features:
 
 ## Quick Label and Duplicate Actions with Keyboard Shortcuts
 
-You can apply labels or close issues as duplicates directly from the Triage UI without leaving the triage view.
+You can apply labels or close items (issues and pull requests) as duplicates directly from the Triage UI without leaving the triage view.
 
 - Use the **Quick Label** search field to find and select a repository label. The field accepts free-text search so you can type any part of a label name.
 - Click **Apply + next** (or press **L**) to apply the selected label and immediately advance to the next item.
 - Click **Next** (or press **N**) to move to the next item without applying a label.
-- To close an issue as a duplicate, use the **Duplicate reference** input to enter the reference number of the original issue, then click **Close as duplicate** (or press **D**) to close the current issue and advance.
-- The **Duplicate reference** input is shown inline when the duplicate action is selected, allowing you to specify the related issue number before confirming the closure.
+- To close the current item as a duplicate, use the **Duplicate reference** input to enter the reference number of the original issue, then click **Close as duplicate** (or press **D**) to close the current item and advance.
+- The **Duplicate reference** input is shown inline in the duplicate closure section, allowing you to specify the related issue number before confirming the closure.
 - Keyboard shortcuts work when the action button row is focused. Typing in the Quick Label or Duplicate reference fields does not trigger shortcuts.
 - Primary success and failure feedback appears inline in the triage view via the operation alert, with additional snackbar notifications used for selected error conditions.
 

--- a/docs/user-guide/triage-ui.md
+++ b/docs/user-guide/triage-ui.md
@@ -29,17 +29,20 @@ Key features:
 5. Use the progress indicator and session context to track your position and the number of remaining items.
 
 
-## Quick Label Actions and Keyboard Shortcuts
 
-You can apply labels to issues directly from the Triage UI without leaving the triage view.
+## Quick Label and Duplicate Actions with Keyboard Shortcuts
+
+You can apply labels or close issues as duplicates directly from the Triage UI without leaving the triage view.
 
 - Use the **Quick Label** search field to find and select a repository label. The field accepts free-text search so you can type any part of a label name.
 - Click **Apply + next** (or press **L**) to apply the selected label and immediately advance to the next item.
 - Click **Next** (or press **N**) to move to the next item without applying a label.
-- Keyboard shortcuts work when the action button row is focused. Typing in the Quick Label field does not trigger shortcuts.
+- To close an issue as a duplicate, use the **Duplicate reference** input to enter the reference number of the original issue, then click **Close as duplicate** (or press **D**) to close the current issue and advance.
+- The **Duplicate reference** input is shown inline when the duplicate action is selected, allowing you to specify the related issue number before confirming the closure.
+- Keyboard shortcuts work when the action button row is focused. Typing in the Quick Label or Duplicate reference fields does not trigger shortcuts.
 - Primary success and failure feedback appears inline in the triage view via the operation alert, with additional snackbar notifications used for selected error conditions.
 
-The two-action model keeps the triage rhythm straightforward: every item is either labelled and advanced, or advanced without changes.
+The action model now supports three flows: label and advance, close as duplicate and advance, or advance without changes. This keeps the triage rhythm straightforward and efficient.
 
 ## Assigning Milestones from the Triage UI
 

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -167,8 +167,8 @@ Labels: `type/epic`, `area/triage`
 - [x] As a solo developer, I want to start a triage session that presents unlabelled issues one at a time, supports progress tracking, and allows skipping and returning later so that I can work through them efficiently. _(Issue #145 — implemented 2026-03-18.)_
 - [x] As a solo developer, I want to apply labels to an issue with a single click or keyboard shortcut so that triage is fast. _(Issue #146 — implemented 2026-03-26.)_
 - [x] As a solo developer, I want to assign a milestone to an issue and add it to a GitHub project board column without leaving the triage view so that I can organise my work and plan in context. _(Issue #147 — implemented 2026-05-05.)_
-  - [x] As a solo developer, I want to mark an issue as a duplicate and close it with a reference so that duplicate tracking is clean. _(Issue #148 — implemented 2026-05-06.)_
-  - [ ] **Future follow-on improvement:** When a triage item is closed as a duplicate, if the repository's canonical label scheme includes a `duplicate` label, SoloDevBoard should also apply that label. _(Planned as a future improvement; see issue #176: [Story] Apply the canonical duplicate label during Triage duplicate closure.)_
+- [x] As a solo developer, I want to mark an issue as a duplicate and close it with a reference so that duplicate tracking is clean. _(Issue #148 — implemented 2026-05-06.)_
+- [ ] **Future follow-on improvement:** When a triage item is closed as a duplicate, if the repository's canonical label scheme includes a `duplicate` label, SoloDevBoard should also apply that label. _(Planned as a future improvement; see issue #176: [Story] Apply the canonical duplicate label during Triage duplicate closure.)_
 - [ ] As a solo developer, I want to see a summary at the end of a triage session showing all actions taken, and have the option to skip and return to issues later, so that I have a record of what was done and am not blocked by difficult triage decisions. _(Issue #149)_
 - [ ] As a solo developer, I want to triage unlabelled pull requests alongside issues so that my entire GitHub workload, including open PRs, is managed in one place. _(Issue #150)_
 

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -167,7 +167,8 @@ Labels: `type/epic`, `area/triage`
 - [x] As a solo developer, I want to start a triage session that presents unlabelled issues one at a time, supports progress tracking, and allows skipping and returning later so that I can work through them efficiently. _(Issue #145 — implemented 2026-03-18.)_
 - [x] As a solo developer, I want to apply labels to an issue with a single click or keyboard shortcut so that triage is fast. _(Issue #146 — implemented 2026-03-26.)_
 - [x] As a solo developer, I want to assign a milestone to an issue and add it to a GitHub project board column without leaving the triage view so that I can organise my work and plan in context. _(Issue #147 — implemented 2026-05-05.)_
-- [ ] As a solo developer, I want to mark an issue as a duplicate and close it with a reference so that duplicate tracking is clean. _(Issue #148)_
+  - [x] As a solo developer, I want to mark an issue as a duplicate and close it with a reference so that duplicate tracking is clean. _(Issue #148 — implemented 2026-05-06.)_
+  - [ ] **Future follow-on improvement:** When a triage item is closed as a duplicate, if the repository's canonical label scheme includes a `duplicate` label, SoloDevBoard should also apply that label. _(Planned as a future improvement; see issue #176: [Story] Apply the canonical duplicate label during Triage duplicate closure.)_
 - [ ] As a solo developer, I want to see a summary at the end of a triage session showing all actions taken, and have the option to skip and return to issues later, so that I have a record of what was done and am not blocked by difficult triage decisions. _(Issue #149)_
 - [ ] As a solo developer, I want to triage unlabelled pull requests alongside issues so that my entire GitHub workload, including open PRs, is managed in one place. _(Issue #150)_
 

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
@@ -197,8 +197,37 @@
                     </MudStack>
 
                     <MudText Typo="Typo.caption" data-testid="triage-keyboard-shortcuts-legend">
-                        Keyboard shortcuts (when the action buttons are focused): L applies selected label and advances, and N moves to the next item without changes.
+                        Keyboard shortcuts (when the action buttons are focused): L applies selected label and advances, N moves to the next item without changes, and D closes the current item as a duplicate.
                     </MudText>
+
+                    <MudStack Spacing="1" data-testid="triage-duplicate-action-region">
+                        <MudText Typo="Typo.subtitle2">Duplicate closure</MudText>
+                        <MudText Typo="Typo.body2" data-testid="triage-duplicate-help">
+                            Close the current item as a duplicate and include the canonical issue or pull-request reference.
+                        </MudText>
+
+                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                            <MudTextField T="string"
+                                          Value="duplicateReference"
+                                          ValueChanged="OnDuplicateReferenceChangedAsync"
+                                          Label="Duplicate reference"
+                                          Placeholder="#123 or https://github.com/owner/repo/issues/123"
+                                          Variant="Variant.Outlined"
+                                          Disabled="isApplyingSessionAction"
+                                          Immediate="true"
+                                          Clearable="true"
+                                          Class="flex-grow-1"
+                                          data-testid="triage-duplicate-reference-input" />
+
+                            <MudButton Variant="Variant.Outlined"
+                                       Color="Color.Warning"
+                                       Disabled="!CanCloseAsDuplicate"
+                                       OnClick="CloseCurrentItemAsDuplicateAsync"
+                                       data-testid="triage-close-duplicate-button">
+                                Close as duplicate
+                            </MudButton>
+                        </MudStack>
+                    </MudStack>
 
                     <MudDivider />
 

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
@@ -203,7 +203,7 @@
                     <MudStack Spacing="1" data-testid="triage-duplicate-action-region">
                         <MudText Typo="Typo.subtitle2">Duplicate closure</MudText>
                         <MudText Typo="Typo.body2" data-testid="triage-duplicate-help">
-                            Close the current item as a duplicate and include the canonical issue or pull-request reference.
+                            Close the current item as a duplicate and include the canonical issue or pull request reference.
                         </MudText>
 
                         <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
@@ -52,6 +52,7 @@ public partial class Triage : ComponentBase
     private IReadOnlyList<TriageMilestoneOptionDto> availableMilestoneOptions = [];
     private IReadOnlyList<TriageProjectBoardOptionDto> availableProjectBoardOptions = [];
     private string selectedQuickActionLabelName = string.Empty;
+    private string duplicateReference = string.Empty;
     private int? selectedMilestoneNumber;
     private string selectedProjectBoardId = string.Empty;
     private string selectedProjectBoardStatusOptionId = string.Empty;
@@ -75,6 +76,11 @@ public partial class Triage : ComponentBase
         => !isApplyingSessionAction
             && CurrentItem is not null
             && LabelExists(selectedQuickActionLabelName);
+
+    private bool CanCloseAsDuplicate
+        => !isApplyingSessionAction
+            && CurrentItem is not null
+            && !string.IsNullOrWhiteSpace(duplicateReference);
 
     private bool CanAssignMilestone
         => !isApplyingSessionAction
@@ -221,6 +227,7 @@ public partial class Triage : ComponentBase
             availableMilestoneOptions = [];
             availableProjectBoardOptions = [];
             selectedQuickActionLabelName = string.Empty;
+            duplicateReference = string.Empty;
             selectedMilestoneNumber = null;
             selectedProjectBoardId = string.Empty;
             selectedProjectBoardStatusOptionId = string.Empty;
@@ -338,6 +345,12 @@ public partial class Triage : ComponentBase
         return Task.CompletedTask;
     }
 
+    private Task OnDuplicateReferenceChangedAsync(string value)
+    {
+        duplicateReference = value ?? string.Empty;
+        return Task.CompletedTask;
+    }
+
     private Task<IEnumerable<string>> SearchQuickActionLabelsAsync(string? value, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -441,6 +454,52 @@ public partial class Triage : ComponentBase
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while moving to the next item without changes.";
             Snackbar.Add("Could not move to the next item without changes.", Severity.Error);
+        }
+        finally
+        {
+            isApplyingSessionAction = false;
+        }
+    }
+
+    private async Task CloseCurrentItemAsDuplicateAsync()
+    {
+        if (currentSession is null || CurrentItem is null || !CanCloseAsDuplicate)
+        {
+            return;
+        }
+
+        isApplyingSessionAction = true;
+
+        try
+        {
+            var closedItemNumber = CurrentItem.Number;
+            var trimmedDuplicateReference = duplicateReference.Trim();
+
+            var duplicateClosedSession = await TriageService.CloseCurrentItemAsDuplicateAsync(
+                currentSession,
+                trimmedDuplicateReference);
+
+            currentSession = await TriageService.AdvanceSessionAsync(duplicateClosedSession);
+            SyncPlanningSelectionFromCurrentItem();
+
+            operationSeverity = Severity.Success;
+            operationMessage = currentSession.CurrentItem is null
+                ? $"Closed item #{closedItemNumber} as a duplicate of '{trimmedDuplicateReference}'. Reached the end of the current queue."
+                : $"Closed item #{closedItemNumber} as a duplicate of '{trimmedDuplicateReference}' and moved to {CurrentPositionText}.";
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while closing triage item as duplicate.");
+            operationSeverity = Severity.Error;
+            operationMessage = $"GitHub API request failed while closing as duplicate. {ex.Message}";
+            Snackbar.Add("Could not close the item as a duplicate due to a GitHub API error.", Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to close the current triage item as duplicate.");
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while closing this item as a duplicate.";
+            Snackbar.Add("Could not close the item as a duplicate.", Severity.Error);
         }
         finally
         {
@@ -698,6 +757,7 @@ public partial class Triage : ComponentBase
     private void SyncPlanningSelectionFromCurrentItem()
     {
         selectedMilestoneNumber = CurrentItem?.MilestoneNumber;
+        duplicateReference = string.Empty;
 
         if (!availableProjectBoardOptions.Any(option => option.Id.Equals(selectedProjectBoardId, StringComparison.Ordinal)))
         {
@@ -728,6 +788,10 @@ public partial class Triage : ComponentBase
             case "n":
             case "N":
                 await CompleteWithoutChangesAsync();
+                break;
+            case "d":
+            case "D":
+                await CloseCurrentItemAsDuplicateAsync();
                 break;
             default:
                 break;

--- a/src/Application/SoloDevBoard.Application/Services/Triage/ITriageService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/ITriageService.cs
@@ -75,6 +75,16 @@ public interface ITriageService
         string statusOptionName,
         CancellationToken cancellationToken = default);
 
+    /// <summary>Closes the current session item as a duplicate with a canonical reference.</summary>
+    /// <param name="session">The current session state.</param>
+    /// <param name="duplicateReference">The canonical duplicate reference to include in the closure comment.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The updated triage session DTO.</returns>
+    Task<TriageSessionDto> CloseCurrentItemAsDuplicateAsync(
+        TriageSessionDto session,
+        string duplicateReference,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Builds the latest triage session summary from current session state.</summary>
     /// <param name="session">The current session state.</param>
     /// <returns>The computed triage session summary DTO.</returns>

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
@@ -392,6 +392,57 @@ public sealed class TriageService : ITriageService
     }
 
     /// <inheritdoc/>
+    public async Task<TriageSessionDto> CloseCurrentItemAsDuplicateAsync(
+        TriageSessionDto session,
+        string duplicateReference,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentException.ThrowIfNullOrWhiteSpace(duplicateReference);
+
+        var domainSession = ToDomain(session);
+        if (domainSession.CurrentIndex >= domainSession.Queue.Count)
+        {
+            return ToDto(domainSession);
+        }
+
+        var currentItem = domainSession.Queue[domainSession.CurrentIndex];
+        if (!TryParseRepositoryScope(currentItem.RepositoryFullName, out var owner, out var repo))
+        {
+            throw new ArgumentException(
+                $"Repository scope '{currentItem.RepositoryFullName}' must be in owner/repository format.",
+                nameof(session));
+        }
+
+        var trimmedDuplicateReference = duplicateReference.Trim();
+        var gitHubItemType = ToGitHubTriageItemType(currentItem.ItemType);
+
+        await _gitHubService
+            .CloseTriageItemAsDuplicateAsync(owner, repo, gitHubItemType, currentItem.Number, trimmedDuplicateReference, cancellationToken)
+            .ConfigureAwait(false);
+
+        var action = new TriageAction
+        {
+            ActionType = TriageActionType.ClosedAsDuplicate,
+            ItemType = currentItem.ItemType,
+            ItemNumber = currentItem.Number,
+            RepositoryFullName = currentItem.RepositoryFullName,
+            Detail = $"Closed as duplicate of '{trimmedDuplicateReference}'.",
+            OccurredAt = DateTimeOffset.UtcNow,
+        };
+
+        var updatedActionHistory = domainSession.ActionHistory
+            .Concat([action])
+            .ToArray();
+
+        return UpdateSessionState(domainSession with
+        {
+            ActionHistory = updatedActionHistory,
+        });
+    }
+
+    /// <inheritdoc/>
     public TriageSessionSummaryDto BuildSessionSummary(TriageSessionDto session)
     {
         ArgumentNullException.ThrowIfNull(session);
@@ -418,6 +469,14 @@ public sealed class TriageService : ITriageService
         repo = segments[1];
         return true;
     }
+
+    private static GitHubTriageItemType ToGitHubTriageItemType(TriageItemType itemType)
+        => itemType switch
+        {
+            TriageItemType.Issue => GitHubTriageItemType.Issue,
+            TriageItemType.PullRequest => GitHubTriageItemType.PullRequest,
+            _ => throw new ArgumentOutOfRangeException(nameof(itemType), itemType, "Unsupported triage item type."),
+        };
 
     private static TriageSessionDto UpdateSessionState(TriageSession session)
     {

--- a/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
@@ -697,6 +697,143 @@ public sealed class TriageTests
             Times.Once);
     }
 
+    [Fact]
+    public async Task Triage_CloseAsDuplicateClicked_ClosesCurrentItemAndAdvancesSession()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [
+                CreateItem(701, "Issue 701", "owner/repo"),
+                CreateItem(702, "Issue 702", "owner/repo"),
+            ],
+            currentIndex: 0,
+            skippedItems: []);
+
+        var duplicateClosedSession = startedSession with
+        {
+            ActionHistory =
+            [
+                new TriageActionDto(TriageActionTypeDto.ClosedAsDuplicate, TriageItemTypeDto.Issue, 701, "owner/repo", "Closed as duplicate of '#555'.", DateTimeOffset.UtcNow),
+            ],
+            Summary = new TriageSessionSummaryDto(2, 0, 2, 0, 0, 0, 0, 1),
+        };
+
+        var advancedSession = duplicateClosedSession with
+        {
+            CurrentIndex = 1,
+            Progress = new TriageSessionProgressDto(2, 1, 1, 0),
+            Summary = new TriageSessionSummaryDto(2, 1, 1, 0, 0, 0, 0, 1),
+        };
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.CloseCurrentItemAsDuplicateAsync(It.IsAny<TriageSessionDto>(), "#555", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(duplicateClosedSession);
+
+        _triageServiceMock
+            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(advancedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+        cut.WaitForAssertion(() => Assert.Contains("Issue 701", cut.Markup));
+
+        var duplicateReferenceInput = cut
+            .FindComponents<MudTextField<string>>()
+            .Single(component => string.Equals(component.Instance.Label, "Duplicate reference", StringComparison.Ordinal));
+
+        await cut.InvokeAsync(() => duplicateReferenceInput.Instance.ValueChanged.InvokeAsync("#555"));
+
+        cut.Find("[data-testid='triage-close-duplicate-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Issue 702", cut.Markup);
+            Assert.Contains("Closed item #701 as a duplicate of '#555' and moved to Item 2 of 2", cut.Markup, StringComparison.Ordinal);
+        });
+
+        _triageServiceMock.Verify(
+            service => service.CloseCurrentItemAsDuplicateAsync(It.IsAny<TriageSessionDto>(), "#555", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _triageServiceMock.Verify(
+            service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Triage_ActionSurfaceShortcutD_PressedClosesCurrentItemAsDuplicate()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [CreateItem(703, "Issue 703", "owner/repo")],
+            currentIndex: 0,
+            skippedItems: []);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.CloseCurrentItemAsDuplicateAsync(It.IsAny<TriageSessionDto>(), "#556", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("[data-testid='triage-action-surface-region']")));
+
+        var duplicateReferenceInput = cut
+            .FindComponents<MudTextField<string>>()
+            .Single(component => string.Equals(component.Instance.Label, "Duplicate reference", StringComparison.Ordinal));
+
+        await cut.InvokeAsync(() => duplicateReferenceInput.Instance.ValueChanged.InvokeAsync("#556"));
+
+        cut.Find("[data-testid='triage-action-buttons-row']").KeyDown("d");
+
+        // Assert
+        _triageServiceMock.Verify(
+            service => service.CloseCurrentItemAsDuplicateAsync(It.IsAny<TriageSessionDto>(), "#556", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _triageServiceMock.Verify(
+            service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private static async Task SelectQuickLabelAsync(IRenderedComponent<Triage> cut, string labelName)
     {
         ArgumentNullException.ThrowIfNull(cut);

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
@@ -403,6 +403,76 @@ public sealed class TriageServiceTests
     }
 
     [Fact]
+    public async Task CloseCurrentItemAsDuplicateAsync_ActiveIssueExists_ClosesDuplicateAndRecordsAction()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var session = CreateSession(queueCount: 1, currentIndex: 0);
+
+        // Act
+        var result = await sut.CloseCurrentItemAsDuplicateAsync(session, "#123");
+
+        // Assert
+        Assert.Single(result.ActionHistory);
+        Assert.Equal(TriageActionTypeDto.ClosedAsDuplicate, result.ActionHistory[0].ActionType);
+        Assert.Contains("#123", result.ActionHistory[0].Detail, StringComparison.Ordinal);
+        Assert.Equal(1, result.Summary.DuplicateClosuresCount);
+
+        _gitHubServiceMock.Verify(
+            service => service.CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 1, "#123", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CloseCurrentItemAsDuplicateAsync_ActivePullRequestExists_ClosesPullRequestDuplicate()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var pullRequestItem = new TriageItemDto(
+            TriageItemTypeDto.PullRequest,
+            21,
+            21,
+            "owner/repo",
+            "Pull request 21",
+            "https://github.com/owner/repo/pull/21",
+            string.Empty,
+            "open",
+            "mark",
+            [],
+            null,
+            string.Empty,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+
+        var session = new TriageSessionDto(
+            Guid.NewGuid(),
+            "owner",
+            "repo",
+            false,
+            [pullRequestItem],
+            0,
+            [],
+            [],
+            new TriageSessionProgressDto(1, 0, 1, 0),
+            new TriageSessionSummaryDto(1, 0, 1, 0, 0, 0, 0, 0),
+            DateTimeOffset.UtcNow);
+
+        // Act
+        _ = await sut.CloseCurrentItemAsDuplicateAsync(session, "https://github.com/owner/repo/pull/20");
+
+        // Assert
+        _gitHubServiceMock.Verify(
+            service => service.CloseTriageItemAsDuplicateAsync(
+                "owner",
+                "repo",
+                GitHubTriageItemType.PullRequest,
+                21,
+                "https://github.com/owner/repo/pull/20",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public void BuildSessionSummary_ActionHistoryIncludesAllActionTypes_ReturnsComputedCounts()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Implements issue #148 — duplicate closure support in the Triage UI.

## Changes

- Added `CloseCurrentItemAsDuplicateAsync` to `ITriageService` and `TriageService`
- Inline duplicate reference input and **Close as duplicate** button in Triage action surface
- **D** keyboard shortcut for duplicate closure on action buttons row
- Success/failure feedback in triage feedback region; session position preserved
- Application and bUnit tests for issue and pull-request duplicate closure paths
- User guide and backlog updated

## Tests

221/221 passing.

Closes #148