### PR TITLE
[Story] Browse built-in workflow templates (#235)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ It is built with the solo developer in mind: opinionated defaults, minimal confi
 | **One-Click Migration** | Migrate labels and milestones from one repository to another in a single action. Project board migration is planned. | Partially Available |
 | **Board Rules Visualiser** | Visualise supported board states and transitions for GitHub Project v2 boards. | Partially Available |
 | **Triage UI** | Keyboard-friendly interface for triaging incoming issues quickly. | Available |
-| **Workflow Templates** | Browse, customise, and apply GitHub Actions workflow templates across repositories. | Coming Soon |
+| **Workflow Templates** | Browse built-in GitHub Actions workflow templates. Customise, apply, and track template coverage across repositories. | Partially Available |
 
 ---
 

--- a/docs/user-guide/workflow-templates.md
+++ b/docs/user-guide/workflow-templates.md
@@ -5,7 +5,7 @@ parent: User Guide
 nav_order: 6
 ---
 
-> ⚠️ **Under Development** — This feature is planned for Phase 4. This page will be updated as the feature progresses.
+> ⚠️ **Partially Available** — Template browsing is available. Customisation, apply, and staleness tracking are planned for later Phase 4 stories.
 
 ---
 
@@ -22,11 +22,25 @@ Key goals of Workflow Templates:
 
 ## How to Use
 
-*Coming soon — this section will describe the Workflow Templates interface once the feature is complete.*
+### Browse built-in templates
 
-Planned interactions include:
-- Browsing the built-in template library (e.g. CI, CD, release, dependabot).
-- Selecting a template and customising its parameters for a target repository.
+1. Open **Workflow Templates** from the navigation menu or the home dashboard.
+2. Review the built-in template cards for common .NET workflows such as CI, Azure CD (Aspire), and Dependabot auto-merge.
+3. Use the search field to filter templates by name, category, or tag.
+4. Select a category chip (for example **CI** or **CD**) to narrow the list.
+5. Select a template card to highlight it before customising or applying the template in a later workflow.
+
+Each template card shows:
+
+- Template name and description.
+- Category and tags.
+- Target workflow file path.
+- Trigger summary describing when the workflow runs.
+
+### Coming soon
+
+The following interactions are planned for later Phase 4 stories:
+- Customising template parameters before applying a template to a repository.
 - Applying a template to one or more repositories.
 - Viewing which repositories already have a template applied and whether it differs from the canonical version.
 - Updating an out-of-date workflow file across multiple repositories.

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -177,7 +177,7 @@ Labels: `type/epic`, `area/board-rules`
 - [ ] As a solo developer, I want the Workflow Templates page and template library planned against an approved wireframe so that Phase 4 delivery is complete. _(see wireframes/workflow-templates-wireframe.md.)_
 
 **Stories:**
-- [ ] As a solo developer, I want to browse built-in GitHub Actions workflow templates so that I can choose a starting point without copying YAML manually.
+- [x] As a solo developer, I want to browse built-in GitHub Actions workflow templates so that I can choose a starting point without copying YAML manually. _(Issue #235 — implemented 2026-07-17.)_
 - [ ] As a solo developer, I want to customise workflow template parameters before applying a template so that each repository gets the right configuration.
 - [ ] As a solo developer, I want to apply a workflow template to one or more repositories from a central page so that template application is consistent.
 - [ ] As a solo developer, I want to see which repositories already have a workflow template applied so that I can avoid duplicate work.

--- a/src/App/SoloDevBoard.App/Components/Features/Workflows/Pages/Workflows.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Workflows/Pages/Workflows.razor
@@ -2,9 +2,98 @@
 
 <PageTitle>Workflow Templates</PageTitle>
 
-<MudStack Spacing="2">
+<MudStack Spacing="3">
     <MudText Typo="Typo.h4">Workflow Templates</MudText>
-    <MudPaper Class="pa-4" Elevation="1">
-        <MudText Typo="Typo.body1">This feature is coming soon.</MudText>
+    <MudText Typo="Typo.body1">Browse built-in GitHub Actions workflow templates and choose a starting point without copying YAML manually.</MudText>
+
+    <MudPaper Class="pa-4" Elevation="1" data-testid="workflow-template-browser-region">
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.h6">Template browser</MudText>
+
+            <MudTextField @bind-Value="SearchText"
+                          Placeholder="Search templates by name, category, or tags"
+                          Variant="Variant.Outlined"
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Filled.Search"
+                          Immediate="true"
+                          InputType="InputType.Search"
+                          Disabled="ShowLoadingState"
+                          data-testid="workflow-template-search" />
+
+            <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center" data-testid="workflow-template-category-filters">
+                @foreach (var category in AvailableCategories)
+                {
+                    <MudChip T="string"
+                             Color="@(IsCategorySelected(category) ? Color.Primary : Color.Default)"
+                             Variant="@(IsCategorySelected(category) ? Variant.Filled : Variant.Outlined)"
+                             OnClick="() => SelectCategory(category)"
+                             aria-pressed="@IsCategorySelected(category).ToString().ToLowerInvariant()"
+                             data-testid="@($"workflow-template-category-{category.ToLowerInvariant()}")">
+                        @category
+                    </MudChip>
+                }
+            </MudStack>
+        </MudStack>
+    </MudPaper>
+
+    <MudPaper Class="pa-4" Elevation="1" aria-label="Workflow template results" data-testid="workflow-template-results-region">
+        @if (ShowLoadingState)
+        {
+            <MudStack AlignItems="AlignItems.Center" Spacing="1" aria-live="polite" role="status" data-testid="workflow-templates-loading-state">
+                <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading workflow templates" />
+                <MudText Typo="Typo.body2">Loading workflow templates...</MudText>
+            </MudStack>
+        }
+        else if (hasLoadFailure)
+        {
+            <MudStack Spacing="1" aria-live="polite" data-testid="workflow-templates-error-state">
+                <MudText Typo="Typo.h6">Unable to load workflow templates</MudText>
+                <MudText Typo="Typo.body2">Try refreshing the page. If the problem persists, check the application logs.</MudText>
+            </MudStack>
+        }
+        else if (FilteredTemplates.Count == 0)
+        {
+            <MudStack Spacing="1" aria-live="polite" data-testid="workflow-templates-empty-state">
+                <MudText Typo="Typo.h6">No templates found</MudText>
+                <MudText Typo="Typo.body2">Try a different search term or category filter.</MudText>
+            </MudStack>
+        }
+        else
+        {
+            <MudGrid Spacing="3" data-testid="workflow-template-grid">
+                @foreach (var template in FilteredTemplates)
+                {
+                    <MudItem xs="12" md="6" xl="4">
+                        <MudCard Outlined="@(selectedTemplateId == template.Id)"
+                                 Elevation="@(selectedTemplateId == template.Id ? 4 : 1)"
+                                 aria-label="@($"{template.Name} template card")"
+                                 data-testid="@($"workflow-template-card-{template.Id}")"
+                                 @onclick="() => SelectTemplate(template)">
+                            <MudCardContent>
+                                <MudStack Spacing="1">
+                                    <MudText Typo="Typo.h6">@template.Name</MudText>
+                                    <MudText Typo="Typo.body2">@template.Description</MudText>
+
+                                    <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center">
+                                        <MudChip T="string" Color="Color.Secondary" Variant="Variant.Outlined" Size="Size.Small">@template.Category</MudChip>
+                                        @foreach (var tag in template.Tags)
+                                        {
+                                            <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small">@tag</MudChip>
+                                        }
+                                    </MudStack>
+
+                                    <MudText Typo="Typo.caption">
+                                        <strong>Workflow file:</strong> @template.WorkflowFilePath
+                                    </MudText>
+                                    <MudText Typo="Typo.caption">
+                                        <strong>Trigger:</strong> @template.TriggerDescription
+                                    </MudText>
+                                </MudStack>
+                            </MudCardContent>
+                        </MudCard>
+                    </MudItem>
+                }
+            </MudGrid>
+        }
     </MudPaper>
 </MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/Workflows/Pages/Workflows.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Workflows/Pages/Workflows.razor
@@ -66,12 +66,10 @@
                     <MudItem xs="12" md="6" xl="4">
                         <MudCard Outlined="@(selectedTemplateId == template.Id)"
                                  Elevation="@(selectedTemplateId == template.Id ? 4 : 1)"
-                                 aria-label="@($"{template.Name} template card")"
-                                 data-testid="@($"workflow-template-card-{template.Id}")"
-                                 @onclick="() => SelectTemplate(template)">
+                                 data-testid="@($"workflow-template-card-{template.Id}")">
                             <MudCardContent>
                                 <MudStack Spacing="1">
-                                    <MudText Typo="Typo.h6">@template.Name</MudText>
+                                    <MudText Typo="Typo.h6" id="@GetTemplateHeadingId(template)">@template.Name</MudText>
                                     <MudText Typo="Typo.body2">@template.Description</MudText>
 
                                     <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center">
@@ -90,6 +88,16 @@
                                     </MudText>
                                 </MudStack>
                             </MudCardContent>
+                            <MudCardActions>
+                                <MudButton Variant="@(selectedTemplateId == template.Id ? Variant.Filled : Variant.Outlined)"
+                                           Color="Color.Primary"
+                                           aria-pressed="@(selectedTemplateId == template.Id ? "true" : "false")"
+                                           aria-labelledby="@GetTemplateHeadingId(template)"
+                                           data-testid="@($"workflow-template-select-{template.Id}")"
+                                           OnClick="() => SelectTemplate(template)">
+                                    @(selectedTemplateId == template.Id ? "Selected" : "Select template")
+                                </MudButton>
+                            </MudCardActions>
                         </MudCard>
                     </MudItem>
                 }

--- a/src/App/SoloDevBoard.App/Components/Features/Workflows/Pages/Workflows.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Workflows/Pages/Workflows.razor.cs
@@ -101,4 +101,7 @@ public partial class Workflows : ComponentBase
     {
         selectedTemplateId = template.Id;
     }
+
+    private static string GetTemplateHeadingId(WorkflowTemplateDto template)
+        => $"workflow-template-heading-{template.Id}";
 }

