### PR TITLE
[Story] Triage session summary with grouped details and skip/revisit (#149)

### DIFF
--- a/docs/user-guide/triage-ui.md
+++ b/docs/user-guide/triage-ui.md
@@ -62,8 +62,28 @@ The Triage UI allows you to add issues to a GitHub project board and set their s
 - In the **Planning Actions** section, select a project board from the available list.
 - Choose the desired project status (column) for the issue.
 - Click the **Add to project board** button to place the issue in the selected board and status.
-- Success or failure feedback will appear in the user feedback region, confirming the result of the operation.
+- Success or failure feedback appears in the user feedback region, confirming the result of the operation.
 
 If the issue is already on the selected board, you can update its status column directly. Any errors encountered during project board placement will be surfaced with actionable feedback.
 
 All planning actions use MudBlazor controls for a consistent and accessible experience, and the workflow aligns with the [triage wireframe](../../plan/wireframes/triage-ui-wireframe.md).
+
+## Session Completion Summary and Skip/Revisit Workflow
+
+When you complete a triage session, a grouped summary is shown with details for all actions taken during the session. The summary includes:
+
+- Labels applied to issues and pull requests.
+- Milestones assigned.
+- Project board actions performed.
+- Items closed as duplicates (with references).
+- Items skipped (with optional reasons).
+
+You can now skip the current item at any point during triage by clicking **Skip** or pressing **S** on your keyboard. When skipping, you may optionally provide a reason for skipping the item.
+
+After all items are processed, the session-complete summary allows you to revisit any skipped items. Skipped items are listed in a dedicated grouped section, and skip reasons (if provided) appear in the recorded action details.
+
+The triage UI layout uses MudBlazor components and a responsive grid stack, ensuring readability and usability on both desktop and mobile devices.
+
+### Keyboard Shortcuts
+
+- Press **S** to skip the current item.

--- a/docs/user-guide/triage-ui.md
+++ b/docs/user-guide/triage-ui.md
@@ -76,14 +76,15 @@ When you complete a triage session, a grouped summary is shown with details for 
 - Milestones assigned.
 - Project board actions performed.
 - Items closed as duplicates (with references).
-- Items skipped (with optional reasons).
+- Skip actions (including optional reasons).
+- Items currently skipped for revisit.
 
-You can now skip the current item at any point during triage by clicking **Skip** or pressing **S** on your keyboard. When skipping, you may optionally provide a reason for skipping the item.
+You can now skip the current item at any point during triage by clicking **Skip** or pressing **S** on your keyboard when the action button row is focused. When skipping, you may optionally provide a reason for skipping the item.
 
-After all items are processed, the session-complete summary allows you to revisit any skipped items. Skipped items are listed in a dedicated grouped section, and skip reasons (if provided) appear in the recorded action details.
+After all items are processed, the session-complete summary allows you to revisit any skipped items. Skipped items are listed in a dedicated grouped section, and skip reasons (if provided) appear in the **Skip actions** detail section.
 
 The triage UI layout uses MudBlazor components and a responsive grid stack, ensuring readability and usability on both desktop and mobile devices.
 
 ### Keyboard Shortcuts
 
-- Press **S** to skip the current item.
+- Press **S** to skip the current item when the action button row is focused.

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -169,7 +169,8 @@ Labels: `type/epic`, `area/triage`
 - [x] As a solo developer, I want to assign a milestone to an issue and add it to a GitHub project board column without leaving the triage view so that I can organise my work and plan in context. _(Issue #147 — implemented 2026-05-05.)_
 - [x] As a solo developer, I want to mark an issue as a duplicate and close it with a reference so that duplicate tracking is clean. _(Issue #148 — implemented 2026-05-06.)_
 - [ ] **Future follow-on improvement:** When a triage item is closed as a duplicate, if the repository's canonical label scheme includes a `duplicate` label, SoloDevBoard should also apply that label. _(Planned as a future improvement; see issue #176: [Story] Apply the canonical duplicate label during Triage duplicate closure.)_
-- [ ] As a solo developer, I want to see a summary at the end of a triage session showing all actions taken, and have the option to skip and return to issues later, so that I have a record of what was done and am not blocked by difficult triage decisions. _(Issue #149)_
+- [x] As a solo developer, I want to see a summary at the end of a triage session showing all actions taken, and have the option to skip and return to issues later, so that I have a record of what was done and am not blocked by difficult triage decisions. _(Issue #149 — implemented 2026-05-07.)_
+  - Implementation note: Session completion now shows grouped summary details from the Application layer for labels, milestones, project actions, duplicate closures, and skipped items. Users can skip the current item (with optional reason) and revisit skipped items from the session-complete state. Keyboard shortcut S is available to skip. Layout uses MudBlazor and is responsive for desktop/mobile.
 - [ ] As a solo developer, I want to triage unlabelled pull requests alongside issues so that my entire GitHub workload, including open PRs, is managed in one place. _(Issue #150)_
 
 **Enablers:**

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
@@ -197,7 +197,7 @@
                     </MudStack>
 
                     <MudText Typo="Typo.caption" data-testid="triage-keyboard-shortcuts-legend">
-                        Keyboard shortcuts (when the action buttons are focused): L applies selected label and advances, N moves to the next item without changes, and D closes the current item as a duplicate.
+                        Keyboard shortcuts (when the action buttons are focused): L applies selected label and advances, N moves to the next item without changes, D closes the current item as a duplicate, and S skips the current item for later review.
                     </MudText>
 
                     <MudStack Spacing="1" data-testid="triage-duplicate-action-region">
@@ -225,6 +225,35 @@
                                        OnClick="CloseCurrentItemAsDuplicateAsync"
                                        data-testid="triage-close-duplicate-button">
                                 Close as duplicate
+                            </MudButton>
+                        </MudStack>
+                    </MudStack>
+
+                    <MudStack Spacing="1" data-testid="triage-skip-action-region">
+                        <MudText Typo="Typo.subtitle2">Skip and return later</MudText>
+                        <MudText Typo="Typo.body2" data-testid="triage-skip-help">
+                            Skip this item for now and return to it later from the session summary.
+                        </MudText>
+
+                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                            <MudTextField T="string"
+                                          Value="skipReason"
+                                          ValueChanged="OnSkipReasonChangedAsync"
+                                          Label="Skip reason (optional)"
+                                          Placeholder="Add context for when you revisit this item"
+                                          Variant="Variant.Outlined"
+                                          Disabled="isApplyingSessionAction"
+                                          Immediate="true"
+                                          Clearable="true"
+                                          Class="flex-grow-1"
+                                          data-testid="triage-skip-reason-input" />
+
+                            <MudButton Variant="Variant.Outlined"
+                                       Color="Color.Tertiary"
+                                       Disabled="!CanSkipCurrentItem"
+                                       OnClick="SkipCurrentItemAsync"
+                                       data-testid="triage-skip-item-button">
+                                Skip item
                             </MudButton>
                         </MudStack>
                     </MudStack>
@@ -313,9 +342,148 @@
         else
         {
             <MudPaper Class="pa-4" Elevation="1" data-testid="triage-session-complete-region">
-                <MudStack Spacing="1">
+                <MudStack Spacing="2">
                     <MudText Typo="Typo.h6">Session complete</MudText>
-                    <MudText Typo="Typo.body2">@SessionCompleteSummaryText</MudText>
+                    <MudText Typo="Typo.body2" data-testid="triage-session-summary-text">@SessionCompleteSummaryText</MudText>
+
+                    <MudGrid Spacing="2" data-testid="triage-session-summary-counts">
+                        <MudItem xs="12" sm="6" md="4" lg="3">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="triage-summary-label-count">
+                                <MudText Typo="Typo.subtitle2">Labels applied</MudText>
+                                <MudText Typo="Typo.h6">@currentSession.Summary.LabelsAppliedCount</MudText>
+                            </MudPaper>
+                        </MudItem>
+
+                        <MudItem xs="12" sm="6" md="4" lg="3">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="triage-summary-milestone-count">
+                                <MudText Typo="Typo.subtitle2">Milestones assigned</MudText>
+                                <MudText Typo="Typo.h6">@currentSession.Summary.MilestonesAssignedCount</MudText>
+                            </MudPaper>
+                        </MudItem>
+
+                        <MudItem xs="12" sm="6" md="4" lg="3">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="triage-summary-project-count">
+                                <MudText Typo="Typo.subtitle2">Project actions</MudText>
+                                <MudText Typo="Typo.h6">@currentSession.Summary.ProjectAssignmentsCount</MudText>
+                            </MudPaper>
+                        </MudItem>
+
+                        <MudItem xs="12" sm="6" md="4" lg="3">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="triage-summary-duplicate-count">
+                                <MudText Typo="Typo.subtitle2">Duplicate closures</MudText>
+                                <MudText Typo="Typo.h6">@currentSession.Summary.DuplicateClosuresCount</MudText>
+                            </MudPaper>
+                        </MudItem>
+
+                        <MudItem xs="12" sm="6" md="4" lg="3">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="triage-summary-skipped-count">
+                                <MudText Typo="Typo.subtitle2">Skipped items</MudText>
+                                <MudText Typo="Typo.h6">@currentSession.Summary.SkippedItems</MudText>
+                            </MudPaper>
+                        </MudItem>
+                    </MudGrid>
+
+                    <MudGrid Spacing="2" data-testid="triage-session-summary-details">
+                        <MudItem xs="12" md="6">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="triage-summary-label-details">
+                                <MudText Typo="Typo.subtitle2">Label actions</MudText>
+
+                                @if (currentSession.Summary.LabelActionDetails.Count == 0)
+                                {
+                                    <MudText Typo="Typo.body2">No label actions were recorded.</MudText>
+                                }
+                                else
+                                {
+                                    <MudList T="string" Dense="true">
+                                        @foreach (var detail in currentSession.Summary.LabelActionDetails)
+                                        {
+                                            <MudListItem T="string" Text="@detail" />
+                                        }
+                                    </MudList>
+                                }
+                            </MudPaper>
+                        </MudItem>
+
+                        <MudItem xs="12" md="6">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="triage-summary-milestone-details">
+                                <MudText Typo="Typo.subtitle2">Milestone actions</MudText>
+
+                                @if (currentSession.Summary.MilestoneActionDetails.Count == 0)
+                                {
+                                    <MudText Typo="Typo.body2">No milestone actions were recorded.</MudText>
+                                }
+                                else
+                                {
+                                    <MudList T="string" Dense="true">
+                                        @foreach (var detail in currentSession.Summary.MilestoneActionDetails)
+                                        {
+                                            <MudListItem T="string" Text="@detail" />
+                                        }
+                                    </MudList>
+                                }
+                            </MudPaper>
+                        </MudItem>
+
+                        <MudItem xs="12" md="6">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="triage-summary-project-details">
+                                <MudText Typo="Typo.subtitle2">Project actions</MudText>
+
+                                @if (currentSession.Summary.ProjectActionDetails.Count == 0)
+                                {
+                                    <MudText Typo="Typo.body2">No project actions were recorded.</MudText>
+                                }
+                                else
+                                {
+                                    <MudList T="string" Dense="true">
+                                        @foreach (var detail in currentSession.Summary.ProjectActionDetails)
+                                        {
+                                            <MudListItem T="string" Text="@detail" />
+                                        }
+                                    </MudList>
+                                }
+                            </MudPaper>
+                        </MudItem>
+
+                        <MudItem xs="12" md="6">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="triage-summary-duplicate-details">
+                                <MudText Typo="Typo.subtitle2">Duplicate closures</MudText>
+
+                                @if (currentSession.Summary.DuplicateActionDetails.Count == 0)
+                                {
+                                    <MudText Typo="Typo.body2">No duplicate closures were recorded.</MudText>
+                                }
+                                else
+                                {
+                                    <MudList T="string" Dense="true">
+                                        @foreach (var detail in currentSession.Summary.DuplicateActionDetails)
+                                        {
+                                            <MudListItem T="string" Text="@detail" />
+                                        }
+                                    </MudList>
+                                }
+                            </MudPaper>
+                        </MudItem>
+
+                        <MudItem xs="12">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="triage-summary-skipped-details">
+                                <MudText Typo="Typo.subtitle2">Skipped items</MudText>
+
+                                @if (currentSession.Summary.SkippedItemDetails.Count == 0)
+                                {
+                                    <MudText Typo="Typo.body2">No items are currently skipped.</MudText>
+                                }
+                                else
+                                {
+                                    <MudList T="string" Dense="true">
+                                        @foreach (var detail in currentSession.Summary.SkippedItemDetails)
+                                        {
+                                            <MudListItem T="string" Text="@detail" />
+                                        }
+                                    </MudList>
+                                }
+                            </MudPaper>
+                        </MudItem>
+                    </MudGrid>
 
                     @if (currentSession.SkippedItems.Count > 0)
                     {

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
@@ -464,6 +464,26 @@
                             </MudPaper>
                         </MudItem>
 
+                        <MudItem xs="12" md="6">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="triage-summary-skip-action-details">
+                                <MudText Typo="Typo.subtitle2">Skip actions</MudText>
+
+                                @if (currentSession.Summary.SkippedActionDetails.Count == 0)
+                                {
+                                    <MudText Typo="Typo.body2">No skip actions were recorded.</MudText>
+                                }
+                                else
+                                {
+                                    <MudList T="string" Dense="true">
+                                        @foreach (var detail in currentSession.Summary.SkippedActionDetails)
+                                        {
+                                            <MudListItem T="string" Text="@detail" />
+                                        }
+                                    </MudList>
+                                }
+                            </MudPaper>
+                        </MudItem>
+
                         <MudItem xs="12">
                             <MudPaper Class="pa-3" Outlined="true" data-testid="triage-summary-skipped-details">
                                 <MudText Typo="Typo.subtitle2">Skipped items</MudText>

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
@@ -53,6 +53,7 @@ public partial class Triage : ComponentBase
     private IReadOnlyList<TriageProjectBoardOptionDto> availableProjectBoardOptions = [];
     private string selectedQuickActionLabelName = string.Empty;
     private string duplicateReference = string.Empty;
+    private string skipReason = string.Empty;
     private int? selectedMilestoneNumber;
     private string selectedProjectBoardId = string.Empty;
     private string selectedProjectBoardStatusOptionId = string.Empty;
@@ -81,6 +82,10 @@ public partial class Triage : ComponentBase
         => !isApplyingSessionAction
             && CurrentItem is not null
             && !string.IsNullOrWhiteSpace(duplicateReference);
+
+    private bool CanSkipCurrentItem
+        => !isApplyingSessionAction
+            && CurrentItem is not null;
 
     private bool CanAssignMilestone
         => !isApplyingSessionAction
@@ -228,6 +233,7 @@ public partial class Triage : ComponentBase
             availableProjectBoardOptions = [];
             selectedQuickActionLabelName = string.Empty;
             duplicateReference = string.Empty;
+            skipReason = string.Empty;
             selectedMilestoneNumber = null;
             selectedProjectBoardId = string.Empty;
             selectedProjectBoardStatusOptionId = string.Empty;
@@ -348,6 +354,12 @@ public partial class Triage : ComponentBase
     private Task OnDuplicateReferenceChangedAsync(string value)
     {
         duplicateReference = value ?? string.Empty;
+        return Task.CompletedTask;
+    }
+
+    private Task OnSkipReasonChangedAsync(string value)
+    {
+        skipReason = value ?? string.Empty;
         return Task.CompletedTask;
     }
 
@@ -500,6 +512,39 @@ public partial class Triage : ComponentBase
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while closing this item as a duplicate.";
             Snackbar.Add("Could not close the item as a duplicate.", Severity.Error);
+        }
+        finally
+        {
+            isApplyingSessionAction = false;
+        }
+    }
+
+    private async Task SkipCurrentItemAsync()
+    {
+        if (currentSession is null || CurrentItem is null || !CanSkipCurrentItem)
+        {
+            return;
+        }
+
+        isApplyingSessionAction = true;
+
+        try
+        {
+            var skippedItemNumber = CurrentItem.Number;
+            currentSession = await TriageService.SkipCurrentItemAsync(currentSession, skipReason);
+            SyncPlanningSelectionFromCurrentItem();
+
+            operationSeverity = Severity.Info;
+            operationMessage = currentSession.CurrentItem is null
+                ? $"Skipped item #{skippedItemNumber} for later review. Reached the end of the current queue."
+                : $"Skipped item #{skippedItemNumber} for later review and moved to {CurrentPositionText}.";
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to skip the current triage item.");
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while skipping this item.";
+            Snackbar.Add("Could not skip the current item.", Severity.Error);
         }
         finally
         {
@@ -758,6 +803,7 @@ public partial class Triage : ComponentBase
     {
         selectedMilestoneNumber = CurrentItem?.MilestoneNumber;
         duplicateReference = string.Empty;
+        skipReason = string.Empty;
 
         if (!availableProjectBoardOptions.Any(option => option.Id.Equals(selectedProjectBoardId, StringComparison.Ordinal)))
         {
@@ -792,6 +838,10 @@ public partial class Triage : ComponentBase
             case "d":
             case "D":
                 await CloseCurrentItemAsDuplicateAsync();
+                break;
+            case "s":
+            case "S":
+                await SkipCurrentItemAsync();
                 break;
             default:
                 break;

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
@@ -529,6 +529,7 @@ public sealed class TriageService : ITriageService
             MilestoneActionDetails = BuildActionDetails(actionHistory, TriageActionType.MilestoneAssigned),
             ProjectActionDetails = BuildActionDetails(actionHistory, TriageActionType.ProjectBoardAssigned),
             DuplicateActionDetails = BuildActionDetails(actionHistory, TriageActionType.ClosedAsDuplicate),
+            SkippedActionDetails = BuildActionDetails(actionHistory, TriageActionType.Skipped),
             SkippedItemDetails = skippedItems.Select(FormatSkippedItemDetail).ToArray(),
         };
     }
@@ -720,6 +721,7 @@ public sealed class TriageService : ITriageService
             MilestoneActionDetails = summary.MilestoneActionDetails,
             ProjectActionDetails = summary.ProjectActionDetails,
             DuplicateActionDetails = summary.DuplicateActionDetails,
+            SkippedActionDetails = summary.SkippedActionDetails,
             SkippedItemDetails = summary.SkippedItemDetails,
         };
 
@@ -750,6 +752,7 @@ public sealed class TriageService : ITriageService
             MilestoneActionDetails = summary.MilestoneActionDetails,
             ProjectActionDetails = summary.ProjectActionDetails,
             DuplicateActionDetails = summary.DuplicateActionDetails,
+            SkippedActionDetails = summary.SkippedActionDetails,
             SkippedItemDetails = summary.SkippedItemDetails,
         };
     }

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
@@ -48,7 +48,7 @@ public sealed class TriageService : ITriageService
             SkippedItems = [],
             ActionHistory = [],
             Progress = BuildProgress(orderedQueue.Length, 0, 0),
-            Summary = BuildSummary(orderedQueue.Length, 0, 0, []),
+            Summary = BuildSummary(orderedQueue.Length, 0, [], []),
             StartedAt = DateTimeOffset.UtcNow,
         };
 
@@ -481,7 +481,7 @@ public sealed class TriageService : ITriageService
     private static TriageSessionDto UpdateSessionState(TriageSession session)
     {
         var progress = BuildProgress(session.Queue.Count, session.CurrentIndex, session.SkippedItems.Count);
-        var summary = BuildSummary(session.Queue.Count, session.CurrentIndex, session.SkippedItems.Count, session.ActionHistory);
+        var summary = BuildSummary(session.Queue.Count, session.CurrentIndex, session.SkippedItems, session.ActionHistory);
 
         var updated = session with
         {
@@ -506,7 +506,11 @@ public sealed class TriageService : ITriageService
         };
     }
 
-    private static TriageSessionSummary BuildSummary(int totalItems, int currentIndex, int skippedItems, IReadOnlyList<TriageAction> actionHistory)
+    private static TriageSessionSummary BuildSummary(
+        int totalItems,
+        int currentIndex,
+        IReadOnlyList<TriageItem> skippedItems,
+        IReadOnlyList<TriageAction> actionHistory)
     {
         var processed = Math.Min(Math.Max(currentIndex, 0), totalItems);
         var remaining = Math.Max(totalItems - processed, 0);
@@ -516,12 +520,43 @@ public sealed class TriageService : ITriageService
             TotalItems = totalItems,
             ProcessedItems = processed,
             RemainingItems = remaining,
-            SkippedItems = skippedItems,
+            SkippedItems = skippedItems.Count,
             LabelsAppliedCount = actionHistory.Count(action => action.ActionType == TriageActionType.LabelApplied),
             MilestonesAssignedCount = actionHistory.Count(action => action.ActionType == TriageActionType.MilestoneAssigned),
             ProjectAssignmentsCount = actionHistory.Count(action => action.ActionType == TriageActionType.ProjectBoardAssigned),
             DuplicateClosuresCount = actionHistory.Count(action => action.ActionType == TriageActionType.ClosedAsDuplicate),
+            LabelActionDetails = BuildActionDetails(actionHistory, TriageActionType.LabelApplied),
+            MilestoneActionDetails = BuildActionDetails(actionHistory, TriageActionType.MilestoneAssigned),
+            ProjectActionDetails = BuildActionDetails(actionHistory, TriageActionType.ProjectBoardAssigned),
+            DuplicateActionDetails = BuildActionDetails(actionHistory, TriageActionType.ClosedAsDuplicate),
+            SkippedItemDetails = skippedItems.Select(FormatSkippedItemDetail).ToArray(),
         };
+    }
+
+    private static IReadOnlyList<string> BuildActionDetails(IReadOnlyList<TriageAction> actionHistory, TriageActionType actionType)
+    {
+        return actionHistory
+            .Where(action => action.ActionType == actionType)
+            .Select(FormatActionDetail)
+            .ToArray();
+    }
+
+    private static string FormatActionDetail(TriageAction action)
+    {
+        var itemTypeText = action.ItemType == TriageItemType.PullRequest
+            ? "Pull request"
+            : "Issue";
+
+        return $"{itemTypeText} #{action.ItemNumber} ({action.RepositoryFullName}): {action.Detail}";
+    }
+
+    private static string FormatSkippedItemDetail(TriageItem item)
+    {
+        var itemTypeText = item.ItemType == TriageItemType.PullRequest
+            ? "Pull request"
+            : "Issue";
+
+        return $"{itemTypeText} #{item.Number} ({item.RepositoryFullName}): {item.Title}";
     }
 
     private static TriageItem ToDomainIssueItem(string owner, string repo, Issue issue)
@@ -679,7 +714,14 @@ public sealed class TriageService : ITriageService
             summary.LabelsAppliedCount,
             summary.MilestonesAssignedCount,
             summary.ProjectAssignmentsCount,
-            summary.DuplicateClosuresCount);
+            summary.DuplicateClosuresCount)
+        {
+            LabelActionDetails = summary.LabelActionDetails,
+            MilestoneActionDetails = summary.MilestoneActionDetails,
+            ProjectActionDetails = summary.ProjectActionDetails,
+            DuplicateActionDetails = summary.DuplicateActionDetails,
+            SkippedItemDetails = summary.SkippedItemDetails,
+        };
 
     private static TriageSessionProgress ToDomain(TriageSessionProgressDto progress)
     {
@@ -704,6 +746,11 @@ public sealed class TriageService : ITriageService
             MilestonesAssignedCount = summary.MilestonesAssignedCount,
             ProjectAssignmentsCount = summary.ProjectAssignmentsCount,
             DuplicateClosuresCount = summary.DuplicateClosuresCount,
+            LabelActionDetails = summary.LabelActionDetails,
+            MilestoneActionDetails = summary.MilestoneActionDetails,
+            ProjectActionDetails = summary.ProjectActionDetails,
+            DuplicateActionDetails = summary.DuplicateActionDetails,
+            SkippedItemDetails = summary.SkippedItemDetails,
         };
     }
 

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionSummaryDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionSummaryDto.cs
@@ -17,4 +17,20 @@ public sealed record TriageSessionSummaryDto(
     int LabelsAppliedCount,
     int MilestonesAssignedCount,
     int ProjectAssignmentsCount,
-    int DuplicateClosuresCount);
+    int DuplicateClosuresCount)
+{
+    /// <summary>Gets grouped detail lines for label actions.</summary>
+    public IReadOnlyList<string> LabelActionDetails { get; init; } = [];
+
+    /// <summary>Gets grouped detail lines for milestone assignment actions.</summary>
+    public IReadOnlyList<string> MilestoneActionDetails { get; init; } = [];
+
+    /// <summary>Gets grouped detail lines for project-board actions.</summary>
+    public IReadOnlyList<string> ProjectActionDetails { get; init; } = [];
+
+    /// <summary>Gets grouped detail lines for duplicate closure actions.</summary>
+    public IReadOnlyList<string> DuplicateActionDetails { get; init; } = [];
+
+    /// <summary>Gets grouped detail lines for items currently skipped for revisit.</summary>
+    public IReadOnlyList<string> SkippedItemDetails { get; init; } = [];
+}

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionSummaryDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageSessionSummaryDto.cs
@@ -31,6 +31,9 @@ public sealed record TriageSessionSummaryDto(
     /// <summary>Gets grouped detail lines for duplicate closure actions.</summary>
     public IReadOnlyList<string> DuplicateActionDetails { get; init; } = [];
 
+    /// <summary>Gets grouped detail lines for skip actions, including optional reasons.</summary>
+    public IReadOnlyList<string> SkippedActionDetails { get; init; } = [];
+
     /// <summary>Gets grouped detail lines for items currently skipped for revisit.</summary>
     public IReadOnlyList<string> SkippedItemDetails { get; init; } = [];
 }

--- a/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageSessionSummary.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageSessionSummary.cs
@@ -29,4 +29,19 @@ public sealed record TriageSessionSummary : IAggregate
 
     /// <summary>Gets the number of duplicate closure actions recorded.</summary>
     public int DuplicateClosuresCount { get; init; }
+
+    /// <summary>Gets grouped detail lines for label actions.</summary>
+    public IReadOnlyList<string> LabelActionDetails { get; init; } = [];
+
+    /// <summary>Gets grouped detail lines for milestone assignment actions.</summary>
+    public IReadOnlyList<string> MilestoneActionDetails { get; init; } = [];
+
+    /// <summary>Gets grouped detail lines for project-board actions.</summary>
+    public IReadOnlyList<string> ProjectActionDetails { get; init; } = [];
+
+    /// <summary>Gets grouped detail lines for duplicate closure actions.</summary>
+    public IReadOnlyList<string> DuplicateActionDetails { get; init; } = [];
+
+    /// <summary>Gets grouped detail lines for items currently skipped for revisit.</summary>
+    public IReadOnlyList<string> SkippedItemDetails { get; init; } = [];
 }

--- a/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageSessionSummary.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Triage/TriageSessionSummary.cs
@@ -42,6 +42,9 @@ public sealed record TriageSessionSummary : IAggregate
     /// <summary>Gets grouped detail lines for duplicate closure actions.</summary>
     public IReadOnlyList<string> DuplicateActionDetails { get; init; } = [];
 
