### PR TITLE
Publish 11 May 2026 weekly review and roadmap sync update

### DIFF
--- a/.github/scripts/roadmap-sync.mjs
+++ b/.github/scripts/roadmap-sync.mjs
@@ -29,15 +29,6 @@ const phaseOptionsByMilestone = new Map([
     ['v1.0.0', 'dfa36cee'],
 ]);
 
-const phaseOptionsByAreaLabel = new Map([
-    ['area/infrastructure', '1fbac877'],
-    ['area/labels', '0f90ba94'],
-    ['area/migration', 'f3de38ba'],
-    ['area/triage', 'f3de38ba'],
-    ['area/board-rules', 'f5bc6726'],
-    ['area/workflows', 'f5bc6726'],
-]);
-
 const priorityOptionsByLabel = new Map([
     ['priority/critical', '8d63dbb3'],
     ['priority/high', 'e89555ab'],
@@ -359,14 +350,6 @@ function determinePhaseOptionId(issue) {
 
     if (milestoneTitle && phaseOptionsByMilestone.has(milestoneTitle)) {
         return phaseOptionsByMilestone.get(milestoneTitle);
-    }
-
-    const labels = getLabelNames(issue);
-
-    for (const [label, optionId] of phaseOptionsByAreaLabel.entries()) {
-        if (labels.has(label)) {
-            return optionId;
-        }
     }
 
     return null;

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 | **Repositories** | View and manage repositories accessible to your GitHub account. | Available |
 | **One-Click Migration** | Migrate labels and milestones from one repository to another in a single action. Project board migration is planned. | Partially Available |
 | **Board Rules Visualiser** | Visualise automation rules configured on GitHub project boards. | Coming Soon |
-| **Triage UI** | Keyboard-friendly interface for triaging incoming issues quickly. | Coming Soon |
+| **Triage UI** | Keyboard-friendly interface for triaging incoming issues quickly. | Available |
 | **Workflow Templates** | Browse, customise, and apply GitHub Actions workflow templates across repositories. | Coming Soon |
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ It is built with the solo developer in mind: opinionated defaults, minimal confi
 | **Repositories** | View and manage repositories accessible to your GitHub account. | Available |
 | **One-Click Migration** | Migrate labels and milestones from one repository to another in a single action. Project board migration is planned. | Partially Available |
 | **Board Rules Visualiser** | Visualise automation rules configured on GitHub project boards. | Coming Soon |
-| **Triage UI** | Keyboard-friendly interface for triaging incoming issues quickly. | Coming Soon |
+| **Triage UI** | Keyboard-friendly interface for triaging incoming issues quickly. | Available |
 | **Workflow Templates** | Browse, customise, and apply GitHub Actions workflow templates across repositories. | Coming Soon |
 
 ---

--- a/docs/user-guide/dashboard-shell.md
+++ b/docs/user-guide/dashboard-shell.md
@@ -29,7 +29,8 @@ Each panel includes:
 - Short description
 - Navigation link to the feature route
 
-In Phase 1, some feature pages are placeholders and display a "coming soon" message while implementation continues.
+
+In Phase 1, some feature pages (Board Rules Visualiser and Workflow Templates) are placeholders and display a "coming soon" message while implementation continues. The Triage UI is now fully implemented and available to use.
 
 ## Navigation
 

--- a/docs/user-guide/dashboard-shell.md
+++ b/docs/user-guide/dashboard-shell.md
@@ -30,7 +30,7 @@ Each panel includes:
 - Navigation link to the feature route
 
 
-In Phase 1, some feature pages (Board Rules Visualiser and Workflow Templates) are placeholders and display a "coming soon" message while implementation continues. The Triage UI is now fully implemented and available to use.
+At present, some feature pages (Board Rules Visualiser and Workflow Templates) are placeholders and display a "coming soon" message while implementation continues. The Triage UI is now fully implemented and available to use.
 
 ## Navigation
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -19,6 +19,7 @@ The SoloDevBoard user guide provides detailed documentation for available featur
 - [Label Manager](label-manager.md) — Create, edit, synchronise, and enforce label taxonomies across multiple repositories.
 - [Repositories](repositories.md) — View and manage repositories accessible to your GitHub account.
 - [One-Click Migration](one-click-migration.md) — Migrate labels and milestones from one repository to another in a single action.
+- [Triage UI](triage-ui.md) — Keyboard-friendly interface for triaging incoming issues quickly.
 - [About](about.md) — Application version, runtime environment, and repository link.
 - [Azure Deployment Costs](azure-costs.md) — Understand Azure resource charges, SKUs, and cost optimisation for SoloDevBoard deployments.
 - [Hosted Authentication](hosted-authentication.md) — Guide to hosted sign-in, operator allow-lists, and fallback modes for production deployments.
@@ -26,7 +27,6 @@ The SoloDevBoard user guide provides detailed documentation for available featur
 ## Coming Soon
 
 - [Board Rules Visualiser](board-rules-visualiser.md) — Visualise automation rules configured on GitHub project boards.
-- [Triage UI](triage-ui.md) — Keyboard-friendly interface for triaging incoming issues quickly.
 - [Workflow Templates](workflow-templates.md) — Browse, customise, and apply GitHub Actions workflow templates across repositories.
 
 ## Coming Later

--- a/plan/weekly-updates/2026-05-11.md
+++ b/plan/weekly-updates/2026-05-11.md
@@ -1,0 +1,77 @@
+# Weekly Review — 11 May 2026
+
+## Overall Status
+Phase 3 is on track for completion, with all core implementation work finished and only two parent issues remaining open. Governance and backlog hygiene improved this week, and the project is positioned to transition into Phase 4 after closing the final v0.3.0 containers.
+
+## Project Board Status Update
+- **Status:** On track.
+- **Start date:** 2026-03-12.
+- **Target date:** 2026-05-18 (tentative, based on closing the remaining Phase 3 parent issues and transitioning into Phase 4 this week).
+
+```markdown
+## Weekly Status — 11 May 2026
+
+### Phase 3 Summary
+Phase 3 implementation is effectively complete. All Triage UI stories and tests are closed, and the roadmap-sync governance logic has been corrected. Only two parent issues remain open, pending final review and closure.
+
+### Delivered since the last review
+- Closed 8 issues during the review week: #173 and #147 to #153.
+- All remaining Triage UI stories and tests are now closed.
+- Fixed the roadmap-sync phase-governance defect so Phase is derived only from recognised milestones.
+- Detached issue #176 from the former Phase 3 parent chain so it no longer implies unfinished core Triage delivery.
+
+### This week's focus
+- Close the remaining v0.3.0 parent/container issues.
+- Refresh live roadmap metadata and project board fields.
+- Begin the first v0.4.0 delivery slice.
+
+### Health Indicators
+| Metric                | Value                |
+|-----------------------|----------------------|
+| Total issues          | 117                  |
+| Open issues           | 22                   |
+| Closed issues         | 95                   |
+| Open issue status     | 22 todo, 0 in-progress, 0 in-review |
+| Open PRs              | 0                    |
+| Tests                 | 244/244 passing      |
+| Compile errors        | 0                    |
+| Active blockers       | 0 explicit / 1 mild process risk |
+```
+
+## Project Board Metadata
+- **Phase:** 3 (Triage UI and Governance)
+- **Milestone:** v0.3.0 (final closure in progress)
+- **Board:** SoloDevBoard Roadmap (GitHub Project #8)
+
+## Executive Summary
+
+### Milestone Health
+Phase 3 is effectively complete at the implementation level, but two open parent/container issues still need closure. The project is ready to transition to Phase 4 after these are resolved.
+
+### Scope / Governance Health
+Governance hygiene improved this week because phase inheritance from area/* labels was removed and #176 was detached from the old parent chain. No scope drift was detected.
+
+### Backlog Hygiene
+All Triage UI stories and tests are closed. The backlog is current, with no unreviewed or stale issues.
+
+### Release Confidence
+Release confidence is high. #171 intentionally remains in v1.0.0 because the Aspire decision should be made before the first proper Azure deployment.
+
+### Quality Metrics
+All 244 tests are passing. There are no compile errors. No new defects were introduced.
+
+### Delivery Activity Since Last Review
+Closed 8 issues: #173 and #147 to #153. Fixed roadmap-sync governance logic. Detached #176 from the Phase 3 parent chain.
+
+### Blocker / Process Analysis
+There are no explicit blockers. Mild process risk remains because there are currently no active in-progress issues.
+
+### Top 3 Priorities for This Week
+1. Close the remaining v0.3.0 parent/container issues.
+2. Refresh live roadmap metadata and project board fields.
+3. Begin the first v0.4.0 delivery slice.
+
+### Recommended Actions
+- Complete closure of Phase 3 parent issues.
+- Update project board and roadmap metadata.
+- Initiate Phase 4 planning and delivery.


### PR DESCRIPTION
## Summary
This PR publishes the weekly review for 11 May 2026 and includes the associated governance and documentation updates completed on the `weekly-review` branch.

## What changed
- add the weekly review note for 11 May 2026
- stop roadmap phase assignment from inheriting from `area/*` labels when no recognised milestone is present
- update public docs so Triage UI is shown as available rather than coming soon
- keep the review narrative aligned with the agreed governance decisions for `#176` and `#171`

## Validation
- `dotnet test` passed: 244/244
- changed files are limited to the roadmap sync script, related docs, and the weekly update note