### PR TITLE
[type/story] Include unlabelled pull requests in Triage UI sessions

### DIFF
--- a/docs/user-guide/triage-ui.md
+++ b/docs/user-guide/triage-ui.md
@@ -8,11 +8,12 @@ nav_order: 5
 
 ## Overview
 
-The Triage UI enables you to work through untriaged GitHub items for a single selected repository in a focused, step-by-step session. Unlabelled issues are always included, and you can optionally include pull requests in the same queue.
+The Triage UI enables you to work through untriaged GitHub items for a single selected repository in a focused, step-by-step session. Unlabelled issues are always included, and you can optionally include unlabelled pull requests in the same queue.
 
 Key features:
 - You can start a triage session for one repository at a time.
-- The queue includes unlabelled issues, with an option to include pull requests.
+- The queue includes unlabelled issues, with an option to include unlabelled pull requests. When enabled, both types appear in the same queue.
+- Each item in the queue displays a clear item-type indicator: **Issue** or **Pull request**.
 - The interface shows your current position (e.g., Item 3 of 10), a remaining count, and a progress indicator.
 - Use the **Quick Label** field to search and select a label, then click **Apply + next** to apply it and move on.
 - Click **Next** to advance without making any change to the current item.
@@ -21,12 +22,14 @@ Key features:
 ## How to Use
 
 1. Select a repository to start a triage session.
-2. The Triage UI queues all unlabelled issues for that repository.
+2. The Triage UI queues all unlabelled issues for that repository. If pull request inclusion is enabled, unlabelled pull requests are also included in the queue.
 3. Review each item in turn, then either:
-   - Search for a label in the **Quick Label** field and click **Apply + next** to label the issue and advance, or
+   - Search for a label in the **Quick Label** field and click **Apply + next** to label the item and advance, or
    - Click **Next** to advance to the next item without applying a label.
 4. The session completes once all queued items have been processed.
 5. Use the progress indicator and session context to track your position and the number of remaining items.
