### PR TITLE
[type/story] Select a repository and project board to visualise

### DIFF
--- a/docs/user-guide/board-rules-visualiser.md
+++ b/docs/user-guide/board-rules-visualiser.md
@@ -5,7 +5,7 @@ parent: User Guide
 nav_order: 4
 ---
 
-> ⚠️ **Under Development** — This feature is planned for Phase 4. This page will be updated as the feature progresses.
+> ⚠️ **Under Development** — Repository and project board selection is available. The interactive diagram and rule inspection views are delivered in later slices.
 
 ---
 
@@ -24,13 +24,20 @@ Key goals of the Board Rules Visualiser:
 
 ## How to Use
 
-*Coming soon — this section will describe the Board Rules Visualiser interface once the feature is complete.*
+### Select a repository and project board
 
-Planned interactions include:
-- Selecting a repository and project board to visualise.
-- Viewing an interactive flow diagram of board columns and transition rules.
-- Clicking on a rule to see its full configuration.
-- Highlighting rules that may conflict or produce unexpected behaviour.
+1. Open **Board Rules Visualiser** from the navigation menu or dashboard.
+2. Use the repository search box to choose one active repository. SoloDevBoard reuses the same repository selector pattern as Label Manager and Migration.
+3. After a repository is selected, SoloDevBoard loads GitHub Project v2 boards linked to that repository.
+4. Choose a supported project board from the **Project board** dropdown. Supported boards must expose a **Status** field.
+5. When a board is selected, the visualisation area confirms the board context is ready. The interactive diagram arrives in a later delivery slice.
+
+### Empty and unsupported states
+
+- **No repository selected:** The visualisation area prompts you to choose a repository and project board.
+- **No supported boards:** If the repository has no GitHub Project v2 board with a Status field, SoloDevBoard explains why the visualiser cannot continue and does not show the diagram state.
+- **Loading:** Progress indicators appear while repositories or project boards are loading.
+- **Errors:** If GitHub cannot be reached, an error message appears with a retry action.
 
 ---
 

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -160,7 +160,7 @@ Labels: `type/epic`, `area/board-rules`
 - [x] Enabler: Add board rules contracts and GitHub Projects v2 query support so the Application and Infrastructure layers can retrieve and map supported board-rule data. _(Issue #182; implemented 2026-07-14.)_
 
 **Stories:**
-- [ ] As a solo developer, I want to see all GitHub project boards for a selected repository so that I can choose which one to visualise. _(Issue #183; planned 2026-05-07.)_
+- [x] As a solo developer, I want to see all GitHub project boards for a selected repository so that I can choose which one to visualise. _(Issue #183; implemented 2026-07-14.)_
 - [ ] As a solo developer, I want to see an interactive diagram of a project board's columns and automation rules so that I can understand how issues flow. _(Issue #184; planned 2026-05-07; see wireframes/board-rules-visualiser-wireframe.md.)_
 - [ ] As a solo developer, I want to click on a rule in the diagram to see its full configuration so that I can understand what triggers it. _(Issue #185; planned 2026-05-07.)_
 - [ ] As a solo developer, I want to see highlighted rules that may conflict or produce unexpected behaviour so that I can diagnose automation issues. _(Issue #186; planned 2026-05-07.)_

--- a/src/App/SoloDevBoard.App/Components/Features/BoardRules/Pages/BoardRules.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/BoardRules/Pages/BoardRules.razor
@@ -2,9 +2,162 @@
 
 <PageTitle>Board Rules Visualiser</PageTitle>
 
-<MudStack Spacing="2">
+<MudStack Spacing="3">
     <MudText Typo="Typo.h4">Board Rules Visualiser</MudText>
-    <MudPaper Class="pa-4" Elevation="1">
-        <MudText Typo="Typo.body1">This feature is coming soon.</MudText>
+    <MudText Typo="Typo.body1">Choose a repository and GitHub Project v2 board to inspect its automation rules and column flow.</MudText>
+
+    <MudPaper Class="pa-4" Elevation="1" data-testid="board-rules-selector-region">
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.h6">Repository and project board</MudText>
+
+            @if (isLoadingRepositories)
+            {
+                <MudStack AlignItems="AlignItems.Center" Spacing="1" aria-live="polite" role="status" data-testid="board-rules-repositories-loading-state">
+                    <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading repositories" />
+                    <MudText Typo="Typo.body2">Loading repositories...</MudText>
+                </MudStack>
+            }
+            else if (availableRepositories.Count == 0)
+            {
+                <MudStack Spacing="1" aria-live="polite" data-testid="board-rules-repositories-empty-state">
+                    <MudText Typo="Typo.body2">No active repositories are available for board rules visualisation.</MudText>
+                </MudStack>
+            }
+            else
+            {
+                <MudGrid Spacing="2">
+                    <MudItem xs="12" md="6">
+                        <RepositorySelector
+                            Title=""
+                            Label="Repository"
+                            Placeholder="Search repositories and select"
+                            EmptyStateText="No active repositories are available for board rules visualisation."
+                            AvailableRepositories="availableRepositoryFullNames"
+                            SelectedRepositories="selectedRepositoryFullNames"
+                            SelectedRepositoriesChanged="OnSelectedRepositoriesChangedAsync"
+                            SummaryText="@RepositorySelectorSummary"
+                            ShowSelectedChips="true"
+                            ShowSelectionActions="false"
+                            SingleSelectionOnly="true"
+                            Disabled="ShowLoadingState"
+                            AutocompleteTestId="board-rules-repository-autocomplete"
+                            SummaryTestId="board-rules-repository-selector-summary" />
+                    </MudItem>
+
+                    <MudItem xs="12" md="6">
+                        <MudPaper Class="pa-3" Outlined="true" data-testid="board-rules-project-board-selector">
+                            <MudStack Spacing="1">
+                                <MudText Typo="Typo.subtitle2">Project board</MudText>
+                                <MudText Typo="Typo.body2">Select a GitHub Project v2 board with a Status field to inspect.</MudText>
+
+                                @if (!HasSelectedRepository)
+                                {
+                                    <MudText Typo="Typo.body2" data-testid="board-rules-board-selector-prompt">Select a repository to load supported project boards.</MudText>
+                                }
+                                else if (isLoadingProjectBoards)
+                                {
+                                    <MudStack AlignItems="AlignItems.Center" Spacing="1" aria-live="polite" role="status" data-testid="board-rules-boards-loading-state">
+                                        <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading project boards" />
+                                        <MudText Typo="Typo.body2">Loading project boards...</MudText>
+                                    </MudStack>
+                                }
+                                else if (availableProjectBoardOptions.Count == 0)
+                                {
+                                    <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Outlined" data-testid="board-rules-unsupported-boards-message">
+                                        No supported GitHub Project v2 boards were found for this repository. SoloDevBoard can only visualise boards that expose a Status field.
+                                    </MudAlert>
+                                }
+                                else
+                                {
+                                    <MudSelect T="string"
+                                               Value="selectedProjectBoardId"
+                                               ValueChanged="OnSelectedProjectBoardChangedAsync"
+                                               Label="Project board"
+                                               Variant="Variant.Outlined"
+                                               Disabled="ShowLoadingState">
+                                        @foreach (var projectBoardOption in availableProjectBoardOptions)
+                                        {
+                                            <MudSelectItem T="string" Value="@projectBoardOption.Id">@projectBoardOption.Title</MudSelectItem>
+                                        }
+                                    </MudSelect>
+                                }
+                            </MudStack>
+                        </MudPaper>
+                    </MudItem>
+                </MudGrid>
+            }
+        </MudStack>
+    </MudPaper>
+
+    <MudPaper Class="pa-4" Elevation="1" Outlined="true" aria-label="Board rules visualisation area" data-testid="board-rules-visualisation-region">
+        @if (!HasSelectedRepository)
+        {
+            <MudStack Spacing="1" aria-live="polite" data-testid="board-rules-empty-state">
+                <MudText Typo="Typo.h6">Select a repository and project board</MudText>
+                <MudText Typo="Typo.body2">Choose a repository and supported project board above to begin inspecting board rules.</MudText>
+            </MudStack>
+        }
+        else if (isLoadingProjectBoards)
+        {
+            <MudStack AlignItems="AlignItems.Center" Spacing="1" aria-live="polite" role="status" data-testid="board-rules-diagram-loading-state">
+                <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading board context" />
+                <MudText Typo="Typo.body2">Preparing board context...</MudText>
+            </MudStack>
+        }
+        else if (availableProjectBoardOptions.Count == 0)
+        {
+            <MudStack Spacing="1" aria-live="polite" data-testid="board-rules-no-supported-board-state">
+                <MudText Typo="Typo.h6">No supported board available</MudText>
+                <MudText Typo="Typo.body2">This repository does not expose a GitHub Project v2 board with a Status field, so the visualiser cannot continue to the diagram state.</MudText>
+            </MudStack>
+        }
+        else if (!HasSelectedProjectBoard)
+        {
+            <MudStack Spacing="1" aria-live="polite" data-testid="board-rules-board-not-selected-state">
+                <MudText Typo="Typo.h6">Select a project board</MudText>
+                <MudText Typo="Typo.body2">Choose a supported project board to prepare the visualisation context.</MudText>
+            </MudStack>
+        }
+        else
+        {
+            <MudStack Spacing="1" data-testid="board-rules-board-context-ready-state">
+                <MudText Typo="Typo.h6">Board context ready</MudText>
+                <MudText Typo="Typo.body2">
+                    Ready to visualise <strong>@ActiveProjectBoard!.Title</strong> for <strong>@selectedRepository!.FullName</strong>.
+                    The interactive diagram will appear here in a later delivery slice.
+                </MudText>
+            </MudStack>
+        }
+    </MudPaper>
+
+    <MudPaper Class="pa-4" Elevation="1" aria-live="polite" data-testid="board-rules-feedback-region">
+        <MudStack Spacing="1">
+            <MudText Typo="Typo.h6">Status</MudText>
+
+            @if (!string.IsNullOrWhiteSpace(errorMessage))
+            {
+                <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Outlined" data-testid="board-rules-error-alert">
+                    <MudText Typo="Typo.subtitle2">@ErrorTitle</MudText>
+                    <MudText Typo="Typo.body2">@errorMessage</MudText>
+                </MudAlert>
+
+                @if (hasRepositoryLoadFailure)
+                {
+                    <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="ReloadRepositoriesAsync" data-testid="board-rules-reload-repositories-button">
+                        Try loading repositories again
+                    </MudButton>
+                }
+                else if (hasProjectBoardLoadFailure)
+                {
+                    <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="ReloadProjectBoardsAsync" data-testid="board-rules-reload-boards-button">
+                        Try loading project boards again
+                    </MudButton>
+                }
+            }
+            else
+            {
+                <MudText Typo="Typo.body2">No active status messages.</MudText>
+            }
+        </MudStack>
     </MudPaper>
 </MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/BoardRules/Pages/BoardRules.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/BoardRules/Pages/BoardRules.razor.cs
@@ -1,0 +1,222 @@
+using Microsoft.AspNetCore.Components;
+using SoloDevBoard.Application.Services.BoardRules;
+using SoloDevBoard.Application.Services.Repositories;
+
+namespace SoloDevBoard.App.Components.Features.BoardRules.Pages;
+
+/// <summary>Provides the entry workflow for selecting a repository and project board to visualise.</summary>
+public partial class BoardRules : ComponentBase
+{
+    /// <summary>Gets or sets the application service used to retrieve repositories.</summary>
+    [Inject]
+    public IRepositoryService RepositoryService { get; set; } = default!;
+
+    /// <summary>Gets or sets the application service used to retrieve board rules metadata.</summary>
+    [Inject]
+    public IBoardRulesService BoardRulesService { get; set; } = default!;
+
+    /// <summary>Gets or sets the logger for board rules page diagnostics.</summary>
+    [Inject]
+    public ILogger<BoardRules> Logger { get; set; } = default!;
+
+    private IReadOnlyList<RepositoryDto> availableRepositories = [];
+    private RepositoryDto? selectedRepository;
+    private IReadOnlyList<BoardRulesProjectBoardOptionDto> availableProjectBoardOptions = [];
+    private string selectedProjectBoardId = string.Empty;
+    private bool isLoadingRepositories = true;
+    private bool isLoadingProjectBoards;
+    private bool hasRepositoryLoadFailure;
+    private bool hasProjectBoardLoadFailure;
+    private string? errorMessage;
+
+    /// <inheritdoc/>
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadRepositoriesAsync();
+    }
+
+    private async Task ReloadRepositoriesAsync()
+    {
+        await LoadRepositoriesAsync();
+    }
+
+    private async Task ReloadProjectBoardsAsync()
+    {
+        if (selectedRepository is null)
+        {
+            return;
+        }
+
+        await LoadProjectBoardOptionsAsync(selectedRepository);
+    }
+
+    private async Task LoadRepositoriesAsync()
+    {
+        isLoadingRepositories = true;
+        hasRepositoryLoadFailure = false;
+        errorMessage = null;
+        selectedRepository = null;
+        availableProjectBoardOptions = [];
+        selectedProjectBoardId = string.Empty;
+
+        try
+        {
+            availableRepositories = (await RepositoryService.GetActiveRepositoriesAsync())
+                .OrderBy(repository => repository.FullName, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        catch (HttpRequestException ex)
+        {
+            hasRepositoryLoadFailure = true;
+            errorMessage = $"GitHub API request failed. {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            hasRepositoryLoadFailure = true;
+            Logger.LogError(ex, "Failed to load repositories for the Board Rules Visualiser.");
+            errorMessage = "An unexpected error occurred while loading repositories.";
+        }
+        finally
+        {
+            isLoadingRepositories = false;
+        }
+    }
+
+    private async Task OnSelectedRepositoriesChangedAsync(IReadOnlyList<string> repositoryFullNames)
+    {
+        ArgumentNullException.ThrowIfNull(repositoryFullNames);
+
+        var selectedFullName = repositoryFullNames
+            .FirstOrDefault(fullName => !string.IsNullOrWhiteSpace(fullName));
+
+        if (string.IsNullOrWhiteSpace(selectedFullName))
+        {
+            selectedRepository = null;
+            availableProjectBoardOptions = [];
+            selectedProjectBoardId = string.Empty;
+            hasProjectBoardLoadFailure = false;
+            return;
+        }
+
+        selectedRepository = availableRepositories
+            .FirstOrDefault(repository => repository.FullName.Equals(selectedFullName, StringComparison.OrdinalIgnoreCase));
+
+        if (selectedRepository is null)
+        {
+            availableProjectBoardOptions = [];
+            selectedProjectBoardId = string.Empty;
+            return;
+        }
+
+        await LoadProjectBoardOptionsAsync(selectedRepository);
+    }
+
+    private async Task LoadProjectBoardOptionsAsync(RepositoryDto repository)
+    {
+        ArgumentNullException.ThrowIfNull(repository);
+
+        var owner = ResolveOwner(repository.FullName);
+        var repo = ResolveRepositoryName(repository.FullName);
+
+        if (string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(repo))
+        {
+            availableProjectBoardOptions = [];
+            selectedProjectBoardId = string.Empty;
+            hasProjectBoardLoadFailure = true;
+            errorMessage = "The selected repository name is not in owner/name form.";
+            return;
+        }
+
+        isLoadingProjectBoards = true;
+        hasProjectBoardLoadFailure = false;
+        errorMessage = null;
+        availableProjectBoardOptions = [];
+        selectedProjectBoardId = string.Empty;
+
+        try
+        {
+            availableProjectBoardOptions = await BoardRulesService.GetProjectBoardOptionsAsync(owner, repo);
+            selectedProjectBoardId = availableProjectBoardOptions.FirstOrDefault()?.Id ?? string.Empty;
+        }
+        catch (HttpRequestException ex)
+        {
+            hasProjectBoardLoadFailure = true;
+            errorMessage = $"GitHub API request failed while loading project boards. {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            hasProjectBoardLoadFailure = true;
+            Logger.LogError(ex, "Failed to load project boards for repository {RepositoryFullName}.", repository.FullName);
+            errorMessage = "An unexpected error occurred while loading project boards.";
+        }
+        finally
+        {
+            isLoadingProjectBoards = false;
+        }
+    }
+
+    private Task OnSelectedProjectBoardChangedAsync(string projectBoardId)
+    {
+        selectedProjectBoardId = projectBoardId ?? string.Empty;
+        return Task.CompletedTask;
+    }
+
+    private static string ResolveOwner(string fullName)
+    {
+        if (string.IsNullOrWhiteSpace(fullName))
+        {
+            return string.Empty;
+        }
+
+        var parts = fullName.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return parts.Length > 0 ? parts[0] : string.Empty;
+    }
+
+    private static string ResolveRepositoryName(string fullName)
+    {
+        if (string.IsNullOrWhiteSpace(fullName))
+        {
+            return string.Empty;
+        }
+
+        var parts = fullName.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return parts.Length > 1 ? parts[1] : string.Empty;
+    }
+
+    private bool ShowLoadingState => isLoadingRepositories || isLoadingProjectBoards;
+
+    private bool HasSelectedRepository => selectedRepository is not null;
+
+    private bool HasSelectedProjectBoard
+        => !string.IsNullOrWhiteSpace(selectedProjectBoardId)
+            && availableProjectBoardOptions.Any(option => option.Id.Equals(selectedProjectBoardId, StringComparison.Ordinal));
+
+    private BoardRulesProjectBoardOptionDto? ActiveProjectBoard
+        => availableProjectBoardOptions.FirstOrDefault(option => option.Id.Equals(selectedProjectBoardId, StringComparison.Ordinal));
+
+    private string RepositorySelectorSummary
+    {
+        get
+        {
+            var repositoryCount = availableRepositories.Count;
+            var repositoryNoun = repositoryCount == 1 ? "repository" : "repositories";
+
+            return $"Showing {repositoryCount} active {repositoryNoun}. {(selectedRepository is null ? 0 : 1)} selected. Archived repositories are hidden by default.";
+        }
+    }
+
+    private IReadOnlyList<string> availableRepositoryFullNames
+        => availableRepositories
+            .Select(repository => repository.FullName)
+            .OrderBy(fullName => fullName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private IReadOnlyList<string> selectedRepositoryFullNames
+        => selectedRepository is null
+            ? []
+            : [selectedRepository.FullName];
+
+    private string ErrorTitle => hasRepositoryLoadFailure
+        ? "Unable to load repositories"
+        : "Unable to load project boards";
+}

--- a/src/App/SoloDevBoard.App/Components/_Imports.razor
+++ b/src/App/SoloDevBoard.App/Components/_Imports.razor
@@ -16,6 +16,7 @@
 @using SoloDevBoard.App.Components.Features.Labels.Components
 @using SoloDevBoard.App.Components.Features.Labels.Dialogs
 @using SoloDevBoard.App.Components.Features.Migration.Components
+@using SoloDevBoard.Application.Services.BoardRules
 @using SoloDevBoard.Application.Services.Audit
 @using SoloDevBoard.Application.Services.Common
 @using SoloDevBoard.Application.Services.Labels

--- a/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesProjectBoardOptionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesProjectBoardOptionDto.cs
@@ -1,0 +1,10 @@
+namespace SoloDevBoard.Application.Services.BoardRules;
+
+/// <summary>Represents a supported GitHub Project v2 board available for visualisation.</summary>
+/// <param name="Id">The GitHub node identifier for the project board.</param>
+/// <param name="Title">The project board title.</param>
+/// <param name="OwnerLogin">The login of the project owner.</param>
+public sealed record BoardRulesProjectBoardOptionDto(
+    string Id,
+    string Title,
+    string OwnerLogin);

--- a/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesService.cs
@@ -26,4 +26,24 @@ public sealed class BoardRulesService : IBoardRulesService
             .GetBoardRulesDefinitionAsync(owner, repo, projectId, cancellationToken)
             .ConfigureAwait(false);
     }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<BoardRulesProjectBoardOptionDto>> GetProjectBoardOptionsAsync(string owner, string repo, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var projectBoards = await _gitHubService
+            .GetProjectBoardsForRepositoryAsync(owner, repo, cancellationToken)
+            .ConfigureAwait(false);
+
+        return projectBoards
+            .Select(projectBoard => new BoardRulesProjectBoardOptionDto(
+                projectBoard.Id,
+                projectBoard.Title,
+                projectBoard.OwnerLogin))
+            .OrderBy(projectBoard => projectBoard.Title, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
 }

--- a/src/Application/SoloDevBoard.Application/Services/BoardRules/IBoardRulesService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/BoardRules/IBoardRulesService.cs
@@ -10,4 +10,11 @@ public interface IBoardRulesService
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>The board rules metadata read model.</returns>
     Task<BoardRulesDefinitionDto> GetBoardRulesAsync(string owner, string repo, string projectId, CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves supported GitHub Project v2 boards linked to the specified repository.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A read-only list of supported project board options for the repository.</returns>
+    Task<IReadOnlyList<BoardRulesProjectBoardOptionDto>> GetProjectBoardOptionsAsync(string owner, string repo, CancellationToken cancellationToken = default);
 }

--- a/tests/App.Tests/SoloDevBoard.App.Tests/BoardRulesTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/BoardRulesTests.cs
@@ -1,0 +1,209 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MudBlazor;
+using MudBlazor.Services;
+using SoloDevBoard.App.Components.Features.BoardRules.Pages;
+using SoloDevBoard.App.Components.Shared.Components;
+using SoloDevBoard.Application.Services.BoardRules;
+using SoloDevBoard.Application.Services.Repositories;
+
+namespace SoloDevBoard.App.Tests;
+
+/// <summary>Component tests for the <see cref="BoardRules"/> page.</summary>
+public sealed class BoardRulesTests
+{
+    private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
+    private readonly Mock<IBoardRulesService> _boardRulesServiceMock = new();
+
+    [Fact]
+    public async Task BoardRules_WhileRepositoryServiceIsLoading_ShowsLoadingState()
+    {
+        // Arrange
+        var repositoriesTask = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .Returns(repositoriesTask.Task);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<BoardRules>();
+
+        // Assert
+        Assert.Contains("Loading repositories", cut.Markup);
+    }
+
+    [Fact]
+    public async Task BoardRules_InitialLoad_ShowsEmptyVisualisationPrompt()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                CreateRepository("owner", "repo-a"),
+            ]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<BoardRules>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Select a repository and project board", cut.Markup);
+            Assert.Single(cut.FindAll("[data-testid='board-rules-empty-state']"));
+        });
+    }
+
+    [Fact]
+    public async Task BoardRules_PageLayout_RendersRepositorySelectorBeforeVisualisationRegion()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                CreateRepository("owner", "repo-a"),
+            ]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<BoardRules>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='board-rules-selector-region']"));
+            Assert.Single(cut.FindAll("[data-testid='board-rules-visualisation-region']"));
+
+            var markup = cut.Markup;
+            var selectorPosition = markup.IndexOf("board-rules-selector-region", StringComparison.Ordinal);
+            var visualisationPosition = markup.IndexOf("board-rules-visualisation-region", StringComparison.Ordinal);
+            Assert.True(selectorPosition >= 0);
+            Assert.True(visualisationPosition > selectorPosition);
+        });
+    }
+
+    [Fact]
+    public async Task BoardRules_RepositorySelected_LoadsSupportedProjectBoards()
+    {
+        // Arrange
+        var repository = CreateRepository("owner", "repo-a");
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repository]);
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
+                new BoardRulesProjectBoardOptionDto("PVT_beta", "Beta Board", "owner"),
+            ]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<BoardRules>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='board-rules-repository-autocomplete']"));
+        await SelectRepositoryAsync(cut, repository);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Alpha Board", cut.Markup);
+            Assert.Contains("Board context ready", cut.Markup);
+            Assert.Single(cut.FindAll("[data-testid='board-rules-board-context-ready-state']"));
+        });
+
+        _boardRulesServiceMock.Verify(
+            service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task BoardRules_NoSupportedProjectBoards_ShowsUnsupportedMessageAndBlocksDiagramState()
+    {
+        // Arrange
+        var repository = CreateRepository("owner", "repo-a");
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repository]);
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<BoardRules>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='board-rules-repository-autocomplete']"));
+        await SelectRepositoryAsync(cut, repository);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='board-rules-unsupported-boards-message']"));
+            Assert.Single(cut.FindAll("[data-testid='board-rules-no-supported-board-state']"));
+            Assert.DoesNotContain("Board context ready", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task BoardRules_RepositoryLoadFailure_ShowsRetryAction()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("GitHub unavailable"));
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<BoardRules>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Unable to load repositories", cut.Markup);
+            Assert.Single(cut.FindAll("[data-testid='board-rules-reload-repositories-button']"));
+        });
+    }
+
+    private BunitContext CreateContext()
+    {
+        var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddMudServices();
+        ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
+        ctx.Services.AddScoped(_ => _boardRulesServiceMock.Object);
+
+        ctx.Render<MudPopoverProvider>();
+        ctx.Render<MudDialogProvider>();
+        ctx.Render<MudSnackbarProvider>();
+
+        return ctx;
+    }
+
+    private static async Task SelectRepositoryAsync(IRenderedComponent<BoardRules> cut, RepositoryDto repository)
+    {
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync([repository.FullName]));
+    }
+
+    private static RepositoryDto CreateRepository(string owner, string name)
+        => new(
+            Id: 0,
+            Name: name,
+            FullName: $"{owner}/{name}",
+            Description: string.Empty,
+            Url: string.Empty,
+            IsPrivate: false,
+            IsArchived: false,
+            CreatedAt: DateTimeOffset.UnixEpoch,
+            UpdatedAt: DateTimeOffset.UnixEpoch);
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/BoardRulesServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/BoardRulesServiceTests.cs
@@ -1,6 +1,7 @@
 using Moq;
 using SoloDevBoard.Application.Services.BoardRules;
 using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Domain.Entities.Triage;
 
 namespace SoloDevBoard.Application.Tests;
 