+    /// <summary>Gets grouped detail lines for skip actions, including optional reasons.</summary>
+    public IReadOnlyList<string> SkippedActionDetails { get; init; } = [];
+
     /// <summary>Gets grouped detail lines for items currently skipped for revisit.</summary>
     public IReadOnlyList<string> SkippedItemDetails { get; init; } = [];
 }

--- a/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
@@ -834,6 +834,210 @@ public sealed class TriageTests
             Times.Once);
     }
 
+    [Fact]
+    public async Task Triage_SkipItemClicked_RecordsSkipAndMovesToNextItem()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [
+                CreateItem(801, "Issue 801", "owner/repo"),
+                CreateItem(802, "Issue 802", "owner/repo"),
+            ],
+            currentIndex: 0,
+            skippedItems: []);
+
+        var skippedSession = new TriageSessionDto(
+            startedSession.SessionId,
+            "owner",
+            "repo",
+            false,
+            [CreateItem(802, "Issue 802", "owner/repo")],
+            0,
+            [CreateItem(801, "Issue 801", "owner/repo")],
+            [
+                new TriageActionDto(TriageActionTypeDto.Skipped, TriageItemTypeDto.Issue, 801, "owner/repo", "Skipped for later review. Reason: Requires broader context", DateTimeOffset.UtcNow),
+            ],
+            new TriageSessionProgressDto(1, 0, 1, 1),
+            new TriageSessionSummaryDto(1, 0, 1, 1, 0, 0, 0, 0)
+            {
+                SkippedItemDetails = ["Issue #801 (owner/repo): Issue 801"],
+            },
+            DateTimeOffset.UtcNow);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.SkipCurrentItemAsync(It.IsAny<TriageSessionDto>(), "Requires broader context", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(skippedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+        cut.WaitForAssertion(() => Assert.Contains("Issue 801", cut.Markup));
+
+        var skipReasonInput = cut
+            .FindComponents<MudTextField<string>>()
+            .Single(component => string.Equals(component.Instance.Label, "Skip reason (optional)", StringComparison.Ordinal));
+
+        await cut.InvokeAsync(() => skipReasonInput.Instance.ValueChanged.InvokeAsync("Requires broader context"));
+        cut.Find("[data-testid='triage-skip-item-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Issue 802", cut.Markup);
+            Assert.Contains("Skipped: 1 item", cut.Markup);
+            Assert.Contains("Skipped item #801 for later review and moved to Item 1 of 1", cut.Markup, StringComparison.Ordinal);
+        });
+
+        _triageServiceMock.Verify(
+            service => service.SkipCurrentItemAsync(It.IsAny<TriageSessionDto>(), "Requires broader context", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Triage_SessionCompleted_ShowsGroupedSummaryDetailsAndSkippedRevisitButton()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var completedSession = new TriageSessionDto(
+            Guid.NewGuid(),
+            "owner",
+            "repo",
+            false,
+            [CreateItem(901, "Issue 901", "owner/repo")],
+            1,
+            [CreateItem(902, "Issue 902", "owner/repo")],
+            [],
+            new TriageSessionProgressDto(1, 1, 0, 1),
+            new TriageSessionSummaryDto(1, 1, 0, 1, 2, 1, 1, 1)
+            {
+                LabelActionDetails = ["Issue #901 (owner/repo): Applied label 'type/story'.", "Issue #902 (owner/repo): Applied label 'priority/high'."],
+                MilestoneActionDetails = ["Issue #901 (owner/repo): Assigned milestone 'v0.3.0'."],
+                ProjectActionDetails = ["Issue #901 (owner/repo): Added to project board 'Roadmap' with status 'In Progress'."],
+                DuplicateActionDetails = ["Issue #902 (owner/repo): Closed as duplicate of '#321'."],
+                SkippedItemDetails = ["Issue #902 (owner/repo): Issue 902"],
+            },
+            DateTimeOffset.UtcNow);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(completedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotEmpty(cut.FindAll("[data-testid='triage-session-complete-region']"));
+            Assert.Contains("Processed 1 of 1 items. 1 skipped item(s) are available to revisit.", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Issue #901 (owner/repo): Applied label 'type/story'.", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Issue #901 (owner/repo): Assigned milestone 'v0.3.0'.", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Issue #901 (owner/repo): Added to project board 'Roadmap' with status 'In Progress'.", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Issue #902 (owner/repo): Closed as duplicate of '#321'.", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Issue #902 (owner/repo): Issue 902", cut.Markup, StringComparison.Ordinal);
+            Assert.NotEmpty(cut.FindAll("[data-testid='triage-revisit-skipped-button']"));
+        });
+    }
+
+    [Fact]
+    public async Task Triage_RevisitSkippedItemsClicked_ResumesSessionFromSkippedQueue()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var completedSession = new TriageSessionDto(
+            Guid.NewGuid(),
+            "owner",
+            "repo",
+            false,
+            [CreateItem(950, "Issue 950", "owner/repo")],
+            1,
+            [CreateItem(951, "Issue 951", "owner/repo")],
+            [],
+            new TriageSessionProgressDto(1, 1, 0, 1),
+            new TriageSessionSummaryDto(1, 1, 0, 1, 0, 0, 0, 0)
+            {
+                SkippedItemDetails = ["Issue #951 (owner/repo): Issue 951"],
+            },
+            DateTimeOffset.UtcNow);
+
+        var resumedSession = new TriageSessionDto(
+            completedSession.SessionId,
+            "owner",
+            "repo",
+            false,
+            [CreateItem(951, "Issue 951", "owner/repo")],
+            0,
+            [],
+            [],
+            new TriageSessionProgressDto(1, 0, 1, 0),
+            new TriageSessionSummaryDto(1, 0, 1, 0, 0, 0, 0, 0),
+            DateTimeOffset.UtcNow);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(completedSession);
+
+        _triageServiceMock
+            .Setup(service => service.RevisitSkippedItemsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resumedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("[data-testid='triage-revisit-skipped-button']")));
+
+        cut.Find("[data-testid='triage-revisit-skipped-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Issue 951", cut.Markup);
+            Assert.Contains("Skipped items were appended to the queue for review.", cut.Markup, StringComparison.Ordinal);
+        });
+
+        _triageServiceMock.Verify(
+            service => service.RevisitSkippedItemsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private static async Task SelectQuickLabelAsync(IRenderedComponent<Triage> cut, string labelName)
     {
         ArgumentNullException.ThrowIfNull(cut);

--- a/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
@@ -934,6 +934,7 @@ public sealed class TriageTests
                 MilestoneActionDetails = ["Issue #901 (owner/repo): Assigned milestone 'v0.3.0'."],
                 ProjectActionDetails = ["Issue #901 (owner/repo): Added to project board 'Roadmap' with status 'In Progress'."],
                 DuplicateActionDetails = ["Issue #902 (owner/repo): Closed as duplicate of '#321'."],
+                SkippedActionDetails = ["Issue #902 (owner/repo): Skipped for later review. Reason: Waiting for product clarification"],
                 SkippedItemDetails = ["Issue #902 (owner/repo): Issue 902"],
             },
             DateTimeOffset.UtcNow);