--- a/src/App/SoloDevBoard.App/Components/Features/Workflows/Pages/Workflows.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Workflows/Pages/Workflows.razor.cs
@@ -1,0 +1,104 @@
+using Microsoft.AspNetCore.Components;
+using SoloDevBoard.Application.Services.Workflows;
+
+namespace SoloDevBoard.App.Components.Features.Workflows.Pages;
+
+/// <summary>Provides the workflow template browser for built-in GitHub Actions templates.</summary>
+public partial class Workflows : ComponentBase
+{
+    private const string AllCategoriesLabel = "All";
+
+    /// <summary>Gets or sets the application service used to retrieve workflow templates.</summary>
+    [Inject]
+    public IWorkflowTemplateService WorkflowTemplateService { get; set; } = default!;
+
+    private IReadOnlyList<WorkflowTemplateDto> templates = [];
+    private string searchText = string.Empty;
+    private string selectedCategory = AllCategoriesLabel;
+    private int? selectedTemplateId;
+    private bool isLoadingTemplates = true;
+    private bool hasLoadFailure;
+
+    private bool ShowLoadingState => isLoadingTemplates;
+
+    private string SearchText
+    {
+        get => searchText;
+        set
+        {
+            if (searchText == value)
+            {
+                return;
+            }
+
+            searchText = value;
+            StateHasChanged();
+        }
+    }
+
+    private IReadOnlyList<string> AvailableCategories
+        => [AllCategoriesLabel, .. templates.Select(template => template.Category).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(category => category)];
+
+    private IReadOnlyList<WorkflowTemplateDto> FilteredTemplates
+        => templates
+            .Where(MatchesSelectedCategory)
+            .Where(MatchesSearchText)
+            .OrderBy(template => template.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    /// <inheritdoc/>
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadTemplatesAsync();
+    }
+
+    private async Task LoadTemplatesAsync()
+    {
+        isLoadingTemplates = true;
+        hasLoadFailure = false;
+
+        try
+        {
+            templates = await WorkflowTemplateService.GetTemplatesAsync();
+        }
+        catch
+        {
+            templates = [];
+            hasLoadFailure = true;
+        }
+        finally
+        {
+            isLoadingTemplates = false;
+        }
+    }
+
+    private bool MatchesSelectedCategory(WorkflowTemplateDto template)
+        => selectedCategory.Equals(AllCategoriesLabel, StringComparison.OrdinalIgnoreCase)
+            || template.Category.Equals(selectedCategory, StringComparison.OrdinalIgnoreCase);
+
+    private bool MatchesSearchText(WorkflowTemplateDto template)
+    {
+        if (string.IsNullOrWhiteSpace(searchText))
+        {
+            return true;
+        }
+
+        return template.Name.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+            || template.Description.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+            || template.Category.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+            || template.Tags.Any(tag => tag.Contains(searchText, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private bool IsCategorySelected(string category)
+        => selectedCategory.Equals(category, StringComparison.OrdinalIgnoreCase);
+
+    private void SelectCategory(string category)
+    {
+        selectedCategory = category;
+    }
+
+    private void SelectTemplate(WorkflowTemplateDto template)
+    {
+        selectedTemplateId = template.Id;
+    }
+}

--- a/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using SoloDevBoard.Application.Services.Labels;
 using SoloDevBoard.Application.Services.Migration;
 using SoloDevBoard.Application.Services.Repositories;
 using SoloDevBoard.Application.Services.Triage;
+using SoloDevBoard.Application.Services.Workflows;
 
 namespace SoloDevBoard.Application.Services.Common;
 
@@ -25,6 +26,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<IAuditDashboardService, AuditDashboardService>();
         services.AddScoped<IBoardRulesService, BoardRulesService>();
         services.AddScoped<ITriageService, TriageService>();
+        services.AddScoped<IWorkflowTemplateService, WorkflowTemplateService>();
 
         return services;
     }

--- a/src/Application/SoloDevBoard.Application/Services/Workflows/IWorkflowTemplateService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Workflows/IWorkflowTemplateService.cs
@@ -9,10 +9,12 @@ public interface IWorkflowTemplateService
     Task<IReadOnlyList<WorkflowTemplateDto>> GetTemplatesAsync(CancellationToken cancellationToken = default);
 
     /// <summary>Applies the selected workflow template to the specified repository.</summary>
+    /// <remarks>Not yet implemented. Reserved for a future apply story.</remarks>
     /// <param name="owner">The GitHub account owner login.</param>
     /// <param name="repo">The repository name.</param>
     /// <param name="templateId">The identifier of the workflow template to apply.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>The workflow template that was applied.</returns>
+    /// <exception cref="NotSupportedException">Thrown because applying templates to repositories is not yet implemented.</exception>
     Task<WorkflowTemplateDto> ApplyTemplateAsync(string owner, string repo, int templateId, CancellationToken cancellationToken = default);
 }

--- a/src/Application/SoloDevBoard.Application/Services/Workflows/IWorkflowTemplateService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Workflows/IWorkflowTemplateService.cs
@@ -1,5 +1,3 @@
-using SoloDevBoard.Domain.Entities.Workflows;
-
 namespace SoloDevBoard.Application.Services.Workflows;
 
 /// <summary>Provides workflow template operations.</summary>
@@ -8,7 +6,7 @@ public interface IWorkflowTemplateService
     /// <summary>Retrieves all available workflow templates.</summary>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>A read-only list of available workflow templates.</returns>
-    Task<IReadOnlyList<WorkflowTemplate>> GetTemplatesAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<WorkflowTemplateDto>> GetTemplatesAsync(CancellationToken cancellationToken = default);
 
     /// <summary>Applies the selected workflow template to the specified repository.</summary>
     /// <param name="owner">The GitHub account owner login.</param>
@@ -16,5 +14,5 @@ public interface IWorkflowTemplateService
     /// <param name="templateId">The identifier of the workflow template to apply.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>The workflow template that was applied.</returns>
-    Task<WorkflowTemplate> ApplyTemplateAsync(string owner, string repo, int templateId, CancellationToken cancellationToken = default);
+    Task<WorkflowTemplateDto> ApplyTemplateAsync(string owner, string repo, int templateId, CancellationToken cancellationToken = default);
 }

