### PR TITLE
Implement board rules compare mode and test coverage (#187–#190)

### DIFF
--- a/docs/user-guide/board-rules-visualiser.md
+++ b/docs/user-guide/board-rules-visualiser.md
@@ -5,7 +5,7 @@ parent: User Guide
 nav_order: 4
 ---
 
-> ⚠️ **Partial delivery** — Repository and supported board selection is available, and the board columns plus supported transitions are now visualised. Full rule inspection, warnings, and compare mode are delivered in later slices.
+> ⚠️ **Partial delivery** — Repository and supported board selection is available, board columns and transitions are visualised, rule inspection and warnings are supported, and compare mode lets you contrast two repositories side by side. Full automation-rule retrieval from GitHub remains a later slice.
 
 ---
 
@@ -39,13 +39,21 @@ Key goals of the Board Rules Visualiser:
 - See a warning when the board metadata is only partially visible.
 - Click rule nodes to inspect the full rule name, trigger and action configuration.
 - See potential rule conflicts highlighted when duplicate triggers or incomplete rule details are present.
+- Enable **Compare mode** to select a second repository and project board, then review column, rule, and visibility differences side by side.
 - Reload repositories or project boards if GitHub API requests fail.
+
+### Compare two repositories
+
+1. Turn on **Compare mode** in the repository selector region.
+2. Select the primary repository and project board as usual.
+3. Choose a comparison repository and supported project board in the comparison selector region.
+4. Review the side-by-side summaries and the differences panel when both boards are loaded.
+5. Turn off compare mode to return to single-board inspection without losing your primary selection.
 
 ### What is coming later
 
-- Full rule inspection for board automation rules and trigger conditions.
-- Warning details for conflicting or unsupported rule patterns.
-- Compare mode for differences between repositories.
+- Full rule inspection for board automation rules and trigger conditions directly from GitHub.
+- Deeper warning details for conflicting or unsupported rule patterns beyond the current heuristic checks.
 
 ### Empty and unsupported states
 

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -166,12 +166,12 @@ Labels: `type/epic`, `area/board-rules`
 - [x] As a solo developer, I want to see an interactive diagram of a project board's columns and automation rules so that I can understand how issues flow. _(Issue #184; implemented 2026-07-15.)_
 - [x] As a solo developer, I want to click on a rule in the diagram to see its full configuration so that I can understand what triggers it. _(Issue #185; planned 2026-05-07.)_
 - [x] As a solo developer, I want to see highlighted rules that may conflict or produce unexpected behaviour so that I can diagnose automation issues. _(Issue #186; planned 2026-05-07.)_
-- [ ] As a solo developer, I want to compare the board rules of two repositories so that I can identify differences before a migration. _(Issue #187; planned 2026-05-07.)_
+- [x] As a solo developer, I want to compare the board rules of two repositories so that I can identify differences before a migration. _(Issue #187; planned 2026-05-07.)_
 
 **Tests:**
-- [ ] Test: Application coverage for board rules mapping and warning logic. _(Issue #188; planned 2026-05-07.)_
-- [ ] Test: Infrastructure coverage for GitHub Projects board queries. _(Issue #189; planned 2026-05-07.)_
-- [ ] Test: bUnit coverage for Board Rules Visualiser workflows. _(Issue #190; planned 2026-05-07; references wireframes/board-rules-visualiser-wireframe.md.)_
+- [x] Test: Application coverage for board rules mapping and warning logic. _(Issue #188; planned 2026-05-07.)_
+- [x] Test: Infrastructure coverage for GitHub Projects board queries. _(Issue #189; planned 2026-05-07.)_
+- [x] Test: bUnit coverage for Board Rules Visualiser workflows. _(Issue #190; planned 2026-05-07; references wireframes/board-rules-visualiser-wireframe.md.)_
 
 ---
 

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -127,18 +127,18 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 
 **Milestone:** v0.4.0
 
-**Status:** Not started. Work on this phase begins after Phase 3 is complete.
+**Status:** In progress. Board Rules Visualiser compare mode implementation and testing are currently underway.
 
 ### Key Tasks
 
 #### Board Rules Visualiser
-- [ ] Investigate GitHub Projects v2 GraphQL API for automation rule access
-- [ ] Design `BoardRule` and `BoardDiagram` domain records
-- [ ] Implement `BoardRuleService` in `Application`
-- [ ] Implement GraphQL client in `Infrastructure` (see ADR-0005)
-- [ ] Build interactive MudBlazor-based diagram component (consider using a JS interop charting library where needed)
-- [ ] Write unit tests for `BoardRuleService`
-- [ ] Update `docs/user-guide/board-rules-visualiser.md`
+- [x] Investigate GitHub Projects v2 GraphQL API for automation rule access
+- [x] Design `BoardRule` and `BoardDiagram` domain records
+- [x] Implement `BoardRuleService` in `Application`
+- [x] Implement GraphQL client in `Infrastructure` (see ADR-0005)
+- [x] Build interactive MudBlazor-based diagram component (compare mode now available)
+- [x] Write unit tests for `BoardRuleService`, `BoardRulesComparer`, and compare mode functionality
+- [x] Update `docs/user-guide/board-rules-visualiser.md` _(compare mode documented as available)_
 
 #### Workflow Templates
 - [ ] Design `WorkflowTemplate` domain record

--- a/src/App/SoloDevBoard.App/Components/Features/BoardRules/Pages/BoardRules.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/BoardRules/Pages/BoardRules.razor
@@ -9,7 +9,13 @@
 
         <MudPaper Class="pa-4" Elevation="1" data-testid="board-rules-selector-region">
             <MudStack Spacing="2">
-                <MudText Typo="Typo.h6">Repository and project board</MudText>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Wrap="Wrap.Wrap" Spacing="2">
+                    <MudText Typo="Typo.h6">Repository and project board</MudText>
+                    <MudSwitch T="bool" Value="isCompareModeEnabled" ValueChanged="OnCompareModeToggledAsync"
+                               Color="Color.Primary" Label="Compare mode"
+                               aria-label="Toggle compare mode to inspect two repositories side by side"
+                               data-testid="board-rules-compare-mode-toggle" />
+                </MudStack>
 
                 @if (isLoadingRepositories)
                 {
@@ -103,6 +109,86 @@
                                 </MudPaper>
                             </MudItem>
                         </MudGrid>
+
+                        @if (isCompareModeEnabled)
+                        {
+                            <MudDivider Class="my-2" />
+                            <MudText Typo="Typo.h6" data-testid="board-rules-comparison-selector-heading">Comparison repository and project board</MudText>
+                            <MudText Typo="Typo.body2">Select a second repository and supported project board to compare against the primary selection.</MudText>
+
+                            <MudGrid Spacing="2" data-testid="board-rules-comparison-selector-region">
+                                <MudItem xs="12" md="6">
+                                    <RepositorySelector Title="" Label="Comparison repository" Placeholder="Search repositories and select"
+                                                        EmptyStateText="No active repositories are available for board rules visualisation."
+                                                        AvailableRepositories="availableRepositoryFullNames"
+                                                        SelectedRepositories="comparisonRepositoryFullNames"
+                                                        SelectedRepositoriesChanged="OnComparisonRepositoriesChangedAsync"
+                                                        SummaryText="@ComparisonRepositorySelectorSummary" ShowSelectedChips="true" ShowSelectionActions="false"
+                                                        SingleSelectionOnly="true" Disabled="ShowLoadingState"
+                                                        AutocompleteTestId="board-rules-comparison-repository-autocomplete"
+                                                        SummaryTestId="board-rules-comparison-repository-selector-summary" />
+                                </MudItem>
+
+                                <MudItem xs="12" md="6">
+                                    <MudPaper Class="pa-3" Outlined="true" data-testid="board-rules-comparison-project-board-selector">
+                                        <MudStack Spacing="1">
+                                            <MudText Typo="Typo.subtitle2">Comparison project board</MudText>
+                                            <MudText Typo="Typo.body2">Select a GitHub Project v2 board with a Status field to compare.</MudText>
+
+                                            @if (!HasComparisonRepository)
+                                            {
+                                                <MudText Typo="Typo.body2" data-testid="board-rules-comparison-board-selector-prompt">Select a comparison repository to load supported project boards.</MudText>
+                                            }
+                                            else if (isLoadingComparisonProjectBoards)
+                                            {
+                                                <MudStack AlignItems="AlignItems.Center" Spacing="1" aria-live="polite" role="status"
+                                                          data-testid="board-rules-comparison-boards-loading-state">
+                                                    <MudProgressCircular Indeterminate="true" Color="Color.Primary"
+                                                                         aria-label="Loading comparison project boards" />
+                                                    <MudText Typo="Typo.body2">Loading comparison project boards...</MudText>
+                                                </MudStack>
+                                            }
+                                            else if (comparisonProjectBoardOptions.Count == 0 && !hasComparisonProjectBoardLoadFailure)
+                                            {
+                                                @if (HasComparisonInaccessibleProjectBoardsWarning)
+                                                {
+                                                    <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined"
+                                                              data-testid="board-rules-comparison-inaccessible-project-boards-warning">
+                                                        @comparisonInaccessibleProjectBoardsWarning
+                                                    </MudAlert>
+                                                }
+                                                else
+                                                {
+                                                    <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Outlined"
+                                                              data-testid="board-rules-comparison-unsupported-boards-message">
+                                                        No supported GitHub Project v2 boards were found for the comparison repository.
+                                                    </MudAlert>
+                                                }
+                                            }
+                                            else
+                                            {
+                                                @if (HasComparisonInaccessibleProjectBoardsWarning)
+                                                {
+                                                    <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined"
+                                                              data-testid="board-rules-comparison-inaccessible-project-boards-warning">
+                                                        @comparisonInaccessibleProjectBoardsWarning
+                                                    </MudAlert>
+                                                }
+
+                                                <MudSelect T="string" Value="comparisonProjectBoardId"
+                                                           ValueChanged="OnComparisonProjectBoardChangedAsync" Label="Comparison project board"
+                                                           Variant="Variant.Outlined" Disabled="ShowLoadingState">
+                                                    @foreach (var projectBoardOption in comparisonProjectBoardOptions)
+                                                    {
+                                                        <MudSelectItem T="string" Value="@projectBoardOption.Id">@projectBoardOption.Title</MudSelectItem>
+                                                    }
+                                                </MudSelect>
+                                            }
+                                        </MudStack>
+                                    </MudPaper>
+                                </MudItem>
+                            </MudGrid>
+                        }
                     }
                 </MudStack>
             </MudPaper>
@@ -173,6 +259,71 @@
                                     Visualising <strong>@selectedBoardRules.ProjectTitle</strong> for
                                     <strong>@selectedBoardRules.OwnerLogin</strong>.
                                 </MudText>
+
+                                @if (ShowComparisonResults && boardRulesComparison is not null)
+                                {
+                                    var comparison = boardRulesComparison;
+                                    <MudPaper Class="pa-4" Outlined="true" data-testid="board-rules-comparison-results">
+                                        <MudStack Spacing="2">
+                                            <MudText Typo="Typo.subtitle1">Board comparison</MudText>
+                                            <MudText Typo="Typo.body2">
+                                                Comparing <strong>@selectedBoardRules.ProjectTitle</strong> with
+                                                <strong>@comparison.RightDefinition.ProjectTitle</strong>.
+                                            </MudText>
+
+                                            <MudGrid Spacing="2">
+                                                <MudItem xs="12" lg="6">
+                                                    <MudPaper Class="pa-3" Outlined="true" data-testid="board-rules-comparison-primary-summary">
+                                                        <MudStack Spacing="1">
+                                                            <MudText Typo="Typo.subtitle2">Primary board</MudText>
+                                                            <MudText Typo="Typo.body2"><strong>@selectedBoardRules.ProjectTitle</strong></MudText>
+                                                            <MudText Typo="Typo.body2">Columns: @string.Join(", ", selectedBoardRules.Columns.Select(column => column.Name))</MudText>
+                                                            <MudText Typo="Typo.body2">Rules: @(selectedBoardRules.Rules.Count == 0 ? "None available" : string.Join(", ", selectedBoardRules.Rules.Select(rule => rule.Name)))</MudText>
+                                                        </MudStack>
+                                                    </MudPaper>
+                                                </MudItem>
+                                                <MudItem xs="12" lg="6">
+                                                    <MudPaper Class="pa-3" Outlined="true" data-testid="board-rules-comparison-secondary-summary">
+                                                        <MudStack Spacing="1">
+                                                            <MudText Typo="Typo.subtitle2">Comparison board</MudText>
+                                                            <MudText Typo="Typo.body2"><strong>@comparison.RightDefinition.ProjectTitle</strong></MudText>
+                                                            <MudText Typo="Typo.body2">Columns: @string.Join(", ", comparison.RightDefinition.Columns.Select(column => column.Name))</MudText>
+                                                            <MudText Typo="Typo.body2">Rules: @(comparison.RightDefinition.Rules.Count == 0 ? "None available" : string.Join(", ", comparison.RightDefinition.Rules.Select(rule => rule.Name)))</MudText>
+                                                        </MudStack>
+                                                    </MudPaper>
+                                                </MudItem>
+                                            </MudGrid>
+
+                                            @if (comparison.HasDifferences)
+                                            {
+                                                <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined"
+                                                          data-testid="board-rules-comparison-differences-alert">
+                                                    <MudText Typo="Typo.subtitle2">Differences detected</MudText>
+                                                    @foreach (var difference in comparison.Differences)
+                                                    {
+                                                        <MudText Typo="Typo.body2" data-testid="board-rules-comparison-difference">
+                                                            <strong>@difference.Category (@difference.DifferenceType):</strong> @difference.Details
+                                                        </MudText>
+                                                    }
+                                                </MudAlert>
+                                            }
+                                            else
+                                            {
+                                                <MudAlert Severity="Severity.Success" Dense="true" Variant="Variant.Outlined"
+                                                          data-testid="board-rules-comparison-no-differences-alert">
+                                                    No structural differences were detected between the selected boards.
+                                                </MudAlert>
+                                            }
+                                        </MudStack>
+                                    </MudPaper>
+                                }
+                                else if (isCompareModeEnabled && HasSelectedProjectBoard && comparisonBoardRules is null)
+                                {
+                                    <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Outlined"
+                                              data-testid="board-rules-comparison-awaiting-selection">
+                                        Select a comparison repository and project board to view side-by-side differences.
+                                    </MudAlert>
+                                }
 
                                 <MudGrid Spacing="2">
                                     <MudItem xs="12" lg="7">

--- a/src/App/SoloDevBoard.App/Components/Features/BoardRules/Pages/BoardRules.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/BoardRules/Pages/BoardRules.razor.cs
@@ -9,7 +9,7 @@ using SoloDevBoard.Application.Services.Repositories;
 namespace SoloDevBoard.App.Components.Features.BoardRules.Pages;
 
 /// <summary>Provides the entry workflow for selecting a repository and project board to visualise.</summary>
-public partial class BoardRules : ComponentBase
+public partial class BoardRules : ComponentBase, IAsyncDisposable
 {
     /// <summary>Gets or sets the application service used to retrieve repositories.</summary>
     [Inject]
@@ -52,8 +52,18 @@ public partial class BoardRules : ComponentBase
     private bool hasComparisonProjectBoardLoadFailure;
     private string? comparisonInaccessibleProjectBoardsWarning;
     private BoardRulesComparisonResultDto? boardRulesComparison;
+    private CancellationTokenSource? _primaryProjectBoardsLoadCts;
+    private CancellationTokenSource? _primaryBoardRulesLoadCts;
+    private CancellationTokenSource? _comparisonProjectBoardsLoadCts;
+    private CancellationTokenSource? _comparisonBoardRulesLoadCts;
 
     /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        CancelPrimaryLoads();
+        CancelComparisonLoads();
+        await ValueTask.CompletedTask;
+    }
     protected override async Task OnInitializedAsync()
     {
         await LoadRepositoriesAsync();
@@ -86,6 +96,7 @@ public partial class BoardRules : ComponentBase
 
     private async Task LoadRepositoriesAsync()
     {
+        CancelPrimaryLoads();
         isLoadingRepositories = true;
         hasRepositoryLoadFailure = false;
         errorMessage = null;
@@ -136,6 +147,7 @@ public partial class BoardRules : ComponentBase
 
         if (string.IsNullOrWhiteSpace(selectedFullName))
         {
+            CancelPrimaryLoads();
             selectedRepository = null;
             availableProjectBoardOptions = [];
             selectedProjectBoardId = string.Empty;
@@ -188,6 +200,7 @@ public partial class BoardRules : ComponentBase
 
         if (string.IsNullOrWhiteSpace(selectedFullName))
         {
+            CancelComparisonLoads();
             comparisonRepository = null;
             comparisonProjectBoardOptions = [];
             comparisonProjectBoardId = string.Empty;
@@ -203,6 +216,7 @@ public partial class BoardRules : ComponentBase
 
         if (comparisonRepository is null)
         {
+            CancelComparisonLoads();
             comparisonProjectBoardOptions = [];
             comparisonProjectBoardId = string.Empty;
             comparisonBoardRules = null;
@@ -244,9 +258,20 @@ public partial class BoardRules : ComponentBase
         selectedProjectBoardId = string.Empty;
         selectedRule = null;
 
+        var loadCts = BeginPrimaryProjectBoardsLoad();
+        var cancellationToken = loadCts.Token;
+
         try
         {
-            var discovery = await BoardRulesService.GetProjectBoardOptionsAsync(owner, repo);
+            var discovery = await BoardRulesService
+                .GetProjectBoardOptionsAsync(owner, repo, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (IsStalePrimaryProjectBoardsLoad(loadCts, repository))
+            {
+                return;
+            }
+
             availableProjectBoardOptions = discovery.Options;
             inaccessibleProjectBoardsWarning = LinkedProjectBoardVisibility.BuildInaccessibleProjectsWarning(
                 discovery.TotalLinkedProjectCount,
@@ -262,6 +287,10 @@ public partial class BoardRules : ComponentBase
                 UpdateBoardRulesComparison();
             }
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
         catch (HostedAuthenticationRequiredException ex)
         {
             if (HostedAuthRecovery.TryInitiateRecovery(ex))
@@ -271,12 +300,22 @@ public partial class BoardRules : ComponentBase
         }
         catch (HttpRequestException ex)
         {
+            if (IsStalePrimaryProjectBoardsLoad(loadCts, repository))
+            {
+                return;
+            }
+
             hasProjectBoardLoadFailure = true;
             errorMessage = $"GitHub API request failed while loading project boards. {ex.Message}";
             UpdateBoardRulesComparison();
         }
         catch (Exception ex)
         {
+            if (IsStalePrimaryProjectBoardsLoad(loadCts, repository))
+            {
+                return;
+            }
+
             hasProjectBoardLoadFailure = true;
             Logger.LogError(ex, "Failed to load project boards for repository {RepositoryFullName}.", repository.FullName);
             errorMessage = "An unexpected error occurred while loading project boards.";
@@ -284,7 +323,10 @@ public partial class BoardRules : ComponentBase
         }
         finally
         {
-            isLoadingProjectBoards = false;
+            if (ReferenceEquals(_primaryProjectBoardsLoadCts, loadCts))
+            {
+                isLoadingProjectBoards = false;
+            }
         }
     }
 
@@ -310,9 +352,20 @@ public partial class BoardRules : ComponentBase
         comparisonProjectBoardOptions = [];
         comparisonProjectBoardId = string.Empty;
 
+        var loadCts = BeginComparisonProjectBoardsLoad();
+        var cancellationToken = loadCts.Token;
+
         try
         {
-            var discovery = await BoardRulesService.GetProjectBoardOptionsAsync(owner, repo);
+            var discovery = await BoardRulesService
+                .GetProjectBoardOptionsAsync(owner, repo, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (IsStaleComparisonProjectBoardsLoad(loadCts, repository))
+            {
+                return;
+            }
+
             comparisonProjectBoardOptions = discovery.Options;
             comparisonInaccessibleProjectBoardsWarning = LinkedProjectBoardVisibility.BuildInaccessibleProjectsWarning(
                 discovery.TotalLinkedProjectCount,
@@ -328,6 +381,10 @@ public partial class BoardRules : ComponentBase
                 UpdateBoardRulesComparison();
             }
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
         catch (HostedAuthenticationRequiredException ex)
         {
             if (HostedAuthRecovery.TryInitiateRecovery(ex))
@@ -337,18 +394,31 @@ public partial class BoardRules : ComponentBase
         }
         catch (HttpRequestException)
         {
+            if (IsStaleComparisonProjectBoardsLoad(loadCts, repository))
+            {
+                return;
+            }
+
             hasComparisonProjectBoardLoadFailure = true;
             UpdateBoardRulesComparison();
         }
         catch (Exception ex)
         {
+            if (IsStaleComparisonProjectBoardsLoad(loadCts, repository))
+            {
+                return;
+            }
+
             hasComparisonProjectBoardLoadFailure = true;
             Logger.LogError(ex, "Failed to load comparison project boards for repository {RepositoryFullName}.", repository.FullName);
             UpdateBoardRulesComparison();
         }
         finally
         {
-            isLoadingComparisonProjectBoards = false;
+            if (ReferenceEquals(_comparisonProjectBoardsLoadCts, loadCts))
+            {
+                isLoadingComparisonProjectBoards = false;
+            }
         }
     }
 
@@ -365,11 +435,27 @@ public partial class BoardRules : ComponentBase
         hasBoardRulesLoadFailure = false;
         errorMessage = null;
 
+        var loadCts = BeginPrimaryBoardRulesLoad();
+        var cancellationToken = loadCts.Token;
+
         try
         {
-            selectedBoardRules = await BoardRulesService.GetBoardRulesAsync(owner, repo, projectBoardId).ConfigureAwait(false);
+            var boardRules = await BoardRulesService
+                .GetBoardRulesAsync(owner, repo, projectBoardId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (IsStalePrimaryBoardRulesLoad(loadCts, projectBoardId))
+            {
+                return;
+            }
+
+            selectedBoardRules = boardRules;
             selectedTransition = BoardTransitions.FirstOrDefault();
             UpdateBoardRulesComparison();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
         }
         catch (HostedAuthenticationRequiredException ex)
         {
@@ -380,12 +466,22 @@ public partial class BoardRules : ComponentBase
         }
         catch (HttpRequestException ex)
         {
+            if (IsStalePrimaryBoardRulesLoad(loadCts, projectBoardId))
+            {
+                return;
+            }
+
             hasBoardRulesLoadFailure = true;
             errorMessage = $"GitHub API request failed while loading board rules. {ex.Message}";
             UpdateBoardRulesComparison();
         }
         catch (Exception ex)
         {
+            if (IsStalePrimaryBoardRulesLoad(loadCts, projectBoardId))
+            {
+                return;
+            }
+
             hasBoardRulesLoadFailure = true;
             Logger.LogError(ex, "Failed to load board rules for project board {ProjectBoardId} in repository {Owner}/{Repo}.", projectBoardId, owner, repo);
             errorMessage = "An unexpected error occurred while loading board rules.";
@@ -393,7 +489,10 @@ public partial class BoardRules : ComponentBase
         }
         finally
         {
-            isLoadingBoardRules = false;
+            if (ReferenceEquals(_primaryBoardRulesLoadCts, loadCts))
+            {
+                isLoadingBoardRules = false;
+            }
         }
     }
 
@@ -407,10 +506,26 @@ public partial class BoardRules : ComponentBase
         comparisonBoardRules = null;
         hasComparisonProjectBoardLoadFailure = false;
 
+        var loadCts = BeginComparisonBoardRulesLoad();
+        var cancellationToken = loadCts.Token;
+
         try
         {
-            comparisonBoardRules = await BoardRulesService.GetBoardRulesAsync(owner, repo, projectBoardId).ConfigureAwait(false);
+            var boardRules = await BoardRulesService
+                .GetBoardRulesAsync(owner, repo, projectBoardId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (IsStaleComparisonBoardRulesLoad(loadCts, projectBoardId))
+            {
+                return;
+            }
+
+            comparisonBoardRules = boardRules;
             UpdateBoardRulesComparison();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
         }
         catch (HostedAuthenticationRequiredException ex)
         {
@@ -421,18 +536,31 @@ public partial class BoardRules : ComponentBase
         }
         catch (HttpRequestException)
         {
+            if (IsStaleComparisonBoardRulesLoad(loadCts, projectBoardId))
+            {
+                return;
+            }
+
             hasComparisonProjectBoardLoadFailure = true;
             UpdateBoardRulesComparison();
         }
         catch (Exception ex)
         {
+            if (IsStaleComparisonBoardRulesLoad(loadCts, projectBoardId))
+            {
+                return;
+            }
+
             hasComparisonProjectBoardLoadFailure = true;
             Logger.LogError(ex, "Failed to load comparison board rules for project board {ProjectBoardId} in repository {Owner}/{Repo}.", projectBoardId, owner, repo);
             UpdateBoardRulesComparison();
         }
         finally
         {
-            isLoadingComparisonBoardRules = false;
+            if (ReferenceEquals(_comparisonBoardRulesLoadCts, loadCts))
+            {
+                isLoadingComparisonBoardRules = false;
+            }
         }
     }
 
@@ -463,6 +591,7 @@ public partial class BoardRules : ComponentBase
 
     private void ClearComparisonState()
     {
+        CancelComparisonLoads();
         comparisonRepository = null;
         comparisonProjectBoardOptions = [];
         comparisonProjectBoardId = string.Empty;
@@ -663,4 +792,74 @@ public partial class BoardRules : ComponentBase
                 : hasBoardRulesLoadFailure
                     ? "Unable to load board rules"
                     : "Unable to load project boards";
+
+    private CancellationTokenSource BeginPrimaryProjectBoardsLoad()
+    {
+        CancelPrimaryLoads();
+        _primaryProjectBoardsLoadCts = new CancellationTokenSource();
+        return _primaryProjectBoardsLoadCts;
+    }
+
+    private CancellationTokenSource BeginPrimaryBoardRulesLoad()
+    {
+        _primaryBoardRulesLoadCts?.Cancel();
+        _primaryBoardRulesLoadCts?.Dispose();
+        _primaryBoardRulesLoadCts = new CancellationTokenSource();
+        return _primaryBoardRulesLoadCts;
+    }
+
+    private CancellationTokenSource BeginComparisonProjectBoardsLoad()
+    {
+        CancelComparisonLoads();
+        _comparisonProjectBoardsLoadCts = new CancellationTokenSource();
+        return _comparisonProjectBoardsLoadCts;
+    }
+
+    private CancellationTokenSource BeginComparisonBoardRulesLoad()
+    {
+        _comparisonBoardRulesLoadCts?.Cancel();
+        _comparisonBoardRulesLoadCts?.Dispose();
+        _comparisonBoardRulesLoadCts = new CancellationTokenSource();
+        return _comparisonBoardRulesLoadCts;
+    }
+
+    private void CancelPrimaryLoads()
+    {
+        _primaryProjectBoardsLoadCts?.Cancel();
+        _primaryProjectBoardsLoadCts?.Dispose();
+        _primaryProjectBoardsLoadCts = null;
+        _primaryBoardRulesLoadCts?.Cancel();
+        _primaryBoardRulesLoadCts?.Dispose();
+        _primaryBoardRulesLoadCts = null;
+    }
+
+    private void CancelComparisonLoads()
+    {
+        _comparisonProjectBoardsLoadCts?.Cancel();
+        _comparisonProjectBoardsLoadCts?.Dispose();
+        _comparisonProjectBoardsLoadCts = null;
+        _comparisonBoardRulesLoadCts?.Cancel();
+        _comparisonBoardRulesLoadCts?.Dispose();
+        _comparisonBoardRulesLoadCts = null;
+    }
+
+    private bool IsStalePrimaryProjectBoardsLoad(CancellationTokenSource loadCts, RepositoryDto repository)
+        => loadCts.IsCancellationRequested
+            || !ReferenceEquals(_primaryProjectBoardsLoadCts, loadCts)
+            || !string.Equals(selectedRepository?.FullName, repository.FullName, StringComparison.OrdinalIgnoreCase);
+
+    private bool IsStalePrimaryBoardRulesLoad(CancellationTokenSource loadCts, string projectBoardId)
+        => loadCts.IsCancellationRequested
+            || !ReferenceEquals(_primaryBoardRulesLoadCts, loadCts)
+            || !string.Equals(selectedProjectBoardId, projectBoardId, StringComparison.Ordinal);
+
+    private bool IsStaleComparisonProjectBoardsLoad(CancellationTokenSource loadCts, RepositoryDto repository)
+        => loadCts.IsCancellationRequested
+            || !ReferenceEquals(_comparisonProjectBoardsLoadCts, loadCts)
+            || !string.Equals(comparisonRepository?.FullName, repository.FullName, StringComparison.OrdinalIgnoreCase);
+
+    private bool IsStaleComparisonBoardRulesLoad(CancellationTokenSource loadCts, string projectBoardId)
+        => loadCts.IsCancellationRequested
+            || !ReferenceEquals(_comparisonBoardRulesLoadCts, loadCts)
+            || !string.Equals(comparisonProjectBoardId, projectBoardId, StringComparison.Ordinal);
 }

--- a/src/App/SoloDevBoard.App/Components/Features/BoardRules/Pages/BoardRules.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/BoardRules/Pages/BoardRules.razor.cs
@@ -42,6 +42,16 @@ public partial class BoardRules : ComponentBase
     private bool hasBoardRulesLoadFailure;
     private string? errorMessage;
     private string? inaccessibleProjectBoardsWarning;
+    private bool isCompareModeEnabled;
+    private RepositoryDto? comparisonRepository;
+    private IReadOnlyList<BoardRulesProjectBoardOptionDto> comparisonProjectBoardOptions = [];
+    private string comparisonProjectBoardId = string.Empty;
+    private BoardRulesDefinitionDto? comparisonBoardRules;
+    private bool isLoadingComparisonProjectBoards;
+    private bool isLoadingComparisonBoardRules;
+    private bool hasComparisonProjectBoardLoadFailure;
+    private string? comparisonInaccessibleProjectBoardsWarning;
+    private BoardRulesComparisonResultDto? boardRulesComparison;
 
     /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
@@ -64,6 +74,16 @@ public partial class BoardRules : ComponentBase
         await LoadProjectBoardOptionsAsync(selectedRepository);
     }
 
+    private async Task ReloadComparisonProjectBoardsAsync()
+    {
+        if (comparisonRepository is null)
+        {
+            return;
+        }
+
+        await LoadComparisonProjectBoardOptionsAsync(comparisonRepository);
+    }
+
     private async Task LoadRepositoriesAsync()
     {
         isLoadingRepositories = true;
@@ -75,6 +95,7 @@ public partial class BoardRules : ComponentBase
         selectedBoardRules = null;
         selectedTransition = null;
         selectedRule = null;
+        ClearComparisonState();
 
         try
         {
@@ -125,6 +146,7 @@ public partial class BoardRules : ComponentBase
             hasProjectBoardLoadFailure = false;
             hasBoardRulesLoadFailure = false;
             inaccessibleProjectBoardsWarning = null;
+            UpdateBoardRulesComparison();
             return;
         }
 
@@ -142,6 +164,7 @@ public partial class BoardRules : ComponentBase
             hasProjectBoardLoadFailure = false;
             hasBoardRulesLoadFailure = false;
             inaccessibleProjectBoardsWarning = null;
+            UpdateBoardRulesComparison();
             return;
         }
 
@@ -154,6 +177,46 @@ public partial class BoardRules : ComponentBase
         inaccessibleProjectBoardsWarning = null;
 
         await LoadProjectBoardOptionsAsync(selectedRepository);
+    }
+
+    private async Task OnComparisonRepositoriesChangedAsync(IReadOnlyList<string> repositoryFullNames)
+    {
+        ArgumentNullException.ThrowIfNull(repositoryFullNames);
+
+        var selectedFullName = repositoryFullNames
+            .FirstOrDefault(fullName => !string.IsNullOrWhiteSpace(fullName));
+
+        if (string.IsNullOrWhiteSpace(selectedFullName))
+        {
+            comparisonRepository = null;
+            comparisonProjectBoardOptions = [];
+            comparisonProjectBoardId = string.Empty;
+            comparisonBoardRules = null;
+            hasComparisonProjectBoardLoadFailure = false;
+            comparisonInaccessibleProjectBoardsWarning = null;
+            UpdateBoardRulesComparison();
+            return;
+        }
+
+        comparisonRepository = availableRepositories
+            .FirstOrDefault(repository => repository.FullName.Equals(selectedFullName, StringComparison.OrdinalIgnoreCase));
+
+        if (comparisonRepository is null)
+        {
+            comparisonProjectBoardOptions = [];
+            comparisonProjectBoardId = string.Empty;
+            comparisonBoardRules = null;
+            hasComparisonProjectBoardLoadFailure = false;
+            comparisonInaccessibleProjectBoardsWarning = null;
+            UpdateBoardRulesComparison();
+            return;
+        }
+
+        comparisonBoardRules = null;
+        hasComparisonProjectBoardLoadFailure = false;
+        comparisonInaccessibleProjectBoardsWarning = null;
+
+        await LoadComparisonProjectBoardOptionsAsync(comparisonRepository);
     }
 
     private async Task LoadProjectBoardOptionsAsync(RepositoryDto repository)
@@ -169,6 +232,7 @@ public partial class BoardRules : ComponentBase
             selectedProjectBoardId = string.Empty;
             hasProjectBoardLoadFailure = true;
             errorMessage = "The selected repository name is not in owner/name form.";
+            UpdateBoardRulesComparison();
             return;
         }
 
@@ -192,6 +256,11 @@ public partial class BoardRules : ComponentBase
             {
                 await LoadBoardRulesDefinitionAsync(owner, repo, selectedProjectBoardId);
             }
+            else
+            {
+                selectedBoardRules = null;
+                UpdateBoardRulesComparison();
+            }
         }
         catch (HostedAuthenticationRequiredException ex)
         {
@@ -204,16 +273,82 @@ public partial class BoardRules : ComponentBase
         {
             hasProjectBoardLoadFailure = true;
             errorMessage = $"GitHub API request failed while loading project boards. {ex.Message}";
+            UpdateBoardRulesComparison();
         }
         catch (Exception ex)
         {
             hasProjectBoardLoadFailure = true;
             Logger.LogError(ex, "Failed to load project boards for repository {RepositoryFullName}.", repository.FullName);
             errorMessage = "An unexpected error occurred while loading project boards.";
+            UpdateBoardRulesComparison();
         }
         finally
         {
             isLoadingProjectBoards = false;
+        }
+    }
+
+    private async Task LoadComparisonProjectBoardOptionsAsync(RepositoryDto repository)
+    {
+        ArgumentNullException.ThrowIfNull(repository);
+
+        var owner = ResolveOwner(repository.FullName);
+        var repo = ResolveRepositoryName(repository.FullName);
+
+        if (string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(repo))
+        {
+            comparisonProjectBoardOptions = [];
+            comparisonProjectBoardId = string.Empty;
+            hasComparisonProjectBoardLoadFailure = true;
+            UpdateBoardRulesComparison();
+            return;
+        }
+
+        isLoadingComparisonProjectBoards = true;
+        hasComparisonProjectBoardLoadFailure = false;
+        comparisonInaccessibleProjectBoardsWarning = null;
+        comparisonProjectBoardOptions = [];
+        comparisonProjectBoardId = string.Empty;
+
+        try
+        {
+            var discovery = await BoardRulesService.GetProjectBoardOptionsAsync(owner, repo);
+            comparisonProjectBoardOptions = discovery.Options;
+            comparisonInaccessibleProjectBoardsWarning = LinkedProjectBoardVisibility.BuildInaccessibleProjectsWarning(
+                discovery.TotalLinkedProjectCount,
+                discovery.InaccessibleLinkedProjectCount);
+            comparisonProjectBoardId = comparisonProjectBoardOptions.FirstOrDefault()?.Id ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(comparisonProjectBoardId))
+            {
+                await LoadComparisonBoardRulesDefinitionAsync(owner, repo, comparisonProjectBoardId);
+            }
+            else
+            {
+                comparisonBoardRules = null;
+                UpdateBoardRulesComparison();
+            }
+        }
+        catch (HostedAuthenticationRequiredException ex)
+        {
+            if (HostedAuthRecovery.TryInitiateRecovery(ex))
+            {
+                return;
+            }
+        }
+        catch (HttpRequestException)
+        {
+            hasComparisonProjectBoardLoadFailure = true;
+            UpdateBoardRulesComparison();
+        }
+        catch (Exception ex)
+        {
+            hasComparisonProjectBoardLoadFailure = true;
+            Logger.LogError(ex, "Failed to load comparison project boards for repository {RepositoryFullName}.", repository.FullName);
+            UpdateBoardRulesComparison();
+        }
+        finally
+        {
+            isLoadingComparisonProjectBoards = false;
         }
     }
 
@@ -234,6 +369,7 @@ public partial class BoardRules : ComponentBase
         {
             selectedBoardRules = await BoardRulesService.GetBoardRulesAsync(owner, repo, projectBoardId).ConfigureAwait(false);
             selectedTransition = BoardTransitions.FirstOrDefault();
+            UpdateBoardRulesComparison();
         }
         catch (HostedAuthenticationRequiredException ex)
         {
@@ -246,17 +382,96 @@ public partial class BoardRules : ComponentBase
         {
             hasBoardRulesLoadFailure = true;
             errorMessage = $"GitHub API request failed while loading board rules. {ex.Message}";
+            UpdateBoardRulesComparison();
         }
         catch (Exception ex)
         {
             hasBoardRulesLoadFailure = true;
             Logger.LogError(ex, "Failed to load board rules for project board {ProjectBoardId} in repository {Owner}/{Repo}.", projectBoardId, owner, repo);
             errorMessage = "An unexpected error occurred while loading board rules.";
+            UpdateBoardRulesComparison();
         }
         finally
         {
             isLoadingBoardRules = false;
         }
+    }
+
+    private async Task LoadComparisonBoardRulesDefinitionAsync(string owner, string repo, string projectBoardId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectBoardId);
+
+        isLoadingComparisonBoardRules = true;
+        comparisonBoardRules = null;
+        hasComparisonProjectBoardLoadFailure = false;
+
+        try
+        {
+            comparisonBoardRules = await BoardRulesService.GetBoardRulesAsync(owner, repo, projectBoardId).ConfigureAwait(false);
+            UpdateBoardRulesComparison();
+        }
+        catch (HostedAuthenticationRequiredException ex)
+        {
+            if (HostedAuthRecovery.TryInitiateRecovery(ex))
+            {
+                return;
+            }
+        }
+        catch (HttpRequestException)
+        {
+            hasComparisonProjectBoardLoadFailure = true;
+            UpdateBoardRulesComparison();
+        }
+        catch (Exception ex)
+        {
+            hasComparisonProjectBoardLoadFailure = true;
+            Logger.LogError(ex, "Failed to load comparison board rules for project board {ProjectBoardId} in repository {Owner}/{Repo}.", projectBoardId, owner, repo);
+            UpdateBoardRulesComparison();
+        }
+        finally
+        {
+            isLoadingComparisonBoardRules = false;
+        }
+    }
+
+    private void UpdateBoardRulesComparison()
+    {
+        if (!isCompareModeEnabled || selectedBoardRules is null || comparisonBoardRules is null)
+        {
+            boardRulesComparison = null;
+            return;
+        }
+
+        boardRulesComparison = BoardRulesService.CompareBoardRules(selectedBoardRules, comparisonBoardRules);
+    }
+
+    private async Task OnCompareModeToggledAsync(bool enabled)
+    {
+        isCompareModeEnabled = enabled;
+
+        if (!enabled)
+        {
+            ClearComparisonState();
+            return;
+        }
+
+        UpdateBoardRulesComparison();
+        await Task.CompletedTask;
+    }
+
+    private void ClearComparisonState()
+    {
+        comparisonRepository = null;
+        comparisonProjectBoardOptions = [];
+        comparisonProjectBoardId = string.Empty;
+        comparisonBoardRules = null;
+        isLoadingComparisonProjectBoards = false;
+        isLoadingComparisonBoardRules = false;
+        hasComparisonProjectBoardLoadFailure = false;
+        comparisonInaccessibleProjectBoardsWarning = null;
+        boardRulesComparison = null;
     }
 
     private IReadOnlyList<BoardColumnTransition> BoardTransitions
@@ -296,31 +511,10 @@ public partial class BoardRules : ComponentBase
             : Color.Default;
 
     private bool IsRuleWarning(BoardRuleDto rule)
-        => BoardRuleWarnings.Any(warning => warning.Contains($"'{rule.Name}'", StringComparison.OrdinalIgnoreCase));
+        => BoardRulesWarningAnalyser.IsRuleWarning(rule, BoardRuleWarnings);
 
     private IReadOnlyList<string> BoardRuleWarnings
-    {
-        get
-        {
-            if (selectedBoardRules?.Rules is not { Count: > 0 } rules)
-            {
-                return [];
-            }
-
-            var duplicateTriggerWarnings = rules
-                .GroupBy(rule => string.IsNullOrWhiteSpace(rule.Trigger) ? string.Empty : rule.Trigger.Trim(), StringComparer.OrdinalIgnoreCase)
-                .Where(group => !string.IsNullOrWhiteSpace(group.Key) && group.Count() > 1)
-                .Select(group => $"Rules with the same trigger '{group.Key}' may conflict: {string.Join(", ", group.Select(rule => rule.Name))}.")
-                .ToArray();
-
-            var incompleteConfigurationWarnings = rules
-                .Where(rule => string.IsNullOrWhiteSpace(rule.Trigger) || string.IsNullOrWhiteSpace(rule.Action))
-                .Select(rule => $"Rule '{rule.Name}' has incomplete configuration and may behave unexpectedly.")
-                .ToArray();
-
-            return duplicateTriggerWarnings.Concat(incompleteConfigurationWarnings).ToArray();
-        }
-    }
+        => BoardRulesWarningAnalyser.AnalyseWarnings(selectedBoardRules);
 
     private bool HasRuleWarnings => BoardRuleWarnings.Count > 0;
 
@@ -343,6 +537,7 @@ public partial class BoardRules : ComponentBase
 
         if (!HasSelectedRepository || string.IsNullOrWhiteSpace(selectedProjectBoardId))
         {
+            UpdateBoardRulesComparison();
             return;
         }
 
@@ -350,6 +545,24 @@ public partial class BoardRules : ComponentBase
         var repo = ResolveRepositoryName(selectedRepository.FullName);
 
         await LoadBoardRulesDefinitionAsync(owner, repo, selectedProjectBoardId);
+    }
+
+    private async Task OnComparisonProjectBoardChangedAsync(string projectBoardId)
+    {
+        comparisonProjectBoardId = projectBoardId ?? string.Empty;
+        comparisonBoardRules = null;
+        hasComparisonProjectBoardLoadFailure = false;
+
+        if (!HasComparisonRepository || string.IsNullOrWhiteSpace(comparisonProjectBoardId))
+        {
+            UpdateBoardRulesComparison();
+            return;
+        }
+
+        var owner = ResolveOwner(comparisonRepository!.FullName);
+        var repo = ResolveRepositoryName(comparisonRepository.FullName);
+
+        await LoadComparisonBoardRulesDefinitionAsync(owner, repo, comparisonProjectBoardId);
     }
 
     private static string ResolveOwner(string fullName)
@@ -377,16 +590,32 @@ public partial class BoardRules : ComponentBase
     private bool HasInaccessibleProjectBoardsWarning
         => !string.IsNullOrWhiteSpace(inaccessibleProjectBoardsWarning);
 
-    private bool ShowLoadingState => isLoadingRepositories || isLoadingProjectBoards || isLoadingBoardRules;
+    private bool HasComparisonInaccessibleProjectBoardsWarning
+        => !string.IsNullOrWhiteSpace(comparisonInaccessibleProjectBoardsWarning);
+
+    private bool ShowLoadingState
+        => isLoadingRepositories
+            || isLoadingProjectBoards
+            || isLoadingBoardRules
+            || (isCompareModeEnabled && (isLoadingComparisonProjectBoards || isLoadingComparisonBoardRules));
 
     private bool HasSelectedRepository => selectedRepository is not null;
+
+    private bool HasComparisonRepository => comparisonRepository is not null;
 
     private bool HasSelectedProjectBoard
         => !string.IsNullOrWhiteSpace(selectedProjectBoardId)
             && availableProjectBoardOptions.Any(option => option.Id.Equals(selectedProjectBoardId, StringComparison.Ordinal));
 
-    private BoardRulesProjectBoardOptionDto? ActiveProjectBoard
-        => availableProjectBoardOptions.FirstOrDefault(option => option.Id.Equals(selectedProjectBoardId, StringComparison.Ordinal));
+    private bool HasComparisonProjectBoard
+        => !string.IsNullOrWhiteSpace(comparisonProjectBoardId)
+            && comparisonProjectBoardOptions.Any(option => option.Id.Equals(comparisonProjectBoardId, StringComparison.Ordinal));
+
+    private bool ShowComparisonResults
+        => isCompareModeEnabled
+            && selectedBoardRules is not null
+            && comparisonBoardRules is not null
+            && boardRulesComparison is not null;
 
     private string RepositorySelectorSummary
     {
@@ -396,6 +625,17 @@ public partial class BoardRules : ComponentBase
             var repositoryNoun = repositoryCount == 1 ? "repository" : "repositories";
 
             return $"Showing {repositoryCount} active {repositoryNoun}. {(selectedRepository is null ? 0 : 1)} selected. Archived repositories are hidden by default.";
+        }
+    }
+
+    private string ComparisonRepositorySelectorSummary
+    {
+        get
+        {
+            var repositoryCount = availableRepositories.Count;
+            var repositoryNoun = repositoryCount == 1 ? "repository" : "repositories";
+
+            return $"Showing {repositoryCount} active {repositoryNoun}. {(comparisonRepository is null ? 0 : 1)} selected for comparison.";
         }
     }
 
@@ -409,6 +649,11 @@ public partial class BoardRules : ComponentBase
         => selectedRepository is null
             ? []
             : [selectedRepository.FullName];
+
+    private IReadOnlyList<string> comparisonRepositoryFullNames
+        => comparisonRepository is null
+            ? []
+            : [comparisonRepository.FullName];
 
     private string ErrorTitle
         => hasRepositoryLoadFailure

--- a/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesComparer.cs
+++ b/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesComparer.cs
@@ -1,0 +1,178 @@
+namespace SoloDevBoard.Application.Services.BoardRules;
+
+/// <summary>Compares two board rules definitions and produces structured difference results.</summary>
+public static class BoardRulesComparer
+{
+    /// <summary>Compares two board rules definitions and returns structured differences.</summary>
+    /// <param name="left">The primary board rules definition.</param>
+    /// <param name="right">The comparison board rules definition.</param>
+    /// <returns>A comparison result describing missing, extra, and changed board structure.</returns>
+    public static BoardRulesComparisonResultDto Compare(
+        BoardRulesDefinitionDto left,
+        BoardRulesDefinitionDto right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+
+        var differences = new List<BoardRulesComparisonDifferenceDto>();
+
+        CompareColumns(left, right, differences);
+        CompareRules(left, right, differences);
+        CompareVisibility(left, right, differences);
+
+        return new BoardRulesComparisonResultDto(left, right, differences);
+    }
+
+    private static void CompareColumns(
+        BoardRulesDefinitionDto left,
+        BoardRulesDefinitionDto right,
+        ICollection<BoardRulesComparisonDifferenceDto> differences)
+    {
+        var leftColumnNames = left.Columns
+            .Select(column => column.Name.Trim())
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .ToArray();
+        var rightColumnNames = right.Columns
+            .Select(column => column.Name.Trim())
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .ToArray();
+
+        var leftColumnSet = new HashSet<string>(leftColumnNames, StringComparer.OrdinalIgnoreCase);
+        var rightColumnSet = new HashSet<string>(rightColumnNames, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var columnName in leftColumnNames.Where(name => !rightColumnSet.Contains(name)))
+        {
+            differences.Add(new BoardRulesComparisonDifferenceDto(
+                "Column",
+                "Missing in comparison board",
+                columnName,
+                $"Column '{columnName}' exists on the primary board but not on the comparison board."));
+        }
+
+        foreach (var columnName in rightColumnNames.Where(name => !leftColumnSet.Contains(name)))
+        {
+            differences.Add(new BoardRulesComparisonDifferenceDto(
+                "Column",
+                "Extra on comparison board",
+                columnName,
+                $"Column '{columnName}' exists on the comparison board but not on the primary board."));
+        }
+
+        var sharedColumns = leftColumnNames
+            .Where(name => rightColumnSet.Contains(name))
+            .ToArray();
+
+        if (sharedColumns.Length > 1)
+        {
+            var leftOrder = sharedColumns
+                .Select(name => Array.FindIndex(leftColumnNames, candidate => candidate.Equals(name, StringComparison.OrdinalIgnoreCase)))
+                .ToArray();
+            var rightOrder = sharedColumns
+                .Select(name => Array.FindIndex(rightColumnNames, candidate => candidate.Equals(name, StringComparison.OrdinalIgnoreCase)))
+                .ToArray();
+
+            if (!leftOrder.SequenceEqual(rightOrder))
+            {
+                differences.Add(new BoardRulesComparisonDifferenceDto(
+                    "Column",
+                    "Order changed",
+                    "Shared columns",
+                    $"Shared columns appear in a different order. Primary: {string.Join(" → ", leftColumnNames)}. Comparison: {string.Join(" → ", rightColumnNames)}."));
+            }
+        }
+    }
+
+    private static void CompareRules(
+        BoardRulesDefinitionDto left,
+        BoardRulesDefinitionDto right,
+        ICollection<BoardRulesComparisonDifferenceDto> differences)
+    {
+        var leftRules = left.Rules
+            .Where(rule => !string.IsNullOrWhiteSpace(rule.Name))
+            .GroupBy(rule => rule.Name.Trim(), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+        var rightRules = right.Rules
+            .Where(rule => !string.IsNullOrWhiteSpace(rule.Name))
+            .GroupBy(rule => rule.Name.Trim(), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (ruleName, leftRule) in leftRules.Where(pair => !rightRules.ContainsKey(pair.Key)))
+        {
+            differences.Add(new BoardRulesComparisonDifferenceDto(
+                "Rule",
+                "Missing in comparison board",
+                ruleName,
+                $"Rule '{ruleName}' exists on the primary board but not on the comparison board."));
+        }
+
+        foreach (var (ruleName, rightRule) in rightRules.Where(pair => !leftRules.ContainsKey(pair.Key)))
+        {
+            differences.Add(new BoardRulesComparisonDifferenceDto(
+                "Rule",
+                "Extra on comparison board",
+                ruleName,
+                $"Rule '{ruleName}' exists on the comparison board but not on the primary board."));
+        }
+
+        foreach (var ruleName in leftRules.Keys.Where(rightRules.ContainsKey))
+        {
+            var leftRule = leftRules[ruleName];
+            var rightRule = rightRules[ruleName];
+
+            if (!RulesAreEquivalent(leftRule, rightRule))
+            {
+                differences.Add(new BoardRulesComparisonDifferenceDto(
+                    "Rule",
+                    "Changed",
+                    ruleName,
+                    BuildRuleChangeDetails(leftRule, rightRule)));
+            }
+        }
+    }
+
+    private static void CompareVisibility(
+        BoardRulesDefinitionDto left,
+        BoardRulesDefinitionDto right,
+        ICollection<BoardRulesComparisonDifferenceDto> differences)
+    {
+        if (left.HasFullVisibility == right.HasFullVisibility)
+        {
+            return;
+        }
+
+        differences.Add(new BoardRulesComparisonDifferenceDto(
+            "Visibility",
+            "Changed",
+            "Board metadata visibility",
+            left.HasFullVisibility
+                ? "The primary board has full visibility, but the comparison board is only partially visible."
+                : "The comparison board has full visibility, but the primary board is only partially visible."));
+    }
+
+    private static bool RulesAreEquivalent(BoardRuleDto leftRule, BoardRuleDto rightRule)
+        => leftRule.IsEnabled == rightRule.IsEnabled
+            && string.Equals(leftRule.Trigger.Trim(), rightRule.Trigger.Trim(), StringComparison.OrdinalIgnoreCase)
+            && string.Equals(leftRule.Action.Trim(), rightRule.Action.Trim(), StringComparison.OrdinalIgnoreCase);
+
+    private static string BuildRuleChangeDetails(BoardRuleDto leftRule, BoardRuleDto rightRule)
+    {
+        var changes = new List<string>();
+
+        if (!string.Equals(leftRule.Trigger.Trim(), rightRule.Trigger.Trim(), StringComparison.OrdinalIgnoreCase))
+        {
+            changes.Add($"trigger changed from '{leftRule.Trigger}' to '{rightRule.Trigger}'");
+        }
+
+        if (!string.Equals(leftRule.Action.Trim(), rightRule.Action.Trim(), StringComparison.OrdinalIgnoreCase))
+        {
+            changes.Add($"action changed from '{leftRule.Action}' to '{rightRule.Action}'");
+        }
+
+        if (leftRule.IsEnabled != rightRule.IsEnabled)
+        {
+            changes.Add($"enabled state changed from {(leftRule.IsEnabled ? "enabled" : "disabled")} to {(rightRule.IsEnabled ? "enabled" : "disabled")}");
+        }
+
+        return $"Rule '{leftRule.Name}' differs: {string.Join("; ", changes)}.";
+    }
+}

--- a/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesComparisonDifferenceDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesComparisonDifferenceDto.cs
@@ -1,0 +1,12 @@
+namespace SoloDevBoard.Application.Services.BoardRules;
+
+/// <summary>Represents a single difference detected when comparing two board rules definitions.</summary>
+/// <param name="Category">The comparison category, such as column or rule.</param>
+/// <param name="DifferenceType">The difference type, such as missing, extra, or changed.</param>
+/// <param name="Name">The display name of the affected column or rule.</param>
+/// <param name="Details">Additional context describing the difference.</param>
+public sealed record BoardRulesComparisonDifferenceDto(
+    string Category,
+    string DifferenceType,
+    string Name,
+    string Details);

--- a/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesComparisonResultDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesComparisonResultDto.cs
@@ -1,0 +1,14 @@
+namespace SoloDevBoard.Application.Services.BoardRules;
+
+/// <summary>Represents the outcome of comparing two board rules definitions.</summary>
+/// <param name="LeftDefinition">The primary board rules definition.</param>
+/// <param name="RightDefinition">The comparison board rules definition.</param>
+/// <param name="Differences">The detected differences between the two definitions.</param>
+public sealed record BoardRulesComparisonResultDto(
+    BoardRulesDefinitionDto LeftDefinition,
+    BoardRulesDefinitionDto RightDefinition,
+    IReadOnlyList<BoardRulesComparisonDifferenceDto> Differences)
+{
+    /// <summary>Gets a value indicating whether any differences were detected.</summary>
+    public bool HasDifferences => Differences.Count > 0;
+}

--- a/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesService.cs
@@ -51,4 +51,8 @@ public sealed class BoardRulesService : IBoardRulesService
             discovery.TotalLinkedProjectCount,
             discovery.InaccessibleLinkedProjectCount);
     }
+
+    /// <inheritdoc/>
+    public BoardRulesComparisonResultDto CompareBoardRules(BoardRulesDefinitionDto left, BoardRulesDefinitionDto right)
+        => BoardRulesComparer.Compare(left, right);
 }

--- a/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesWarningAnalyser.cs
+++ b/src/Application/SoloDevBoard.Application/Services/BoardRules/BoardRulesWarningAnalyser.cs
@@ -1,0 +1,44 @@
+namespace SoloDevBoard.Application.Services.BoardRules;
+
+/// <summary>Analyses board rules for potential conflicts and incomplete configuration.</summary>
+public static class BoardRulesWarningAnalyser
+{
+    /// <summary>Analyses the supplied board rules definition for warning conditions.</summary>
+    /// <param name="definition">The board rules definition to analyse.</param>
+    /// <returns>Human-readable warning messages for detected issues.</returns>
+    public static IReadOnlyList<string> AnalyseWarnings(BoardRulesDefinitionDto? definition)
+    {
+        if (definition?.Rules is not { Count: > 0 } rules)
+        {
+            return [];
+        }
+
+        var duplicateTriggerWarnings = rules
+            .GroupBy(
+                rule => string.IsNullOrWhiteSpace(rule.Trigger) ? string.Empty : rule.Trigger.Trim(),
+                StringComparer.OrdinalIgnoreCase)
+            .Where(group => !string.IsNullOrWhiteSpace(group.Key) && group.Count() > 1)
+            .Select(group =>
+                $"Rules with the same trigger '{group.Key}' may conflict: {string.Join(", ", group.Select(rule => rule.Name))}.")
+            .ToArray();
+
+        var incompleteConfigurationWarnings = rules
+            .Where(rule => string.IsNullOrWhiteSpace(rule.Trigger) || string.IsNullOrWhiteSpace(rule.Action))
+            .Select(rule => $"Rule '{rule.Name}' has incomplete configuration and may behave unexpectedly.")
+            .ToArray();
+
+        return duplicateTriggerWarnings.Concat(incompleteConfigurationWarnings).ToArray();
+    }
+
+    /// <summary>Determines whether the supplied rule is referenced by a warning message.</summary>
+    /// <param name="rule">The rule to inspect.</param>
+    /// <param name="warnings">The warning messages produced by <see cref="AnalyseWarnings"/>.</param>
+    /// <returns><see langword="true"/> when the rule appears in a warning message; otherwise <see langword="false"/>.</returns>
+    public static bool IsRuleWarning(BoardRuleDto rule, IReadOnlyList<string> warnings)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        ArgumentNullException.ThrowIfNull(warnings);
+
+        return warnings.Any(warning => warning.Contains($"'{rule.Name}'", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Application/SoloDevBoard.Application/Services/BoardRules/IBoardRulesService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/BoardRules/IBoardRulesService.cs
@@ -17,4 +17,10 @@ public interface IBoardRulesService
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>Supported project board options and visibility metadata for the repository.</returns>
     Task<BoardRulesProjectBoardDiscoveryDto> GetProjectBoardOptionsAsync(string owner, string repo, CancellationToken cancellationToken = default);
+
+    /// <summary>Compares two board rules definitions and returns structured differences.</summary>
+    /// <param name="left">The primary board rules definition.</param>
+    /// <param name="right">The comparison board rules definition.</param>
+    /// <returns>A comparison result describing missing, extra, and changed board structure.</returns>
+    BoardRulesComparisonResultDto CompareBoardRules(BoardRulesDefinitionDto left, BoardRulesDefinitionDto right);
 }

--- a/tests/App.Tests/SoloDevBoard.App.Tests/BoardRulesTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/BoardRulesTests.cs
@@ -505,6 +505,339 @@ public sealed class BoardRulesTests
         });
     }
 
+    [Fact]
+    public async Task BoardRules_NoActiveRepositories_ShowsEmptyRepositoriesState()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<BoardRules>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='board-rules-repositories-empty-state']"));
+            Assert.Contains("No active repositories are available", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task BoardRules_ProjectBoardLoadFailure_ShowsRetryAction()
+    {
+        // Arrange
+        var repository = CreateRepository("owner", "repo-a");
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repository]);
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("GitHub unavailable"));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<BoardRules>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='board-rules-repository-autocomplete']"));
+        await SelectRepositoryAsync(cut, repository);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Unable to load project boards", cut.Markup);
+            Assert.Single(cut.FindAll("[data-testid='board-rules-reload-boards-button']"));
+        });
+    }
+
+    [Fact]
+    public async Task BoardRules_BoardRulesLoadFailure_ShowsRetryAction()
+    {
+        // Arrange
+        var repository = CreateRepository("owner", "repo-a");
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repository]);
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+            [
+                new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
+            ],
+            1,
+            0));
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("GitHub unavailable"));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<BoardRules>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='board-rules-repository-autocomplete']"));
+        await SelectRepositoryAsync(cut, repository);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Unable to load board rules", cut.Markup);
+            Assert.Single(cut.FindAll("[data-testid='board-rules-reload-boards-button']"));
+        });
+    }
+
+    [Fact]
+    public async Task BoardRules_WhileProjectBoardsAreLoading_ShowsDiagramLoadingState()
+    {
+        // Arrange
+        var repository = CreateRepository("owner", "repo-a");
+        var projectBoardsTask = new TaskCompletionSource<BoardRulesProjectBoardDiscoveryDto>();
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repository]);
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
+            .Returns(projectBoardsTask.Task);
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<BoardRules>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='board-rules-repository-autocomplete']"));
+        var selectTask = SelectRepositoryAsync(cut, repository);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(
+                cut.FindAll("[data-testid='board-rules-diagram-loading-state']").Count > 0
+                || cut.FindAll("[data-testid='board-rules-boards-loading-state']").Count > 0);
+        });
+
+        projectBoardsTask.SetResult(new BoardRulesProjectBoardDiscoveryDto([], 0, 0));
+        await selectTask;
+    }
+
+    [Fact]
+    public async Task BoardRules_SupportedBoardsWithoutSelection_ShowsBoardNotSelectedState()
+    {
+        // Arrange
+        var repository = CreateRepository("owner", "repo-a");
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repository]);
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+            [
+                new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
+                new BoardRulesProjectBoardOptionDto("PVT_beta", "Beta Board", "owner"),
+            ],
+            2,
+            0));
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BoardRulesDefinitionDto(
+                "PVT_alpha",
+                "Alpha Board",
+                "owner",
+                [new BoardColumnDto(0, "To Do", 0, ["To Do"])],
+                [],
+                []));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<BoardRules>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='board-rules-repository-autocomplete']"));
+        await SelectRepositoryAsync(cut, repository);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='board-rules-board-context-ready-state']"));
+            Assert.Contains("Alpha Board", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task BoardRules_NoRuleWarnings_ShowsNeutralDiagramWithoutConflictAlert()
+    {
+        // Arrange
+        var repository = CreateRepository("owner", "repo-a");
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repository]);
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+            [
+                new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
+            ],
+            1,
+            0));
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BoardRulesDefinitionDto(
+                "PVT_alpha",
+                "Alpha Board",
+                "owner",
+                [
+                    new BoardColumnDto(0, "To Do", 0, ["To Do"]),
+                    new BoardColumnDto(1, "Done", 1, ["Done"]),
+                ],
+                [
+                    new BoardRuleDto(1, "Healthy rule", "When item added", "Assign reviewer", true),
+                ],
+                []));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<BoardRules>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='board-rules-repository-autocomplete']"));
+        await SelectRepositoryAsync(cut, repository);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.DoesNotContain("Potential rule conflicts detected", cut.Markup);
+            Assert.Single(cut.FindAll("[data-testid='board-rules-board-context-ready-state']"));
+        });
+    }
+
+    [Fact]
+    public async Task BoardRules_CompareModeEnabled_ShowsComparisonSelector()
+    {
+        // Arrange
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                CreateRepository("owner", "repo-a"),
+                CreateRepository("owner", "repo-b"),
+            ]);
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<BoardRules>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='board-rules-compare-mode-toggle']"));
+
+        // Act
+        var compareSwitch = cut.FindComponent<MudSwitch<bool>>();
+        await cut.InvokeAsync(() => compareSwitch.Instance.ValueChanged.InvokeAsync(true));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='board-rules-comparison-selector-region']"));
+            Assert.Contains("Comparison repository and project board", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task BoardRules_CompareModeWithTwoBoards_RendersComparisonDifferences()
+    {
+        // Arrange
+        var repositoryA = CreateRepository("owner", "repo-a");
+        var repositoryB = CreateRepository("owner", "repo-b");
+        var primaryDefinition = new BoardRulesDefinitionDto(
+            "PVT_alpha",
+            "Alpha Board",
+            "owner",
+            [
+                new BoardColumnDto(0, "To Do", 0, ["To Do"]),
+                new BoardColumnDto(1, "Done", 1, ["Done"]),
+            ],
+            [
+                new BoardRuleDto(1, "Auto-assign", "When item added", "Assign reviewer", true),
+            ],
+            []);
+        var comparisonDefinition = new BoardRulesDefinitionDto(
+            "PVT_beta",
+            "Beta Board",
+            "owner",
+            [
+                new BoardColumnDto(0, "Backlog", 0, ["Backlog"]),
+                new BoardColumnDto(1, "Done", 1, ["Done"]),
+            ],
+            [],
+            []);
+        var comparisonResult = new BoardRulesComparisonResultDto(
+            primaryDefinition,
+            comparisonDefinition,
+            [
+                new BoardRulesComparisonDifferenceDto(
+                    "Column",
+                    "Missing in comparison board",
+                    "To Do",
+                    "Column 'To Do' exists on the primary board but not on the comparison board."),
+            ]);
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repositoryA, repositoryB]);
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+            [
+                new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
+            ],
+            1,
+            0));
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-b", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+            [
+                new BoardRulesProjectBoardOptionDto("PVT_beta", "Beta Board", "owner"),
+            ],
+            1,
+            0));
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(primaryDefinition);
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetBoardRulesAsync("owner", "repo-b", "PVT_beta", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(comparisonDefinition);
+
+        _boardRulesServiceMock
+            .Setup(service => service.CompareBoardRules(primaryDefinition, comparisonDefinition))
+            .Returns(comparisonResult);
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<BoardRules>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='board-rules-compare-mode-toggle']"));
+
+        var compareSwitch = cut.FindComponent<MudSwitch<bool>>();
+        await cut.InvokeAsync(() => compareSwitch.Instance.ValueChanged.InvokeAsync(true));
+
+        await SelectRepositoryAsync(cut, repositoryA);
+        cut.WaitForAssertion(() => Assert.Contains("Alpha Board", cut.Markup));
+
+        await SelectComparisonRepositoryAsync(cut, repositoryB);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='board-rules-comparison-results']"));
+            Assert.Contains("Differences detected", cut.Markup);
+            Assert.Contains("Column 'To Do' exists on the primary board but not on the comparison board.", cut.Markup);
+            Assert.Single(cut.FindAll("[data-testid='board-rules-comparison-primary-summary']"));
+            Assert.Single(cut.FindAll("[data-testid='board-rules-comparison-secondary-summary']"));
+        });
+
+        _boardRulesServiceMock.Verify(
+            service => service.CompareBoardRules(primaryDefinition, comparisonDefinition),
+            Times.Once);
+    }
+
     private BunitContext CreateContext()
     {
         var ctx = new BunitContext();
@@ -525,6 +858,13 @@ public sealed class BoardRulesTests
     {
         var selector = cut.FindComponent<RepositorySelector>();
         await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync([repository.FullName]));
+    }
+
+    private static async Task SelectComparisonRepositoryAsync(IRenderedComponent<BoardRules> cut, RepositoryDto repository)
+    {
+        var selectors = cut.FindComponents<RepositorySelector>();
+        var comparisonSelector = selectors[^1];
+        await cut.InvokeAsync(() => comparisonSelector.Instance.SelectedRepositoriesChanged.InvokeAsync([repository.FullName]));
     }
 
     private static RepositoryDto CreateRepository(string owner, string name)