@@ -962,6 +963,7 @@ public sealed class TriageTests
             Assert.Contains("Issue #901 (owner/repo): Assigned milestone 'v0.3.0'.", cut.Markup, StringComparison.Ordinal);
             Assert.Contains("Issue #901 (owner/repo): Added to project board 'Roadmap' with status 'In Progress'.", cut.Markup, StringComparison.Ordinal);
             Assert.Contains("Issue #902 (owner/repo): Closed as duplicate of '#321'.", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Issue #902 (owner/repo): Skipped for later review. Reason: Waiting for product clarification", cut.Markup, StringComparison.Ordinal);
             Assert.Contains("Issue #902 (owner/repo): Issue 902", cut.Markup, StringComparison.Ordinal);
             Assert.NotEmpty(cut.FindAll("[data-testid='triage-revisit-skipped-button']"));
         });

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
@@ -484,6 +484,7 @@ public sealed class TriageServiceTests
             new TriageActionDto(TriageActionTypeDto.MilestoneAssigned, TriageItemTypeDto.Issue, 3, "owner/repo", string.Empty, DateTimeOffset.UtcNow),
             new TriageActionDto(TriageActionTypeDto.ProjectBoardAssigned, TriageItemTypeDto.Issue, 4, "owner/repo", string.Empty, DateTimeOffset.UtcNow),
             new TriageActionDto(TriageActionTypeDto.ClosedAsDuplicate, TriageItemTypeDto.Issue, 5, "owner/repo", string.Empty, DateTimeOffset.UtcNow),
