### PR TITLE
[Chore] Add noopener noreferrer to About page external repository link (#194)

### DIFF
--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -280,6 +280,7 @@ Labels: `type/chore`, `area/infrastructure`
 - [x] As a solo developer, I want the application version to be declared in a single place so that all version references (user-agent, About page, build artefacts) remain consistent automatically. _(#57 — done, 2026-03-10)_
 - [x] As a solo developer, I want the GitHub API user-agent string to reflect the running application version so that it never drifts from the actual release. _(#58 — done, 2026-03-10)_
 - [x] As a solo developer, I want an About page showing the application version and .NET runtime version so that I always know which version I am running. _(#59 — done, 2026-03-10)_
+- [x] Chore: The About page repository link uses `rel="noopener noreferrer"` for external links opened in a new tab so that link behaviour matches the Audit and Triage pages. _(Issue #194 — implemented 2026-07-18.)_
 
 
 <!-- Production-Readiness Batch: Planned 2026-03-12 for v1.0.0 (Epic #101: Public Release Infrastructure and Authentication) -->

--- a/src/App/SoloDevBoard.App/Components/Features/About/Pages/About.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/About/Pages/About.razor
@@ -22,6 +22,7 @@
 
             <MudLink Href="@RepositoryUrl"
                      Target="_blank"
+                     rel="noopener noreferrer"
                      Typo="Typo.body2"
                      data-testid="about-repository-link">
                 View the source repository

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
@@ -62,6 +62,8 @@ public sealed class AboutTests : BunitContext
         // Assert
         var link = cut.Find("[data-testid='about-repository-link']");
         Assert.Equal("https://github.com/markheydon/solo-dev-board", link.GetAttribute("href"));
+        Assert.Equal("_blank", link.GetAttribute("target"));
+        Assert.Equal("noopener noreferrer", link.GetAttribute("rel"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary of Changes

Adds `rel="noopener noreferrer"` to the About page external repository link so links opened with `Target="_blank"` match Audit and Triage page behaviour.

## Related Issue(s)

Closes #194

## Type of Change

- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `.github/copilot-instructions.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, `plan/BACKLOG.md` and `docs/index.md` have been updated

## Additional Notes

- Extended the existing bUnit test to assert `target` and `rel` attributes on the repository link.
- `dotnet test SoloDevBoard.slnx --filter "FullyQualifiedName~AboutTests"` — 4 passed.
- `dotnet format SoloDevBoard.slnx --verify-no-changes` — passed.