+
+When both issues and pull requests are present, the queue operates in a mixed mode, but you still triage one item at a time using the same action surface. Where supported by GitHub, all actions are available for both item types.
 
 
 

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -193,7 +193,7 @@ Labels: `type/epic`, `area/triage`
 - [ ] **Future follow-on improvement:** When a triage item is closed as a duplicate, if the repository's canonical label scheme includes a `duplicate` label, SoloDevBoard should also apply that label. _(Planned as a future improvement; see issue #176: [Story] Apply the canonical duplicate label during Triage duplicate closure.)_
 - [x] As a solo developer, I want to see a summary at the end of a triage session showing all actions taken, and have the option to skip and return to issues later, so that I have a record of what was done and am not blocked by difficult triage decisions. _(Issue #149 — implemented 2026-05-07.)_
   - Implementation note: Session completion now shows grouped summary details from the Application layer for labels, milestones, project actions, duplicate closures, and skipped items. Users can skip the current item (with optional reason) and revisit skipped items from the session-complete state. Keyboard shortcut S is available to skip. Layout uses MudBlazor and is responsive for desktop/mobile.
-- [ ] As a solo developer, I want to triage unlabelled pull requests alongside issues so that my entire GitHub workload, including open PRs, is managed in one place. _(Issue #150)_
+- [x] As a solo developer, I want to triage unlabelled pull requests alongside issues so that my entire GitHub workload, including open PRs, is managed in one place. _(Issue #150 — completed 2026-05-08.)_
 
 **Enablers:**
 - [x] Triage session orchestration implemented on branch feature/issue-143-144-triage-session-and-github-actions. _(Issue #143; domain model and Application DTO/service orchestration complete; tests passing.)_

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
@@ -397,7 +397,18 @@
                                     <MudList T="string" Dense="true">
                                         @foreach (var detail in currentSession.Summary.LabelActionDetails)
                                         {
-                                            <MudListItem T="string" Text="@detail" />
+                                            @if (TryCreateSummaryDetailLink(detail, out var linkText, out var linkUrl, out var remainingDetail))
+                                            {
+                                                <MudListItem T="string">
+                                                    <MudText Typo="Typo.body2">
+                                                        <MudLink Href="@linkUrl" Target="_blank">@linkText</MudLink>@remainingDetail
+                                                    </MudText>
+                                                </MudListItem>
+                                            }
+                                            else
+                                            {
+                                                <MudListItem T="string" Text="@detail" />
+                                            }
                                         }
                                     </MudList>
                                 }
@@ -417,7 +428,18 @@
                                     <MudList T="string" Dense="true">
                                         @foreach (var detail in currentSession.Summary.MilestoneActionDetails)
                                         {
-                                            <MudListItem T="string" Text="@detail" />
+                                            @if (TryCreateSummaryDetailLink(detail, out var linkText, out var linkUrl, out var remainingDetail))
+                                            {
+                                                <MudListItem T="string">
+                                                    <MudText Typo="Typo.body2">
+                                                        <MudLink Href="@linkUrl" Target="_blank">@linkText</MudLink>@remainingDetail
+                                                    </MudText>
+                                                </MudListItem>
+                                            }
+                                            else
+                                            {
+                                                <MudListItem T="string" Text="@detail" />
+                                            }
                                         }
                                     </MudList>
                                 }
@@ -437,7 +459,18 @@
                                     <MudList T="string" Dense="true">
                                         @foreach (var detail in currentSession.Summary.ProjectActionDetails)
                                         {
-                                            <MudListItem T="string" Text="@detail" />
+                                            @if (TryCreateSummaryDetailLink(detail, out var linkText, out var linkUrl, out var remainingDetail))
+                                            {
+                                                <MudListItem T="string">
+                                                    <MudText Typo="Typo.body2">
+                                                        <MudLink Href="@linkUrl" Target="_blank">@linkText</MudLink>@remainingDetail
+                                                    </MudText>
+                                                </MudListItem>
+                                            }
+                                            else
+                                            {
+                                                <MudListItem T="string" Text="@detail" />
+                                            }
                                         }
                                     </MudList>
                                 }
@@ -457,7 +490,18 @@
                                     <MudList T="string" Dense="true">
                                         @foreach (var detail in currentSession.Summary.DuplicateActionDetails)
                                         {
-                                            <MudListItem T="string" Text="@detail" />
+                                            @if (TryCreateSummaryDetailLink(detail, out var linkText, out var linkUrl, out var remainingDetail))
+                                            {
+                                                <MudListItem T="string">
+                                                    <MudText Typo="Typo.body2">
+                                                        <MudLink Href="@linkUrl" Target="_blank">@linkText</MudLink>@remainingDetail
+                                                    </MudText>
+                                                </MudListItem>
+                                            }
+                                            else
+                                            {
+                                                <MudListItem T="string" Text="@detail" />
+                                            }
                                         }
                                     </MudList>
                                 }
@@ -477,7 +521,18 @@
                                     <MudList T="string" Dense="true">
                                         @foreach (var detail in currentSession.Summary.SkippedActionDetails)
                                         {
-                                            <MudListItem T="string" Text="@detail" />
+                                            @if (TryCreateSummaryDetailLink(detail, out var linkText, out var linkUrl, out var remainingDetail))
+                                            {
+                                                <MudListItem T="string">
+                                                    <MudText Typo="Typo.body2">
+                                                        <MudLink Href="@linkUrl" Target="_blank">@linkText</MudLink>@remainingDetail
+                                                    </MudText>
+                                                </MudListItem>
+                                            }
+                                            else
+                                            {
+                                                <MudListItem T="string" Text="@detail" />
+                                            }
                                         }
                                     </MudList>
                                 }
@@ -497,7 +552,18 @@
                                     <MudList T="string" Dense="true">
                                         @foreach (var detail in currentSession.Summary.SkippedItemDetails)
                                         {
-                                            <MudListItem T="string" Text="@detail" />
+                                            @if (TryCreateSummaryDetailLink(detail, out var linkText, out var linkUrl, out var remainingDetail))
+                                            {
+                                                <MudListItem T="string">
+                                                    <MudText Typo="Typo.body2">
+                                                        <MudLink Href="@linkUrl" Target="_blank">@linkText</MudLink>@remainingDetail
+                                                    </MudText>
+                                                </MudListItem>
+                                            }
+                                            else
+                                            {
+                                                <MudListItem T="string" Text="@detail" />
+                                            }
                                         }
                                     </MudList>
                                 }

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor
@@ -401,7 +401,7 @@
                                             {
                                                 <MudListItem T="string">
                                                     <MudText Typo="Typo.body2">
-                                                        <MudLink Href="@linkUrl" Target="_blank">@linkText</MudLink>@remainingDetail
+                                                        <MudLink Href="@linkUrl" Target="_blank" UserAttributes="externalLinkUserAttributes">@linkText</MudLink>@remainingDetail
                                                     </MudText>
                                                 </MudListItem>
                                             }