--- a/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateDto.cs
@@ -1,0 +1,20 @@
+namespace SoloDevBoard.Application.Services.Workflows;
+
+/// <summary>Represents a workflow template exposed to the presentation layer.</summary>
+/// <param name="Id">The unique identifier of the workflow template.</param>
+/// <param name="Name">The display name of the workflow template.</param>
+/// <param name="Description">The description shown in the template browser.</param>
+/// <param name="Category">The template category used for browsing and filtering.</param>
+/// <param name="Tags">The tags associated with the workflow template.</param>
+/// <param name="WorkflowFilePath">The relative workflow file path applied to repositories.</param>
+/// <param name="TriggerDescription">A short description of when the workflow runs.</param>
+/// <param name="CreatedAt">The date and time when the template was created.</param>
+public sealed record WorkflowTemplateDto(
+    int Id,
+    string Name,
+    string Description,
+    string Category,
+    IReadOnlyList<string> Tags,
+    string WorkflowFilePath,
+    string TriggerDescription,
+    DateTimeOffset CreatedAt);

--- a/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateService.cs
@@ -2,21 +2,136 @@ using SoloDevBoard.Domain.Entities.Workflows;
 
 namespace SoloDevBoard.Application.Services.Workflows;
 
-/// <summary>Stub implementation of <see cref="IWorkflowTemplateService"/>.</summary>
+/// <summary>Provides built-in workflow templates for browsing and future apply flows.</summary>
 public sealed class WorkflowTemplateService : IWorkflowTemplateService
 {
+    private static readonly DateTimeOffset BuiltInCreatedAt = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private static readonly IReadOnlyList<WorkflowTemplate> BuiltInTemplates = BuildBuiltInTemplates();
+
     /// <inheritdoc/>
-    public Task<IReadOnlyList<WorkflowTemplate>> GetTemplatesAsync(CancellationToken cancellationToken = default)
+    public Task<IReadOnlyList<WorkflowTemplateDto>> GetTemplatesAsync(CancellationToken cancellationToken = default)
     {
-        // TODO: Implement retrieval of workflow templates from a data store.
-        IReadOnlyList<WorkflowTemplate> result = [];
+        cancellationToken.ThrowIfCancellationRequested();
+
+        IReadOnlyList<WorkflowTemplateDto> result = BuiltInTemplates
+            .Select(MapToDto)
+            .ToArray();
+
         return Task.FromResult(result);
     }
 
     /// <inheritdoc/>
-    public Task<WorkflowTemplate> ApplyTemplateAsync(string owner, string repo, int templateId, CancellationToken cancellationToken = default)
+    public Task<WorkflowTemplateDto> ApplyTemplateAsync(string owner, string repo, int templateId, CancellationToken cancellationToken = default)
     {
-        // TODO: Implement applying a workflow template to a repository.
-        return Task.FromResult(new WorkflowTemplate { Id = templateId });
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var template = BuiltInTemplates.FirstOrDefault(candidate => candidate.Id == templateId)
+            ?? throw new InvalidOperationException($"Workflow template '{templateId}' was not found.");
+
+        return Task.FromResult(MapToDto(template));
     }
+
+    private static WorkflowTemplateDto MapToDto(WorkflowTemplate template)
+        => new(
+            template.Id,
+            template.Name,
+            template.Description,
+            template.Category,
+            template.Tags,
+            template.WorkflowFilePath,
+            template.TriggerDescription,
+            template.CreatedAt);
+
+    private static IReadOnlyList<WorkflowTemplate> BuildBuiltInTemplates()
+        =>
+        [
+            new WorkflowTemplate
+            {
+                Id = 1,
+                Name = ".NET CI",
+                Description = "Build and test a .NET solution on every push and pull request to the main branch.",
+                Category = "CI",
+                Tags = ["dotnet", "github-actions", "build", "test"],
+                WorkflowFilePath = ".github/workflows/ci.yml",
+                TriggerDescription = "Push and pull request to main",
+                YamlContent = """
+                    name: CI
+
+                    on:
+                      push:
+                        branches:
+                          - main
+                      pull_request:
+                        branches:
+                          - main
+
+                    jobs:
+                      build-and-test:
+                        runs-on: ubuntu-latest
+                        steps:
+                          - uses: actions/checkout@v7
+                          - uses: actions/setup-dotnet@v5
+                          - run: dotnet build
+                          - run: dotnet test
+                    """,
+                CreatedAt = BuiltInCreatedAt,
+            },
+            new WorkflowTemplate
+            {
+                Id = 2,
+                Name = "Azure CD (Aspire)",
+                Description = "Deploy the application to Azure Container Apps using Aspire after operator approval.",
+                Category = "CD",
+                Tags = ["aspire", "azure", "deploy", "container-apps"],
+                WorkflowFilePath = ".github/workflows/cd.yml",
+                TriggerDescription = "Manual workflow dispatch",
+                YamlContent = """
+                    name: CD - Deploy to Azure
+
+                    on:
+                      workflow_dispatch:
+
+                    jobs:
+                      deploy:
+                        runs-on: ubuntu-latest
+                        environment: production
+                        steps:
+                          - uses: actions/checkout@v7
+                          - uses: actions/setup-dotnet@v5
+                          - run: dotnet tool install --global aspire.cli
+                          - run: aspire deploy
+                    """,
+                CreatedAt = BuiltInCreatedAt,
+            },
+            new WorkflowTemplate
+            {
+                Id = 3,
+                Name = "Dependabot Auto-Merge",
+                Description = "Automatically enable auto-merge for low-risk Dependabot pull requests after metadata checks.",
+                Category = "Maintenance",
+                Tags = ["dependabot", "security", "automation"],
+                WorkflowFilePath = ".github/workflows/dependabot-auto-merge.yml",
+                TriggerDescription = "Dependabot pull requests targeting main",
+                YamlContent = """
+                    name: Dependabot Auto-Merge
+
+                    on:
+                      pull_request_target:
+                        branches:
+                          - main
+
+                    jobs:
+                      enable-auto-merge:
+                        if: github.actor == 'dependabot[bot]'
+                        runs-on: ubuntu-latest
+                        steps:
+                          - uses: dependabot/fetch-metadata@v3
+                          - run: gh pr merge --auto --squash "$PR_URL"
+                    """,
+                CreatedAt = BuiltInCreatedAt,
+            },
+        ];
 }