+            new TriageActionDto(TriageActionTypeDto.Skipped, TriageItemTypeDto.Issue, 99, "owner/repo", "Skipped for later review. Reason: Needs wider context", DateTimeOffset.UtcNow),
         };
 
         var session = new TriageSessionDto(
@@ -530,8 +531,10 @@ public sealed class TriageServiceTests
         Assert.Single(result.MilestoneActionDetails);
         Assert.Single(result.ProjectActionDetails);
         Assert.Single(result.DuplicateActionDetails);
+        Assert.Single(result.SkippedActionDetails);
         Assert.Single(result.SkippedItemDetails);
         Assert.Contains("Issue #1", result.LabelActionDetails[0], StringComparison.Ordinal);
+        Assert.Contains("Reason: Needs wider context", result.SkippedActionDetails[0], StringComparison.Ordinal);
         Assert.Contains("Skipped item", result.SkippedItemDetails[0], StringComparison.Ordinal);
     }
 

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
@@ -493,9 +493,25 @@ public sealed class TriageServiceTests
             false,
             CreateQueue(3),
             2,
-            [],
+            [
+                new TriageItemDto(
+                    TriageItemTypeDto.Issue,
+                    99,
+                    99,
+                    "owner/repo",
+                    "Skipped item",
+                    string.Empty,
+                    string.Empty,
+                    "open",
+                    "mark",
+                    [],
+                    null,
+                    string.Empty,
+                    DateTimeOffset.UtcNow,
+                    DateTimeOffset.UtcNow),
+            ],
             actions,