@@ -432,7 +432,7 @@
                                             {
                                                 <MudListItem T="string">
                                                     <MudText Typo="Typo.body2">
-                                                        <MudLink Href="@linkUrl" Target="_blank">@linkText</MudLink>@remainingDetail
+                                                        <MudLink Href="@linkUrl" Target="_blank" UserAttributes="externalLinkUserAttributes">@linkText</MudLink>@remainingDetail
                                                     </MudText>
                                                 </MudListItem>
                                             }
@@ -463,7 +463,7 @@
                                             {
                                                 <MudListItem T="string">
                                                     <MudText Typo="Typo.body2">
-                                                        <MudLink Href="@linkUrl" Target="_blank">@linkText</MudLink>@remainingDetail
+                                                        <MudLink Href="@linkUrl" Target="_blank" UserAttributes="externalLinkUserAttributes">@linkText</MudLink>@remainingDetail
                                                     </MudText>
                                                 </MudListItem>
                                             }
@@ -494,7 +494,7 @@
                                             {
                                                 <MudListItem T="string">
                                                     <MudText Typo="Typo.body2">
-                                                        <MudLink Href="@linkUrl" Target="_blank">@linkText</MudLink>@remainingDetail
+                                                        <MudLink Href="@linkUrl" Target="_blank" UserAttributes="externalLinkUserAttributes">@linkText</MudLink>@remainingDetail
                                                     </MudText>
                                                 </MudListItem>
                                             }
@@ -525,7 +525,7 @@
                                             {
                                                 <MudListItem T="string">
                                                     <MudText Typo="Typo.body2">
-                                                        <MudLink Href="@linkUrl" Target="_blank">@linkText</MudLink>@remainingDetail
+                                                        <MudLink Href="@linkUrl" Target="_blank" UserAttributes="externalLinkUserAttributes">@linkText</MudLink>@remainingDetail
                                                     </MudText>
                                                 </MudListItem>
                                             }
@@ -556,7 +556,7 @@
                                             {
                                                 <MudListItem T="string">
                                                     <MudText Typo="Typo.body2">
-                                                        <MudLink Href="@linkUrl" Target="_blank">@linkText</MudLink>@remainingDetail
+                                                        <MudLink Href="@linkUrl" Target="_blank" UserAttributes="externalLinkUserAttributes">@linkText</MudLink>@remainingDetail
                                                     </MudText>
                                                 </MudListItem>
                                             }

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
@@ -20,6 +20,10 @@ public partial class Triage : ComponentBase
 
     private static readonly Regex hrefRegex = new("href=\"(?<url>[^\"]+)\"", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
     private static readonly Regex imageRegex = new("<img[^>]*>", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+    private static readonly Regex summaryItemDetailRegex = new(
+        "^(?<itemType>Issue|Pull request) #(?<itemNumber>\\d+) [(](?<repository>[^)]+)[)]: (?<description>.+)$",
+        RegexOptions.CultureInvariant,
+        TimeSpan.FromMilliseconds(100));
 
     /// <summary>Gets or sets the repository service used to load available repository scope options.</summary>
     [Inject]
@@ -935,5 +939,60 @@ public partial class Triage : ComponentBase
     }
 
     private static string GetItemCountLabel(int count) => count == 1 ? "item" : "items";
+
+    private static bool TryCreateSummaryDetailLink(
+        string detail,
+        out string linkText,
+        out string linkUrl,
+        out string remainingDetail)
+    {
+        linkText = string.Empty;
+        linkUrl = string.Empty;
+        remainingDetail = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(detail))
+        {
+            return false;
+        }
+
+        Match match;
+
+        try
+        {
+            match = summaryItemDetailRegex.Match(detail);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return false;
+        }
+
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var itemType = match.Groups["itemType"].Value;
+        var itemNumber = match.Groups["itemNumber"].Value;
+        var repository = match.Groups["repository"].Value;
+        var description = match.Groups["description"].Value;
+
+        if (string.IsNullOrWhiteSpace(itemType)
+            || string.IsNullOrWhiteSpace(itemNumber)
+            || string.IsNullOrWhiteSpace(repository)
+            || string.IsNullOrWhiteSpace(description))
+        {
+            return false;
+        }
+
+        var itemPathSegment = string.Equals(itemType, "Pull request", StringComparison.Ordinal)
+            ? "pull"
+            : "issues";
+
+        linkText = $"{itemType} #{itemNumber}";
+        linkUrl = $"https://github.com/{repository}/{itemPathSegment}/{itemNumber}";
+        remainingDetail = $" ({repository}): {description}";
+
+        return true;
+    }
 
 }

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
@@ -24,6 +24,10 @@ public partial class Triage : ComponentBase
         "^(?<itemType>Issue|Pull request) #(?<itemNumber>\\d+) [(](?<repository>[^)]+)[)]: (?<description>.+)$",
         RegexOptions.CultureInvariant,
         TimeSpan.FromMilliseconds(100));
+    private static readonly Dictionary<string, object> externalLinkUserAttributes = new()
+    {
+        ["rel"] = "noopener noreferrer",
+    };
 
     /// <summary>Gets or sets the repository service used to load available repository scope options.</summary>
     [Inject]

--- a/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Triage/TriageService.cs
@@ -30,7 +30,9 @@ public sealed class TriageService : ITriageService
         if (includePullRequests)
         {
             var pullRequests = await _gitHubService.GetPullRequestsAsync(owner, repo, cancellationToken).ConfigureAwait(false);
-            queue.AddRange(pullRequests.Select(pullRequest => ToDomainPullRequestItem(owner, repo, pullRequest)));
+            queue.AddRange(pullRequests
+                .Where(pullRequest => pullRequest.Labels.Count == 0)
+                .Select(pullRequest => ToDomainPullRequestItem(owner, repo, pullRequest)));
         }
 
         var orderedQueue = queue
@@ -597,8 +599,8 @@ public sealed class TriageService : ITriageService
             Body = pullRequest.Body,
             State = pullRequest.State,
             AuthorLogin = pullRequest.AuthorLogin,
-            Labels = [],
-            Milestone = null,
+            Labels = pullRequest.Labels,
+            Milestone = pullRequest.Milestone,
             CreatedAt = pullRequest.CreatedAt,
             UpdatedAt = pullRequest.UpdatedAt,
         };

--- a/src/Domain/SoloDevBoard.Domain/Entities/Triage/PullRequest.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Triage/PullRequest.cs
@@ -1,3 +1,6 @@
+using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Domain.Entities.Milestones;
+
 namespace SoloDevBoard.Domain.Entities.Triage;
 
 /// <summary>Represents a GitHub pull request.</summary>
@@ -32,6 +35,12 @@ public sealed record PullRequest : IAggregate
 
     /// <summary>Gets a value indicating whether the pull request is a draft.</summary>
     public bool IsDraft { get; init; }
+
+    /// <summary>Gets the labels currently assigned to the pull request.</summary>
+    public IReadOnlyList<Label> Labels { get; init; } = [];
+
+    /// <summary>Gets the milestone currently assigned to the pull request, if present.</summary>
+    public Milestone? Milestone { get; init; }
 
     /// <summary>Gets the date and time when the pull request was created.</summary>
     public DateTimeOffset CreatedAt { get; init; }

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
@@ -833,6 +833,12 @@ public sealed class GitHubService : IGitHubService
         [JsonPropertyName("draft")]
         public bool IsDraft { get; init; }
 
+        [JsonPropertyName("labels")]
+        public List<LabelResponseDto> Labels { get; init; } = [];
+
+        [JsonPropertyName("milestone")]
+        public MilestoneResponseDto? Milestone { get; init; }
+
         [JsonPropertyName("created_at")]
         public DateTimeOffset CreatedAt { get; init; }
 
@@ -851,6 +857,8 @@ public sealed class GitHubService : IGitHubService
             HeadBranch = Head?.ReferenceName ?? string.Empty,
             BaseBranch = Base?.ReferenceName ?? string.Empty,
             IsDraft = IsDraft,