@@ -46,5 +47,57 @@ public sealed class BoardRulesServiceTests
         // Assert
         Assert.Same(expected, result);
         _gitHubServiceMock.Verify(service => service.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetProjectBoardOptionsAsync_ProjectBoardsReturned_ReturnsSortedOptions()
+    {
+        // Arrange
+        _gitHubServiceMock
+            .Setup(service => service.GetProjectBoardsForRepositoryAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new TriageProjectBoard
+                {
+                    Id = "PVT_beta",
+                    Title = "Beta Board",
+                    OwnerLogin = "owner",
+                    StatusFieldId = "status-field",
+                    StatusOptions = [],
+                },
+                new TriageProjectBoard
+                {
+                    Id = "PVT_alpha",
+                    Title = "Alpha Board",
+                    OwnerLogin = "owner",
+                    StatusFieldId = "status-field",
+                    StatusOptions = [],
+                },
+            ]);
+
+        var sut = new BoardRulesService(_gitHubServiceMock.Object);
+
+        // Act
+        var result = await sut.GetProjectBoardOptionsAsync("owner", "repo");
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("PVT_alpha", result[0].Id);
+        Assert.Equal("Alpha Board", result[0].Title);
+        Assert.Equal("owner", result[0].OwnerLogin);
+        Assert.Equal("PVT_beta", result[1].Id);
+        _gitHubServiceMock.Verify(service => service.GetProjectBoardsForRepositoryAsync("owner", "repo", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetProjectBoardOptionsAsync_OwnerIsWhitespace_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = new BoardRulesService(_gitHubServiceMock.Object);
+
+        // Act
+        var action = () => sut.GetProjectBoardOptionsAsync(" ", "repo");
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
     }
 }


### PR DESCRIPTION
## Summary of Changes

- Adds the Board Rules Visualiser entry workflow so users can choose a repository and supported GitHub Project v2 board before visualisation.
- Reuses the shared RepositorySelector component and loads supported boards through IBoardRulesService.
- Implements loading, empty, error, and unsupported-board states aligned with the approved wireframe.
- Confirms board context when a supported board is selected without entering the diagram state yet.

## Related Issue(s)

Closes #183

Relates to #181

## Type of Change

- [x] Feature (non-breaking change that adds functionality)
- [x] Documentation (updates to docs, comments, or README)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in AGENTS.md
- [x] All new and existing tests pass (dotnet test)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in docs/ or plan/
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in UK English
- [x] If this adds a new feature, plan/BACKLOG.md and docs/index.md have been updated

## Test plan

- [x] dotnet build
- [x] dotnet test
- [x] Manual: open /board-rules, select a repository, verify supported boards load
- [x] Manual: verify unsupported-board messaging when no Status field boards exist

Made with [Cursor](https://cursor.com)