-            new TriageSessionProgressDto(3, 2, 1, 0),
+            new TriageSessionProgressDto(3, 2, 1, 1),
             new TriageSessionSummaryDto(3, 2, 1, 0, 0, 0, 0, 0),
             DateTimeOffset.UtcNow);
 
@@ -510,6 +526,13 @@ public sealed class TriageServiceTests
         Assert.Equal(1, result.MilestonesAssignedCount);
         Assert.Equal(1, result.ProjectAssignmentsCount);
         Assert.Equal(1, result.DuplicateClosuresCount);
+        Assert.Equal(2, result.LabelActionDetails.Count);
+        Assert.Single(result.MilestoneActionDetails);
+        Assert.Single(result.ProjectActionDetails);
+        Assert.Single(result.DuplicateActionDetails);
+        Assert.Single(result.SkippedItemDetails);
+        Assert.Contains("Issue #1", result.LabelActionDetails[0], StringComparison.Ordinal);
+        Assert.Contains("Skipped item", result.SkippedItemDetails[0], StringComparison.Ordinal);
     }
 
     private static TriageSessionDto CreateSession(int queueCount, int currentIndex)


### PR DESCRIPTION
## Summary of Changes

Implements the session-complete summary view and skip/revisit workflow for the Triage UI. At the end of a triage session users see grouped detail panels showing every action taken (labels applied, milestones assigned, project board actions, duplicate closures, skipped items). Users can skip the current item during a session with an optional reason, and revisit all skipped items from the session-complete view.

