### PR TITLE
Add global.json for .NET SDK versioning

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Set up .NET 10
+      - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: "10.x"
+          global-json-file: global.json
 
       - name: Restore dependencies
         run: dotnet restore src/App/SoloDevBoard.App/SoloDevBoard.App.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Set up .NET 10
+      - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: "10.x"
+          global-json-file: global.json
 
       - name: Restore dependencies
         run: dotnet restore SoloDevBoard.slnx

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "10.0.300",
+        "rollForward": "latestFeature"
+    }
+}


### PR DESCRIPTION
## Summary of Changes

Introduce a `global.json` file to specify the .NET SDK version and roll-forward policy. Update the GitHub Actions workflow to use this configuration for setting up the .NET SDK.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [ ] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [ ] I have updated relevant documentation in `docs/` or `plan/`
- [ ] No new compiler warnings have been introduced
- [ ] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated
