### PR TITLE
[type/test] Add test coverage for Triage session orchestration, GitHub triage actions, and Triage UI workflow

### DIFF
--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -177,10 +177,11 @@ Labels: `type/epic`, `area/triage`
 - [x] Triage session orchestration implemented on branch feature/issue-143-144-triage-session-and-github-actions. _(Issue #143; domain model and Application DTO/service orchestration complete; tests passing.)_
 - [x] Triage UI state management implemented on branch feature/issue-143-144-triage-session-and-github-actions. _(Issue #144; GitHub triage write operations and project-board assignment GraphQL support in IGitHubService and GitHubService complete; tests passing.)_
 
+
 **Tests:**
-- [ ] Triage session orchestration unit tests. _(Issue #151)_
-- [ ] Triage UI state management unit tests. _(Issue #152)_
-- [ ] Triage UI bUnit tests. _(Issue #153)_
+- [x] Triage session orchestration unit tests. _(Issue #151 — implemented 2026-05-07.)_
+- [x] Triage UI state management unit tests. _(Issue #152 — implemented 2026-05-07.)_
+- [x] Triage UI bUnit tests. _(Issue #153 — implemented 2026-05-07.)_
 
 - [ ] As a solo developer, I want to see which repositories already have a particular workflow template applied so that I have a clear overview of my CI/CD coverage.
 - [ ] As a solo developer, I want to be alerted when a repository's workflow file differs from the canonical template so that I can update it.

--- a/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
@@ -8,6 +8,7 @@ using SoloDevBoard.App.Components.Shared.Components;
 using SoloDevBoard.Application.Services.Labels;
 using SoloDevBoard.Application.Services.Repositories;
 using SoloDevBoard.Application.Services.Triage;
+using System.Net;
 
 namespace SoloDevBoard.App.Tests;
 
@@ -17,6 +18,174 @@ public sealed class TriageTests
     private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
     private readonly Mock<ITriageService> _triageServiceMock = new();
     private readonly Mock<ILabelManagerService> _labelManagerServiceMock = new();
+
+    [Fact]
+    public async Task Triage_RepositoriesAreLoading_ShowsLoadingStateUntilRepositoryDataArrives()
+    {
+        // Arrange
+        var repositoryTaskSource = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .Returns(repositoryTaskSource.Task);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+
+        // Assert
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-loading-repositories']"));
+
+        repositoryTaskSource.SetResult([CreateRepository("owner", "repo")]);
+
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+    }
+
+    [Fact]
+    public async Task Triage_NoRepositoriesReturned_ShowsNoRepositoriesWarningState()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<RepositoryDto>());
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotEmpty(cut.FindAll("[data-testid='triage-no-repositories-alert']"));
+            Assert.Contains("No active repositories are available for triage.", cut.Markup, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public async Task Triage_StartSessionFailure_ShowsErrorFeedbackRegion()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Bad gateway", null, HttpStatusCode.BadGateway));
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotEmpty(cut.FindAll("[data-testid='triage-operation-alert']"));
+            Assert.Contains("GitHub API request failed while starting triage session.", cut.Markup, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public async Task Triage_StartSessionWithEmptyQueue_ShowsSummaryStateAndEmptyQueueMessage()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var emptySession = CreateSession(
+            "owner",
+            "repo",
+            [],
+            currentIndex: 0,
+            skippedItems: []);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(emptySession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotEmpty(cut.FindAll("[data-testid='triage-session-complete-region']"));
+            Assert.Contains("No untriaged items were found in owner/repo.", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Processed 0 of 0 items. 0 skipped item(s) are available to revisit.", cut.Markup, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public async Task Triage_StartedSessionWithPullRequestCurrentItem_ShowsPullRequestVariantAndKeyboardLegend()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var pullRequestItem = new TriageItemDto(
+            TriageItemTypeDto.PullRequest,
+            2201,
+            2201,
+            "owner/repo",
+            "PR 2201",
+            "https://github.com/owner/repo/pull/2201",
+            "Body for PR 2201",
+            "open",
+            "markheydon",
+            [],
+            null,
+            string.Empty,
+            DateTimeOffset.UtcNow.AddDays(-4),
+            DateTimeOffset.UtcNow.AddDays(-1));
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [pullRequestItem],
+            currentIndex: 0,
+            skippedItems: []);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Pull request", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Open item #2201 on GitHub", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Keyboard shortcuts (when the action buttons are focused)", cut.Markup, StringComparison.Ordinal);
+        });
+    }
 
     [Fact]
     public async Task Triage_StartSessionClicked_LoadsFirstItemAndShowsRemainingCount()

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
@@ -25,6 +25,32 @@ public sealed class TriageServiceTests
     }
 
     [Fact]
+    public async Task StartSessionAsync_OwnerIsWhitespace_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+
+        // Act
+        var action = async () => _ = await sut.StartSessionAsync(" ", "repo");
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
+    }
+
+    [Fact]
+    public async Task StartSessionAsync_RepositoryIsWhitespace_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+
+        // Act
+        var action = async () => _ = await sut.StartSessionAsync("owner", " ");
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
+    }
+
+    [Fact]
     public async Task StartSessionAsync_IssuesOnly_BuildsIssueQueueAndInitialProgress()
     {
         // Arrange
@@ -276,6 +302,47 @@ public sealed class TriageServiceTests
     }
 
     [Fact]
+    public async Task ApplyLabelToCurrentItemAsync_InvalidRepositoryScope_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var invalidScopeItem = new TriageItemDto(
+            TriageItemTypeDto.Issue,
+            1,
+            1,
+            "invalid-scope",
+            "Item 1",
+            string.Empty,
+            string.Empty,
+            "open",
+            "mark",
+            [],
+            null,
+            string.Empty,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+
+        var session = new TriageSessionDto(
+            Guid.NewGuid(),
+            "owner",
+            "repo",
+            false,
+            [invalidScopeItem],
+            0,
+            [],
+            [],
+            new TriageSessionProgressDto(1, 0, 1, 0),
+            new TriageSessionSummaryDto(1, 0, 1, 0, 0, 0, 0, 0),
+            DateTimeOffset.UtcNow);
+
+        // Act
+        var action = async () => _ = await sut.ApplyLabelToCurrentItemAsync(session, "type/story");
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
+    }
+
+    [Fact]
     public async Task GetMilestoneOptionsAsync_MilestonesReturned_ReturnsSortedOptions()
     {
         // Arrange
@@ -400,6 +467,53 @@ public sealed class TriageServiceTests
         _gitHubServiceMock.Verify(
             service => service.UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress", It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task AddCurrentItemToProjectBoardAsync_InvalidRepositoryScope_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = new TriageService(_gitHubServiceMock.Object);
+        var invalidScopeItem = new TriageItemDto(
+            TriageItemTypeDto.Issue,
+            1,
+            1,
+            "invalid-scope",
+            "Item 1",
+            string.Empty,
+            string.Empty,
+            "open",
+            "mark",
+            [],
+            null,
+            string.Empty,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+
+        var session = new TriageSessionDto(
+            Guid.NewGuid(),
+            "owner",
+            "repo",
+            false,
+            [invalidScopeItem],
+            0,
+            [],
+            [],
+            new TriageSessionProgressDto(1, 0, 1, 0),
+            new TriageSessionSummaryDto(1, 0, 1, 0, 0, 0, 0, 0),
+            DateTimeOffset.UtcNow);
+
+        // Act
+        var action = async () => _ = await sut.AddCurrentItemToProjectBoardAsync(
+            session,
+            "project-id",
+            "Roadmap",
+            "status-field-id",
+            "in-progress",
+            "In Progress");
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -684,6 +684,45 @@ public sealed class GitHubServiceTests
     }
 
     [Fact]
+    public async Task ApplyLabelsToTriageItemAsync_DuplicateAndWhitespaceLabels_NormalisesPayload()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler([
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]", Encoding.UTF8, "application/json"),
+            },
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        await sut.ApplyLabelsToTriageItemAsync("owner", "repo", 42, [" priority/high ", "", "type/story", "priority/high"]);
+
+        // Assert
+        Assert.Single(handler.Requests);
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        var labels = document.RootElement.GetProperty("labels");
+        Assert.Equal(2, labels.GetArrayLength());
+        Assert.Equal("priority/high", labels[0].GetString());
+        Assert.Equal("type/story", labels[1].GetString());
+    }
+
+    [Fact]
+    public async Task ApplyLabelsToTriageItemAsync_ItemNumberIsNotPositive_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var sut = CreateSubject(new QueueMessageHandler([]));
+
+        // Act
+        var action = async () => await sut.ApplyLabelsToTriageItemAsync("owner", "repo", 0, ["type/story"]);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(action);
+    }
+
+    [Fact]
     public async Task AssignMilestoneToTriageItemAsync_NullMilestone_SendsPatchWithNullMilestone()
     {
         // Arrange
@@ -748,6 +787,45 @@ public sealed class GitHubServiceTests
         Assert.Equal("https://api.github.com/graphql", handler.Requests[1].RequestUri!.ToString());
     }
 
+        [Fact]
+        public async Task AddTriageItemToProjectBoardAsync_GraphQlErrorsPresent_ThrowsHttpRequestException()
+        {
+                // Arrange
+                var handler = new QueueMessageHandler(
+                [
+                        CreateJsonResponse(HttpStatusCode.OK, """
+                        {
+                            "node_id": "I_kwDOABCDE123"
+                        }
+                        """),
+                        CreateJsonResponse(HttpStatusCode.OK, """
+                        {
+                            "data": {
+                                "addProjectV2ItemById": {
+                                    "item": {
+                                        "id": null
+                                    }
+                                }
+                            },
+                            "errors": [
+                                {
+                                    "message": "Project item could not be created"
+                                }
+                            ]
+                        }
+                        """),
+                ]);
+
+                var sut = CreateSubject(handler);
+
+                // Act
+                var action = async () => _ = await sut.AddTriageItemToProjectBoardAsync("owner", "repo", 55, "project-id");
+
+                // Assert
+                var exception = await Assert.ThrowsAsync<HttpRequestException>(action);
+                Assert.Contains("GitHub GraphQL request failed", exception.Message, StringComparison.Ordinal);
+        }
+
     [Fact]
     public async Task GetProjectBoardsForRepositoryAsync_StatusFieldPresent_ReturnsProjectBoardOptions()
     {
@@ -801,6 +879,36 @@ public sealed class GitHubServiceTests
     }
 
     [Fact]
+    public async Task GetProjectBoardsForRepositoryAsync_GraphQlErrorsPresent_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": null
+                },
+                "errors": [
+                    {
+                        "message": "Repository not found"
+                    }
+                ]
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        var action = async () => _ = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo");
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(action);
+        Assert.Contains("GitHub GraphQL request failed", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task UpdateProjectBoardItemStatusAsync_ValidResponse_PostsGraphQlMutation()
     {
         // Arrange
@@ -837,6 +945,36 @@ public sealed class GitHubServiceTests
         Assert.Equal("project-item-id", variables.GetProperty("itemId").GetString());
         Assert.Equal("status-field-id", variables.GetProperty("fieldId").GetString());
         Assert.Equal("in-progress", variables.GetProperty("statusOptionId").GetString());
+    }
+
+    [Fact]
+    public async Task UpdateProjectBoardItemStatusAsync_GraphQlErrorsPresent_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "updateProjectV2ItemFieldValue": null
+                },
+                "errors": [
+                    {
+                        "message": "Field value could not be updated"
+                    }
+                ]
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        var action = async () => await sut.UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress");
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(action);
+        Assert.Contains("GitHub GraphQL request failed", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -895,6 +1033,29 @@ public sealed class GitHubServiceTests
         Assert.Equal("https://api.github.com/repos/owner/repo/issues/100/comments", handler.Requests[0].RequestUri!.ToString());
         Assert.Equal(HttpMethod.Patch, handler.Requests[1].Method);
         Assert.Equal("https://api.github.com/repos/owner/repo/pulls/100", handler.Requests[1].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task CloseTriageItemAsDuplicateAsync_CommentRequestFails_ThrowsAndDoesNotAttemptCloseRequest()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("{\"message\":\"Validation failed\"}", Encoding.UTF8, "application/json"),
+            },
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        var action = async () => await sut.CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 99, "#12");
+
+        // Assert
+        await Assert.ThrowsAsync<HttpRequestException>(action);
+        Assert.Single(handler.Requests);
+        Assert.Equal("https://api.github.com/repos/owner/repo/issues/99/comments", handler.Requests[0].RequestUri!.ToString());
     }
 
     private static GitHubService CreateSubject(HttpMessageHandler handler)


### PR DESCRIPTION
## Summary of Changes

Adds missing test coverage for the Triage UI feature across all three test projects. Covers Application-layer guard clauses and edge cases, Infrastructure-layer HTTP error paths for triage write operations, and bUnit component tests for loading state, empty queue, error feedback, and pull request item variant rendering.

## Related Issue(s)

Closes #151
Closes #152
Closes #153

## Type of Change

- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Additional Notes

All 239 tests pass (6 Domain, 79 Application, 74 Infrastructure, 80 App).
No new user-facing functionality — this PR covers test coverage only.
`plan/BACKLOG.md` updated to mark issues #151, #152, and #153 as implemented (2026-05-07).