--- a/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateService.cs
@@ -28,10 +28,8 @@ public sealed class WorkflowTemplateService : IWorkflowTemplateService
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var template = BuiltInTemplates.FirstOrDefault(candidate => candidate.Id == templateId)
-            ?? throw new InvalidOperationException($"Workflow template '{templateId}' was not found.");
-
-        return Task.FromResult(MapToDto(template));
+        throw new NotSupportedException(
+            "Applying workflow templates to repositories is not yet implemented. Use the template browser to review built-in templates.");
     }
 
     private static WorkflowTemplateDto MapToDto(WorkflowTemplate template)

--- a/src/Domain/SoloDevBoard.Domain/Entities/Workflows/WorkflowTemplate.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Workflows/WorkflowTemplate.cs
@@ -12,6 +12,18 @@ public sealed record WorkflowTemplate
     /// <summary>Gets the description of the workflow template.</summary>
     public string Description { get; init; } = string.Empty;
 
+    /// <summary>Gets the template category used for browsing and filtering.</summary>
+    public string Category { get; init; } = string.Empty;
+
+    /// <summary>Gets the tags associated with the workflow template.</summary>
+    public IReadOnlyList<string> Tags { get; init; } = [];
+
+    /// <summary>Gets the relative workflow file path applied to repositories.</summary>
+    public string WorkflowFilePath { get; init; } = string.Empty;
+
+    /// <summary>Gets a short description of when the workflow runs.</summary>
+    public string TriggerDescription { get; init; } = string.Empty;
+
     /// <summary>Gets the YAML content of the workflow template.</summary>
     public string YamlContent { get; init; } = string.Empty;
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/WorkflowsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/WorkflowsTests.cs
@@ -1,0 +1,181 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MudBlazor;
+using MudBlazor.Services;
+using SoloDevBoard.App.Components.Features.Workflows.Pages;
+using SoloDevBoard.Application.Services.Workflows;
+
+namespace SoloDevBoard.App.Tests;
+
+/// <summary>Component tests for the <see cref="Workflows"/> page.</summary>
+public sealed class WorkflowsTests
+{
+    private readonly Mock<IWorkflowTemplateService> _workflowTemplateServiceMock = new();
+
+    [Fact]
+    public async Task Workflows_WhileTemplatesAreLoading_ShowsLoadingState()
+    {
+        // Arrange
+        var templatesTask = new TaskCompletionSource<IReadOnlyList<WorkflowTemplateDto>>();
+        _workflowTemplateServiceMock
+            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
+            .Returns(templatesTask.Task);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Workflows>();
+
+        // Assert
+        Assert.Contains("Loading workflow templates", cut.Markup);
+    }
+
+    [Fact]
+    public async Task Workflows_InitialLoad_RendersBuiltInTemplateCards()
+    {
+        // Arrange
+        _workflowTemplateServiceMock
+            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTemplates());
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Workflows>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='workflow-template-browser-region']"));
+            Assert.Single(cut.FindAll("[data-testid='workflow-template-grid']"));
+            Assert.Contains(".NET CI", cut.Markup);
+            Assert.Contains("Azure CD (Aspire)", cut.Markup);
+            Assert.Contains("Dependabot Auto-Merge", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task Workflows_SearchByTag_FiltersTemplateCards()
+    {
+        // Arrange
+        _workflowTemplateServiceMock
+            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTemplates());
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<Workflows>();
+
+        cut.WaitForAssertion(() => Assert.Equal(3, cut.FindAll("[data-testid^='workflow-template-card-']").Count));
+
+        // Act
+        var searchField = cut.Find("[data-testid='workflow-template-search']");
+        searchField.Input("dependabot");
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid^='workflow-template-card-']"));
+            Assert.Contains("Dependabot Auto-Merge", cut.Markup);
+            Assert.DoesNotContain("Azure CD (Aspire)", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task Workflows_CategoryFilter_ShowsOnlyMatchingTemplates()
+    {
+        // Arrange
+        _workflowTemplateServiceMock
+            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTemplates());
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<Workflows>();
+
+        cut.WaitForAssertion(() => Assert.Equal(3, cut.FindAll("[data-testid^='workflow-template-card-']").Count));
+
+        // Act
+        var ciChip = cut.Find("[data-testid='workflow-template-category-ci']");
+        await cut.InvokeAsync(() => ciChip.Click());
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid^='workflow-template-card-']"));
+            Assert.Contains(".NET CI", cut.Markup);
+            Assert.DoesNotContain("Dependabot Auto-Merge", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task Workflows_NoMatchingResults_ShowsEmptyState()
+    {
+        // Arrange
+        _workflowTemplateServiceMock
+            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTemplates());
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<Workflows>();
+
+        cut.WaitForAssertion(() => Assert.Equal(3, cut.FindAll("[data-testid^='workflow-template-card-']").Count));
+
+        // Act
+        var searchField = cut.Find("[data-testid='workflow-template-search']");
+        searchField.Input("nonexistent-template");
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='workflow-templates-empty-state']"));
+            Assert.Contains("No templates found", cut.Markup);
+        });
+    }
+
+    private BunitContext CreateContext()
+    {
+        var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddMudServices();
+        ctx.Services.AddTestHostedAuthenticationRecovery();
+        ctx.Services.AddScoped(_ => _workflowTemplateServiceMock.Object);
+
+        ctx.Render<MudPopoverProvider>();
+        ctx.Render<MudDialogProvider>();
+        ctx.Render<MudSnackbarProvider>();
+
+        return ctx;
+    }
+
+    private static IReadOnlyList<WorkflowTemplateDto> CreateTemplates()
+        =>
+        [
+            new(
+                1,
+                ".NET CI",
+                "Build and test a .NET solution on every push and pull request to the main branch.",
+                "CI",
+                ["dotnet", "github-actions", "build", "test"],
+                ".github/workflows/ci.yml",
+                "Push and pull request to main",
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)),
+            new(
+                2,
+                "Azure CD (Aspire)",
+                "Deploy the application to Azure Container Apps using Aspire after operator approval.",
+                "CD",
+                ["aspire", "azure", "deploy", "container-apps"],
+                ".github/workflows/cd.yml",
+                "Manual workflow dispatch",
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)),
+            new(
+                3,
+                "Dependabot Auto-Merge",
+                "Automatically enable auto-merge for low-risk Dependabot pull requests after metadata checks.",
+                "Maintenance",
+                ["dependabot", "security", "automation"],
+                ".github/workflows/dependabot-auto-merge.yml",
+                "Dependabot pull requests targeting main",
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)),
+        ];
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/WorkflowsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/WorkflowsTests.cs
@@ -56,6 +56,31 @@ public sealed class WorkflowsTests
     }
 
     [Fact]