+            Labels = Labels.ConvertAll(static label => label.ToDomain()),
+            Milestone = Milestone?.ToDomain(),
             CreatedAt = CreatedAt,
             UpdatedAt = UpdatedAt,
         };

--- a/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
@@ -745,10 +745,6 @@ public sealed class TriageTests
 
         _triageServiceMock
             .Setup(service => service.AssignMilestoneToCurrentItemAsync(It.IsAny<TriageSessionDto>(), 7, "v0.7.0", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
-
-        _triageServiceMock
-            .Setup(service => service.AssignMilestoneToCurrentItemAsync(It.IsAny<TriageSessionDto>(), 7, "v0.7.0", It.IsAny<CancellationToken>()))
             .ReturnsAsync(milestoneAssignedSession);
 
         await using var ctx = CreateContext();
@@ -812,6 +808,15 @@ public sealed class TriageTests
             currentIndex: 0,
             skippedItems: []);
 
+        var milestoneAssignedSession = startedSession with
+        {
+            ActionHistory =
+            [
+                new TriageActionDto(TriageActionTypeDto.MilestoneAssigned, TriageItemTypeDto.PullRequest, 2202, "owner/repo", "Assigned milestone 'v0.7.0'.", DateTimeOffset.UtcNow),
+            ],
+            Summary = new TriageSessionSummaryDto(1, 0, 1, 0, 0, 1, 0, 0),
+        };
+
         _triageServiceMock
             .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(startedSession);
@@ -827,6 +832,10 @@ public sealed class TriageTests
             .Setup(service => service.GetProjectBoardOptionsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
+        _triageServiceMock
+            .Setup(service => service.AssignMilestoneToCurrentItemAsync(It.IsAny<TriageSessionDto>(), 7, "v0.7.0", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(milestoneAssignedSession);
+
         await using var ctx = CreateContext();
 
         // Act
@@ -841,6 +850,11 @@ public sealed class TriageTests
         cut.WaitForAssertion(() => Assert.Contains("PR 2202", cut.Markup, StringComparison.Ordinal));
 
         cut.Find("[data-testid='triage-assign-milestone-button']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Assigned milestone 'v0.7.0' to item #2202", cut.Markup, StringComparison.Ordinal);
+        });
 
         // Assert
         _triageServiceMock.Verify(

--- a/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
@@ -745,6 +745,10 @@ public sealed class TriageTests
 
         _triageServiceMock
             .Setup(service => service.AssignMilestoneToCurrentItemAsync(It.IsAny<TriageSessionDto>(), 7, "v0.7.0", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.AssignMilestoneToCurrentItemAsync(It.IsAny<TriageSessionDto>(), 7, "v0.7.0", It.IsAny<CancellationToken>()))
             .ReturnsAsync(milestoneAssignedSession);
 
         await using var ctx = CreateContext();
@@ -772,6 +776,73 @@ public sealed class TriageTests
             Assert.Contains("Assigned milestone 'v0.7.0' to item #501", cut.Markup, StringComparison.Ordinal);
         });
 
+        _triageServiceMock.Verify(
+            service => service.AssignMilestoneToCurrentItemAsync(It.IsAny<TriageSessionDto>(), 7, "v0.7.0", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Triage_StartSessionWithPullRequestMilestone_PreselectsMilestoneInDropdown()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var startedSession = CreateSession(
+            "owner",
+            "repo",
+            [
+                new TriageItemDto(
+                    TriageItemTypeDto.PullRequest,
+                    2202,
+                    2202,
+                    "owner/repo",
+                    "PR 2202",
+                    "https://github.com/owner/repo/pull/2202",
+                    "Body for PR 2202",
+                    "open",
+                    "markheydon",
+                    [],
+                    7,
+                    "v0.7.0",
+                    DateTimeOffset.UtcNow.AddDays(-3),
+                    DateTimeOffset.UtcNow.AddDays(-1)),
+            ],
+            currentIndex: 0,
+            skippedItems: []);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(startedSession);
+
+        _triageServiceMock
+            .Setup(service => service.GetMilestoneOptionsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new TriageMilestoneOptionDto(7, "v0.7.0"),
+                new TriageMilestoneOptionDto(8, "v0.8.0"),
+            ]);
+
+        _triageServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+
+        cut.WaitForAssertion(() => Assert.Contains("PR 2202", cut.Markup, StringComparison.Ordinal));
+
+        cut.Find("[data-testid='triage-assign-milestone-button']").Click();
+
+        // Assert
         _triageServiceMock.Verify(
             service => service.AssignMilestoneToCurrentItemAsync(It.IsAny<TriageSessionDto>(), 7, "v0.7.0", It.IsAny<CancellationToken>()),
             Times.Once);
@@ -1128,13 +1199,83 @@ public sealed class TriageTests
         {
             Assert.NotEmpty(cut.FindAll("[data-testid='triage-session-complete-region']"));
             Assert.Contains("Processed 1 of 1 items. 1 skipped item(s) are available to revisit.", cut.Markup, StringComparison.Ordinal);
-            Assert.Contains("Issue #901 (owner/repo): Applied label 'type/story'.", cut.Markup, StringComparison.Ordinal);
-            Assert.Contains("Issue #901 (owner/repo): Assigned milestone 'v0.3.0'.", cut.Markup, StringComparison.Ordinal);
-            Assert.Contains("Issue #901 (owner/repo): Added to project board 'Roadmap' with status 'In Progress'.", cut.Markup, StringComparison.Ordinal);
-            Assert.Contains("Issue #902 (owner/repo): Closed as duplicate of '#321'.", cut.Markup, StringComparison.Ordinal);
-            Assert.Contains("Issue #902 (owner/repo): Skipped for later review. Reason: Waiting for product clarification", cut.Markup, StringComparison.Ordinal);
-            Assert.Contains("Issue #902 (owner/repo): Issue 902", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Issue #901", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("(owner/repo): Applied label 'type/story'.", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("(owner/repo): Assigned milestone 'v0.3.0'.", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("(owner/repo): Added to project board 'Roadmap' with status 'In Progress'.", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Issue #902", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("(owner/repo): Closed as duplicate of '#321'.", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("(owner/repo): Skipped for later review. Reason: Waiting for product clarification", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("(owner/repo): Issue 902", cut.Markup, StringComparison.Ordinal);
             Assert.NotEmpty(cut.FindAll("[data-testid='triage-revisit-skipped-button']"));
+        });
+    }
+
+    [Fact]
+    public async Task Triage_SessionCompleted_MixedIssueAndPullRequestSummaryEntries_RenderTypeSpecificGitHubLinks()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([CreateRepository("owner", "repo")]);
+
+        var completedSession = new TriageSessionDto(
+            Guid.NewGuid(),
+            "owner",
+            "repo",
+            false,
+            [CreateItem(1001, "Issue 1001", "owner/repo")],
+            1,
+            [
+                new TriageItemDto(
+                    TriageItemTypeDto.PullRequest,
+                    1002,
+                    1002,
+                    "owner/repo",
+                    "Pull request 1002",
+                    "https://github.com/owner/repo/pull/1002",
+                    "Body for pull request 1002",
+                    "open",
+                    "markheydon",
+                    [],
+                    null,
+                    string.Empty,
+                    DateTimeOffset.UtcNow.AddDays(-3),
+                    DateTimeOffset.UtcNow.AddDays(-1)),
+            ],
+            [],
+            new TriageSessionProgressDto(1, 1, 0, 1),
+            new TriageSessionSummaryDto(1, 1, 0, 1, 1, 1, 1, 1)
+            {
+                LabelActionDetails = ["Issue #1001 (owner/repo): Applied label 'type/story'."],
+                MilestoneActionDetails = ["Pull request #1002 (owner/repo): Assigned milestone 'v0.3.0'."],
+                ProjectActionDetails = ["Pull request #1002 (owner/repo): Added to project board 'Roadmap' with status 'In Progress'."],
+                DuplicateActionDetails = ["Issue #1001 (owner/repo): Closed as duplicate of '#999'."],
+                SkippedActionDetails = ["Pull request #1002 (owner/repo): Skipped for later review. Reason: Waiting for product clarification"],
+                SkippedItemDetails = ["Pull request #1002 (owner/repo): Pull request 1002"],
+            },
+            DateTimeOffset.UtcNow);
+
+        _triageServiceMock
+            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(completedSession);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Triage>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='triage-repository-autocomplete']"));
+
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo" }));
+
+        cut.Find("[data-testid='triage-start-session-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("href=\"https://github.com/owner/repo/issues/1001\"", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("href=\"https://github.com/owner/repo/pull/1002\"", cut.Markup, StringComparison.Ordinal);
         });
     }
 

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
@@ -109,6 +109,119 @@ public sealed class TriageServiceTests
     }
 
     [Fact]
