### PR TITLE
[Chore] Set up Aspire dev environment + Aspire MCP config for Cursor

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "aspire": {
+      "command": "aspire",
+      "args": [
+        "agent",
+        "mcp"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -402,6 +402,7 @@ FodyWeavers.xsd
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/mcp.json
 !.vscode/*.code-snippets
 
 # Local History for Visual Studio Code

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,12 @@
+{
+  "servers": {
+    "aspire": {
+      "type": "stdio",
+      "command": "aspire",
+      "args": [
+        "agent",
+        "mcp"
+      ]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,9 +226,8 @@ Durable, non-obvious notes for running SoloDevBoard in the Cursor Cloud VM. Stan
 
 ### Toolchain
 
-- The .NET SDK pinned by `global.json` (`10.0.300`) is installed at `~/.dotnet` and added to `PATH` via `~/.bashrc`. Non-login shells (for example `bash -c`) do not source `~/.bashrc`, so invoke the SDK with the absolute path `~/.dotnet/dotnet` when `dotnet` is not already on `PATH`.
-- The startup update script only runs `dotnet restore SoloDevBoard.slnx`. Building, testing, linting, and running are left to you.
-- The **Aspire CLI is not installed**. Use the direct `dotnet run` path documented below rather than `aspire start`; it is the reliable path in this environment. Everything (build, test, lint, run) works with the plain .NET SDK because the app has no database or other backing services.
+- The .NET SDK pinned by `global.json` (`10.0.300`) is installed at `~/.dotnet`; the Aspire CLI (`13.4.6`, matching `Aspire.AppHost.Sdk`) is installed as a global tool at `~/.dotnet/tools`. Both are on `PATH` via `~/.bashrc`. Non-login shells (for example `bash -c`) do not source `~/.bashrc`, so invoke the SDK with the absolute path `~/.dotnet/dotnet` when `dotnet`/`aspire` are not already on `PATH`.
+- The startup update script only runs `dotnet restore SoloDevBoard.slnx` (this also restores the AppHost). Building, testing, linting, and running are left to you.
 
 ### Build, test, lint
 
@@ -236,13 +235,26 @@ Durable, non-obvious notes for running SoloDevBoard in the Cursor Cloud VM. Stan
 - Test (xUnit, fully offline — GitHub is mocked): `dotnet test SoloDevBoard.slnx`.
 - Lint is `dotnet format SoloDevBoard.slnx --verify-no-changes` (same check CI runs in `.github/workflows/ci.yml`). `EnforceCodeStyleInBuild` is on, so style violations also surface during build.
 
-### Running the app
+### Running the app (Aspire — the standard path)
 
-- Run directly: `dotnet run --project src/App/SoloDevBoard.App`. By default `dotnet run` applies `launchSettings.json` and listens on `https://localhost:5074`. To force a plain-HTTP URL (simpler for in-VM browser testing), pass `--no-launch-profile` and set `ASPNETCORE_URLS`, for example `ASPNETCORE_URLS=http://0.0.0.0:5080 dotnet run --project src/App/SoloDevBoard.App --no-launch-profile`.
+- Start: `aspire start --apphost src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj --non-interactive` (runs in the background). Then `aspire ps` for the dashboard URL/token, `aspire describe` for the `app` resource URL (proxied at `https://localhost:5074`), and `aspire stop` to release file locks before rebuilding.
+- If a build fails with `MSB3491`/`CS2012` (file locks), run `aspire stop` first — Aspire holds locks on `bin/`/`obj/` while running. See the `aspire-orchestration` skill.
+- Query logs/traces without the dashboard via `aspire logs app`, `aspire otel`, or the Aspire MCP server (see below).
 - Health endpoint: `GET /health` returns `Healthy`. The Home page (`/`) is static navigation and renders without any GitHub call.
+- A direct `dotnet run --project src/App/SoloDevBoard.App --no-launch-profile` (with `ASPNETCORE_URLS`) still works as a fallback, but Aspire is the preferred path and matches how the app is developed.
+
+### Aspire MCP server
+
+- `.cursor/mcp.json` (and `.vscode/mcp.json` for Copilot) registers an `aspire` MCP server via `aspire agent mcp`. It connects to the running AppHost and exposes tools such as `list_console_logs`, `list_structured_logs`, `list_traces`, `list_resources`, and `execute_resource_command` for debugging the live app. It only returns data while an AppHost is running (`aspire start`). Cursor loads `.cursor/mcp.json` at client start, so a reload is needed after first adding it.
+
+### AppHost parameters and secrets
+
+- The AppHost defines these parameters (see `src/SoloDevBoard.AppHost/AppHost.cs`): `hosted-sign-in-enabled`, `gh-pat` (secret), `gh-app-client-id`, `gh-app-client-secret` (secret), `hosted-admission-enabled`, `allowed-user-logins`, `allowed-org-logins`. Non-secret defaults live in `src/SoloDevBoard.AppHost/appsettings.json` (PAT mode by default).
+- Provide values in priority order: **environment variable `Parameters__<name>` (highest, e.g. `Parameters__gh-pat`)** > AppHost user secrets (`aspire secret set Parameters:<name> "…"` or `dotnet user-secrets … --project src/SoloDevBoard.AppHost`) > `appsettings.json`. Cloud Secrets-panel entries are injected as env vars, so naming a secret `Parameters__gh-pat` feeds it straight into the AppHost parameter (verified working) and overrides the persisted placeholder.
+- The persisted AppHost user secrets in this VM hold placeholder values (`gh-pat` = the ambient `gh` installation token, `gh-app-client-secret` = `-`) so `aspire start` boots without extra setup. Real functionality needs a genuine token (below).
 
 ### GitHub authentication caveat (important)
 
-- In the default PAT mode the app **fails fast at startup** unless a token is configured. Supply it via the environment variable `GitHubAuth__PersonalAccessToken` (and optionally `GitHubAuth__OwnerLogin` to skip the `/user` login-resolution call).
+- In the default PAT mode the app **fails fast at startup** unless a token is configured, and it resolves your login from the token via `/user` unless `GitHubAuth:OwnerLogin` is set.
 - All data-driven pages (Audit Dashboard, Repositories, Label Manager, Migration) list repositories through the authenticated `/user/repos` endpoint. This needs a **GitHub user PAT** with `repo`, `read:org`, `workflow`, and `read:project` scopes.
-- The ambient `gh` CLI token in this VM is a GitHub App **installation** token: it can reach repo-scoped endpoints (`/repos/{owner}/{repo}/...`) but returns `403 "Resource not accessible by integration"` on `/user` and `/user/repos`. It is enough to boot the app but **not** enough to exercise the repo-list flows — use a real user PAT for end-to-end feature testing.
+- The ambient `gh` CLI token in this VM is a GitHub App **installation** token: it can reach repo-scoped endpoints (`/repos/{owner}/{repo}/...`) but returns `403 "Resource not accessible by integration"` on `/user` and `/user/repos`. Because it cannot resolve `/user`, an app-level user secret `GitHubAuth:OwnerLogin=markheydon` (on `src/App/SoloDevBoard.App`) is set so the app boots for demos; it is harmless with a real owner PAT and can be removed once a genuine user PAT is supplied (the login then auto-resolves). The installation token boots the app but **cannot** exercise the repo-list flows — supply a real user PAT (via the `Parameters__gh-pat` secret) for end-to-end feature testing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,11 @@ Durable, non-obvious notes for running SoloDevBoard in the Cursor Cloud VM. Stan
 - Health endpoint: `GET /health` returns `Healthy`. The Home page (`/`) is static navigation and renders without any GitHub call.
 - A direct `dotnet run --project src/App/SoloDevBoard.App --no-launch-profile` (with `ASPNETCORE_URLS`) still works as a fallback, but Aspire is the preferred path and matches how the app is developed.
 
+### HTTPS dev certificate (in-VM browser caveat)
+
+- On a normal dev machine, `aspire certs trust` (or `dotnet dev-certs https --trust`) trusts the cert and browsers stop warning. In this headless Linux VM that does **not** fully work for Chrome: even after installing `libnss3-tools` and importing the cert into `~/.pki/nssdb` as a trusted CA (`certutil ... -t "C,,"`), Chrome still reports `NET::ERR_CERT_INVALID` (a long-standing ASP.NET-dev-cert-on-Chromium-Linux issue). Do not rabbit-hole on it.
+- For in-VM browser testing either click **Advanced → Proceed to localhost (unsafe)** once, or run the app on plain HTTP (`ASPNETCORE_URLS=http://0.0.0.0:5080 dotnet run --project src/App/SoloDevBoard.App --no-launch-profile`). `curl -k` also bypasses the check for scripted checks.
+
 ### Aspire MCP server
 
 - `.cursor/mcp.json` (and `.vscode/mcp.json` for Copilot) registers an `aspire` MCP server via `aspire agent mcp`. It connects to the running AppHost and exposes tools such as `list_console_logs`, `list_structured_logs`, `list_traces`, `list_resources`, and `execute_resource_command` for debugging the live app. It only returns data while an AppHost is running (`aspire start`). Cursor loads `.cursor/mcp.json` at client start, so a reload is needed after first adding it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,8 +250,20 @@ Durable, non-obvious notes for running SoloDevBoard in the Cursor Cloud VM. Stan
 ### AppHost parameters and secrets
 
 - The AppHost defines these parameters (see `src/SoloDevBoard.AppHost/AppHost.cs`): `hosted-sign-in-enabled`, `gh-pat` (secret), `gh-app-client-id`, `gh-app-client-secret` (secret), `hosted-admission-enabled`, `allowed-user-logins`, `allowed-org-logins`. Non-secret defaults live in `src/SoloDevBoard.AppHost/appsettings.json` (PAT mode by default).
-- Provide values in priority order: **environment variable `Parameters__<name>` (highest, e.g. `Parameters__gh-pat`)** > AppHost user secrets (`aspire secret set Parameters:<name> "…"` or `dotnet user-secrets … --project src/SoloDevBoard.AppHost`) > `appsettings.json`. Cloud Secrets-panel entries are injected as env vars, so naming a secret `Parameters__gh-pat` feeds it straight into the AppHost parameter (verified working) and overrides the persisted placeholder.
-- The persisted AppHost user secrets in this VM hold placeholder values (`gh-pat` = the ambient `gh` installation token, `gh-app-client-secret` = `-`) so `aspire start` boots without extra setup. Real functionality needs a genuine token (below).
+- **Cloud Secrets → Aspire parameters mapping.** The parameter names contain hyphens, and a direct `Parameters__<name>` env var is impossible because environment-variable names cannot contain hyphens (the Cursor Secrets panel rejects them with a sync `400`). Instead, add Cursor secrets with hyphen-free names and let the startup update script map them into AppHost user secrets:
+
+  | Cursor secret (hyphen-free) | AppHost parameter |
+  |---|---|
+  | `SDB_GH_PAT` | `gh-pat` |
+  | `SDB_GH_APP_CLIENT_ID` | `gh-app-client-id` |
+  | `SDB_GH_APP_CLIENT_SECRET` | `gh-app-client-secret` |
+  | `SDB_HOSTED_SIGN_IN_ENABLED` | `hosted-sign-in-enabled` |
+  | `SDB_HOSTED_ADMISSION_ENABLED` | `hosted-admission-enabled` |
+  | `SDB_ALLOWED_USER_LOGINS` | `allowed-user-logins` |
+  | `SDB_ALLOWED_ORG_LOGINS` | `allowed-org-logins` |
+
+  The update script runs `dotnet user-secrets set "Parameters:<name>" "$SDB_…"` for each variable that is set (guarded, idempotent), so provided secrets are picked up automatically on every session. Values persist in AppHost user secrets; removing a Cursor secret does not clear a previously-mapped value, so run `dotnet user-secrets remove "Parameters:<name>" --project src/SoloDevBoard.AppHost` if you need to clear one. You can also set values manually with `aspire secret set Parameters:<name> "…"`.
+- The persisted AppHost user secrets in this VM hold placeholder values (`gh-pat` = the ambient `gh` installation token, `gh-app-client-secret` = `-`) so `aspire start` boots without extra setup. Real functionality needs a genuine user PAT via `SDB_GH_PAT` (below).
 
 ### GitHub authentication caveat (important)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,3 +217,32 @@ Default workflow order for feature delivery:
 - **Prompts:** `.github/prompts/*.prompt.md` (Copilot)
 - **Cursor commands:** [`.cursor/commands/implement-issue.md`](.cursor/commands/implement-issue.md) — type `/implement-issue` in Agent chat after planning (Copilot handles PM prompts)
 - **Copilot stack baseline:** `.github/copilot-instructions.md` and `.github/instructions/*.md`
+
+---
+
+## Cursor Cloud specific instructions
+
+Durable, non-obvious notes for running SoloDevBoard in the Cursor Cloud VM. Standard commands live in `docs/getting-started.md`; this section only captures what is easy to get wrong here.
+
+### Toolchain
+
+- The .NET SDK pinned by `global.json` (`10.0.300`) is installed at `~/.dotnet` and added to `PATH` via `~/.bashrc`. Non-login shells (for example `bash -c`) do not source `~/.bashrc`, so invoke the SDK with the absolute path `~/.dotnet/dotnet` when `dotnet` is not already on `PATH`.
+- The startup update script only runs `dotnet restore SoloDevBoard.slnx`. Building, testing, linting, and running are left to you.
+- The **Aspire CLI is not installed**. Use the direct `dotnet run` path documented below rather than `aspire start`; it is the reliable path in this environment. Everything (build, test, lint, run) works with the plain .NET SDK because the app has no database or other backing services.
+
+### Build, test, lint
+
+- Build: `dotnet build SoloDevBoard.slnx`.
+- Test (xUnit, fully offline — GitHub is mocked): `dotnet test SoloDevBoard.slnx`.
+- Lint is `dotnet format SoloDevBoard.slnx --verify-no-changes` (same check CI runs in `.github/workflows/ci.yml`). `EnforceCodeStyleInBuild` is on, so style violations also surface during build.
+
+### Running the app
+
+- Run directly: `dotnet run --project src/App/SoloDevBoard.App`. By default `dotnet run` applies `launchSettings.json` and listens on `https://localhost:5074`. To force a plain-HTTP URL (simpler for in-VM browser testing), pass `--no-launch-profile` and set `ASPNETCORE_URLS`, for example `ASPNETCORE_URLS=http://0.0.0.0:5080 dotnet run --project src/App/SoloDevBoard.App --no-launch-profile`.
+- Health endpoint: `GET /health` returns `Healthy`. The Home page (`/`) is static navigation and renders without any GitHub call.
+
+### GitHub authentication caveat (important)
+
+- In the default PAT mode the app **fails fast at startup** unless a token is configured. Supply it via the environment variable `GitHubAuth__PersonalAccessToken` (and optionally `GitHubAuth__OwnerLogin` to skip the `/user` login-resolution call).
+- All data-driven pages (Audit Dashboard, Repositories, Label Manager, Migration) list repositories through the authenticated `/user/repos` endpoint. This needs a **GitHub user PAT** with `repo`, `read:org`, `workflow`, and `read:project` scopes.
+- The ambient `gh` CLI token in this VM is a GitHub App **installation** token: it can reach repo-scoped endpoints (`/repos/{owner}/{repo}/...`) but returns `403 "Resource not accessible by integration"` on `/user` and `/user/repos`. It is enough to boot the app but **not** enough to exercise the repo-list flows — use a real user PAT for end-to-end feature testing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for SoloDevBoard to run via **.NET Aspire** (the documented, standard path), wires the **Aspire MCP server** for log/trace debugging, and records durable run notes for future agents. Verified end to end with a real GitHub user PAT.

- Adds `.cursor/mcp.json` and `.vscode/mcp.json` registering the `aspire` MCP server (`aspire agent mcp`) so Cursor and Copilot can query the running app's logs/traces/resources. Adds `.vscode/mcp.json` to the `.gitignore` allow-list.
- Documents the Aspire run path, AppHost parameters, the cloud-secret → Aspire-parameter mapping, the Aspire MCP tools, and the GitHub auth caveat in `AGENTS.md` → `## Cursor Cloud specific instructions`.

Environment configured on the VM (persisted in snapshot, not committed): .NET SDK `10.0.300` at `~/.dotnet`, Aspire CLI `13.4.6` global tool, AppHost user secrets for the AppHost parameters.

### Secrets mapping (startup update script)

Aspire parameter names contain hyphens, and environment-variable names cannot (the Secrets panel rejects them with a sync `400`). So the update script restores dependencies and maps hyphen-free Cursor secrets into AppHost user secrets (`SDB_GH_PAT` → `Parameters:gh-pat`, etc., guarded/idempotent).

## Verification

- `dotnet build SoloDevBoard.slnx` — 0 warnings/errors.
- `dotnet test SoloDevBoard.slnx` — 314 tests pass.
- `dotnet format SoloDevBoard.slnx --verify-no-changes` — passes (matches CI).
- `aspire start …` — AppHost + all parameter resources Running; `app` healthy at `https://localhost:5074`.
- Aspire MCP server connects to the running AppHost and exposes `list_console_logs`, `list_structured_logs`, `list_traces`, `list_resources`, `execute_resource_command`, etc.
- **End-to-end with a real user PAT**: app resolves the GitHub login from the token, Repositories page lists 83 real repos, and the Audit Dashboard produces a live summary for `solo-dev-board` (9 open issues, 1 open PR, 0 unlabelled/stale/failing).

### Hello-world (real GitHub data via Aspire)
<a href="https://cursor.com/agents/bc-b089d087-629c-49c9-8eeb-6a6e658fa377/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhelloworld_audit_real_github_data.mp4"><img src="https://cursor.com/artifacts/c/art-12eb6a97-6abf-4c16-816d-0192c8b0e2c9" alt="helloworld_audit_real_github_data.mp4" /></a>

<!-- Repository screenshot removed due to private repos showing on it -->
![Audit Dashboard with real audit data](https://cursor.com/artifacts/c/art-c01a4d35-8821-4467-a39c-01f979b376b8)

### Aspire orchestration
[aspire_dashboard_and_app.mp4](https://cursor.com/agents/bc-b089d087-629c-49c9-8eeb-6a6e658fa377/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faspire_dashboard_and_app.mp4)
![Aspire dashboard resources/parameters running](https://cursor.com/artifacts/c/art-8a42eb1a-a804-4eb1-936c-2c2f51218399)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b089d087-629c-49c9-8eeb-6a6e658fa377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b089d087-629c-49c9-8eeb-6a6e658fa377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