+    public async Task Workflows_SelectTemplateButton_UsesSemanticControlAndShowsSelectedState()
+    {
+        // Arrange
+        _workflowTemplateServiceMock
+            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTemplates());
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<Workflows>();
+
+        cut.WaitForAssertion(() => Assert.Equal(3, cut.FindAll("[data-testid^='workflow-template-select-']").Count));
+
+        // Act
+        var selectButton = cut.Find("[data-testid='workflow-template-select-1']");
+        await cut.InvokeAsync(() => selectButton.Click());
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("true", selectButton.GetAttribute("aria-pressed"));
+            Assert.Contains("Selected", selectButton.TextContent);
+        });
+    }
+
+    [Fact]
     public async Task Workflows_SearchByTag_FiltersTemplateCards()
     {
         // Arrange

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/WorkflowTemplateServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/WorkflowTemplateServiceTests.cs
@@ -39,30 +39,17 @@ public sealed class WorkflowTemplateServiceTests
     }
 
     [Fact]
-    public async Task ApplyTemplateAsync_KnownTemplateId_ReturnsMatchingTemplate()
+    public async Task ApplyTemplateAsync_ThrowsNotSupportedException()
     {
         // Arrange
         var sut = new WorkflowTemplateService();
 
         // Act
-        var result = await sut.ApplyTemplateAsync("owner", "repo", 2);
+        var action = () => sut.ApplyTemplateAsync("owner", "repo", 2);
 
         // Assert
-        Assert.Equal(2, result.Id);
-        Assert.Equal("Azure CD (Aspire)", result.Name);
-    }
-
-    [Fact]
-    public async Task ApplyTemplateAsync_UnknownTemplateId_ThrowsInvalidOperationException()
-    {
-        // Arrange
-        var sut = new WorkflowTemplateService();
-
-        // Act
-        var action = () => sut.ApplyTemplateAsync("owner", "repo", 999);
-
-        // Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(action);
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(action);
+        Assert.Contains("not yet implemented", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Theory]

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/WorkflowTemplateServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/WorkflowTemplateServiceTests.cs
@@ -1,0 +1,123 @@
+using SoloDevBoard.Application.Services.Workflows;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="WorkflowTemplateService"/>.</summary>
+public sealed class WorkflowTemplateServiceTests
+{
+    [Fact]
+    public async Task GetTemplatesAsync_ReturnsBuiltInTemplates()
+    {
+        // Arrange
+        var sut = new WorkflowTemplateService();
+
+        // Act
+        var result = await sut.GetTemplatesAsync();
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Contains(result, template => template.Name == ".NET CI");
+        Assert.Contains(result, template => template.Name == "Azure CD (Aspire)");
+        Assert.Contains(result, template => template.Name == "Dependabot Auto-Merge");
+    }
+
+    [Fact]
+    public async Task GetTemplatesAsync_ReturnsTemplateMetadata()
+    {
+        // Arrange
+        var sut = new WorkflowTemplateService();
+
+        // Act
+        var result = await sut.GetTemplatesAsync();
+        var ciTemplate = result.Single(template => template.Name == ".NET CI");
+
+        // Assert
+        Assert.Equal("CI", ciTemplate.Category);
+        Assert.Equal(".github/workflows/ci.yml", ciTemplate.WorkflowFilePath);
+        Assert.Contains("dotnet", ciTemplate.Tags);
+        Assert.False(string.IsNullOrWhiteSpace(ciTemplate.TriggerDescription));
+    }
+
+    [Fact]
+    public async Task ApplyTemplateAsync_KnownTemplateId_ReturnsMatchingTemplate()
+    {
+        // Arrange
+        var sut = new WorkflowTemplateService();
+
+        // Act
+        var result = await sut.ApplyTemplateAsync("owner", "repo", 2);
+
+        // Assert
+        Assert.Equal(2, result.Id);
+        Assert.Equal("Azure CD (Aspire)", result.Name);
+    }
+
+    [Fact]
+    public async Task ApplyTemplateAsync_UnknownTemplateId_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var sut = new WorkflowTemplateService();
+
+        // Act
+        var action = () => sut.ApplyTemplateAsync("owner", "repo", 999);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(action);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ApplyTemplateAsync_OwnerIsInvalid_ThrowsArgumentException(string owner)
+    {
+        // Arrange
+        var sut = new WorkflowTemplateService();
+
+        // Act
+        var action = () => sut.ApplyTemplateAsync(owner, "repo", 1);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
+    }
+
+    [Fact]
+    public async Task ApplyTemplateAsync_OwnerIsNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var sut = new WorkflowTemplateService();
+
+        // Act
+        var action = () => sut.ApplyTemplateAsync(null!, "repo", 1);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(action);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ApplyTemplateAsync_RepoIsInvalid_ThrowsArgumentException(string repo)
+    {
+        // Arrange
+        var sut = new WorkflowTemplateService();
+
+        // Act
+        var action = () => sut.ApplyTemplateAsync("owner", repo, 1);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
+    }
+
+    [Fact]
+    public async Task ApplyTemplateAsync_RepoIsNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var sut = new WorkflowTemplateService();
+
+        // Act
+        var action = () => sut.ApplyTemplateAsync("owner", null!, 1);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(action);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Implements issue #235 by replacing the `/workflows` placeholder with a built-in workflow template browser.

- Adds `WorkflowTemplateDto` and extends the domain `WorkflowTemplate` record with category, tags, workflow file path, and trigger metadata.
- Implements a built-in template catalogue in `WorkflowTemplateService` for `.NET CI`, `Azure CD (Aspire)`, and `Dependabot Auto-Merge`.
- Builds a MudBlazor browser with search and category filtering, plus accessible **Select template** buttons.
- Registers `IWorkflowTemplateService` in application DI.
- Makes `ApplyTemplateAsync` throw `NotSupportedException` until the apply story is implemented, avoiding a misleading no-op contract.
- Adds Application and bUnit test coverage.
- Updates `docs/user-guide/workflow-templates.md`, `docs/index.md`, and `plan/BACKLOG.md`.

## Related Issue(s)

Closes #235

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

<a href="https://cursor.com/agents/bc-94d1d3e6-1cdb-4ae5-ac33-cf66e2ed8d87/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkflow-templates-review-fixes-demo.mp4"><img src="https://cursor.com/artifacts/c/art-57a0b427-3a66-426d-ba08-ae85c1420941" alt="workflow-templates-review-fixes-demo.mp4" /></a>

## Additional Notes

- Acceptance criteria for #235 are met: built-in templates are listed, searchable/filterable, and each card shows name, description, and key metadata.
- Review feedback addressed: apply semantics are explicit (`NotSupportedException`), and template selection uses semantic buttons with `aria-pressed` and `aria-labelledby`.
- `dotnet test SoloDevBoard.slnx`: 360 passed, 0 failed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94d1d3e6-1cdb-4ae5-ac33-cf66e2ed8d87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94d1d3e6-1cdb-4ae5-ac33-cf66e2ed8d87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

