### PR TITLE
[Story] Complete Workflow Templates page and template library (#234)

### DIFF
--- a/docs/user-guide/workflow-templates.md
+++ b/docs/user-guide/workflow-templates.md
@@ -5,10 +5,6 @@ parent: User Guide
 nav_order: 6
 ---
 
-> ⚠️ **Partially Available** — Template browsing is available. Customisation, apply, and staleness tracking are planned for later Phase 4 stories.
-
----
-
 ## Overview
 
 The Workflow Templates feature allows you to browse, apply, and customise GitHub Actions workflow templates across your repositories, all from within SoloDevBoard. Rather than manually copying YAML files between repositories, you can manage templates centrally and push them where needed.
@@ -25,10 +21,11 @@ Key goals of Workflow Templates:
 ### Browse built-in templates
 
 1. Open **Workflow Templates** from the navigation menu or the home dashboard.
-2. Review the built-in template cards for common .NET workflows such as CI, Azure CD (Aspire), and Dependabot auto-merge.
-3. Use the search field to filter templates by name, category, or tag.
-4. Select a category chip (for example **CI** or **CD**) to narrow the list.
-5. Select a template card to highlight it before customising or applying the template in a later workflow.
+2. Select one or more target repositories using the repository selector at the top of the page.
+3. Review the built-in template cards for common .NET workflows such as CI, Azure CD (Aspire), and Dependabot auto-merge.
+4. Use the search field to filter templates by name, category, or tag.
+5. Select a category chip (for example **CI** or **CD**) to narrow the list.
+6. Select a template card to open the detail panel.
 
 Each template card shows:
 
@@ -37,20 +34,36 @@ Each template card shows:
 - Target workflow file path.
 - Trigger summary describing when the workflow runs.
 
-### Coming soon
+### Customise template parameters
 
-The following interactions are planned for later Phase 4 stories:
-- Customising template parameters before applying a template to a repository.
-- Applying a template to one or more repositories.
-- Viewing which repositories already have a template applied and whether it differs from the canonical version.
-- Updating an out-of-date workflow file across multiple repositories.
+1. With a template selected, review the YAML preview in the detail panel.
+2. Adjust parameter fields such as branch names, .NET versions, or deployment environment names.
+3. Required parameters must be completed before the apply action is enabled.
+
+Parameter values are used to render the workflow file that will be written to each target repository.
+
+### Apply a template to repositories
+
+1. Select the repositories that should receive the workflow file.
+2. Confirm parameter values and review repository status badges in the detail panel.
+3. Select **Apply template to selected repositories**.
+
+The feedback region shows per-repository results, including created, updated, skipped, and failed outcomes. Partial failures are reported clearly so you can retry affected repositories.
+
+### Review repository status and drift
+
+When a template and repositories are selected, the detail panel shows workflow status for each repository:
+
+- **Not applied** — the workflow file is missing.
+- **Applied** — the workflow file matches the rendered template.
+- **Drifted** — the workflow file exists but differs from the canonical template.
+
+Drift detection is informational and does not block browsing or previewing templates. Review drift warnings before applying if you need to preserve local customisations.
 
 ---
 
 ## Configuration
 
-*Coming soon — this section will describe configuration options for Workflow Templates.*
-
 Planned configuration options include:
 - Defining custom template repositories to supplement the built-in library.
-- Configuring default parameter values for templates (e.g. default .NET version, default branch name).
+- Configuring default parameter values for templates (for example default .NET version or default branch name).

--- a/src/App/SoloDevBoard.App/Components/Features/Workflows/Pages/Workflows.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Workflows/Pages/Workflows.razor
@@ -4,7 +4,43 @@
 
 <MudStack Spacing="3">
     <MudText Typo="Typo.h4">Workflow Templates</MudText>
-    <MudText Typo="Typo.body1">Browse built-in GitHub Actions workflow templates and choose a starting point without copying YAML manually.</MudText>
+    <MudText Typo="Typo.body1">Browse built-in GitHub Actions workflow templates, customise parameters, and apply them consistently across repositories.</MudText>
+
+    <MudPaper Class="pa-4" Elevation="1" data-testid="repository-selector-region">
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.h6">Repository selector</MudText>
+
+            @if (isLoadingRepositories)
+            {
+                <MudStack AlignItems="AlignItems.Center" Spacing="1" aria-live="polite" role="status" data-testid="workflow-repositories-loading-state">
+                    <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading repositories" />
+                    <MudText Typo="Typo.body2">Loading repositories...</MudText>
+                </MudStack>
+            }
+            else if (hasRepositoryLoadFailure)
+            {
+                <MudStack Spacing="1" aria-live="polite" data-testid="workflow-repositories-error-state">
+                    <MudText Typo="Typo.h6">Unable to load repositories</MudText>
+                    <MudText Typo="Typo.body2">@repositoryLoadErrorMessage</MudText>
+                </MudStack>
+            }
+            else
+            {
+                <RepositorySelector
+                    Title=""
+                    Label="Repositories"
+                    Placeholder="Search repositories and add to the apply scope"
+                    EmptyStateText="No active repositories are available."
+                    AvailableRepositories="repositoryOptions"
+                    SelectedRepositories="SelectedRepositoryFullNames"
+                    SelectedRepositoriesChanged="OnSelectedRepositoriesChangedAsync"
+                    SummaryText="@RepositorySelectorSummary"
+                    Disabled="ShowLoadingState"
+                    AutocompleteTestId="workflow-repository-autocomplete"
+                    SummaryTestId="workflow-repository-selector-summary" />
+            }
+        </MudStack>
+    </MudPaper>
 
     <MudPaper Class="pa-4" Elevation="1" data-testid="workflow-template-browser-region">
         <MudStack Spacing="2">
@@ -36,72 +72,194 @@
         </MudStack>
     </MudPaper>
 
-    <MudPaper Class="pa-4" Elevation="1" aria-label="Workflow template results" data-testid="workflow-template-results-region">
-        @if (ShowLoadingState)
-        {
-            <MudStack AlignItems="AlignItems.Center" Spacing="1" aria-live="polite" role="status" data-testid="workflow-templates-loading-state">
-                <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading workflow templates" />
-                <MudText Typo="Typo.body2">Loading workflow templates...</MudText>
-            </MudStack>
-        }
-        else if (hasLoadFailure)
-        {
-            <MudStack Spacing="1" aria-live="polite" data-testid="workflow-templates-error-state">
-                <MudText Typo="Typo.h6">Unable to load workflow templates</MudText>
-                <MudText Typo="Typo.body2">Try refreshing the page. If the problem persists, check the application logs.</MudText>
-            </MudStack>
-        }
-        else if (FilteredTemplates.Count == 0)
-        {
-            <MudStack Spacing="1" aria-live="polite" data-testid="workflow-templates-empty-state">
-                <MudText Typo="Typo.h6">No templates found</MudText>
-                <MudText Typo="Typo.body2">Try a different search term or category filter.</MudText>
-            </MudStack>
-        }
-        else
-        {
-            <MudGrid Spacing="3" data-testid="workflow-template-grid">
-                @foreach (var template in FilteredTemplates)
+    <MudGrid Spacing="3">
+        <MudItem xs="12" lg="7">
+            <MudPaper Class="pa-4" Elevation="1" aria-label="Workflow template results" data-testid="workflow-template-results-region">
+                @if (ShowLoadingState)
                 {
-                    <MudItem xs="12" md="6" xl="4">
-                        <MudCard Outlined="@(selectedTemplateId == template.Id)"
-                                 Elevation="@(selectedTemplateId == template.Id ? 4 : 1)"
-                                 data-testid="@($"workflow-template-card-{template.Id}")">
-                            <MudCardContent>
-                                <MudStack Spacing="1">
-                                    <MudText Typo="Typo.h6" id="@GetTemplateHeadingId(template)">@template.Name</MudText>
-                                    <MudText Typo="Typo.body2">@template.Description</MudText>
-
-                                    <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center">
-                                        <MudChip T="string" Color="Color.Secondary" Variant="Variant.Outlined" Size="Size.Small">@template.Category</MudChip>
-                                        @foreach (var tag in template.Tags)
-                                        {
-                                            <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small">@tag</MudChip>
-                                        }
-                                    </MudStack>
-
-                                    <MudText Typo="Typo.caption">
-                                        <strong>Workflow file:</strong> @template.WorkflowFilePath
-                                    </MudText>
-                                    <MudText Typo="Typo.caption">
-                                        <strong>Trigger:</strong> @template.TriggerDescription
-                                    </MudText>
-                                </MudStack>
-                            </MudCardContent>
-                            <MudCardActions>
-                                <MudButton Variant="@(selectedTemplateId == template.Id ? Variant.Filled : Variant.Outlined)"
-                                           Color="Color.Primary"
-                                           aria-pressed="@(selectedTemplateId == template.Id ? "true" : "false")"
-                                           aria-labelledby="@GetTemplateHeadingId(template)"
-                                           data-testid="@($"workflow-template-select-{template.Id}")"
-                                           OnClick="() => SelectTemplate(template)">
-                                    @(selectedTemplateId == template.Id ? "Selected" : "Select template")
-                                </MudButton>
-                            </MudCardActions>
-                        </MudCard>
-                    </MudItem>
+                    <MudStack AlignItems="AlignItems.Center" Spacing="1" aria-live="polite" role="status" data-testid="workflow-templates-loading-state">
+                        <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading workflow templates" />
+                        <MudText Typo="Typo.body2">Loading workflow templates...</MudText>
+                    </MudStack>
                 }
-            </MudGrid>
-        }
-    </MudPaper>
+                else if (hasLoadFailure)
+                {
+                    <MudStack Spacing="1" aria-live="polite" data-testid="workflow-templates-error-state">
+                        <MudText Typo="Typo.h6">Unable to load workflow templates</MudText>
+                        <MudText Typo="Typo.body2">Try refreshing the page. If the problem persists, check the application logs.</MudText>
+                    </MudStack>
+                }
+                else if (FilteredTemplates.Count == 0)
+                {
+                    <MudStack Spacing="1" aria-live="polite" data-testid="workflow-templates-empty-state">
+                        <MudText Typo="Typo.h6">No templates found</MudText>
+                        <MudText Typo="Typo.body2">Try a different search term or category filter.</MudText>
+                    </MudStack>
+                }
+                else
+                {
+                    <MudGrid Spacing="3" data-testid="workflow-template-grid">
+                        @foreach (var template in FilteredTemplates)
+                        {
+                            <MudItem xs="12" md="6">
+                                <MudCard Outlined="@(selectedTemplateId == template.Id)"
+                                         Elevation="@(selectedTemplateId == template.Id ? 4 : 1)"
+                                         data-testid="@($"workflow-template-card-{template.Id}")">
+                                    <MudCardContent>
+                                        <MudStack Spacing="1">
+                                            <MudText Typo="Typo.h6" id="@GetTemplateHeadingId(template)">@template.Name</MudText>
+                                            <MudText Typo="Typo.body2">@template.Description</MudText>
+
+                                            <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center">
+                                                <MudChip T="string" Color="Color.Secondary" Variant="Variant.Outlined" Size="Size.Small">@template.Category</MudChip>
+                                                @foreach (var tag in template.Tags)
+                                                {
+                                                    <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small">@tag</MudChip>
+                                                }
+                                            </MudStack>
+
+                                            <MudText Typo="Typo.caption">
+                                                <strong>Workflow file:</strong> @template.WorkflowFilePath
+                                            </MudText>
+                                            <MudText Typo="Typo.caption">
+                                                <strong>Trigger:</strong> @template.TriggerDescription
+                                            </MudText>
+                                        </MudStack>
+                                    </MudCardContent>
+                                    <MudCardActions>
+                                        <MudButton Variant="@(selectedTemplateId == template.Id ? Variant.Filled : Variant.Outlined)"
+                                                   Color="Color.Primary"
+                                                   aria-pressed="@(selectedTemplateId == template.Id ? "true" : "false")"
+                                                   aria-labelledby="@GetTemplateHeadingId(template)"
+                                                   data-testid="@($"workflow-template-select-{template.Id}")"
+                                                   OnClick="() => SelectTemplate(template)">
+                                            @(selectedTemplateId == template.Id ? "Selected" : "Select template")
+                                        </MudButton>
+                                    </MudCardActions>
+                                </MudCard>
+                            </MudItem>
+                        }
+                    </MudGrid>
+                }
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12" lg="5">
+            <MudPaper Class="pa-4" Elevation="1" data-testid="workflow-template-detail-region">
+                @if (selectedTemplateDetail is null)
+                {
+                    <MudStack Spacing="1" data-testid="workflow-template-detail-empty-state">
+                        <MudText Typo="Typo.h6">Template details</MudText>
+                        <MudText Typo="Typo.body2">Select a template to review YAML, customise parameters, and apply it to repositories.</MudText>
+                    </MudStack>
+                }
+                else
+                {
+                    <MudStack Spacing="2">
+                        <MudText Typo="Typo.h6">@selectedTemplateDetail.Name</MudText>
+                        <MudText Typo="Typo.body2">@selectedTemplateDetail.Description</MudText>
+
+                        <MudText Typo="Typo.subtitle2">YAML preview</MudText>
+                        <MudPaper Class="pa-3" Outlined="true" data-testid="workflow-template-yaml-preview">
+                            <MudText Typo="Typo.caption" Style="white-space: pre-wrap; font-family: monospace;">@selectedTemplateDetail.YamlPreview</MudText>
+                        </MudPaper>
+
+                        @if (selectedTemplateDetail.Parameters.Count > 0)
+                        {
+                            <MudText Typo="Typo.subtitle2">Parameters</MudText>
+                            <MudStack Spacing="2" data-testid="workflow-template-parameter-form">
+                                @foreach (var parameter in selectedTemplateDetail.Parameters)
+                                {
+                                    <MudTextField T="string"
+                                                  Value="@(parameterValues.GetValueOrDefault(parameter.Name, parameter.DefaultValue))"
+                                                  ValueChanged="@(value => OnParameterValueChangedAsync(parameter.Name, value))"
+                                                  Label="@parameter.Label"
+                                                  HelperText="@parameter.Description"
+                                                  Required="@parameter.IsRequired"
+                                                  Variant="Variant.Outlined"
+                                                  data-testid="@($"workflow-template-parameter-{parameter.Name}")" />
+                                }
+                            </MudStack>
+                        }
+
+                        @if (selectedRepositories.Count > 0)
+                        {
+                            <MudText Typo="Typo.subtitle2">Repository status</MudText>
+
+                            @if (isLoadingStatuses)
+                            {
+                                <MudStack AlignItems="AlignItems.Center" Spacing="1" aria-live="polite" role="status" data-testid="workflow-template-status-loading-state">
+                                    <MudProgressCircular Indeterminate="true" Color="Color.Primary" Size="Size.Small" />
+                                    <MudText Typo="Typo.caption">Checking repository workflow files...</MudText>
+                                </MudStack>
+                            }
+                            else if (repositoryStatuses.Count > 0)
+                            {
+                                <MudStack Spacing="1" data-testid="workflow-template-status-list">
+                                    @foreach (var status in repositoryStatuses)
+                                    {
+                                        <MudPaper Class="pa-2" Outlined="true" data-testid="@($"workflow-template-status-{status.RepositoryFullName.Replace('/', '-').ToLowerInvariant()}")">
+                                            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                                                <MudText Typo="Typo.body2">@status.RepositoryFullName</MudText>
+                                                <MudChip T="string" Color="@GetStatusColour(status.Status)" Size="Size.Small" Variant="Variant.Filled">
+                                                    @GetStatusLabel(status.Status)
+                                                </MudChip>
+                                            </MudStack>
+                                            <MudText Typo="Typo.caption">@status.StatusDescription</MudText>
+                                        </MudPaper>
+                                    }
+                                </MudStack>
+                            }
+                        }
+
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   Disabled="@(!CanApplyTemplate)"
+                                   OnClick="ApplyTemplateAsync"
+                                   data-testid="workflow-template-apply-button">
+                            @(isApplyingTemplate ? "Applying..." : "Apply template to selected repositories")
+                        </MudButton>
+                    </MudStack>
+                }
+            </MudPaper>
+        </MudItem>
+    </MudGrid>
+
+    @if (!string.IsNullOrWhiteSpace(operationMessage) || applyResults.Count > 0)
+    {
+        <MudPaper Class="pa-4" Elevation="1" aria-live="polite" data-testid="workflow-template-feedback-region">
+            <MudStack Spacing="2">
+                <MudText Typo="Typo.h6">Apply results</MudText>
+
+                @if (!string.IsNullOrWhiteSpace(operationMessage))
+                {
+                    <MudAlert Severity="@operationSeverity" data-testid="workflow-template-operation-message">@operationMessage</MudAlert>
+                }
+
+                @if (applyResults.Count > 0)
+                {
+                    <MudStack Spacing="1" data-testid="workflow-template-apply-results">
+                        @foreach (var result in applyResults)
+                        {
+                            <MudPaper Class="pa-2" Outlined="true" data-testid="@($"workflow-template-apply-result-{result.RepositoryFullName.Replace('/', '-').ToLowerInvariant()}")">
+                                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                                    <MudText Typo="Typo.body2">@result.RepositoryFullName</MudText>
+                                    <MudChip T="string"
+                                             Color="@(result.HasError ? Color.Error : Color.Success)"
+                                             Size="Size.Small"
+                                             Variant="Variant.Filled">
+                                        @(result.HasError ? "Failed" : result.Action)
+                                    </MudChip>
+                                </MudStack>
+                                @if (result.HasError)
+                                {
+                                    <MudText Typo="Typo.caption" Color="Color.Error">@result.ErrorMessage</MudText>
+                                }
+                            </MudPaper>
+                        }
+                    </MudStack>
+                }
+            </MudStack>
+        </MudPaper>
+    }
 </MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/Workflows/Pages/Workflows.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Workflows/Pages/Workflows.razor.cs
@@ -1,4 +1,8 @@
 using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using SoloDevBoard.App.Authentication;
+using SoloDevBoard.Application.Identity;
+using SoloDevBoard.Application.Services.Repositories;
 using SoloDevBoard.Application.Services.Workflows;
 
 namespace SoloDevBoard.App.Components.Features.Workflows.Pages;
@@ -12,12 +16,37 @@ public partial class Workflows : ComponentBase
     [Inject]
     public IWorkflowTemplateService WorkflowTemplateService { get; set; } = default!;
 
+    /// <summary>Gets or sets the application service used to retrieve repositories.</summary>
+    [Inject]
+    public IRepositoryService RepositoryService { get; set; } = default!;
+
+    /// <summary>Gets or sets the logger for workflow page diagnostics.</summary>
+    [Inject]
+    public ILogger<Workflows> Logger { get; set; } = default!;
+
+    /// <summary>Gets or sets the hosted authentication recovery service.</summary>
+    [Inject]
+    public IHostedAuthenticationRecoveryService HostedAuthRecovery { get; set; } = default!;
+
     private IReadOnlyList<WorkflowTemplateDto> templates = [];
+    private WorkflowTemplateDetailDto? selectedTemplateDetail;
+    private IReadOnlyList<WorkflowTemplateRepositoryStatusDto> repositoryStatuses = [];
+    private IReadOnlyList<WorkflowTemplateRepositoryResultDto> applyResults = [];
+    private IReadOnlyList<string> repositoryOptions = [];
+    private HashSet<string> selectedRepositories = new(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, string> parameterValues = new(StringComparer.OrdinalIgnoreCase);
     private string searchText = string.Empty;
     private string selectedCategory = AllCategoriesLabel;
     private int? selectedTemplateId;
     private bool isLoadingTemplates = true;
+    private bool isLoadingRepositories = true;
+    private bool isLoadingStatuses;
+    private bool isApplyingTemplate;
     private bool hasLoadFailure;
+    private bool hasRepositoryLoadFailure;
+    private string? repositoryLoadErrorMessage;
+    private string? operationMessage;
+    private Severity operationSeverity = Severity.Info;
 
     private bool ShowLoadingState => isLoadingTemplates;
 
@@ -46,10 +75,32 @@ public partial class Workflows : ComponentBase
             .OrderBy(template => template.Name, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
+    private IReadOnlyList<string> SelectedRepositoryFullNames
+        => selectedRepositories
+            .OrderBy(repository => repository, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private string RepositorySelectorSummary
+    {
+        get
+        {
+            var repositoryCount = repositoryOptions.Count;
+            var repositoryNoun = repositoryCount == 1 ? "repository" : "repositories";
+
+            return $"Showing {repositoryCount} active {repositoryNoun}. {selectedRepositories.Count} selected. Archived repositories are hidden by default.";
+        }
+    }
+
+    private bool CanApplyTemplate => selectedTemplateDetail is not null
+        && selectedRepositories.Count > 0
+        && AreRequiredParametersValid()
+        && !isApplyingTemplate
+        && !isLoadingStatuses;
+
     /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
-        await LoadTemplatesAsync();
+        await Task.WhenAll(LoadTemplatesAsync(), LoadRepositoriesAsync());
     }
 
     private async Task LoadTemplatesAsync()
@@ -72,6 +123,197 @@ public partial class Workflows : ComponentBase
         }
     }
 
+    private async Task LoadRepositoriesAsync()
+    {
+        isLoadingRepositories = true;
+        hasRepositoryLoadFailure = false;
+        repositoryLoadErrorMessage = null;
+
+        try
+        {
+            var repositories = await RepositoryService.GetActiveRepositoriesAsync();
+            repositoryOptions = repositories
+                .Select(repository => repository.FullName)
+                .OrderBy(fullName => fullName, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            selectedRepositories.Clear();
+            repositoryStatuses = [];
+            applyResults = [];
+        }
+        catch (HostedAuthenticationRequiredException ex)
+        {
+            if (HostedAuthRecovery.TryInitiateRecovery(ex))
+            {
+                return;
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            hasRepositoryLoadFailure = true;
+            repositoryLoadErrorMessage = $"GitHub API request failed. {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load workflow template repositories.");
+            hasRepositoryLoadFailure = true;
+            repositoryLoadErrorMessage = "An unexpected error occurred while loading repositories.";
+        }
+        finally
+        {
+            isLoadingRepositories = false;
+        }
+    }
+
+    private async Task OnSelectedRepositoriesChangedAsync(IReadOnlyList<string> repositories)
+    {
+        ArgumentNullException.ThrowIfNull(repositories);
+
+        selectedRepositories = repositories
+            .Where(repository => !string.IsNullOrWhiteSpace(repository))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        applyResults = [];
+        operationMessage = null;
+        await RefreshRepositoryStatusesAsync();
+    }
+
+    private async Task SelectCategory(string category)
+    {
+        selectedCategory = category;
+        await Task.CompletedTask;
+    }
+
+    private async Task SelectTemplate(WorkflowTemplateDto template)
+    {
+        selectedTemplateId = template.Id;
+        applyResults = [];
+        operationMessage = null;
+
+        try
+        {
+            selectedTemplateDetail = await WorkflowTemplateService.GetTemplateDetailAsync(template.Id);
+            parameterValues = selectedTemplateDetail.Parameters
+                .ToDictionary(parameter => parameter.Name, parameter => parameter.DefaultValue, StringComparer.OrdinalIgnoreCase);
+            await RefreshRepositoryStatusesAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load workflow template detail for template {TemplateId}.", template.Id);
+            selectedTemplateDetail = null;
+            operationSeverity = Severity.Error;
+            operationMessage = "Unable to load template details.";
+        }
+    }
+
+    private async Task OnParameterValueChangedAsync(string parameterName, string? value)
+    {
+        parameterValues[parameterName] = value ?? string.Empty;
+        applyResults = [];
+        operationMessage = null;
+        await RefreshRepositoryStatusesAsync();
+    }
+
+    private async Task RefreshRepositoryStatusesAsync()
+    {
+        repositoryStatuses = [];
+
+        if (selectedTemplateDetail is null || selectedRepositories.Count == 0)
+        {
+            return;
+        }
+
+        isLoadingStatuses = true;
+
+        try
+        {
+            repositoryStatuses = await WorkflowTemplateService.GetRepositoryStatusesAsync(
+                selectedTemplateDetail.Id,
+                SelectedRepositoryFullNames,
+                parameterValues);
+        }
+        catch (ArgumentException ex)
+        {
+            operationSeverity = Severity.Warning;
+            operationMessage = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load workflow template repository statuses.");
+            operationSeverity = Severity.Error;
+            operationMessage = "Unable to load repository workflow status.";
+        }
+        finally
+        {
+            isLoadingStatuses = false;
+        }
+    }
+
+    private async Task ApplyTemplateAsync()
+    {
+        if (selectedTemplateDetail is null || selectedRepositories.Count == 0)
+        {
+            return;
+        }
+
+        isApplyingTemplate = true;
+        operationMessage = null;
+        applyResults = [];
+
+        try
+        {
+            applyResults = await WorkflowTemplateService.ApplyTemplateAsync(
+                selectedTemplateDetail.Id,
+                SelectedRepositoryFullNames,
+                parameterValues);
+
+            var failedCount = applyResults.Count(result => result.HasError);
+            var createdCount = applyResults.Count(result => result.Action == "Created");
+            var updatedCount = applyResults.Count(result => result.Action == "Updated");
+            var skippedCount = applyResults.Count(result => result.Action == "Skipped");
+
+            if (failedCount == 0)
+            {
+                operationSeverity = Severity.Success;
+                operationMessage = $"Applied template successfully. Created {createdCount}, updated {updatedCount}, skipped {skippedCount}.";
+            }
+            else
+            {
+                operationSeverity = Severity.Warning;
+                operationMessage = $"Applied template with {failedCount} repository errors. Created {createdCount}, updated {updatedCount}, skipped {skippedCount}.";
+            }
+
+            await RefreshRepositoryStatusesAsync();
+        }
+        catch (ArgumentException ex)
+        {
+            operationSeverity = Severity.Error;
+            operationMessage = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to apply workflow template {TemplateId}.", selectedTemplateDetail.Id);
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while applying the workflow template.";
+        }
+        finally
+        {
+            isApplyingTemplate = false;
+        }
+    }
+
+    private bool AreRequiredParametersValid()
+    {
+        if (selectedTemplateDetail is null)
+        {
+            return false;
+        }
+
+        return selectedTemplateDetail.Parameters
+            .Where(parameter => parameter.IsRequired)
+            .All(parameter => parameterValues.TryGetValue(parameter.Name, out var value) && !string.IsNullOrWhiteSpace(value));
+    }
+
     private bool MatchesSelectedCategory(WorkflowTemplateDto template)
         => selectedCategory.Equals(AllCategoriesLabel, StringComparison.OrdinalIgnoreCase)
             || template.Category.Equals(selectedCategory, StringComparison.OrdinalIgnoreCase);
@@ -92,16 +334,22 @@ public partial class Workflows : ComponentBase
     private bool IsCategorySelected(string category)
         => selectedCategory.Equals(category, StringComparison.OrdinalIgnoreCase);
 
-    private void SelectCategory(string category)
-    {
-        selectedCategory = category;
-    }
-
-    private void SelectTemplate(WorkflowTemplateDto template)
-    {
-        selectedTemplateId = template.Id;
-    }
-
     private static string GetTemplateHeadingId(WorkflowTemplateDto template)
         => $"workflow-template-heading-{template.Id}";
+
+    private static Color GetStatusColour(WorkflowTemplateApplicationStatus status)
+        => status switch
+        {
+            WorkflowTemplateApplicationStatus.Applied => Color.Success,
+            WorkflowTemplateApplicationStatus.Drifted => Color.Warning,
+            _ => Color.Default,
+        };
+
+    private static string GetStatusLabel(WorkflowTemplateApplicationStatus status)
+        => status switch
+        {
+            WorkflowTemplateApplicationStatus.Applied => "Applied",
+            WorkflowTemplateApplicationStatus.Drifted => "Drifted",
+            _ => "Not applied",
+        };
 }

--- a/src/Application/SoloDevBoard.Application/Services/Workflows/IWorkflowFileRepository.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Workflows/IWorkflowFileRepository.cs
@@ -1,0 +1,33 @@
+using SoloDevBoard.Domain.Entities.Workflows;
+
+namespace SoloDevBoard.Application.Services.Workflows;
+
+/// <summary>Provides repository operations for managing GitHub workflow files.</summary>
+public interface IWorkflowFileRepository
+{
+    /// <summary>Retrieves a workflow file from the specified repository path.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="path">The relative workflow file path.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The workflow file when present; otherwise, <see langword="null" />.</returns>
+    Task<WorkflowFile?> GetWorkflowFileAsync(string owner, string repo, string path, CancellationToken cancellationToken = default);
+
+    /// <summary>Creates or updates a workflow file in the specified repository.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="path">The relative workflow file path.</param>
+    /// <param name="content">The YAML content to write.</param>
+    /// <param name="existingSha">The existing blob SHA when updating a file; otherwise, <see langword="null" />.</param>
+    /// <param name="commitMessage">The commit message used when writing the file.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous write operation.</returns>
+    Task CreateOrUpdateWorkflowFileAsync(
+        string owner,
+        string repo,
+        string path,
+        string content,
+        string? existingSha,
+        string commitMessage,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Application/SoloDevBoard.Application/Services/Workflows/IWorkflowTemplateService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Workflows/IWorkflowTemplateService.cs
@@ -8,13 +8,33 @@ public interface IWorkflowTemplateService
     /// <returns>A read-only list of available workflow templates.</returns>
     Task<IReadOnlyList<WorkflowTemplateDto>> GetTemplatesAsync(CancellationToken cancellationToken = default);
 
-    /// <summary>Applies the selected workflow template to the specified repository.</summary>
-    /// <remarks>Not yet implemented. Reserved for a future apply story.</remarks>
-    /// <param name="owner">The GitHub account owner login.</param>
-    /// <param name="repo">The repository name.</param>
-    /// <param name="templateId">The identifier of the workflow template to apply.</param>
+    /// <summary>Retrieves detail for a single workflow template, including parameters and YAML preview.</summary>
+    /// <param name="templateId">The identifier of the workflow template.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    /// <returns>The workflow template that was applied.</returns>
-    /// <exception cref="NotSupportedException">Thrown because applying templates to repositories is not yet implemented.</exception>
-    Task<WorkflowTemplateDto> ApplyTemplateAsync(string owner, string repo, int templateId, CancellationToken cancellationToken = default);
+    /// <returns>The workflow template detail.</returns>
+    Task<WorkflowTemplateDetailDto> GetTemplateDetailAsync(int templateId, CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves workflow template application status for the specified repositories.</summary>
+    /// <param name="templateId">The identifier of the workflow template.</param>
+    /// <param name="repositoryFullNames">The repositories in owner/repository format.</param>
+    /// <param name="parameterValues">The parameter values used to render the canonical template content.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A read-only list of per-repository status results.</returns>
+    Task<IReadOnlyList<WorkflowTemplateRepositoryStatusDto>> GetRepositoryStatusesAsync(
+        int templateId,
+        IReadOnlyList<string> repositoryFullNames,
+        IReadOnlyDictionary<string, string> parameterValues,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Applies the selected workflow template to the specified repositories.</summary>
+    /// <param name="templateId">The identifier of the workflow template.</param>
+    /// <param name="repositoryFullNames">The repositories in owner/repository format.</param>
+    /// <param name="parameterValues">The parameter values used to render the template content.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A read-only list of per-repository apply results.</returns>
+    Task<IReadOnlyList<WorkflowTemplateRepositoryResultDto>> ApplyTemplateAsync(
+        int templateId,
+        IReadOnlyList<string> repositoryFullNames,
+        IReadOnlyDictionary<string, string> parameterValues,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateApplicationStatus.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateApplicationStatus.cs
@@ -1,0 +1,14 @@
+namespace SoloDevBoard.Application.Services.Workflows;
+
+/// <summary>Represents the application status of a workflow template in a repository.</summary>
+public enum WorkflowTemplateApplicationStatus
+{
+    /// <summary>The workflow file is not present in the repository.</summary>
+    NotApplied = 0,
+
+    /// <summary>The workflow file matches the canonical template content.</summary>
+    Applied = 1,
+
+    /// <summary>The workflow file exists but differs from the canonical template content.</summary>
+    Drifted = 2,
+}

--- a/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateDetailDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateDetailDto.cs
@@ -1,0 +1,24 @@
+namespace SoloDevBoard.Application.Services.Workflows;
+
+/// <summary>Represents a workflow template with detail fields required for customisation and apply flows.</summary>
+/// <param name="Id">The unique identifier of the workflow template.</param>
+/// <param name="Name">The display name of the workflow template.</param>
+/// <param name="Description">The description shown in the template browser.</param>
+/// <param name="Category">The template category used for browsing and filtering.</param>
+/// <param name="Tags">The tags associated with the workflow template.</param>
+/// <param name="WorkflowFilePath">The relative workflow file path applied to repositories.</param>
+/// <param name="TriggerDescription">A short description of when the workflow runs.</param>
+/// <param name="CreatedAt">The date and time when the template was created.</param>
+/// <param name="YamlPreview">The rendered YAML preview with default parameter values applied.</param>
+/// <param name="Parameters">The configurable parameters for the workflow template.</param>
+public sealed record WorkflowTemplateDetailDto(
+    int Id,
+    string Name,
+    string Description,
+    string Category,
+    IReadOnlyList<string> Tags,
+    string WorkflowFilePath,
+    string TriggerDescription,
+    DateTimeOffset CreatedAt,
+    string YamlPreview,
+    IReadOnlyList<WorkflowTemplateParameterDto> Parameters);

--- a/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateParameterDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateParameterDto.cs
@@ -1,0 +1,14 @@
+namespace SoloDevBoard.Application.Services.Workflows;
+
+/// <summary>Represents a configurable workflow template parameter exposed to the presentation layer.</summary>
+/// <param name="Name">The parameter name used for template substitution.</param>
+/// <param name="Label">The display label shown in the parameter editor.</param>
+/// <param name="Description">The help text describing the parameter.</param>
+/// <param name="DefaultValue">The default value applied when the parameter is optional.</param>
+/// <param name="IsRequired">A value indicating whether the parameter must be provided before apply.</param>
+public sealed record WorkflowTemplateParameterDto(
+    string Name,
+    string Label,
+    string Description,
+    string DefaultValue,
+    bool IsRequired);

--- a/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateRepositoryResultDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateRepositoryResultDto.cs
@@ -1,0 +1,14 @@
+namespace SoloDevBoard.Application.Services.Workflows;
+
+/// <summary>Represents the apply result for a single repository.</summary>
+/// <param name="RepositoryFullName">The owner/repository full name.</param>
+/// <param name="Action">The apply action taken for the repository.</param>
+/// <param name="ErrorMessage">The repository-specific error message when apply fails.</param>
+public sealed record WorkflowTemplateRepositoryResultDto(
+    string RepositoryFullName,
+    string Action,
+    string? ErrorMessage)
+{
+    /// <summary>Gets a value indicating whether the apply operation failed for this repository.</summary>
+    public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
+}

--- a/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateRepositoryStatusDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateRepositoryStatusDto.cs
@@ -1,0 +1,10 @@
+namespace SoloDevBoard.Application.Services.Workflows;
+
+/// <summary>Represents the workflow template status for a single repository.</summary>
+/// <param name="RepositoryFullName">The owner/repository full name.</param>
+/// <param name="Status">The application status for the workflow template.</param>
+/// <param name="StatusDescription">A user-facing description of the repository status.</param>
+public sealed record WorkflowTemplateRepositoryStatusDto(
+    string RepositoryFullName,
+    WorkflowTemplateApplicationStatus Status,
+    string StatusDescription);

--- a/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Workflows/WorkflowTemplateService.cs
@@ -2,12 +2,28 @@ using SoloDevBoard.Domain.Entities.Workflows;
 
 namespace SoloDevBoard.Application.Services.Workflows;
 
-/// <summary>Provides built-in workflow templates for browsing and future apply flows.</summary>
+/// <summary>Provides built-in workflow templates for browsing, customisation, and apply flows.</summary>
 public sealed class WorkflowTemplateService : IWorkflowTemplateService
 {
+    private const string PlaceholderPrefix = "{{";
+    private const string PlaceholderSuffix = "}}";
+
     private static readonly DateTimeOffset BuiltInCreatedAt = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
     private static readonly IReadOnlyList<WorkflowTemplate> BuiltInTemplates = BuildBuiltInTemplates();
+
+    private static readonly IReadOnlyDictionary<int, IReadOnlyList<WorkflowTemplateParameter>> ParametersByTemplateId =
+        BuildParametersByTemplateId();
+
+    private readonly IWorkflowFileRepository _workflowFileRepository;
+
+    /// <summary>Initialises a new instance of the <see cref="WorkflowTemplateService"/> class.</summary>
+    /// <param name="workflowFileRepository">The repository used to read and write workflow files.</param>
+    public WorkflowTemplateService(IWorkflowFileRepository workflowFileRepository)
+    {
+        ArgumentNullException.ThrowIfNull(workflowFileRepository);
+        _workflowFileRepository = workflowFileRepository;
+    }
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<WorkflowTemplateDto>> GetTemplatesAsync(CancellationToken cancellationToken = default)
@@ -22,15 +38,172 @@ public sealed class WorkflowTemplateService : IWorkflowTemplateService
     }
 
     /// <inheritdoc/>
-    public Task<WorkflowTemplateDto> ApplyTemplateAsync(string owner, string repo, int templateId, CancellationToken cancellationToken = default)
+    public Task<WorkflowTemplateDetailDto> GetTemplateDetailAsync(int templateId, CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
-        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
         cancellationToken.ThrowIfCancellationRequested();
 
-        throw new NotSupportedException(
-            "Applying workflow templates to repositories is not yet implemented. Use the template browser to review built-in templates.");
+        var template = ResolveTemplate(templateId);
+        var parameters = GetParameters(templateId);
+        var resolvedValues = ResolveParameterValues(parameters, new Dictionary<string, string>());
+        var yamlPreview = ApplyParameterValues(template.YamlContent, resolvedValues);
+
+        return Task.FromResult(MapToDetailDto(template, parameters, yamlPreview));
     }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<WorkflowTemplateRepositoryStatusDto>> GetRepositoryStatusesAsync(
+        int templateId,
+        IReadOnlyList<string> repositoryFullNames,
+        IReadOnlyDictionary<string, string> parameterValues,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(repositoryFullNames);
+        ArgumentNullException.ThrowIfNull(parameterValues);
+
+        if (repositoryFullNames.Count == 0)
+        {
+            return [];
+        }
+
+        var template = ResolveTemplate(templateId);
+        var parameters = GetParameters(templateId);
+        var resolvedValues = ResolveParameterValues(parameters, parameterValues);
+        ValidateParameterValues(parameters, resolvedValues);
+        var canonicalContent = NormaliseContent(ApplyParameterValues(template.YamlContent, resolvedValues));
+
+        var normalisedRepositories = NormaliseRepositories(repositoryFullNames);
+        var statusTasks = normalisedRepositories
+            .Select(repositoryFullName => BuildRepositoryStatusAsync(template, repositoryFullName, canonicalContent, cancellationToken))
+            .ToArray();
+
+        var statuses = await Task.WhenAll(statusTasks).ConfigureAwait(false);
+        return statuses
+            .OrderBy(status => status.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<WorkflowTemplateRepositoryResultDto>> ApplyTemplateAsync(
+        int templateId,
+        IReadOnlyList<string> repositoryFullNames,
+        IReadOnlyDictionary<string, string> parameterValues,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(repositoryFullNames);
+        ArgumentNullException.ThrowIfNull(parameterValues);
+
+        var template = ResolveTemplate(templateId);
+        var parameters = GetParameters(templateId);
+        var resolvedValues = ResolveParameterValues(parameters, parameterValues);
+        ValidateParameterValues(parameters, resolvedValues);
+
+        var normalisedRepositories = NormaliseRepositories(repositoryFullNames);
+        var renderedContent = ApplyParameterValues(template.YamlContent, resolvedValues);
+        var canonicalContent = NormaliseContent(renderedContent);
+        var commitMessage = $"Apply {template.Name} workflow template via SoloDevBoard";
+
+        var results = new List<WorkflowTemplateRepositoryResultDto>();
+
+        foreach (var repositoryFullName in normalisedRepositories)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var repository = SplitRepositoryFullName(repositoryFullName);
+                var existingFile = await _workflowFileRepository
+                    .GetWorkflowFileAsync(repository.Owner, repository.Name, template.WorkflowFilePath, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (existingFile is not null && NormaliseContent(existingFile.Content) == canonicalContent)
+                {
+                    results.Add(new WorkflowTemplateRepositoryResultDto(repositoryFullName, "Skipped", null));
+                    continue;
+                }
+
+                await _workflowFileRepository
+                    .CreateOrUpdateWorkflowFileAsync(
+                        repository.Owner,
+                        repository.Name,
+                        template.WorkflowFilePath,
+                        renderedContent,
+                        existingFile?.Sha,
+                        commitMessage,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+                var action = existingFile is null ? "Created" : "Updated";
+                results.Add(new WorkflowTemplateRepositoryResultDto(repositoryFullName, action, null));
+            }
+            catch (Exception ex) when (ex is HttpRequestException or KeyNotFoundException or ArgumentException)
+            {
+                results.Add(new WorkflowTemplateRepositoryResultDto(repositoryFullName, "Failed", ex.Message));
+            }
+        }
+
+        return results
+            .OrderBy(result => result.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private async Task<WorkflowTemplateRepositoryStatusDto> BuildRepositoryStatusAsync(
+        WorkflowTemplate template,
+        string repositoryFullName,
+        string canonicalContent,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var repository = SplitRepositoryFullName(repositoryFullName);
+            var existingFile = await _workflowFileRepository
+                .GetWorkflowFileAsync(repository.Owner, repository.Name, template.WorkflowFilePath, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (existingFile is null)
+            {
+                return new WorkflowTemplateRepositoryStatusDto(
+                    repositoryFullName,
+                    WorkflowTemplateApplicationStatus.NotApplied,
+                    "Workflow file is not present in this repository.");
+            }
+
+            if (NormaliseContent(existingFile.Content) == canonicalContent)
+            {
+                return new WorkflowTemplateRepositoryStatusDto(
+                    repositoryFullName,
+                    WorkflowTemplateApplicationStatus.Applied,
+                    "Workflow file matches the canonical template.");
+            }
+
+            return new WorkflowTemplateRepositoryStatusDto(
+                repositoryFullName,
+                WorkflowTemplateApplicationStatus.Drifted,
+                "Workflow file differs from the canonical template.");
+        }
+        catch (Exception ex) when (ex is HttpRequestException or ArgumentException)
+        {
+            return new WorkflowTemplateRepositoryStatusDto(
+                repositoryFullName,
+                WorkflowTemplateApplicationStatus.NotApplied,
+                $"Unable to inspect workflow file: {ex.Message}");
+        }
+    }
+
+    private static WorkflowTemplate ResolveTemplate(int templateId)
+    {
+        var template = BuiltInTemplates.FirstOrDefault(candidate => candidate.Id == templateId);
+        if (template is null)
+        {
+            throw new KeyNotFoundException($"Workflow template '{templateId}' was not found.");
+        }
+
+        return template;
+    }
+
+    private static IReadOnlyList<WorkflowTemplateParameter> GetParameters(int templateId)
+        => ParametersByTemplateId.TryGetValue(templateId, out var parameters)
+            ? parameters
+            : [];
 
     private static WorkflowTemplateDto MapToDto(WorkflowTemplate template)
         => new(
@@ -42,6 +215,161 @@ public sealed class WorkflowTemplateService : IWorkflowTemplateService
             template.WorkflowFilePath,
             template.TriggerDescription,
             template.CreatedAt);
+
+    private static WorkflowTemplateDetailDto MapToDetailDto(
+        WorkflowTemplate template,
+        IReadOnlyList<WorkflowTemplateParameter> parameters,
+        string yamlPreview)
+        => new(
+            template.Id,
+            template.Name,
+            template.Description,
+            template.Category,
+            template.Tags,
+            template.WorkflowFilePath,
+            template.TriggerDescription,
+            template.CreatedAt,
+            yamlPreview,
+            parameters.Select(MapParameterToDto).ToArray());
+
+    private static WorkflowTemplateParameterDto MapParameterToDto(WorkflowTemplateParameter parameter)
+        => new(
+            parameter.Name,
+            parameter.Label,
+            parameter.Description,
+            parameter.DefaultValue,
+            parameter.IsRequired);
+
+    private static IReadOnlyDictionary<string, string> ResolveParameterValues(
+        IReadOnlyList<WorkflowTemplateParameter> parameters,
+        IReadOnlyDictionary<string, string> parameterValues)
+    {
+        var resolved = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var parameter in parameters)
+        {
+            if (parameterValues.TryGetValue(parameter.Name, out var providedValue))
+            {
+                resolved[parameter.Name] = string.IsNullOrWhiteSpace(providedValue)
+                    ? string.Empty
+                    : providedValue.Trim();
+                continue;
+            }
+
+            resolved[parameter.Name] = parameter.DefaultValue;
+        }
+
+        return resolved;
+    }
+
+    private static void ValidateParameterValues(
+        IReadOnlyList<WorkflowTemplateParameter> parameters,
+        IReadOnlyDictionary<string, string> resolvedValues)
+    {
+        foreach (var parameter in parameters.Where(parameter => parameter.IsRequired))
+        {
+            if (!resolvedValues.TryGetValue(parameter.Name, out var value) || string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException($"Parameter '{parameter.Label}' is required.");
+            }
+        }
+    }
+
+    private static string ApplyParameterValues(string yamlContent, IReadOnlyDictionary<string, string> resolvedValues)
+    {
+        var rendered = yamlContent;
+
+        foreach (var (name, value) in resolvedValues)
+        {
+            rendered = rendered.Replace($"{PlaceholderPrefix}{name}{PlaceholderSuffix}", value, StringComparison.Ordinal);
+        }
+
+        return rendered;
+    }
+
+    private static string NormaliseContent(string content)
+        => content.ReplaceLineEndings("\n").TrimEnd();
+
+    private static IReadOnlyList<string> NormaliseRepositories(IReadOnlyList<string> repositories)
+    {
+        ArgumentNullException.ThrowIfNull(repositories);
+
+        var normalised = repositories
+            .Select(repository => repository?.Trim())
+            .Where(repository => !string.IsNullOrWhiteSpace(repository))
+            .Select(repository => repository!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (normalised.Length == 0)
+        {
+            throw new ArgumentException("At least one repository must be provided.", nameof(repositories));
+        }
+
+        return normalised;
+    }
+
+    private static RepositoryCoordinates SplitRepositoryFullName(string fullName)
+    {
+        if (string.IsNullOrWhiteSpace(fullName))
+        {
+            throw new ArgumentException("Repository full name must be provided.", nameof(fullName));
+        }
+
+        var parts = fullName.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length != 2)
+        {
+            throw new ArgumentException($"Repository '{fullName}' must be in owner/repository format.", nameof(fullName));
+        }
+
+        return new RepositoryCoordinates(parts[0], parts[1]);
+    }
+
+    private static IReadOnlyDictionary<int, IReadOnlyList<WorkflowTemplateParameter>> BuildParametersByTemplateId()
+        => new Dictionary<int, IReadOnlyList<WorkflowTemplateParameter>>
+        {
+            [1] =
+            [
+                new WorkflowTemplateParameter
+                {
+                    Name = "mainBranch",
+                    Label = "Main branch",
+                    Description = "The branch that triggers CI builds.",
+                    DefaultValue = "main",
+                    IsRequired = true,
+                },
+                new WorkflowTemplateParameter
+                {
+                    Name = "dotnetVersion",
+                    Label = ".NET version",
+                    Description = "The .NET SDK version used by the workflow.",
+                    DefaultValue = "10.0.x",
+                    IsRequired = false,
+                },
+            ],
+            [2] =
+            [
+                new WorkflowTemplateParameter
+                {
+                    Name = "environmentName",
+                    Label = "Deployment environment",
+                    Description = "The GitHub environment used for deployment approval.",
+                    DefaultValue = "production",
+                    IsRequired = true,
+                },
+            ],
+            [3] =
+            [
+                new WorkflowTemplateParameter
+                {
+                    Name = "targetBranch",
+                    Label = "Target branch",
+                    Description = "The branch that Dependabot pull requests must target.",
+                    DefaultValue = "main",
+                    IsRequired = true,
+                },
+            ],
+        };
 
     private static IReadOnlyList<WorkflowTemplate> BuildBuiltInTemplates()
         =>
@@ -61,10 +389,10 @@ public sealed class WorkflowTemplateService : IWorkflowTemplateService
                     on:
                       push:
                         branches:
-                          - main
+                          - {{mainBranch}}
                       pull_request:
                         branches:
-                          - main
+                          - {{mainBranch}}
 
                     jobs:
                       build-and-test:
@@ -72,6 +400,8 @@ public sealed class WorkflowTemplateService : IWorkflowTemplateService
                         steps:
                           - uses: actions/checkout@v7
                           - uses: actions/setup-dotnet@v5
+                            with:
+                              dotnet-version: '{{dotnetVersion}}'
                           - run: dotnet build
                           - run: dotnet test
                     """,
@@ -95,7 +425,7 @@ public sealed class WorkflowTemplateService : IWorkflowTemplateService
                     jobs:
                       deploy:
                         runs-on: ubuntu-latest
-                        environment: production
+                        environment: {{environmentName}}
                         steps:
                           - uses: actions/checkout@v7
                           - uses: actions/setup-dotnet@v5
@@ -119,7 +449,7 @@ public sealed class WorkflowTemplateService : IWorkflowTemplateService
                     on:
                       pull_request_target:
                         branches:
-                          - main
+                          - {{targetBranch}}
 
                     jobs:
                       enable-auto-merge:
@@ -132,4 +462,6 @@ public sealed class WorkflowTemplateService : IWorkflowTemplateService
                 CreatedAt = BuiltInCreatedAt,
             },
         ];
+
+    private sealed record RepositoryCoordinates(string Owner, string Name);
 }

--- a/src/Domain/SoloDevBoard.Domain/Entities/Workflows/WorkflowFile.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Workflows/WorkflowFile.cs
@@ -1,0 +1,14 @@
+namespace SoloDevBoard.Domain.Entities.Workflows;
+
+/// <summary>Represents a workflow file stored in a GitHub repository.</summary>
+public sealed record WorkflowFile
+{
+    /// <summary>Gets the relative path of the workflow file in the repository.</summary>
+    public string Path { get; init; } = string.Empty;
+
+    /// <summary>Gets the decoded YAML content of the workflow file.</summary>
+    public string Content { get; init; } = string.Empty;
+
+    /// <summary>Gets the Git blob SHA used for optimistic concurrency when updating the file.</summary>
+    public string? Sha { get; init; }
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/Workflows/WorkflowTemplateParameter.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Workflows/WorkflowTemplateParameter.cs
@@ -1,0 +1,20 @@
+namespace SoloDevBoard.Domain.Entities.Workflows;
+
+/// <summary>Represents a configurable parameter for a workflow template.</summary>
+public sealed record WorkflowTemplateParameter
+{
+    /// <summary>Gets the parameter name used for template substitution.</summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Gets the display label shown in the parameter editor.</summary>
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>Gets the help text describing the parameter.</summary>
+    public string Description { get; init; } = string.Empty;
+
+    /// <summary>Gets the default value applied when the parameter is optional.</summary>
+    public string DefaultValue { get; init; } = string.Empty;
+
+    /// <summary>Gets a value indicating whether the parameter must be provided before apply.</summary>
+    public bool IsRequired { get; init; }
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/Common/InfrastructureServiceExtensions.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/Common/InfrastructureServiceExtensions.cs
@@ -6,10 +6,12 @@ using SoloDevBoard.Application.Services.Common;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Application.Services.Labels;
 using SoloDevBoard.Application.Services.Migration;
+using SoloDevBoard.Application.Services.Workflows;
 using SoloDevBoard.Infrastructure.GitHub;
 using SoloDevBoard.Infrastructure.Identity;
 using SoloDevBoard.Infrastructure.Labels;
 using SoloDevBoard.Infrastructure.Milestones;
+using SoloDevBoard.Infrastructure.Workflows;
 
 namespace SoloDevBoard.Infrastructure.Common;
 
@@ -66,6 +68,7 @@ public static class InfrastructureServiceExtensions
         services.AddScoped<IGitHubService, GitHubService>();
         services.AddScoped<ILabelRepository, GitHubLabelRepository>();
         services.AddScoped<IMilestoneRepository, GitHubMilestoneRepository>();
+        services.AddScoped<IWorkflowFileRepository, GitHubWorkflowFileRepository>();
 
         return services;
     }

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/Workflows/GitHubWorkflowFileRepository.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/Workflows/GitHubWorkflowFileRepository.cs
@@ -1,0 +1,126 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SoloDevBoard.Application.Services.Workflows;
+using SoloDevBoard.Domain.Entities.Workflows;
+using SoloDevBoard.Infrastructure.GitHub;
+
+namespace SoloDevBoard.Infrastructure.Workflows;
+
+/// <summary>GitHub REST API implementation of <see cref="IWorkflowFileRepository"/>.</summary>
+public sealed class GitHubWorkflowFileRepository : IWorkflowFileRepository
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    /// <summary>Initialises a new instance of the <see cref="GitHubWorkflowFileRepository"/> class.</summary>
+    /// <param name="httpClientFactory">The factory used to create named <see cref="HttpClient"/> instances.</param>
+    public GitHubWorkflowFileRepository(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+    }
+
+    /// <inheritdoc/>
+    public async Task<WorkflowFile?> GetWorkflowFileAsync(string owner, string repo, string path, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var client = CreateClient();
+        var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/contents/{path}";
+
+        using var response = await client.GetAsync(endpoint, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        await GitHubService.EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var fileResponse = await response.Content.ReadFromJsonAsync<WorkflowFileResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw GitHubService.CreateInvalidResponseException("Workflow file response was empty.", endpoint);
+
+        return new WorkflowFile
+        {
+            Path = fileResponse.Path ?? path,
+            Content = DecodeContent(fileResponse.Content),
+            Sha = fileResponse.Sha,
+        };
+    }
+
+    /// <inheritdoc/>
+    public async Task CreateOrUpdateWorkflowFileAsync(
+        string owner,
+        string repo,
+        string path,
+        string content,
+        string? existingSha,
+        string commitMessage,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentException.ThrowIfNullOrWhiteSpace(commitMessage);
+
+        var client = CreateClient();
+        var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/contents/{path}";
+        var request = new WorkflowFileUpsertRequestDto
+        {
+            Message = commitMessage,
+            Content = Convert.ToBase64String(Encoding.UTF8.GetBytes(content)),
+            Sha = existingSha,
+        };
+
+        using var response = await client.PutAsJsonAsync(endpoint, request, JsonOptions, cancellationToken).ConfigureAwait(false);
+        await GitHubService.EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string DecodeContent(string? encodedContent)
+    {
+        if (string.IsNullOrWhiteSpace(encodedContent))
+        {
+            return string.Empty;
+        }
+
+        var normalised = encodedContent.ReplaceLineEndings(string.Empty);
+        var bytes = Convert.FromBase64String(normalised);
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    private HttpClient CreateClient()
+        => _httpClientFactory.CreateClient(GitHubService.GitHubApiClientName);
+
+    private sealed class WorkflowFileResponseDto
+    {
+        [JsonPropertyName("path")]
+        public string? Path { get; init; }
+
+        [JsonPropertyName("sha")]
+        public string? Sha { get; init; }
+
+        [JsonPropertyName("content")]
+        public string? Content { get; init; }
+    }
+
+    private sealed class WorkflowFileUpsertRequestDto
+    {
+        [JsonPropertyName("message")]
+        public string Message { get; init; } = string.Empty;
+
+        [JsonPropertyName("content")]
+        public string Content { get; init; } = string.Empty;
+
+        [JsonPropertyName("sha")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Sha { get; init; }
+    }
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/WorkflowsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/WorkflowsTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using MudBlazor;
 using MudBlazor.Services;
 using SoloDevBoard.App.Components.Features.Workflows.Pages;
+using SoloDevBoard.Application.Services.Repositories;
 using SoloDevBoard.Application.Services.Workflows;
 
 namespace SoloDevBoard.App.Tests;
@@ -12,6 +13,7 @@ namespace SoloDevBoard.App.Tests;
 public sealed class WorkflowsTests
 {
     private readonly Mock<IWorkflowTemplateService> _workflowTemplateServiceMock = new();
+    private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
 
     [Fact]
     public async Task Workflows_WhileTemplatesAreLoading_ShowsLoadingState()
@@ -21,6 +23,10 @@ public sealed class WorkflowsTests
         _workflowTemplateServiceMock
             .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
             .Returns(templatesTask.Task);
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateRepositories());
 
         await using var ctx = CreateContext();
 
@@ -32,12 +38,10 @@ public sealed class WorkflowsTests
     }
 
     [Fact]
-    public async Task Workflows_InitialLoad_RendersBuiltInTemplateCards()
+    public async Task Workflows_InitialLoad_RendersBuiltInTemplateCardsAndRepositorySelector()
     {
         // Arrange
-        _workflowTemplateServiceMock
-            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateTemplates());
+        SetupDefaultServices();
 
         await using var ctx = CreateContext();
 
@@ -47,6 +51,7 @@ public sealed class WorkflowsTests
         // Assert
         cut.WaitForAssertion(() =>
         {
+            Assert.Single(cut.FindAll("[data-testid='repository-selector-region']"));
             Assert.Single(cut.FindAll("[data-testid='workflow-template-browser-region']"));
             Assert.Single(cut.FindAll("[data-testid='workflow-template-grid']"));
             Assert.Contains(".NET CI", cut.Markup);
@@ -59,9 +64,10 @@ public sealed class WorkflowsTests
     public async Task Workflows_SelectTemplateButton_UsesSemanticControlAndShowsSelectedState()
     {
         // Arrange
+        SetupDefaultServices();
         _workflowTemplateServiceMock
-            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateTemplates());
+            .Setup(service => service.GetTemplateDetailAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTemplateDetail());
 
         await using var ctx = CreateContext();
         var cut = ctx.Render<Workflows>();
@@ -77,6 +83,152 @@ public sealed class WorkflowsTests
         {
             Assert.Equal("true", selectButton.GetAttribute("aria-pressed"));
             Assert.Contains("Selected", selectButton.TextContent);
+            Assert.Single(cut.FindAll("[data-testid='workflow-template-detail-region']"));
+            Assert.Contains("YAML preview", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task Workflows_SelectTemplate_ShowsParameterFields()
+    {
+        // Arrange
+        SetupDefaultServices();
+        _workflowTemplateServiceMock
+            .Setup(service => service.GetTemplateDetailAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTemplateDetail());
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<Workflows>();
+
+        cut.WaitForAssertion(() => Assert.Equal(3, cut.FindAll("[data-testid^='workflow-template-select-']").Count));
+
+        // Act
+        await cut.InvokeAsync(() => cut.Find("[data-testid='workflow-template-select-1']").Click());
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='workflow-template-parameter-form']"));
+            Assert.Single(cut.FindAll("[data-testid='workflow-template-parameter-mainBranch']"));
+            Assert.Single(cut.FindAll("[data-testid='workflow-template-parameter-dotnetVersion']"));
+        });
+    }
+
+    [Fact]
+    public async Task Workflows_RequiredParameterCleared_DisablesApplyButton()
+    {
+        // Arrange
+        SetupDefaultServices();
+        _workflowTemplateServiceMock
+            .Setup(service => service.GetTemplateDetailAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTemplateDetail());
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<Workflows>();
+
+        cut.WaitForAssertion(() => Assert.Equal(3, cut.FindAll("[data-testid^='workflow-template-select-']").Count));
+        await cut.InvokeAsync(() => cut.Find("[data-testid='workflow-template-select-1']").Click());
+
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='workflow-template-parameter-mainBranch']")));
+
+        // Act
+        var mainBranchField = cut.FindComponents<MudTextField<string>>()
+            .First(field => field.Instance.Label == "Main branch");
+        await cut.InvokeAsync(() => mainBranchField.Instance.ValueChanged.InvokeAsync(string.Empty));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            var applyButton = cut.Find("[data-testid='workflow-template-apply-button']");
+            Assert.True(applyButton.HasAttribute("disabled"));
+        });
+    }
+
+    [Fact]
+    public async Task Workflows_ApplyTemplate_ShowsSuccessFeedback()
+    {
+        // Arrange
+        SetupDefaultServices();
+        _workflowTemplateServiceMock
+            .Setup(service => service.GetTemplateDetailAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTemplateDetail());
+
+        _workflowTemplateServiceMock
+            .Setup(service => service.GetRepositoryStatusesAsync(1, It.IsAny<IReadOnlyList<string>>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new WorkflowTemplateRepositoryStatusDto("owner/repo-a", WorkflowTemplateApplicationStatus.NotApplied, "Workflow file is not present in this repository."),
+            ]);
+
+        _workflowTemplateServiceMock
+            .Setup(service => service.ApplyTemplateAsync(1, It.IsAny<IReadOnlyList<string>>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new WorkflowTemplateRepositoryResultDto("owner/repo-a", "Created", null),
+            ]);
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<Workflows>();
+
+        cut.WaitForAssertion(() => Assert.Equal(3, cut.FindAll("[data-testid^='workflow-template-select-']").Count));
+        await cut.InvokeAsync(() => cut.Find("[data-testid='workflow-template-select-1']").Click());
+
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='workflow-repository-autocomplete']")));
+        var autocomplete = cut.FindComponent<MudAutocomplete<string>>();
+        await cut.InvokeAsync(() => autocomplete.Instance.ValueChanged.InvokeAsync("owner/repo-a"));
+
+        cut.WaitForAssertion(() => Assert.Contains("owner/repo-a", cut.Markup));
+
+        // Act
+        await cut.InvokeAsync(() => cut.Find("[data-testid='workflow-template-apply-button']").Click());
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='workflow-template-feedback-region']"));
+            Assert.Contains("Applied template successfully", cut.Markup);
+            Assert.Single(cut.FindAll("[data-testid='workflow-template-apply-results']"));
+        });
+    }
+
+    [Fact]
+    public async Task Workflows_ApplyTemplateFailure_ShowsErrorFeedback()
+    {
+        // Arrange
+        SetupDefaultServices();
+        _workflowTemplateServiceMock
+            .Setup(service => service.GetTemplateDetailAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTemplateDetail());
+
+        _workflowTemplateServiceMock
+            .Setup(service => service.GetRepositoryStatusesAsync(1, It.IsAny<IReadOnlyList<string>>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new WorkflowTemplateRepositoryStatusDto("owner/repo-a", WorkflowTemplateApplicationStatus.NotApplied, "Workflow file is not present in this repository."),
+            ]);
+
+        _workflowTemplateServiceMock
+            .Setup(service => service.ApplyTemplateAsync(1, It.IsAny<IReadOnlyList<string>>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new WorkflowTemplateRepositoryResultDto("owner/repo-a", "Failed", "GitHub API request failed."),
+            ]);
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<Workflows>();
+
+        cut.WaitForAssertion(() => Assert.Equal(3, cut.FindAll("[data-testid^='workflow-template-select-']").Count));
+        await cut.InvokeAsync(() => cut.Find("[data-testid='workflow-template-select-1']").Click());
+
+        var autocomplete = cut.FindComponent<MudAutocomplete<string>>();
+        await cut.InvokeAsync(() => autocomplete.Instance.ValueChanged.InvokeAsync("owner/repo-a"));
+
+        cut.WaitForAssertion(() => Assert.Contains("owner/repo-a", cut.Markup));
+
+        // Act
+        await cut.InvokeAsync(() => cut.Find("[data-testid='workflow-template-apply-button']").Click());
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("repository errors", cut.Markup);
+            Assert.Contains("GitHub API request failed.", cut.Markup);
         });
     }
 
@@ -84,9 +236,7 @@ public sealed class WorkflowsTests
     public async Task Workflows_SearchByTag_FiltersTemplateCards()
     {
         // Arrange
-        _workflowTemplateServiceMock
-            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateTemplates());
+        SetupDefaultServices();
 
         await using var ctx = CreateContext();
         var cut = ctx.Render<Workflows>();
@@ -110,9 +260,7 @@ public sealed class WorkflowsTests
     public async Task Workflows_CategoryFilter_ShowsOnlyMatchingTemplates()
     {
         // Arrange
-        _workflowTemplateServiceMock
-            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateTemplates());
+        SetupDefaultServices();
 
         await using var ctx = CreateContext();
         var cut = ctx.Render<Workflows>();
@@ -136,9 +284,7 @@ public sealed class WorkflowsTests
     public async Task Workflows_NoMatchingResults_ShowsEmptyState()
     {
         // Arrange
-        _workflowTemplateServiceMock
-            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateTemplates());
+        SetupDefaultServices();
 
         await using var ctx = CreateContext();
         var cut = ctx.Render<Workflows>();
@@ -157,6 +303,17 @@ public sealed class WorkflowsTests
         });
     }
 
+    private void SetupDefaultServices()
+    {
+        _workflowTemplateServiceMock
+            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTemplates());
+
+        _repositoryServiceMock
+            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateRepositories());
+    }
+
     private BunitContext CreateContext()
     {
         var ctx = new BunitContext();
@@ -164,6 +321,7 @@ public sealed class WorkflowsTests
         ctx.Services.AddMudServices();
         ctx.Services.AddTestHostedAuthenticationRecovery();
         ctx.Services.AddScoped(_ => _workflowTemplateServiceMock.Object);
+        ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
 
         ctx.Render<MudPopoverProvider>();
         ctx.Render<MudDialogProvider>();
@@ -171,6 +329,29 @@ public sealed class WorkflowsTests
 
         return ctx;
     }
+
+    private static IReadOnlyList<RepositoryDto> CreateRepositories()
+        =>
+        [
+            new(1, "repo-a", "owner/repo-a", "Repository A", "https://github.com/owner/repo-a", false, false, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new(2, "repo-b", "owner/repo-b", "Repository B", "https://github.com/owner/repo-b", false, false, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+        ];
+
+    private static WorkflowTemplateDetailDto CreateTemplateDetail()
+        => new(
+            1,
+            ".NET CI",
+            "Build and test a .NET solution on every push and pull request to the main branch.",
+            "CI",
+            ["dotnet", "github-actions", "build", "test"],
+            ".github/workflows/ci.yml",
+            "Push and pull request to main",
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            "name: CI",
+            [
+                new WorkflowTemplateParameterDto("mainBranch", "Main branch", "The branch that triggers CI builds.", "main", true),
+                new WorkflowTemplateParameterDto("dotnetVersion", ".NET version", "The .NET SDK version used by the workflow.", "10.0.x", false),
+            ]);
 
     private static IReadOnlyList<WorkflowTemplateDto> CreateTemplates()
         =>

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/WorkflowTemplateServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/WorkflowTemplateServiceTests.cs
@@ -1,15 +1,32 @@
+using Moq;
 using SoloDevBoard.Application.Services.Workflows;
+using SoloDevBoard.Domain.Entities.Workflows;
 
 namespace SoloDevBoard.Application.Tests;
 
 /// <summary>Tests for <see cref="WorkflowTemplateService"/>.</summary>
 public sealed class WorkflowTemplateServiceTests
 {
+    private readonly Mock<IWorkflowFileRepository> _workflowFileRepositoryMock = new();
+
+    [Fact]
+    public void Constructor_WorkflowFileRepositoryIsNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        IWorkflowFileRepository? workflowFileRepository = null;
+
+        // Act
+        var action = () => _ = new WorkflowTemplateService(workflowFileRepository!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(action);
+    }
+
     [Fact]
     public async Task GetTemplatesAsync_ReturnsBuiltInTemplates()
     {
         // Arrange
-        var sut = new WorkflowTemplateService();
+        var sut = CreateSut();
 
         // Act
         var result = await sut.GetTemplatesAsync();
@@ -25,7 +42,7 @@ public sealed class WorkflowTemplateServiceTests
     public async Task GetTemplatesAsync_ReturnsTemplateMetadata()
     {
         // Arrange
-        var sut = new WorkflowTemplateService();
+        var sut = CreateSut();
 
         // Act
         var result = await sut.GetTemplatesAsync();
@@ -39,72 +56,270 @@ public sealed class WorkflowTemplateServiceTests
     }
 
     [Fact]
-    public async Task ApplyTemplateAsync_ThrowsNotSupportedException()
+    public async Task GetTemplateDetailAsync_ReturnsParametersAndYamlPreview()
     {
         // Arrange
-        var sut = new WorkflowTemplateService();
+        var sut = CreateSut();
 
         // Act
-        var action = () => sut.ApplyTemplateAsync("owner", "repo", 2);
+        var result = await sut.GetTemplateDetailAsync(1);
 
         // Assert
-        var exception = await Assert.ThrowsAsync<NotSupportedException>(action);
-        Assert.Contains("not yet implemented", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(".NET CI", result.Name);
+        Assert.Equal(2, result.Parameters.Count);
+        Assert.Contains("main", result.YamlPreview, StringComparison.Ordinal);
+        Assert.DoesNotContain("{{mainBranch}}", result.YamlPreview, StringComparison.Ordinal);
     }
 
-    [Theory]
-    [InlineData("")]
-    [InlineData("   ")]
-    public async Task ApplyTemplateAsync_OwnerIsInvalid_ThrowsArgumentException(string owner)
+    [Fact]
+    public async Task GetTemplateDetailAsync_UnknownTemplate_ThrowsKeyNotFoundException()
     {
         // Arrange
-        var sut = new WorkflowTemplateService();
+        var sut = CreateSut();
 
         // Act
-        var action = () => sut.ApplyTemplateAsync(owner, "repo", 1);
+        var action = () => sut.GetTemplateDetailAsync(999);
+
+        // Assert
+        await Assert.ThrowsAsync<KeyNotFoundException>(action);
+    }
+
+    [Fact]
+    public async Task GetRepositoryStatusesAsync_MissingWorkflowFile_ReturnsNotAppliedStatus()
+    {
+        // Arrange
+        _workflowFileRepositoryMock
+            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WorkflowFile?)null);
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.GetRepositoryStatusesAsync(1, ["owner/repo-a"], new Dictionary<string, string>());
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(WorkflowTemplateApplicationStatus.NotApplied, result[0].Status);
+    }
+
+    [Fact]
+    public async Task GetRepositoryStatusesAsync_MatchingWorkflowFile_ReturnsAppliedStatus()
+    {
+        // Arrange
+        var canonicalYaml = await GetRenderedCiYamlAsync();
+
+        _workflowFileRepositoryMock
+            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WorkflowFile
+            {
+                Path = ".github/workflows/ci.yml",
+                Content = canonicalYaml,
+                Sha = "abc123",
+            });
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.GetRepositoryStatusesAsync(1, ["owner/repo-a"], new Dictionary<string, string>());
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(WorkflowTemplateApplicationStatus.Applied, result[0].Status);
+    }
+
+    [Fact]
+    public async Task GetRepositoryStatusesAsync_DifferentWorkflowFile_ReturnsDriftedStatus()
+    {
+        // Arrange
+        _workflowFileRepositoryMock
+            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WorkflowFile
+            {
+                Path = ".github/workflows/ci.yml",
+                Content = "name: Custom CI",
+                Sha = "abc123",
+            });
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.GetRepositoryStatusesAsync(1, ["owner/repo-a"], new Dictionary<string, string>());
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(WorkflowTemplateApplicationStatus.Drifted, result[0].Status);
+    }
+
+    [Fact]
+    public async Task GetRepositoryStatusesAsync_RequiredParameterMissing_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var action = () => sut.GetRepositoryStatusesAsync(1, ["owner/repo-a"], new Dictionary<string, string> { ["mainBranch"] = "   " });
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
     }
 
     [Fact]
-    public async Task ApplyTemplateAsync_OwnerIsNull_ThrowsArgumentNullException()
+    public async Task ApplyTemplateAsync_MissingWorkflowFile_CreatesWorkflowFile()
     {
         // Arrange
-        var sut = new WorkflowTemplateService();
+        _workflowFileRepositoryMock
+            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WorkflowFile?)null);
+
+        var sut = CreateSut();
 
         // Act
-        var action = () => sut.ApplyTemplateAsync(null!, "repo", 1);
+        var result = await sut.ApplyTemplateAsync(1, ["owner/repo-a"], new Dictionary<string, string>());
 
         // Assert
-        await Assert.ThrowsAsync<ArgumentNullException>(action);
+        Assert.Single(result);
+        Assert.Equal("Created", result[0].Action);
+        Assert.False(result[0].HasError);
+        _workflowFileRepositoryMock.Verify(
+            repository => repository.CreateOrUpdateWorkflowFileAsync(
+                "owner",
+                "repo-a",
+                ".github/workflows/ci.yml",
+                It.Is<string>(content => content.Contains("name: CI", StringComparison.Ordinal)),
+                null,
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ApplyTemplateAsync_MatchingWorkflowFile_SkipsRepository()
+    {
+        // Arrange
+        var canonicalYaml = await GetRenderedCiYamlAsync();
+
+        _workflowFileRepositoryMock
+            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WorkflowFile
+            {
+                Path = ".github/workflows/ci.yml",
+                Content = canonicalYaml,
+                Sha = "abc123",
+            });
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ApplyTemplateAsync(1, ["owner/repo-a"], new Dictionary<string, string>());
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("Skipped", result[0].Action);
+        _workflowFileRepositoryMock.Verify(
+            repository => repository.CreateOrUpdateWorkflowFileAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ApplyTemplateAsync_CustomParameterValues_RenderInWorkflowContent()
+    {
+        // Arrange
+        _workflowFileRepositoryMock
+            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WorkflowFile?)null);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.ApplyTemplateAsync(
+            1,
+            ["owner/repo-a"],
+            new Dictionary<string, string>
+            {
+                ["mainBranch"] = "develop",
+                ["dotnetVersion"] = "9.0.x",
+            });
+
+        // Assert
+        _workflowFileRepositoryMock.Verify(
+            repository => repository.CreateOrUpdateWorkflowFileAsync(
+                "owner",
+                "repo-a",
+                ".github/workflows/ci.yml",
+                It.Is<string>(content => content.Contains("- develop", StringComparison.Ordinal) && content.Contains("9.0.x", StringComparison.Ordinal)),
+                null,
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ApplyTemplateAsync_OneRepositoryFails_ReturnsErrorAndContinues()
+    {
+        // Arrange
+        _workflowFileRepositoryMock
+            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WorkflowFile?)null);
+
+        _workflowFileRepositoryMock
+            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-b", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Rate limited"));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ApplyTemplateAsync(1, ["owner/repo-a", "owner/repo-b"], new Dictionary<string, string>());
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, item => item.RepositoryFullName == "owner/repo-a" && item.Action == "Created" && !item.HasError);
+        Assert.Contains(result, item => item.RepositoryFullName == "owner/repo-b" && item.HasError && item.ErrorMessage == "Rate limited");
     }
 
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public async Task ApplyTemplateAsync_RepoIsInvalid_ThrowsArgumentException(string repo)
+    public async Task ApplyTemplateAsync_EmptyRepositoryList_ThrowsArgumentException(string repository)
     {
         // Arrange
-        var sut = new WorkflowTemplateService();
+        var sut = CreateSut();
 
         // Act
-        var action = () => sut.ApplyTemplateAsync("owner", repo, 1);
+        var action = () => sut.ApplyTemplateAsync(1, [repository], new Dictionary<string, string>());
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
     }
 
     [Fact]
-    public async Task ApplyTemplateAsync_RepoIsNull_ThrowsArgumentNullException()
+    public async Task ApplyTemplateAsync_InvalidRepositoryFormat_ReturnsErrorResult()
     {
         // Arrange
-        var sut = new WorkflowTemplateService();
+        var sut = CreateSut();
 
         // Act
-        var action = () => sut.ApplyTemplateAsync("owner", null!, 1);
+        var result = await sut.ApplyTemplateAsync(1, ["invalid-repo"], new Dictionary<string, string>());
 
         // Assert
-        await Assert.ThrowsAsync<ArgumentNullException>(action);
+        Assert.Single(result);
+        Assert.True(result[0].HasError);
+        Assert.Contains("owner/repository format", result[0].ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private WorkflowTemplateService CreateSut()
+        => new(_workflowFileRepositoryMock.Object);
+
+    private static async Task<string> GetRenderedCiYamlAsync()
+    {
+        var sut = new WorkflowTemplateService(new Mock<IWorkflowFileRepository>().Object);
+        var detail = await sut.GetTemplateDetailAsync(1);
+        return detail.YamlPreview;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Completes feature #234 by implementing the remaining Workflow Templates stories: parameter customisation, multi-repository apply, repository status visibility, drift detection, and test coverage.

The Workflow Templates page now supports the full wireframe-aligned flow — repository selection, template browsing, YAML preview with parameter editing, per-repository status badges, apply with partial-failure feedback, and drift warnings before application.

## Related Issue(s)

Closes #234
Closes #236
Closes #237
Closes #238
Closes #239
Closes #240
Closes #241

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)
- [x] 📝 Documentation (updates to docs, comments, or README)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Screenshots (if applicable)

E2E manual test performed against running Aspire app at `https://localhost:5074/workflows`.

## Additional Notes

- Adds `IWorkflowFileRepository` and `GitHubWorkflowFileRepository` using the GitHub Contents API for workflow file read/write.
- Built-in templates now support parameter placeholders (branch names, .NET version, deployment environment).
- Apply results report Created, Updated, Skipped, and Failed outcomes per repository.
- **E2E verification (17 Jul 2026):** Full browser flow tested — template browse → select .NET CI → parameter panel → repository selection → status badge (Not applied) → apply → success feedback (Created 1) → status updated to Applied. All 10 steps passed against live GitHub API.
- Issue label updates (`status/todo` → `status/in-progress`) could not be applied from this environment due to GitHub token permissions; please update labels manually if required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54d19535-36bb-4564-96db-d0f53ef12c43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54d19535-36bb-4564-96db-d0f53ef12c43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