--- a/tests/App.Tests/SoloDevBoard.App.Tests/BoardRulesTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/BoardRulesTests.cs
@@ -838,6 +838,66 @@ public sealed class BoardRulesTests
             Times.Once);
     }
 
+    [Fact]
+    public async Task BoardRules_RapidRepositoryChange_IgnoresStaleProjectBoardResponse()
+    {
+        // Arrange
+        var repositoryA = CreateRepository("owner", "repo-a");
+        var repositoryB = CreateRepository("owner", "repo-b");
+        var repositoryADiscoveryTask = new TaskCompletionSource<BoardRulesProjectBoardDiscoveryDto>();
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([repositoryA, repositoryB]);
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
+            .Returns(repositoryADiscoveryTask.Task);
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-b", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+            [
+                new BoardRulesProjectBoardOptionDto("PVT_beta", "Beta Board", "owner"),
+            ],
+            1,
+            0));
+
+        _boardRulesServiceMock
+            .Setup(service => service.GetBoardRulesAsync("owner", "repo-b", "PVT_beta", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BoardRulesDefinitionDto(
+                "PVT_beta",
+                "Beta Board",
+                "owner",
+                [new BoardColumnDto(0, "Backlog", 0, ["Backlog"])],
+                [],
+                []));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<BoardRules>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='board-rules-repository-autocomplete']"));
+
+        var selectRepositoryATask = SelectRepositoryAsync(cut, repositoryA);
+        await SelectRepositoryAsync(cut, repositoryB);
+        cut.WaitForAssertion(() => Assert.Contains("Beta Board", cut.Markup));
+
+        repositoryADiscoveryTask.SetResult(new BoardRulesProjectBoardDiscoveryDto(
+        [
+            new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
+        ],
+        1,
+        0));
+
+        await selectRepositoryATask;
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Beta Board", cut.Markup);
+            Assert.DoesNotContain("Alpha Board", cut.Markup);
+        });
+    }
+
     private BunitContext CreateContext()
     {
         var ctx = new BunitContext();

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/BoardRulesComparerTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/BoardRulesComparerTests.cs
@@ -1,0 +1,134 @@
+using SoloDevBoard.Application.Services.BoardRules;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="BoardRulesComparer"/>.</summary>
+public sealed class BoardRulesComparerTests
+{
+    [Fact]
+    public void Compare_IdenticalDefinitions_ReturnsNoDifferences()
+    {
+        // Arrange
+        var left = CreateDefinition(
+            ["To Do", "In Progress", "Done"],
+            [new BoardRuleDto(1, "Auto-assign", "When item added", "Assign reviewer", true)]);
+        var right = CreateDefinition(
+            ["To Do", "In Progress", "Done"],
+            [new BoardRuleDto(2, "Auto-assign", "When item added", "Assign reviewer", true)]);
+
+        // Act
+        var result = BoardRulesComparer.Compare(left, right);
+
+        // Assert
+        Assert.False(result.HasDifferences);
+        Assert.Empty(result.Differences);
+    }
+
+    [Fact]
+    public void Compare_MissingColumnOnComparisonBoard_ReturnsMissingDifference()
+    {
+        // Arrange
+        var left = CreateDefinition(["To Do", "In Progress", "Done"], []);
+        var right = CreateDefinition(["To Do", "Done"], []);
+
+        // Act
+        var result = BoardRulesComparer.Compare(left, right);
+
+        // Assert
+        Assert.Contains(result.Differences, difference =>
+            difference.Category == "Column"
+            && difference.DifferenceType == "Missing in comparison board"
+            && difference.Name == "In Progress");
+    }
+
+    [Fact]
+    public void Compare_ExtraColumnOnComparisonBoard_ReturnsExtraDifference()
+    {
+        // Arrange
+        var left = CreateDefinition(["To Do", "Done"], []);
+        var right = CreateDefinition(["To Do", "Review", "Done"], []);
+
+        // Act
+        var result = BoardRulesComparer.Compare(left, right);
+
+        // Assert
+        Assert.Contains(result.Differences, difference =>
+            difference.Category == "Column"
+            && difference.DifferenceType == "Extra on comparison board"
+            && difference.Name == "Review");
+    }
+
+    [Fact]
+    public void Compare_ColumnOrderChanged_ReturnsOrderDifference()
+    {
+        // Arrange
+        var left = CreateDefinition(["To Do", "In Progress", "Done"], []);
+        var right = CreateDefinition(["To Do", "Done", "In Progress"], []);
+
+        // Act
+        var result = BoardRulesComparer.Compare(left, right);
+
+        // Assert
+        Assert.Contains(result.Differences, difference =>
+            difference.Category == "Column"
+            && difference.DifferenceType == "Order changed");
+    }
+
+    [Fact]
+    public void Compare_ChangedRuleConfiguration_ReturnsChangedDifference()
+    {
+        // Arrange
+        var left = CreateDefinition(
+            ["To Do", "Done"],
+            [new BoardRuleDto(1, "Auto-assign", "When item added", "Assign reviewer", true)]);
+        var right = CreateDefinition(
+            ["To Do", "Done"],
+            [new BoardRuleDto(2, "Auto-assign", "When item added", "Close issue", true)]);
+
+        // Act
+        var result = BoardRulesComparer.Compare(left, right);
+
+        // Assert
+        Assert.Contains(result.Differences, difference =>
+            difference.Category == "Rule"
+            && difference.DifferenceType == "Changed"
+            && difference.Name == "Auto-assign");
+    }
+
+    [Fact]
+    public void Compare_PartialVisibilityDiffers_ReturnsVisibilityDifference()
+    {
+        // Arrange
+        var left = CreateDefinition(["To Do", "Done"], [], unsupportedDetails: []);
+        var right = CreateDefinition(
+            ["To Do", "Done"],
+            [],
+            unsupportedDetails: ["Board automation rules are not yet available through the current GitHub query model."]);
+
+        // Act
+        var result = BoardRulesComparer.Compare(left, right);
+
+        // Assert
+        Assert.Contains(result.Differences, difference =>
+            difference.Category == "Visibility"
+            && difference.DifferenceType == "Changed");
+    }
+
+    private static BoardRulesDefinitionDto CreateDefinition(
+        IReadOnlyList<string> columnNames,
+        IReadOnlyList<BoardRuleDto> rules,
+        IReadOnlyList<string>? unsupportedDetails = null)
+    {
+        var columns = columnNames
+            .Select((name, index) => new BoardColumnDto(index, name, index, [name]))
+            .ToArray();
+
+        return new BoardRulesDefinitionDto(
+            "PVT_alpha",
+            "Alpha Board",
+            "owner",
+            columns,
+            rules,
+            unsupportedDetails ?? []);
+    }
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/BoardRulesServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/BoardRulesServiceTests.cs
@@ -105,4 +105,97 @@ public sealed class BoardRulesServiceTests
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
     }
+
+    [Fact]
+    public async Task GetBoardRulesAsync_ProjectIdIsWhitespace_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = new BoardRulesService(_gitHubServiceMock.Object);
+
+        // Act
+        var action = () => sut.GetBoardRulesAsync("owner", "repo", " ");
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
+    }
+
+    [Fact]
+    public async Task GetProjectBoardOptionsAsync_NoSupportedBoards_ReturnsEmptyOptions()
+    {
+        // Arrange
+        _gitHubServiceMock
+            .Setup(service => service.GetProjectBoardsForRepositoryAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RepositoryProjectBoardDiscoveryResult([], 0, 0));
+
+        var sut = new BoardRulesService(_gitHubServiceMock.Object);
+
+        // Act
+        var result = await sut.GetProjectBoardOptionsAsync("owner", "repo");
+
+        // Assert
+        Assert.Empty(result.Options);
+        Assert.Equal(0, result.TotalLinkedProjectCount);
+        Assert.Equal(0, result.InaccessibleLinkedProjectCount);
+    }
+
+    [Fact]
+    public async Task GetProjectBoardOptionsAsync_PartiallyAccessibleBoards_PropagatesVisibilityCounts()
+    {
+        // Arrange
+        _gitHubServiceMock
+            .Setup(service => service.GetProjectBoardsForRepositoryAsync("owner", "repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RepositoryProjectBoardDiscoveryResult(
+            [
+                new TriageProjectBoard
+                {
+                    Id = "PVT_alpha",
+                    Title = "Alpha Board",
+                    OwnerLogin = "owner",
+                    StatusFieldId = "status-field",
+                    StatusOptions = [],
+                },
+            ],
+            3,
+            2));
+
+        var sut = new BoardRulesService(_gitHubServiceMock.Object);
+
+        // Act
+        var result = await sut.GetProjectBoardOptionsAsync("owner", "repo");
+
+        // Assert
+        Assert.Single(result.Options);
+        Assert.Equal(3, result.TotalLinkedProjectCount);
+        Assert.Equal(2, result.InaccessibleLinkedProjectCount);
+    }
+
+    [Fact]
+    public void CompareBoardRules_TwoDefinitions_ReturnsComparisonResult()
+    {
+        // Arrange
+        var left = new BoardRulesDefinitionDto(
+            "PVT_alpha",
+            "Alpha Board",
+            "owner",
+            [new BoardColumnDto(0, "To Do", 0, ["To Do"])],
+            [],
+            []);
+        var right = new BoardRulesDefinitionDto(
+            "PVT_beta",
+            "Beta Board",
+            "owner",
+            [new BoardColumnDto(0, "Backlog", 0, ["Backlog"])],
+            [],
+            []);
+
+        var sut = new BoardRulesService(_gitHubServiceMock.Object);
+
+        // Act
+        var result = sut.CompareBoardRules(left, right);
+
+        // Assert
+        Assert.True(result.HasDifferences);
+        Assert.Equal(left, result.LeftDefinition);
+        Assert.Equal(right, result.RightDefinition);
+    }
 }

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/BoardRulesWarningAnalyserTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/BoardRulesWarningAnalyserTests.cs
@@ -1,0 +1,131 @@
+using SoloDevBoard.Application.Services.BoardRules;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="BoardRulesWarningAnalyser"/>.</summary>
+public sealed class BoardRulesWarningAnalyserTests
+{
+    [Fact]
+    public void AnalyseWarnings_NullDefinition_ReturnsEmptyWarnings()
+    {
+        // Act
+        var result = BoardRulesWarningAnalyser.AnalyseWarnings(null);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AnalyseWarnings_EmptyRules_ReturnsEmptyWarnings()
+    {
+        // Arrange
+        var definition = CreateDefinition(rules: []);
+
+        // Act
+        var result = BoardRulesWarningAnalyser.AnalyseWarnings(definition);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AnalyseWarnings_DuplicateTriggers_ReturnsConflictWarning()
+    {
+        // Arrange
+        var definition = CreateDefinition(
+        [
+            new BoardRuleDto(1, "Rule A", "When item added", "Assign reviewer", true),
+            new BoardRuleDto(2, "Rule B", "When item added", "Close issue", true),
+        ]);
+
+        // Act
+        var result = BoardRulesWarningAnalyser.AnalyseWarnings(definition);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains("Rules with the same trigger 'When item added' may conflict", result[0], StringComparison.Ordinal);
+        Assert.Contains("Rule A", result[0], StringComparison.Ordinal);
+        Assert.Contains("Rule B", result[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnalyseWarnings_IncompleteConfiguration_ReturnsIncompleteWarning()
+    {
+        // Arrange
+        var definition = CreateDefinition(
+        [
+            new BoardRuleDto(1, "Incomplete rule", "When item added", string.Empty, true),
+        ]);
+
+        // Act
+        var result = BoardRulesWarningAnalyser.AnalyseWarnings(definition);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains("Rule 'Incomplete rule' has incomplete configuration", result[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnalyseWarnings_UnsupportedPartialData_ReturnsWarningsForAvailableRulesOnly()
+    {
+        // Arrange
+        var definition = new BoardRulesDefinitionDto(
+            "PVT_alpha",
+            "Alpha Board",
+            "owner",
+            [],
+            [
+                new BoardRuleDto(1, "Duplicate A", "When stale", "Close issue", true),
+                new BoardRuleDto(2, "Duplicate B", "When stale", "Archive issue", true),
+            ],
+            ["Board automation rules are not yet available through the current GitHub query model."]);
+
+        // Act
+        var result = BoardRulesWarningAnalyser.AnalyseWarnings(definition);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains("When stale", result[0], StringComparison.Ordinal);
+        Assert.False(definition.HasFullVisibility);
+    }
+
+    [Fact]
+    public void IsRuleWarning_RuleReferencedInWarning_ReturnsTrue()
+    {
+        // Arrange
+        var rule = new BoardRuleDto(1, "Incomplete rule", "When item added", string.Empty, true);
+        var warnings = BoardRulesWarningAnalyser.AnalyseWarnings(CreateDefinition([rule]));
+
+        // Act
+        var result = BoardRulesWarningAnalyser.IsRuleWarning(rule, warnings);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsRuleWarning_RuleNotReferencedInWarning_ReturnsFalse()
+    {
+        // Arrange
+        var rule = new BoardRuleDto(1, "Healthy rule", "When item added", "Assign reviewer", true);
+        var warnings = BoardRulesWarningAnalyser.AnalyseWarnings(CreateDefinition([rule]));
+
+        // Act
+        var result = BoardRulesWarningAnalyser.IsRuleWarning(rule, warnings);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    private static BoardRulesDefinitionDto CreateDefinition(IReadOnlyList<BoardRuleDto> rules)
+        => new(
+            "PVT_alpha",
+            "Alpha Board",
+            "owner",
+            [
+                new BoardColumnDto(0, "To Do", 0, ["To Do"]),
+                new BoardColumnDto(1, "Done", 1, ["Done"]),
+            ],
+            rules,
+            []);
+}

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -1089,6 +1089,152 @@ public sealed class GitHubServiceTests
     }
 
     [Fact]
+    public async Task GetBoardRulesDefinitionAsync_GraphQlErrorsPresent_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "node": null
+                },
+                "errors": [
+                    {
+                        "message": "Resource not accessible by integration"
+                    }
+                ]
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        var action = async () => _ = await sut.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh");
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(action);
+        Assert.Contains("GitHub GraphQL request failed", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetBoardRulesDefinitionAsync_OwnerIsWhitespace_ThrowsArgumentException()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler([]);
+        var sut = CreateSubject(handler);
+
+        // Act
+        var action = async () => _ = await sut.GetBoardRulesDefinitionAsync(" ", "repo", "PVT_kwHOAJefG84BQ6bh");
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
+    }
+
+    [Fact]
+    public async Task GetBoardRulesDefinitionAsync_StatusFieldWithEmptyOptions_ReturnsEmptyColumnsWithUnsupportedDetail()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "node": {
+                        "id": "PVT_kwHOAJefG84BQ6bh",
+                        "title": "Roadmap",
+                        "owner": { "login": "owner" },
+                        "fields": {
+                            "nodes": [
+                                {
+                                    "id": "PVTF_status",
+                                    "name": "Status",
+                                    "options": []
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        var result = await sut.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh");
+
+        // Assert
+        Assert.Empty(result.Columns);
+        Assert.Empty(result.Rules);
+        Assert.Contains(result.UnsupportedDetails, detail => detail.Contains("not yet available", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetProjectBoardsForRepositoryAsync_OwnerIsWhitespace_ThrowsArgumentException()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler([]);
+        var sut = CreateSubject(handler);
+
+        // Act
+        var action = async () => _ = await sut.GetProjectBoardsForRepositoryAsync(" ", "repo");
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
+    }
+
+    [Fact]
+    public async Task GetProjectBoardsForRepositoryAsync_BoardWithoutStatusField_IsExcludedFromSupportedBoards()
+    {
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "projectsV2": {
+                            "nodes": [
+                                {
+                                    "id": "PVT_no_status",
+                                    "title": "Unsupported Board",
+                                    "owner": { "login": "owner" },
+                                    "fields": {
+                                        "nodes": [
+                                            {
+                                                "id": "PVTF_priority",
+                                                "name": "Priority",
+                                                "options": [
+                                                    { "id": "option-one", "name": "High" }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        var result = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo");
+
+        // Assert
+        Assert.Empty(result.SupportedProjectBoards);
+        Assert.Equal(1, result.TotalLinkedProjectCount);
+        Assert.Equal(0, result.InaccessibleLinkedProjectCount);
+    }
+
+    [Fact]
     public async Task UpdateProjectBoardItemStatusAsync_ValidResponse_PostsGraphQlMutation()
     {
         // Arrange


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Adds compare mode to the Board Rules Visualiser so two repositories can be inspected side by side before migration or alignment work. Extracts warning analysis and comparison logic into the Application layer, and expands Application, Infrastructure, and bUnit test coverage for the board-rules feature area.

**Review follow-up:** primary and comparison board loads now use `CancellationTokenSource` instances so superseded async responses cannot overwrite the current repository, project board, or comparison state.

## Related Issue(s)

Closes #187
Closes #188
Closes #189
Closes #190

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [x] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

N/A — compare mode UI follows the approved wireframe in `plan/wireframes/board-rules-visualiser-wireframe.md`.

## Additional Notes

- **#187** — Compare mode toggle, second repository/project-board selector, side-by-side summaries, and structured differences panel.
- **#188** — Application tests for `BoardRulesWarningAnalyser`, `BoardRulesComparer`, and extended `BoardRulesService` coverage.
- **#189** — Infrastructure tests for GitHub Projects board query edge cases and guard clauses.
- **#190** — bUnit tests for selection states, error/retry paths, neutral warnings, and compare-mode workflows.
- **Review fix** — stale async load protection via per-lane cancellation tokens plus `BoardRules_RapidRepositoryChange_IgnoresStaleProjectBoardResponse`.

Verification:

```bash
dotnet build SoloDevBoard.slnx
dotnet test SoloDevBoard.slnx
```

All 345 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e38970cc-2247-4908-8170-c8b88c86a4cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e38970cc-2247-4908-8170-c8b88c86a4cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