+    public async Task StartSessionAsync_IncludePullRequestsWithLabelledPullRequest_ExcludesLabelledPullRequestFromQueue()
+    {
+        // Arrange
+        _gitHubServiceMock
+            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new Issue { Id = 1, Number = 11, Title = "Issue", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2), Labels = [] },
+            ]);
+
+        _gitHubServiceMock
+            .Setup(service => service.GetPullRequestsAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new PullRequest
+                {
+                    Id = 2,
+                    Number = 21,
+                    Title = "Unlabelled pull request",
+                    UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1),
+                    Labels = [],
+                },
+                new PullRequest
+                {
+                    Id = 3,
+                    Number = 22,
+                    Title = "Labelled pull request",
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                    Labels = [new Label { Name = "type/story" }],
+                },
+            ]);
+
+        var sut = new TriageService(_gitHubServiceMock.Object);
+
+        // Act
+        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true);
+
+        // Assert
+        Assert.Equal(2, result.Queue.Count);
+        Assert.Contains(result.Queue, item => item.ItemType == TriageItemTypeDto.Issue && item.Number == 11);
+        Assert.Contains(result.Queue, item => item.ItemType == TriageItemTypeDto.PullRequest && item.Number == 21);
+        Assert.DoesNotContain(result.Queue, item => item.ItemType == TriageItemTypeDto.PullRequest && item.Number == 22);
+    }
+
+    [Fact]
+    public async Task StartSessionAsync_IncludePullRequestsWithMixedItems_OrdersQueueByUpdatedAtAcrossItemTypes()
+    {
+        // Arrange
+        _gitHubServiceMock
+            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new Issue { Id = 1, Number = 11, Title = "Older issue", UpdatedAt = DateTimeOffset.Parse("2026-03-01T10:00:00Z"), Labels = [] },
+                new Issue { Id = 2, Number = 12, Title = "Newer issue", UpdatedAt = DateTimeOffset.Parse("2026-03-03T10:00:00Z"), Labels = [] },
+            ]);
+
+        _gitHubServiceMock
+            .Setup(service => service.GetPullRequestsAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new PullRequest { Id = 3, Number = 21, Title = "Middle pull request", UpdatedAt = DateTimeOffset.Parse("2026-03-02T10:00:00Z"), Labels = [] },
+            ]);
+
+        var sut = new TriageService(_gitHubServiceMock.Object);
+
+        // Act
+        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true);
+
+        // Assert
+        Assert.Equal(3, result.Queue.Count);
+        Assert.Equal(11, result.Queue[0].Number);
+        Assert.Equal(TriageItemTypeDto.Issue, result.Queue[0].ItemType);
+        Assert.Equal(21, result.Queue[1].Number);
+        Assert.Equal(TriageItemTypeDto.PullRequest, result.Queue[1].ItemType);
+        Assert.Equal(12, result.Queue[2].Number);
+        Assert.Equal(TriageItemTypeDto.Issue, result.Queue[2].ItemType);
+    }
+
+    [Fact]
+    public async Task StartSessionAsync_IncludePullRequestsWithMilestoneOnPullRequest_PreservesMilestoneDetails()
+    {
+        // Arrange
+        _gitHubServiceMock
+            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _gitHubServiceMock
+            .Setup(service => service.GetPullRequestsAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new PullRequest
+                {
+                    Id = 3,
+                    Number = 21,
+                    Title = "Pull request with milestone",
+                    UpdatedAt = DateTimeOffset.Parse("2026-03-02T10:00:00Z"),
+                    Labels = [],
+                    Milestone = new SoloDevBoard.Domain.Entities.Milestones.Milestone
+                    {
+                        Number = 7,
+                        Title = "v0.7.0",
+                    },
+                },
+            ]);
+
+        var sut = new TriageService(_gitHubServiceMock.Object);
+
+        // Act
+        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true);
+
+        // Assert
+        var pullRequest = Assert.Single(result.Queue);
+        Assert.Equal(TriageItemTypeDto.PullRequest, pullRequest.ItemType);
+        Assert.Equal(7, pullRequest.MilestoneNumber);
+        Assert.Equal("v0.7.0", pullRequest.MilestoneTitle);
+    }
+
+    [Fact]
     public async Task StartSessionAsync_LabelledIssuePresent_ExcludesLabelledIssueFromQueue()
     {
         // Arrange

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -299,6 +299,19 @@ public sealed class GitHubServiceTests
                     "body": "Description",
                     "state": "open",
                     "user": { "login": "mark" },
+                                        "labels": [
+                                            { "name": "type/story", "color": "1d76db", "description": "Story" }
+                                        ],
+                                        "milestone": {
+                                            "id": 400,
+                                            "number": 7,
+                                            "title": "v0.7.0",
+                                            "description": "Phase 3",
+                                            "state": "open",
+                                            "due_on": "2026-06-01T00:00:00Z",
+                                            "open_issues": 3,
+                                            "closed_issues": 5
+                                        },
                     "head": { "ref": "feature-branch" },
                     "base": { "ref": "main" },
                     "draft": true,
@@ -319,6 +332,11 @@ public sealed class GitHubServiceTests
         Assert.Equal("feature-branch", result[0].HeadBranch);
         Assert.Equal("main", result[0].BaseBranch);
         Assert.True(result[0].IsDraft);
+        Assert.Single(result[0].Labels);
+        Assert.Equal("type/story", result[0].Labels[0].Name);
+        var milestone = Assert.IsType<SoloDevBoard.Domain.Entities.Milestones.Milestone>(result[0].Milestone);
+        Assert.Equal(7, milestone.Number);
+        Assert.Equal("v0.7.0", milestone.Title);
         Assert.Equal("https://api.github.com/repos/owner/repo/pulls?state=all&per_page=100", handler.Requests[0].RequestUri!.ToString());
     }
 


### PR DESCRIPTION
## Summary of Changes

Extends the Triage UI to include unlabelled pull requests in triage sessions alongside unlabelled issues, forming a unified mixed queue ordered by `UpdatedAt`. Two bugs discovered during testing were also fixed in this PR:

- **PR labels not mapped** — the `PullRequest` domain entity now carries a `Labels` collection, plumbed through Infrastructure and Application so the queue filter can exclude already-labelled PRs.
- **PR milestone not preselected** — the `PullRequest` domain entity now carries a `Milestone` property, mapped through Infrastructure and Application so the Assign action defaults to the PR's existing milestone, consistent with issue behaviour.
- **Summary links not type-aware** — all six session summary sections now render a clickable `MudLink` pointing to the correct GitHub URL (`/issues/N` for issues, `/pull/N` for pull requests) instead of plain text.

## Related Issue(s)

Closes #150

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`) — **244 tests, 0 failures**
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

N/A — backend and triage queue logic changes with existing UI updated.

## Additional Notes

### Files changed

| Layer | File | Change |
|-------|------|--------|
| Domain | `Entities/Triage/PullRequest.cs` | Added `Labels` and `Milestone` properties |
| Infrastructure | `GitHub/GitHubService.cs` | Added `labels`/`milestone` JSON mapping in `PullRequestResponseDto` |
| Application | `Services/Triage/TriageService.cs` | Filter unlabelled PRs into queue; propagate `Labels` and `Milestone` |
| App | `Pages/Triage.razor.cs` | Add `TryCreateSummaryDetailLink` regex helper |
| App | `Pages/Triage.razor` | Render type-aware `MudLink` in all six summary detail sections |
| Tests | `TriageServiceTests.cs` | 3 new tests covering PR filtering, ordering, and milestone |
| Tests | `GitHubServiceTests.cs` | Updated fixture + assertions for labels and milestone mapping |
| Tests | `TriageTests.cs` | 2 new tests: summary links and milestone preselection |
| Docs | `docs/user-guide/triage-ui.md` | Updated to document PR inclusion and mixed queue behaviour |
| Plan | `plan/BACKLOG.md` | Story #150 marked complete |

### Architecture compliance

- Domain entity change is additive and backward-compatible.
- Infrastructure-to-Application boundary: domain records returned from `IRepository` as required by ADR-0011.
- Application-to-App boundary: only `TriageItemDto` (DTO) crosses; domain entities do not reach Razor components.
- No business logic in Razor components; all queue logic remains in `TriageService`.