## Related Issue(s)

Closes #149

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`) — 224 passed, 0 failed
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

N/A — session-complete state requires a live session; UI uses MudBlazor responsive grid.

## Additional Notes

### Changes Made

**Domain (`SoloDevBoard.Domain`):**
- `TriageSessionSummary` — 5 new `IReadOnlyList<string>` init properties for grouped action detail lines (`LabelActionDetails`, `MilestoneActionDetails`, `ProjectActionDetails`, `DuplicateActionDetails`, `SkippedItemDetails`)

**Application (`SoloDevBoard.Application`):**
- `TriageSessionSummaryDto` — same 5 properties added to the DTO record
- `TriageService.BuildSummary` — signature changed from `int skippedItems` to `IReadOnlyList<TriageItem> skippedItems`; new static helpers `BuildActionDetails`, `FormatActionDetail`, `FormatSkippedItemDetail` compute grouped lines from action history

**App (`SoloDevBoard.App`):**
- `Triage.razor` — skip action section (optional reason input + Skip item button + S keyboard shortcut legend entry); session-complete view extended with responsive count cards grid and grouped detail panels using `MudList<T>`
- `Triage.razor.cs` — `skipReason` field, `CanSkipCurrentItem` property, `OnSkipReasonChangedAsync`, `SkipCurrentItemAsync`, S keyboard shortcut handler

**Tests:**
- 3 new bUnit tests: `Triage_SkipItemClicked_RecordsSkipAndMovesToNextItem`, `Triage_SessionCompleted_ShowsGroupedSummaryDetailsAndSkippedRevisitButton`, `Triage_RevisitSkippedItemsClicked_ResumesSessionFromSkippedQueue`
- `TriageServiceTests` — `BuildSessionSummary_ActionHistoryIncludesAllActionTypes_ReturnsComputedCounts` extended for all 5 new detail properties

**Docs:**
- `docs/user-guide/triage-ui.md` — new section "Session Completion Summary and Skip/Revisit Workflow"; S shortcut documented
- `plan/BACKLOG.md` — issue #149 marked complete