### PR TITLE
Migrate test stack to xUnit v3, NSubstitute, and Playwright E2E

### DIFF
--- a/.agents/contracts/code-review.md
+++ b/.agents/contracts/code-review.md
@@ -39,8 +39,8 @@ Invoke this agent when you need to review:
 
 ### Testing
 - Verify new or updated tests exist for changed behaviour.
-- Ensure tests use xUnit and Moq only.
-- Confirm there is no `FluentAssertions` usage ([DEC-006](../plan/DECISIONS.md#dec-006-no-fluentassertions--xunit-built-in-assertions-only) prohibits it).
+- Ensure tests use xUnit v3 and NSubstitute only.
+- Confirm there is no `FluentAssertions`, `Moq`, `Shouldly`, `AwesomeAssertions`, `NUnit`, or `MSTest` usage ([DEC-006](../plan/DECISIONS.md#dec-006-no-fluentassertions--xunit-built-in-assertions-only) and [DEC-016](../plan/DECISIONS.md#dec-016-formalised-testing-standard--xunit-v3-nsubstitute-playwright-e2e) prohibit them).
 - Check test naming follows `MethodUnderTest_Scenario_ExpectedOutcome`.
 - Ensure tests are placed in the matching `tests/*` project structure.
 

--- a/.agents/contracts/delivery.md
+++ b/.agents/contracts/delivery.md
@@ -96,8 +96,8 @@ Add or update tests as appropriate.
 
 Requirements:
 
-- xUnit
-- Moq
+- xUnit v3
+- NSubstitute
 - xUnit Assert methods
 - Naming format:
 

--- a/.agents/skills/csharp-xunit/SKILL.md
+++ b/.agents/skills/csharp-xunit/SKILL.md
@@ -10,7 +10,8 @@ Your goal is to help me write effective unit tests with XUnit, covering both sta
 ## Project Setup
 
 - Use a separate test project with naming convention `[ProjectName].Tests`
-- Reference Microsoft.NET.Test.Sdk, xunit, and xunit.runner.visualstudio packages
+- Reference Microsoft.NET.Test.Sdk, xunit.v3, and xunit.runner.visualstudio packages
+- Test projects must set `<OutputType>Exe</OutputType>` (xUnit v3 requirement)
 - Create test classes that match the classes being tested (e.g., `CalculatorTests` for `Calculator`)
 - Use .NET SDK test commands: `dotnet test` for running tests
 
@@ -50,11 +51,13 @@ Your goal is to help me write effective unit tests with XUnit, covering both sta
 - Use `Assert.Contains`/`Assert.DoesNotContain` for collections
 - Use `Assert.Matches`/`Assert.DoesNotMatch` for regex pattern matching
 - Use `Assert.Throws<T>` or `await Assert.ThrowsAsync<T>` to test exceptions
-- **Do not use FluentAssertions** — it requires a commercial licence under the Xceed Software licence and is prohibited in this open-source project (see [DEC-006](../../plan/DECISIONS.md#dec-006-no-fluentassertions--xunit-built-in-assertions-only)). Use xUnit's built-in `Assert.*` methods exclusively.
+- **Do not use FluentAssertions, AwesomeAssertions, Shouldly, Moq, NUnit, or MSTest** — see [DEC-006](../../plan/DECISIONS.md#dec-006-no-fluentassertions--xunit-built-in-assertions-only) and [DEC-016](../../plan/DECISIONS.md#dec-016-formalised-testing-standard--xunit-v3-nsubstitute-playwright-e2e). Use xUnit's built-in `Assert.*` methods exclusively.
 
 ## Mocking and Isolation
 
-- Use `Moq` alongside xUnit for mocking dependencies
+- Use `NSubstitute` alongside xUnit v3 for mocking dependencies
+- Create substitutes with `Substitute.For<TInterface>()`
+- Verify calls with `Received()` and `DidNotReceive()`
 - Mock dependencies to isolate units under test
 - Use interfaces to facilitate mocking
 - Consider using a DI container for complex test setups

--- a/.agents/skills/dotnet-best-practices/SKILL.md
+++ b/.agents/skills/dotnet-best-practices/SKILL.md
@@ -49,8 +49,8 @@ Your task is to ensure .NET/C# code in `${selection}` meets the SoloDevBoard sta
 ## Testing Standards
 
 - Use `xUnit` for tests
-- Use `Moq` for mocking dependencies
-- Use xUnit's built-in `Assert.*` methods for all assertions. **Do not add FluentAssertions** — it requires a commercial licence and is prohibited in this open-source project (see [DEC-006](../../plan/DECISIONS.md#dec-006-no-fluentassertions--xunit-built-in-assertions-only))
+- Use `NSubstitute` for mocking dependencies
+- Use xUnit v3's built-in `Assert.*` methods for all assertions. **Do not add FluentAssertions, AwesomeAssertions, Shouldly, Moq, NUnit, or MSTest** — see [DEC-006](../../plan/DECISIONS.md#dec-006-no-fluentassertions--xunit-built-in-assertions-only) and [DEC-016](../../plan/DECISIONS.md#dec-016-formalised-testing-standard--xunit-v3-nsubstitute-playwright-e2e).
 - Follow AAA pattern (Arrange, Act, Assert)
 - Use test naming convention: `MethodUnderTest_Scenario_ExpectedOutcome`
 - Test both success and failure scenarios

--- a/.agents/skills/mudblazor/references/BUNIT.md
+++ b/.agents/skills/mudblazor/references/BUNIT.md
@@ -11,7 +11,7 @@ using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
 using MudBlazor.Services;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 public class LabelsPageTests : BunitContext

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,8 +36,8 @@ updates:
           - "bunit"
           - "coverlet.collector"
           - "Microsoft.NET.Test.Sdk"
-          - "Moq"
-          - "xunit"
+          - "NSubstitute"
+          - "xunit.v3"
           - "xunit.*"
         update-types:
           - "minor"

--- a/.github/instructions/dotnet-framework.instructions.md
+++ b/.github/instructions/dotnet-framework.instructions.md
@@ -28,9 +28,12 @@ This repository uses SDK-style projects:
 - Follow repository conventions for file-scoped namespaces, nullable reference types, and primary constructors where appropriate.
 
 ## Testing Baseline
-- Test framework: `xUnit`.
-- Mocking framework: `Moq`.
-- Assertions: xUnit built-in `Assert.*` methods. **Do not use FluentAssertions** — it requires a commercial licence under the Xceed Software licence and is prohibited in this open-source project (see [DEC-006](../../plan/DECISIONS.md#dec-006-no-fluentassertions--xunit-built-in-assertions-only)).
+- Test framework: `xUnit` v3 (`xunit.v3` package; test projects use `<OutputType>Exe</OutputType>`).
+- Mocking framework: `NSubstitute`.
+- Component tests: `bUnit` in the App test project.
+- End-to-end tests: `Playwright` for key user journeys (separate from `dotnet test`).
+- AppHost: do not test .NET Aspire AppHost modelling or orchestration.
+- Assertions: xUnit built-in `Assert.*` methods. **Do not use FluentAssertions, AwesomeAssertions, Shouldly, Moq, NUnit, or MSTest** (see [DEC-006](../../plan/DECISIONS.md#dec-006-no-fluentassertions--xunit-built-in-assertions-only) and [DEC-016](../../plan/DECISIONS.md#dec-016-formalised-testing-standard--xunit-v3-nsubstitute-playwright-e2e)).
 - Naming convention: `MethodUnderTest_Scenario_ExpectedOutcome`.
 - Structure tests using Arrange / Act / Assert with blank lines between sections.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,13 @@ jobs:
             dotnet run --project src/App/SoloDevBoard.App --no-launch-profile --no-build &
           APP_PID=$!
 
-          for i in $(seq 1 60); do
-            if curl -sf http://localhost:5080/health > /dev/null; then
-              break
+          ATTEMPTS=0
+          until curl -sf http://localhost:5080/health > /dev/null; do
+            ATTEMPTS=$((ATTEMPTS + 1))
+            if [ "$ATTEMPTS" -ge 60 ]; then
+              echo "Application failed to become healthy within 120 seconds."
+              kill "$APP_PID" || true
+              exit 1
             fi
             sleep 2
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,62 @@ jobs:
 
       - name: Run tests
         run: dotnet test SoloDevBoard.slnx --no-build --verbosity normal
+
+  e2e:
+    name: End-to-End (Playwright)
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up .NET SDK from global.json
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: global.json
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: tests/E2E/package-lock.json
+
+      - name: Restore and build solution
+        run: |
+          dotnet restore SoloDevBoard.slnx
+          dotnet build src/App/SoloDevBoard.App/SoloDevBoard.App.csproj --no-restore
+
+      - name: Install Playwright dependencies
+        working-directory: tests/E2E
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run Playwright smoke tests
+        env:
+          PLAYWRIGHT_BASE_URL: http://localhost:5080
+        run: |
+          ASPNETCORE_URLS=http://localhost:5080 \
+            ASPNETCORE_ENVIRONMENT=Development \
+            GitHubAuth__PersonalAccessToken=ci-e2e-placeholder \
+            GitHubAuth__OwnerLogin=ci-test-user \
+            HostedAdmissionControl__Enabled=false \
+            dotnet run --project src/App/SoloDevBoard.App --no-launch-profile --no-build &
+          APP_PID=$!
+
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:5080/health > /dev/null; then
+              break
+            fi
+            sleep 2
+          done
+
+          cd tests/E2E
+          PLAYWRIGHT_HTML_OPEN=never npm test
+          TEST_EXIT=$?
+
+          kill $APP_PID || true
+          exit $TEST_EXIT

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,12 +87,15 @@ DTOs are `sealed record` types named `<Entity>Dto`, co-located in `SoloDevBoard.
 
 ## Testing
 
-- **Framework:** xUnit
-- **Mocking:** Moq
+- **Framework:** xUnit v3
+- **Mocking:** NSubstitute
+- **Component tests:** bUnit (App test project only; see [DEC-007](plan/DECISIONS.md#dec-007-bunit-for-blazor-component-testing))
+- **End-to-end tests:** Playwright for key user journeys (see [DEC-016](plan/DECISIONS.md#dec-016-formalised-testing-standard--xunit-v3-nsubstitute-playwright-e2e))
+- **AppHost:** Do not test .NET Aspire AppHost modelling or orchestration.
 - **Naming convention:** `MethodUnderTest_Scenario_ExpectedOutcome`
 - Test projects mirror the structure of source projects.
 - Arrange / Act / Assert sections separated by blank lines (no comments required).
-- Use xUnit's built-in `Assert.*` methods for all assertions. **Do not add FluentAssertions** — it requires a commercial licence and is prohibited in this open-source project (see [DEC-006](plan/DECISIONS.md#dec-006-no-fluentassertions--xunit-built-in-assertions-only)).
+- Use xUnit's built-in `Assert.*` methods for all assertions. **Do not add FluentAssertions, AwesomeAssertions, Shouldly, Moq, NUnit, or MSTest** (see [DEC-006](plan/DECISIONS.md#dec-006-no-fluentassertions--xunit-built-in-assertions-only) and [DEC-016](plan/DECISIONS.md#dec-016-formalised-testing-standard--xunit-v3-nsubstitute-playwright-e2e)).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,10 +102,12 @@ When suggesting a feature:
    - Apply file-scoped namespaces
 
 3. **Testing:**
-   - Include unit tests for new functionality (xUnit + Moq)
+   - Include unit tests for new functionality (xUnit v3 + NSubstitute)
    - Use the naming convention: `MethodUnderTest_Scenario_ExpectedOutcome`
    - All tests must pass: `dotnet test`
    - Aim for meaningful test coverage, not just coverage percentage
+   - Use Playwright for end-to-end user journeys where unit tests cannot validate the full workflow.
+   - Do not test .NET Aspire AppHost modelling or orchestration.
 
 4. **Architecture:**
    - Follow the clean/layered architecture (Domain → Application → Infrastructure → App)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,8 +28,8 @@
     <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/plan/CURSOR_CLOUD.md
+++ b/plan/CURSOR_CLOUD.md
@@ -14,7 +14,8 @@ Maintainer notes for running SoloDevBoard in the Cursor Cloud VM. Standard local
 ## Build, test, lint
 
 - Build: `dotnet build SoloDevBoard.slnx`.
-- Test (xUnit, fully offline — GitHub is mocked): `dotnet test SoloDevBoard.slnx`.
+- Test (xUnit v3 + NSubstitute, fully offline — GitHub is mocked): `dotnet test SoloDevBoard.slnx`.
+- End-to-end (Playwright): see [`tests/E2E/README.md`](../tests/E2E/README.md).
 - Lint is `dotnet format SoloDevBoard.slnx --verify-no-changes` (same check CI runs in `.github/workflows/ci.yml`). `EnforceCodeStyleInBuild` is on, so style violations also surface during build.
 
 ---

--- a/plan/DECISIONS.md
+++ b/plan/DECISIONS.md
@@ -41,7 +41,7 @@ A formal migration to GitHub Spec Kit is planned — see [`plan/SPEC_KIT_MIGRATI
 
 ### DEC-004: Moq for test mocking
 
-**Status:** Active  
+**Status:** Superseded by DEC-016  
 **Date:** 2026-02-28  
 **Legacy:** [ADR-0006](../adr/archive/0006-moq-mocking-library.md)  
 **Constitution:** [AGENTS.md — Testing](../AGENTS.md#testing)  
@@ -70,10 +70,10 @@ A formal migration to GitHub Spec Kit is planned — see [`plan/SPEC_KIT_MIGRATI
 
 ### DEC-007: bUnit for Blazor component testing
 
-**Status:** Active  
+**Status:** Active (amended by DEC-016)  
 **Date:** 2026-03-06  
 **Legacy:** [ADR-0010](../adr/archive/0010-bunit-component-testing.md)  
-**Summary:** Use bUnit for Blazor component tests in the App test project. Reject Playwright-only coverage where a bUnit unit/component test suffices for logic and rendering contracts.
+**Summary:** Use bUnit for Blazor component tests in the App test project. Reject Playwright-only coverage where a bUnit unit/component test suffices for logic and rendering contracts. Playwright end-to-end tests complement bUnit for cross-page user journeys (see DEC-016).
 
 ---
 
@@ -152,10 +152,21 @@ A formal migration to GitHub Spec Kit is planned — see [`plan/SPEC_KIT_MIGRATI
 
 ---
 
+### DEC-016: Formalised testing standard — xUnit v3, NSubstitute, Playwright E2E
+
+**Status:** Active  
+**Date:** 2026-07-21  
+**Supersedes:** DEC-004  
+**Constitution:** [AGENTS.md — Testing](../AGENTS.md#testing)  
+**Summary:** Use xUnit v3 for all automated unit and component tests. Use NSubstitute for mocks, stubs, and test doubles. Use built-in xUnit `Assert.*` methods only. Use bUnit for Blazor component tests (DEC-007). Use Playwright for end-to-end tests covering key user journeys — not as a replacement for unit tests. Do not test .NET Aspire AppHost modelling or orchestration. Reject FluentAssertions, AwesomeAssertions, Shouldly, Moq, NUnit, and MSTest.
+
+---
+
 ## Superseded legacy (archive only)
 
 | Legacy ADR | Superseded by | Notes |
 |------------|---------------|-------|
-| [ADR-0002](../adr/archive/0002-testing-framework.md) | DEC-004, DEC-006 | NSubstitute and FluentAssertions removed from testing stack |
+| [ADR-0002](../adr/archive/0002-testing-framework.md) | DEC-016, DEC-006 | Testing stack standardised on xUnit v3 and NSubstitute |
+| DEC-004 | DEC-016 | Moq replaced by NSubstitute per formalised testing standard |
 | [ADR-0003](../adr/archive/0003-bicep-infrastructure.md) | DEC-015 | Hand-maintained Bicep replaced by Aspire-generated deployment |
 | [ADR-0009](../adr/archive/0009-fluent-ui-blazor-component-library.md) | DEC-009 | Fluent UI Blazor replaced by MudBlazor |

--- a/plan/PM_RUNBOOK.md
+++ b/plan/PM_RUNBOOK.md
@@ -130,7 +130,7 @@ Implement issue #[number]
 **What it does:**
 - Invokes the **Delivery** contract ([`.agents/contracts/delivery.md`](../.agents/contracts/delivery.md))
 - Writes code following layered architecture (Domain/Application/Infrastructure/App)
-- Creates xUnit tests (Moq, `Assert.*`, correct naming)
+- Creates xUnit v3 tests (NSubstitute, `Assert.*`, correct naming)
 - Updates user-facing docs in `docs/user-guide/` if needed
 - Creates ADR in `adr/` if architectural decision made
 - Ensures UK English throughout
@@ -380,7 +380,7 @@ START
 
 **Responsibilities:**
 - Implements code (Domain/Application/Infrastructure/App layers)
-- Creates xUnit tests (Moq, `Assert.*`)
+- Creates xUnit v3 tests (NSubstitute, `Assert.*`)
 - Updates user-facing docs
 - Creates ADRs for architectural decisions
 - Ensures UK English throughout

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
@@ -1,6 +1,6 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
+using NSubstitute;
 using MudBlazor.Services;
 using SoloDevBoard.App.Components.Features.About.Pages;
 using SoloDevBoard.Application.Services.Common;
@@ -11,7 +11,7 @@ namespace SoloDevBoard.App.Tests;
 public sealed class AboutTests : BunitContext
 {
     private const string TestVersion = "1.2.3";
-    private readonly Mock<IAppVersionService> _appVersionServiceMock = new();
+    private readonly IAppVersionService _appVersionService = Substitute.For<IAppVersionService>();
 
     /// <summary>Initialises MudBlazor services and test doubles for About page rendering.</summary>
     public AboutTests()
@@ -19,18 +19,14 @@ public sealed class AboutTests : BunitContext
         JSInterop.Mode = JSRuntimeMode.Loose;
         Services.AddMudServices();
         ConfigureVersionService();
-        Services.AddSingleton(_appVersionServiceMock.Object);
+        Services.AddSingleton(_appVersionService);
     }
 
     private void ConfigureVersionService()
     {
-        _appVersionServiceMock
-            .Setup(service => service.Version)
-            .Returns(TestVersion);
+        _appVersionService.Version.Returns(TestVersion);
 
-        _appVersionServiceMock
-            .Setup(service => service.UserAgent)
-            .Returns($"SoloDevBoard/{TestVersion}");
+        _appVersionService.UserAgent.Returns($"SoloDevBoard/{TestVersion}");
     }
 
     [Fact]

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
@@ -1,7 +1,7 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using MudBlazor.Services;
+using NSubstitute;
 using SoloDevBoard.App.Components.Features.About.Pages;
 using SoloDevBoard.Application.Services.Common;
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
@@ -1,8 +1,8 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
+using NSubstitute;
 using SoloDevBoard.App.Components.Features.Audit.Pages;
 using SoloDevBoard.App.Components.Shared.Components;
 using SoloDevBoard.Application.Services.Audit;
@@ -134,7 +134,7 @@ public sealed class AuditTests
         cut.Find("[data-testid='audit-load-selected-button']").Click();
 
         // Assert
-        _auditDashboardService.Received(1).GetAuditSummaryAsync( Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>());
+        await _auditDashboardService.Received(1).GetAuditSummaryAsync(Arg.Is<IReadOnlyList<string>>(repos => repos!.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>());
 
         cut.WaitForAssertion(() =>
         {
@@ -256,8 +256,8 @@ public sealed class AuditTests
                 CreateRepository("owner", "repo-b"),
             ]);
 
-        _auditDashboardService.GetAuditSummaryAsync(Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 2), Arg.Any<CancellationToken>()).Returns(summary);
-        _auditDashboardService.GetAuditSummaryAsync(Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>()).Returns([new RepositoryAuditSummaryDto("owner/repo-a", 4, 2, 1, 1, 0)]);
+        _auditDashboardService.GetAuditSummaryAsync(Arg.Is<IReadOnlyList<string>>(repos => repos!.Count == 2), Arg.Any<CancellationToken>()).Returns(summary);
+        _auditDashboardService.GetAuditSummaryAsync(Arg.Is<IReadOnlyList<string>>(repos => repos!.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>()).Returns([new RepositoryAuditSummaryDto("owner/repo-a", 4, 2, 1, 1, 0)]);
 
         await using var ctx = CreateContext();
 
@@ -269,10 +269,10 @@ public sealed class AuditTests
         cut.Find("[data-testid='audit-load-selected-button']").Click();
 
         // Assert
-        _auditDashboardService.Received(1).GetAuditSummaryAsync( Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>());
-        _auditDashboardService.Received(1).GetUnlabelledIssuesAsync( Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>());
-        _auditDashboardService.Received(1).GetStalePullRequestsAsync( Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), 14, Arg.Any<CancellationToken>());
-        _auditDashboardService.Received(1).GetFailingWorkflowRunsAsync( Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>());
+        await _auditDashboardService.Received(1).GetAuditSummaryAsync(Arg.Is<IReadOnlyList<string>>(repos => repos!.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>());
+        await _auditDashboardService.Received(1).GetUnlabelledIssuesAsync(Arg.Is<IReadOnlyList<string>>(repos => repos!.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>());
+        await _auditDashboardService.Received(1).GetStalePullRequestsAsync(Arg.Is<IReadOnlyList<string>>(repos => repos!.Count == 1 && repos[0] == "owner/repo-a"), 14, Arg.Any<CancellationToken>());
+        await _auditDashboardService.Received(1).GetFailingWorkflowRunsAsync(Arg.Is<IReadOnlyList<string>>(repos => repos!.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>());
     }
 
     private BunitContext CreateContext()

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
@@ -1,6 +1,6 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
+using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
 using SoloDevBoard.App.Components.Features.Audit.Pages;
@@ -13,20 +13,16 @@ namespace SoloDevBoard.App.Tests;
 /// <summary>Component tests for the <see cref="Audit"/> page.</summary>
 public sealed class AuditTests
 {
-    private readonly Mock<IAuditDashboardService> _auditDashboardServiceMock = new();
-    private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
+    private readonly IAuditDashboardService _auditDashboardService = Substitute.For<IAuditDashboardService>();
+    private readonly IRepositoryService _repositoryService = Substitute.For<IRepositoryService>();
 
     [Fact]
     public async Task Audit_WhileServiceIsLoading_ShowsFeedbackRegionSkeleton()
     {
         // Arrange
         var tcs = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .Returns(tcs.Task);
-        _auditDashboardServiceMock
-            .Setup(service => service.GetAuditSummaryAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<RepositoryAuditSummaryDto>());
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns(tcs.Task);
+        _auditDashboardService.GetAuditSummaryAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(Array.Empty<RepositoryAuditSummaryDto>());
 
         await using var ctx = CreateContext();
 
@@ -43,9 +39,7 @@ public sealed class AuditTests
     public async Task Audit_WhenServiceReturnsNoRepositories_ShowsEmptyStateInFeedbackRegion()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<RepositoryDto>());
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns(Array.Empty<RepositoryDto>());
 
         await using var ctx = CreateContext();
 
@@ -71,17 +65,12 @@ public sealed class AuditTests
             new("owner/repo-a", 4, 3, 1, 1, 0),
         };
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
-            [
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
                 CreateRepository("owner", "repo-a"),
                 CreateRepository("owner", "repo-b"),
             ]);
 
-        _auditDashboardServiceMock
-            .Setup(service => service.GetAuditSummaryAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(summary);
+        _auditDashboardService.GetAuditSummaryAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(summary);
 
         await using var ctx = CreateContext();
 
@@ -122,15 +111,11 @@ public sealed class AuditTests
     public async Task Audit_WhenLoadingSelectedRepositories_ShowsAuditLoadingState()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo-a")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo-a")]);
 
         var summaryCompletionSource = new TaskCompletionSource<IReadOnlyList<RepositoryAuditSummaryDto>>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        _auditDashboardServiceMock
-            .Setup(service => service.GetAuditSummaryAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .Returns(summaryCompletionSource.Task);
+        _auditDashboardService.GetAuditSummaryAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(summaryCompletionSource.Task);
 
         await using var ctx = CreateContext();
 
@@ -149,11 +134,7 @@ public sealed class AuditTests
         cut.Find("[data-testid='audit-load-selected-button']").Click();
 
         // Assert
-        _auditDashboardServiceMock.Verify(
-            service => service.GetAuditSummaryAsync(
-                It.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"),
-                It.IsAny<CancellationToken>()),
-            Times.Once);
+        _auditDashboardService.Received(1).GetAuditSummaryAsync( Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>());
 
         cut.WaitForAssertion(() =>
         {
@@ -174,9 +155,7 @@ public sealed class AuditTests
             new("owner/repo-a", 4, 2, 1, 1, 1),
         };
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo-a")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo-a")]);
 
         var issues = new List<IssueDto>
         {
@@ -193,21 +172,13 @@ public sealed class AuditTests
             new("build", "completed", "failure", "https://github.com/owner/repo-a/actions/runs/123", "owner/repo-a", "main"),
         };
 
-        _auditDashboardServiceMock
-            .Setup(service => service.GetAuditSummaryAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(summary);
+        _auditDashboardService.GetAuditSummaryAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(summary);
 
         await using var ctx = CreateContext();
 
-        _auditDashboardServiceMock
-            .Setup(service => service.GetUnlabelledIssuesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(issues);
-        _auditDashboardServiceMock
-            .Setup(service => service.GetStalePullRequestsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(pullRequests);
-        _auditDashboardServiceMock
-            .Setup(service => service.GetFailingWorkflowRunsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(workflows);
+        _auditDashboardService.GetUnlabelledIssuesAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(issues);
+        _auditDashboardService.GetStalePullRequestsAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(pullRequests);
+        _auditDashboardService.GetFailingWorkflowRunsAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(workflows);
 
         // Act
         var cut = ctx.Render<Audit>();
@@ -248,13 +219,9 @@ public sealed class AuditTests
             new("owner/repo-a", 1, 1, 0, 0, 0),
         };
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo-a")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo-a")]);
 
-        _auditDashboardServiceMock
-            .Setup(service => service.GetAuditSummaryAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(summary);
+        _auditDashboardService.GetAuditSummaryAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(summary);
 
         await using var ctx = CreateContext();
 
@@ -284,20 +251,13 @@ public sealed class AuditTests
             new("owner/repo-b", 3, 1, 0, 0, 0),
         };
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
-            [
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
                 CreateRepository("owner", "repo-a"),
                 CreateRepository("owner", "repo-b"),
             ]);
 
-        _auditDashboardServiceMock
-            .Setup(service => service.GetAuditSummaryAsync(It.Is<IReadOnlyList<string>>(repos => repos.Count == 2), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(summary);
-        _auditDashboardServiceMock
-            .Setup(service => service.GetAuditSummaryAsync(It.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new RepositoryAuditSummaryDto("owner/repo-a", 4, 2, 1, 1, 0)]);
+        _auditDashboardService.GetAuditSummaryAsync(Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 2), Arg.Any<CancellationToken>()).Returns(summary);
+        _auditDashboardService.GetAuditSummaryAsync(Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>()).Returns([new RepositoryAuditSummaryDto("owner/repo-a", 4, 2, 1, 1, 0)]);
 
         await using var ctx = CreateContext();
 
@@ -309,47 +269,24 @@ public sealed class AuditTests
         cut.Find("[data-testid='audit-load-selected-button']").Click();
 
         // Assert
-        _auditDashboardServiceMock.Verify(
-            service => service.GetAuditSummaryAsync(
-                It.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"),
-                It.IsAny<CancellationToken>()),
-            Times.Once);
-        _auditDashboardServiceMock.Verify(
-            service => service.GetUnlabelledIssuesAsync(
-                It.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"),
-                It.IsAny<CancellationToken>()),
-            Times.Once);
-        _auditDashboardServiceMock.Verify(
-            service => service.GetStalePullRequestsAsync(
-                It.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"),
-                14,
-                It.IsAny<CancellationToken>()),
-            Times.Once);
-        _auditDashboardServiceMock.Verify(
-            service => service.GetFailingWorkflowRunsAsync(
-                It.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"),
-                It.IsAny<CancellationToken>()),
-            Times.Once);
+        _auditDashboardService.Received(1).GetAuditSummaryAsync( Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>());
+        _auditDashboardService.Received(1).GetUnlabelledIssuesAsync( Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>());
+        _auditDashboardService.Received(1).GetStalePullRequestsAsync( Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), 14, Arg.Any<CancellationToken>());
+        _auditDashboardService.Received(1).GetFailingWorkflowRunsAsync( Arg.Is<IReadOnlyList<string>>(repos => repos.Count == 1 && repos[0] == "owner/repo-a"), Arg.Any<CancellationToken>());
     }
 
     private BunitContext CreateContext()
     {
-        _auditDashboardServiceMock
-            .Setup(service => service.GetUnlabelledIssuesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<IssueDto>());
-        _auditDashboardServiceMock
-            .Setup(service => service.GetStalePullRequestsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<PullRequestDto>());
-        _auditDashboardServiceMock
-            .Setup(service => service.GetFailingWorkflowRunsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<WorkflowRunDto>());
+        _auditDashboardService.GetUnlabelledIssuesAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(Array.Empty<IssueDto>());
+        _auditDashboardService.GetStalePullRequestsAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Array.Empty<PullRequestDto>());
+        _auditDashboardService.GetFailingWorkflowRunsAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(Array.Empty<WorkflowRunDto>());
 
         var ctx = new BunitContext();
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
         ctx.Services.AddTestHostedAuthenticationRecovery();
-        ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
-        ctx.Services.AddScoped(_ => _auditDashboardServiceMock.Object);
+        ctx.Services.AddScoped(_ => _repositoryService);
+        ctx.Services.AddScoped(_ => _auditDashboardService);
 
         ctx.Render<MudPopoverProvider>();
         ctx.Render<MudDialogProvider>();

--- a/tests/App.Tests/SoloDevBoard.App.Tests/BoardRulesTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/BoardRulesTests.cs
@@ -1,6 +1,6 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
+using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
 using SoloDevBoard.App.Components.Features.BoardRules.Pages;
@@ -13,17 +13,15 @@ namespace SoloDevBoard.App.Tests;
 /// <summary>Component tests for the <see cref="BoardRules"/> page.</summary>
 public sealed class BoardRulesTests
 {
-    private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
-    private readonly Mock<IBoardRulesService> _boardRulesServiceMock = new();
+    private readonly IRepositoryService _repositoryService = Substitute.For<IRepositoryService>();
+    private readonly IBoardRulesService _boardRulesService = Substitute.For<IBoardRulesService>();
 
     [Fact]
     public async Task BoardRules_WhileRepositoryServiceIsLoading_ShowsLoadingState()
     {
         // Arrange
         var repositoriesTask = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .Returns(repositoriesTask.Task);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns(repositoriesTask.Task);
 
         await using var ctx = CreateContext();
 
@@ -38,9 +36,7 @@ public sealed class BoardRulesTests
     public async Task BoardRules_InitialLoad_ShowsEmptyVisualisationPrompt()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
                 CreateRepository("owner", "repo-a"),
             ]);
 
@@ -61,9 +57,7 @@ public sealed class BoardRulesTests
     public async Task BoardRules_PageLayout_RendersRepositorySelectorBeforeVisualisationRegion()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
                 CreateRepository("owner", "repo-a"),
             ]);
 
@@ -92,13 +86,9 @@ public sealed class BoardRulesTests
         // Arrange
         var repository = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repository]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto(
             [
                 new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
                 new BoardRulesProjectBoardOptionDto("PVT_beta", "Beta Board", "owner"),
@@ -106,9 +96,7 @@ public sealed class BoardRulesTests
             2,
             0));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesDefinitionDto(
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", Arg.Any<CancellationToken>()).Returns(new BoardRulesDefinitionDto(
                 "PVT_alpha",
                 "Alpha Board",
                 "owner",
@@ -134,12 +122,8 @@ public sealed class BoardRulesTests
             Assert.Single(cut.FindAll("[data-testid='board-rules-board-context-ready-state']"));
         });
 
-        _boardRulesServiceMock.Verify(
-            service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()),
-            Times.Once);
-        _boardRulesServiceMock.Verify(
-            service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", It.IsAny<CancellationToken>()),
-            Times.Once);
+        _boardRulesService.Received(1).GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>());
+        _boardRulesService.Received(1).GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -148,13 +132,9 @@ public sealed class BoardRulesTests
         // Arrange
         var repository = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repository]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto([], 0, 0));
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto([], 0, 0));
 
         await using var ctx = CreateContext();
 
@@ -178,22 +158,16 @@ public sealed class BoardRulesTests
         // Arrange
         var repository = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repository]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto(
             [
                 new BoardRulesProjectBoardOptionDto("PVT_public", "Public Board", "owner"),
             ],
             2,
             1));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_public", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesDefinitionDto(
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-a", "PVT_public", Arg.Any<CancellationToken>()).Returns(new BoardRulesDefinitionDto(
                 "PVT_public",
                 "Public Board",
                 "owner",
@@ -227,22 +201,16 @@ public sealed class BoardRulesTests
         // Arrange
         var repository = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repository]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto(
             [
                 new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
             ],
             1,
             0));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesDefinitionDto(
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", Arg.Any<CancellationToken>()).Returns(new BoardRulesDefinitionDto(
                 "PVT_alpha",
                 "Alpha Board",
                 "owner",
@@ -291,13 +259,9 @@ public sealed class BoardRulesTests
     {
         var repository = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repository]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto(
             [
                 new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
                 new BoardRulesProjectBoardOptionDto("PVT_beta", "Beta Board", "owner"),
@@ -305,9 +269,7 @@ public sealed class BoardRulesTests
             2,
             0));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesDefinitionDto(
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", Arg.Any<CancellationToken>()).Returns(new BoardRulesDefinitionDto(
                 "PVT_alpha",
                 "Alpha Board",
                 "owner",
@@ -320,9 +282,7 @@ public sealed class BoardRulesTests
                 ],
                 []));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_beta", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesDefinitionDto(
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-a", "PVT_beta", Arg.Any<CancellationToken>()).Returns(new BoardRulesDefinitionDto(
                 "PVT_beta",
                 "Beta Board",
                 "owner",
@@ -362,31 +322,23 @@ public sealed class BoardRulesTests
         var repositoryA = CreateRepository("owner", "repo-a");
         var repositoryB = CreateRepository("owner", "repo-b");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repositoryA, repositoryB]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repositoryA, repositoryB]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto(
             [
                 new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
             ],
             1,
             0));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-b", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-b", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto(
             [
                 new BoardRulesProjectBoardOptionDto("PVT_beta", "Beta Board", "owner"),
             ],
             1,
             0));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesDefinitionDto(
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", Arg.Any<CancellationToken>()).Returns(new BoardRulesDefinitionDto(
                 "PVT_alpha",
                 "Alpha Board",
                 "owner",
@@ -399,9 +351,7 @@ public sealed class BoardRulesTests
                 ],
                 []));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-b", "PVT_beta", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesDefinitionDto(
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-b", "PVT_beta", Arg.Any<CancellationToken>()).Returns(new BoardRulesDefinitionDto(
                 "PVT_beta",
                 "Beta Board",
                 "owner",
@@ -439,22 +389,16 @@ public sealed class BoardRulesTests
     {
         var repository = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repository]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto(
             [
                 new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
             ],
             1,
             0));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesDefinitionDto(
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", Arg.Any<CancellationToken>()).Returns(new BoardRulesDefinitionDto(
                 "PVT_alpha",
                 "Alpha Board",
                 "owner",
@@ -488,9 +432,8 @@ public sealed class BoardRulesTests
     public async Task BoardRules_RepositoryLoadFailure_ShowsRetryAction()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("GitHub unavailable"));
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<IReadOnlyList<RepositoryDto>>(new HttpRequestException("GitHub unavailable")));
 
         await using var ctx = CreateContext();
 
@@ -509,9 +452,7 @@ public sealed class BoardRulesTests
     public async Task BoardRules_NoActiveRepositories_ShowsEmptyRepositoriesState()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([]);
 
         await using var ctx = CreateContext();
 
@@ -532,13 +473,10 @@ public sealed class BoardRulesTests
         // Arrange
         var repository = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repository]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("GitHub unavailable"));
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<BoardRulesProjectBoardDiscoveryDto>(new HttpRequestException("GitHub unavailable")));
 
         await using var ctx = CreateContext();
         var cut = ctx.Render<BoardRules>();
@@ -559,22 +497,17 @@ public sealed class BoardRulesTests
         // Arrange
         var repository = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repository]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto(
             [
                 new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
             ],
             1,
             0));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("GitHub unavailable"));
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<BoardRulesDefinitionDto>(new HttpRequestException("GitHub unavailable")));
 
         await using var ctx = CreateContext();
         var cut = ctx.Render<BoardRules>();
@@ -596,13 +529,9 @@ public sealed class BoardRulesTests
         var repository = CreateRepository("owner", "repo-a");
         var projectBoardsTask = new TaskCompletionSource<BoardRulesProjectBoardDiscoveryDto>();
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repository]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .Returns(projectBoardsTask.Task);
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(projectBoardsTask.Task);
 
         await using var ctx = CreateContext();
         var cut = ctx.Render<BoardRules>();
@@ -627,13 +556,9 @@ public sealed class BoardRulesTests
         // Arrange
         var repository = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repository]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto(
             [
                 new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
                 new BoardRulesProjectBoardOptionDto("PVT_beta", "Beta Board", "owner"),
@@ -641,9 +566,7 @@ public sealed class BoardRulesTests
             2,
             0));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesDefinitionDto(
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-a", Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new BoardRulesDefinitionDto(
                 "PVT_alpha",
                 "Alpha Board",
                 "owner",
@@ -670,22 +593,16 @@ public sealed class BoardRulesTests
         // Arrange
         var repository = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repository]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto(
             [
                 new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
             ],
             1,
             0));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesDefinitionDto(
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", Arg.Any<CancellationToken>()).Returns(new BoardRulesDefinitionDto(
                 "PVT_alpha",
                 "Alpha Board",
                 "owner",
@@ -715,9 +632,7 @@ public sealed class BoardRulesTests
     public async Task BoardRules_CompareModeEnabled_ShowsComparisonSelector()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
                 CreateRepository("owner", "repo-a"),
                 CreateRepository("owner", "repo-b"),
             ]);
@@ -777,39 +692,27 @@ public sealed class BoardRulesTests
                     "Column 'To Do' exists on the primary board but not on the comparison board."),
             ]);
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repositoryA, repositoryB]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repositoryA, repositoryB]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto(
             [
                 new BoardRulesProjectBoardOptionDto("PVT_alpha", "Alpha Board", "owner"),
             ],
             1,
             0));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-b", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-b", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto(
             [
                 new BoardRulesProjectBoardOptionDto("PVT_beta", "Beta Board", "owner"),
             ],
             1,
             0));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(primaryDefinition);
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", Arg.Any<CancellationToken>()).Returns(primaryDefinition);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-b", "PVT_beta", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(comparisonDefinition);
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-b", "PVT_beta", Arg.Any<CancellationToken>()).Returns(comparisonDefinition);
 
-        _boardRulesServiceMock
-            .Setup(service => service.CompareBoardRules(primaryDefinition, comparisonDefinition))
-            .Returns(comparisonResult);
+        _boardRulesService.CompareBoardRules(primaryDefinition, comparisonDefinition).Returns(comparisonResult);
 
         await using var ctx = CreateContext();
         var cut = ctx.Render<BoardRules>();
@@ -833,9 +736,7 @@ public sealed class BoardRulesTests
             Assert.Single(cut.FindAll("[data-testid='board-rules-comparison-secondary-summary']"));
         });
 
-        _boardRulesServiceMock.Verify(
-            service => service.CompareBoardRules(primaryDefinition, comparisonDefinition),
-            Times.Once);
+        _boardRulesService.Received(1).CompareBoardRules(primaryDefinition, comparisonDefinition);
     }
 
     [Fact]
@@ -846,26 +747,18 @@ public sealed class BoardRulesTests
         var repositoryB = CreateRepository("owner", "repo-b");
         var repositoryADiscoveryTask = new TaskCompletionSource<BoardRulesProjectBoardDiscoveryDto>();
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repositoryA, repositoryB]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repositoryA, repositoryB]);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .Returns(repositoryADiscoveryTask.Task);
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(repositoryADiscoveryTask.Task);
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync("owner", "repo-b", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesProjectBoardDiscoveryDto(
+        _boardRulesService.GetProjectBoardOptionsAsync("owner", "repo-b", Arg.Any<CancellationToken>()).Returns(new BoardRulesProjectBoardDiscoveryDto(
             [
                 new BoardRulesProjectBoardOptionDto("PVT_beta", "Beta Board", "owner"),
             ],
             1,
             0));
 
-        _boardRulesServiceMock
-            .Setup(service => service.GetBoardRulesAsync("owner", "repo-b", "PVT_beta", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BoardRulesDefinitionDto(
+        _boardRulesService.GetBoardRulesAsync("owner", "repo-b", "PVT_beta", Arg.Any<CancellationToken>()).Returns(new BoardRulesDefinitionDto(
                 "PVT_beta",
                 "Beta Board",
                 "owner",
@@ -904,8 +797,8 @@ public sealed class BoardRulesTests
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
         ctx.Services.AddTestHostedAuthenticationRecovery();
-        ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
-        ctx.Services.AddScoped(_ => _boardRulesServiceMock.Object);
+        ctx.Services.AddScoped(_ => _repositoryService);
+        ctx.Services.AddScoped(_ => _boardRulesService);
 
         ctx.Render<MudPopoverProvider>();
         ctx.Render<MudDialogProvider>();

--- a/tests/App.Tests/SoloDevBoard.App.Tests/BoardRulesTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/BoardRulesTests.cs
@@ -1,8 +1,8 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
+using NSubstitute;
 using SoloDevBoard.App.Components.Features.BoardRules.Pages;
 using SoloDevBoard.App.Components.Shared.Components;
 using SoloDevBoard.Application.Services.BoardRules;
@@ -122,8 +122,8 @@ public sealed class BoardRulesTests
             Assert.Single(cut.FindAll("[data-testid='board-rules-board-context-ready-state']"));
         });
 
-        _boardRulesService.Received(1).GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>());
-        _boardRulesService.Received(1).GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", Arg.Any<CancellationToken>());
+        await _boardRulesService.Received(1).GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>());
+        await _boardRulesService.Received(1).GetBoardRulesAsync("owner", "repo-a", "PVT_alpha", Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/App.Tests/SoloDevBoard.App.Tests/HostedGitHubAuthGatewayTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/HostedGitHubAuthGatewayTests.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 using SoloDevBoard.App.Authentication;
 using SoloDevBoard.Infrastructure.GitHub;
 using SoloDevBoard.Infrastructure.Identity;
@@ -246,10 +246,8 @@ public sealed class HostedGitHubAuthGatewayTests
             BaseAddress = new Uri("https://api.github.com"),
         };
 
-        var httpClientFactory = new Mock<IHttpClientFactory>();
-        httpClientFactory
-            .Setup(factory => factory.CreateClient(HostedGitHubAuthGateway.HostedGitHubAuthClientName))
-            .Returns(httpClient);
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient(HostedGitHubAuthGateway.HostedGitHubAuthClientName).Returns(httpClient);
 
         var authOptions = Options.Create(new GitHubAuthOptions
         {
@@ -266,7 +264,7 @@ public sealed class HostedGitHubAuthGatewayTests
             HostedOrganisationLoginsClaimType = HostedAuthClaimTypes.OrganisationLogins,
         });
 
-        return new HostedGitHubAuthGateway(httpClientFactory.Object, authOptions, admissionOptions);
+        return new HostedGitHubAuthGateway(httpClientFactory, authOptions, admissionOptions);
     }
 
     private static HttpResponseMessage CreateJsonResponse<T>(T payload)

--- a/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
@@ -1,8 +1,8 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
+using NSubstitute;
 using SoloDevBoard.App.Components.Features.Labels.Pages;
 using SoloDevBoard.App.Components.Shared.Components;
 using SoloDevBoard.Application.Services.Labels;
@@ -55,7 +55,7 @@ public sealed class LabelsTests
             Assert.Empty(cut.FindAll("[data-testid='labels-grid']"));
         });
 
-        _labelManagerService.DidNotReceive().GetLabelsForRepositoriesAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+        await _labelManagerService.DidNotReceive().GetLabelsForRepositoriesAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -165,12 +165,12 @@ public sealed class LabelsTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA, repoB]);
 
-        _labelManagerService.GetLabelsForRepositoriesAsync("owner-a", Arg.Is<IReadOnlyList<string>>(repositories => repositories.SequenceEqual(new[] { "repo-a" })), Arg.Any<CancellationToken>()).Returns([
+        _labelManagerService.GetLabelsForRepositoriesAsync("owner-a", Arg.Is<IReadOnlyList<string>>(repositories => repositories!.SequenceEqual(new[] { "repo-a" })), Arg.Any<CancellationToken>()).Returns([
                 new LabelDto("type/story", "1d76db", "Story label", "repo-a"),
                 new LabelDto("priority/high", "d93f0b", "High priority", "repo-a"),
             ]);
 
-        _labelManagerService.GetLabelsForRepositoriesAsync("owner-b", Arg.Is<IReadOnlyList<string>>(repositories => repositories.SequenceEqual(new[] { "repo-b" })), Arg.Any<CancellationToken>()).Returns([
+        _labelManagerService.GetLabelsForRepositoriesAsync("owner-b", Arg.Is<IReadOnlyList<string>>(repositories => repositories!.SequenceEqual(new[] { "repo-b" })), Arg.Any<CancellationToken>()).Returns([
                 new LabelDto("priority/high", "d93f0b", "High priority", "repo-b"),
             ]);
 
@@ -192,9 +192,9 @@ public sealed class LabelsTests
             Assert.Contains("owner-b/repo-b", cut.Markup);
         });
 
-        _labelManagerService.Received(1).GetLabelsForRepositoriesAsync("owner-a", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+        await _labelManagerService.Received(1).GetLabelsForRepositoriesAsync("owner-a", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
 
-        _labelManagerService.Received(1).GetLabelsForRepositoriesAsync("owner-b", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+        await _labelManagerService.Received(1).GetLabelsForRepositoriesAsync("owner-b", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -342,7 +342,7 @@ public sealed class LabelsTests
             Assert.Contains("Applied taxonomy successfully", cut.Markup);
         });
 
-        _labelManagerService.Received(1).ApplyRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+        await _labelManagerService.Received(1).ApplyRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -367,7 +367,7 @@ public sealed class LabelsTests
         cut.Find("[data-testid='preview-taxonomy-button']").Click();
 
         // Assert
-        _labelManagerService.Received(1).PreviewRecommendedTaxonomyAsync("solodevboard", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+        await _labelManagerService.Received(1).PreviewRecommendedTaxonomyAsync("solodevboard", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -400,7 +400,7 @@ public sealed class LabelsTests
         cut.WaitForAssertion(() => Assert.Contains("Taxonomy preview", cut.Markup));
 
         // Assert
-        _labelManagerService.Received(1).PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+        await _labelManagerService.Received(1).PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
@@ -1,6 +1,6 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
+using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
 using SoloDevBoard.App.Components.Features.Labels.Pages;
@@ -13,17 +13,15 @@ namespace SoloDevBoard.App.Tests;
 /// <summary>Component tests for the <see cref="Labels"/> page.</summary>
 public sealed class LabelsTests
 {
-    private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
-    private readonly Mock<ILabelManagerService> _labelManagerServiceMock = new();
+    private readonly IRepositoryService _repositoryService = Substitute.For<IRepositoryService>();
+    private readonly ILabelManagerService _labelManagerService = Substitute.For<ILabelManagerService>();
 
     [Fact]
     public async Task Labels_WhileRepositoryServiceIsLoading_ShowsLoadingState()
     {
         // Arrange
         var repositoriesTask = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .Returns(repositoriesTask.Task);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns(repositoriesTask.Task);
 
         await using var ctx = CreateContext();
 
@@ -38,9 +36,7 @@ public sealed class LabelsTests
     public async Task Labels_InitialLoad_DoesNotFetchLabelsUntilRequested()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
                 CreateRepository("owner", "repo-a"),
             ]);
 
@@ -59,18 +55,14 @@ public sealed class LabelsTests
             Assert.Empty(cut.FindAll("[data-testid='labels-grid']"));
         });
 
-        _labelManagerServiceMock.Verify(
-            service => service.GetLabelsForRepositoriesAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+        _labelManagerService.DidNotReceive().GetLabelsForRepositoriesAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Labels_PageLayout_RendersRepositorySelectorBeforeTabStrip()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
                 CreateRepository("owner", "repo-a"),
             ]);
 
@@ -99,9 +91,7 @@ public sealed class LabelsTests
         // Arrange
         var repoA = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repoA]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
 
         await using var ctx = CreateContext();
 
@@ -122,9 +112,7 @@ public sealed class LabelsTests
     public async Task Labels_RepositoriesLoaded_ArchivedRepositoriesAreHiddenByDefault()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
                 CreateRepository("owner", "repo-a", isArchived: false),
             ]);
 
@@ -147,13 +135,9 @@ public sealed class LabelsTests
         // Arrange
         var repoA = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repoA]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.GetLabelsForRepositoriesAsync("owner", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<LabelDto>());
+        _labelManagerService.GetLabelsForRepositoriesAsync("owner", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(Array.Empty<LabelDto>());
 
         await using var ctx = CreateContext();
 
@@ -179,20 +163,14 @@ public sealed class LabelsTests
         var repoA = CreateRepository("owner-a", "repo-a");
         var repoB = CreateRepository("owner-b", "repo-b");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repoA, repoB]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA, repoB]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.GetLabelsForRepositoriesAsync("owner-a", It.Is<IReadOnlyList<string>>(repositories => repositories.SequenceEqual(new[] { "repo-a" })), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.GetLabelsForRepositoriesAsync("owner-a", Arg.Is<IReadOnlyList<string>>(repositories => repositories.SequenceEqual(new[] { "repo-a" })), Arg.Any<CancellationToken>()).Returns([
                 new LabelDto("type/story", "1d76db", "Story label", "repo-a"),
                 new LabelDto("priority/high", "d93f0b", "High priority", "repo-a"),
             ]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.GetLabelsForRepositoriesAsync("owner-b", It.Is<IReadOnlyList<string>>(repositories => repositories.SequenceEqual(new[] { "repo-b" })), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.GetLabelsForRepositoriesAsync("owner-b", Arg.Is<IReadOnlyList<string>>(repositories => repositories.SequenceEqual(new[] { "repo-b" })), Arg.Any<CancellationToken>()).Returns([
                 new LabelDto("priority/high", "d93f0b", "High priority", "repo-b"),
             ]);
 
@@ -214,13 +192,9 @@ public sealed class LabelsTests
             Assert.Contains("owner-b/repo-b", cut.Markup);
         });
 
-        _labelManagerServiceMock.Verify(
-            service => service.GetLabelsForRepositoriesAsync("owner-a", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+        _labelManagerService.Received(1).GetLabelsForRepositoriesAsync("owner-a", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
 
-        _labelManagerServiceMock.Verify(
-            service => service.GetLabelsForRepositoriesAsync("owner-b", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+        _labelManagerService.Received(1).GetLabelsForRepositoriesAsync("owner-b", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -229,13 +203,9 @@ public sealed class LabelsTests
         // Arrange
         var repoA = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repoA]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.GetLabelsForRepositoriesAsync("owner", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.GetLabelsForRepositoriesAsync("owner", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns([
                 new LabelDto("type/story", "1d76db", "Story label", "repo-a"),
                 new LabelDto("status/done", "cfd3d7", "Completed", "repo-a"),
             ]);
@@ -275,9 +245,8 @@ public sealed class LabelsTests
     public async Task Labels_RepositoryLoadFails_ShowsRepositorySpecificErrorAndAction()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("Service unavailable"));
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<IReadOnlyList<RepositoryDto>>(new HttpRequestException("Service unavailable")));
 
         await using var ctx = CreateContext();
 
@@ -299,13 +268,9 @@ public sealed class LabelsTests
         // Arrange
         var repoA = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repoA]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.PreviewRecommendedTaxonomyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns([
                 new RecommendedTaxonomyRepositoryPreviewDto(
                     "owner/repo-a",
                     [new LabelDto("type/story", "1d76db", "Story", "owner/repo-a")],
@@ -340,13 +305,9 @@ public sealed class LabelsTests
         // Arrange
         var repoA = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repoA]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.PreviewRecommendedTaxonomyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns([
                 new RecommendedTaxonomyRepositoryPreviewDto(
                     "owner/repo-a",
                     [new LabelDto("type/story", "1d76db", "Story", "owner/repo-a")],
@@ -354,15 +315,11 @@ public sealed class LabelsTests
                     []),
             ]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.ApplyRecommendedTaxonomyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.ApplyRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns([
                 new RecommendedTaxonomyRepositoryResultDto("owner/repo-a", 1, 0, 0, null),
             ]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.GetLabelsForRepositoriesAsync("owner", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<LabelDto>());
+        _labelManagerService.GetLabelsForRepositoriesAsync("owner", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(Array.Empty<LabelDto>());
 
         await using var ctx = CreateContext();
 
@@ -385,9 +342,7 @@ public sealed class LabelsTests
             Assert.Contains("Applied taxonomy successfully", cut.Markup);
         });
 
-        _labelManagerServiceMock.Verify(
-            service => service.ApplyRecommendedTaxonomyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+        _labelManagerService.Received(1).ApplyRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -396,13 +351,9 @@ public sealed class LabelsTests
         // Arrange
         var repoA = CreateRepository("owner", "repo-a");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repoA]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.PreviewRecommendedTaxonomyAsync("solodevboard", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.PreviewRecommendedTaxonomyAsync("solodevboard", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns([
                 new RecommendedTaxonomyRepositoryPreviewDto("owner/repo-a", [], [], []),
             ]);
 
@@ -416,9 +367,7 @@ public sealed class LabelsTests
         cut.Find("[data-testid='preview-taxonomy-button']").Click();
 
         // Assert
-        _labelManagerServiceMock.Verify(
-            service => service.PreviewRecommendedTaxonomyAsync("solodevboard", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+        _labelManagerService.Received(1).PreviewRecommendedTaxonomyAsync("solodevboard", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -428,13 +377,9 @@ public sealed class LabelsTests
         var repoA = CreateRepository("owner", "repo-a");
         var previewTask = new TaskCompletionSource<IReadOnlyList<RecommendedTaxonomyRepositoryPreviewDto>>();
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repoA]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.PreviewRecommendedTaxonomyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .Returns(previewTask.Task);
+        _labelManagerService.PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(previewTask.Task);
 
         await using var ctx = CreateContext();
 
@@ -455,9 +400,7 @@ public sealed class LabelsTests
         cut.WaitForAssertion(() => Assert.Contains("Taxonomy preview", cut.Markup));
 
         // Assert
-        _labelManagerServiceMock.Verify(
-            service => service.PreviewRecommendedTaxonomyAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+        _labelManagerService.Received(1).PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -467,9 +410,7 @@ public sealed class LabelsTests
         var repoA = CreateRepository("owner", "repo-a");
         var repoB = CreateRepository("owner", "repo-b");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repoA, repoB]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA, repoB]);
 
         await using var ctx = CreateContext();
 
@@ -495,25 +436,17 @@ public sealed class LabelsTests
         var repoA = CreateRepository("owner", "repo-a");
         var repoB = CreateRepository("owner", "repo-b");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repoA, repoB]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA, repoB]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.PreviewLabelSynchronisationAsync("owner/repo-a", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.PreviewLabelSynchronisationAsync("owner/repo-a", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns([
                 new LabelSyncRepositoryPreviewDto("owner/repo-b", [], [], [], []),
             ]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.ApplyLabelSynchronisationAsync("owner/repo-a", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.ApplyLabelSynchronisationAsync("owner/repo-a", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns([
                 new LabelSyncRepositoryResultDto("owner/repo-b", 1, 2, 3, 4, "GitHub API failure"),
             ]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.GetLabelsForRepositoriesAsync("owner", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<LabelDto>());
+        _labelManagerService.GetLabelsForRepositoriesAsync("owner", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(Array.Empty<LabelDto>());
 
         await using var ctx = CreateContext();
 
@@ -542,13 +475,9 @@ public sealed class LabelsTests
         var repoA = CreateRepository("owner", "repo-a");
         var repoB = CreateRepository("owner", "repo-b");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([repoA, repoB]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA, repoB]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.PreviewLabelSynchronisationAsync("owner/repo-a", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.PreviewLabelSynchronisationAsync("owner/repo-a", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns([
                 new LabelSyncRepositoryPreviewDto(
                     "owner/repo-b",
                     [new LabelDto("priority/high", "d93f0b", "High", "owner/repo-b")],
@@ -585,15 +514,13 @@ public sealed class LabelsTests
         ctx.Services.AddMudServices();
         ctx.Services.AddTestHostedAuthenticationRecovery();
 
-        _labelManagerServiceMock
-            .Setup(service => service.GetRecommendedLabelStrategiesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.GetRecommendedLabelStrategiesAsync(Arg.Any<CancellationToken>()).Returns([
                 new RecommendedLabelStrategyDto("solodevboard", "SoloDevBoard", "SoloDevBoard canonical taxonomy"),
                 new RecommendedLabelStrategyDto("github-default", "GitHub default", "GitHub default labels"),
             ]);
 
-        ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
-        ctx.Services.AddScoped(_ => _labelManagerServiceMock.Object);
+        ctx.Services.AddScoped(_ => _repositoryService);
+        ctx.Services.AddScoped(_ => _labelManagerService);
 
         ctx.Render<MudPopoverProvider>();
         ctx.Render<MudDialogProvider>();

--- a/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
@@ -1,6 +1,6 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
+using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
 using SoloDevBoard.App.Components.Features.Migration.Pages;
@@ -14,16 +14,14 @@ namespace SoloDevBoard.App.Tests;
 /// <summary>Component tests for the <see cref="Migration"/> page.</summary>
 public sealed class MigrationTests
 {
-    private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
-    private readonly Mock<IMigrationService> _migrationServiceMock = new();
+    private readonly IRepositoryService _repositoryService = Substitute.For<IRepositoryService>();
+    private readonly IMigrationService _migrationService = Substitute.For<IMigrationService>();
 
     [Fact]
     public async Task Migration_ConflictStrategyOptions_RenderExplanatoryText()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
                 CreateRepository("owner", "repo-a"),
                 CreateRepository("owner", "repo-b"),
             ]);
@@ -47,9 +45,7 @@ public sealed class MigrationTests
     public async Task Migration_PageLoaded_RendersWorkflowAndFeedbackRegions()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
                 CreateRepository("owner", "repo-a"),
                 CreateRepository("owner", "repo-b"),
             ]);
@@ -76,18 +72,9 @@ public sealed class MigrationTests
         var sourceRepository = CreateRepository("owner", "repo-a");
         var targetRepository = CreateRepository("owner", "repo-b");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([sourceRepository, targetRepository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationServiceMock
-            .Setup(service => service.PreviewMigrationAsync(
-                "owner/repo-a",
-                It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
-                It.Is<MigrationScopeDto>(scope => scope.IncludeLabels && scope.IncludeMilestones),
-                MigrationConflictStrategy.Overwrite,
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Is<MigrationScopeDto>(scope => scope.IncludeLabels && scope.IncludeMilestones), MigrationConflictStrategy.Overwrite, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Overwrite,
                 [new LabelSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])],
                 [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])]));
@@ -112,12 +99,7 @@ public sealed class MigrationTests
         // Assert
         cut.WaitForAssertion(() => Assert.Contains("Migration preview (Overwrite)", cut.Markup));
 
-        _migrationServiceMock.Verify(service => service.PreviewMigrationAsync(
-            "owner/repo-a",
-            It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
-            It.Is<MigrationScopeDto>(scope => scope.IncludeLabels && scope.IncludeMilestones),
-            MigrationConflictStrategy.Overwrite,
-            It.IsAny<CancellationToken>()), Times.Once);
+        _migrationService.Received(1).PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Is<MigrationScopeDto>(scope => scope.IncludeLabels && scope.IncludeMilestones), MigrationConflictStrategy.Overwrite, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -127,18 +109,9 @@ public sealed class MigrationTests
         var sourceRepository = CreateRepository("owner", "repo-a");
         var targetRepository = CreateRepository("owner", "repo-b");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([sourceRepository, targetRepository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationServiceMock
-            .Setup(service => service.PreviewMigrationAsync(
-                "owner/repo-a",
-                It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
-                It.IsAny<MigrationScopeDto>(),
-                MigrationConflictStrategy.Skip,
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Skip,
                 [new LabelSyncRepositoryPreviewDto(
                     "owner/repo-b",
@@ -179,18 +152,9 @@ public sealed class MigrationTests
         var sourceRepository = CreateRepository("owner", "repo-a");
         var targetRepository = CreateRepository("owner", "repo-b");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([sourceRepository, targetRepository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationServiceMock
-            .Setup(service => service.PreviewMigrationAsync(
-                "owner/repo-a",
-                It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
-                It.IsAny<MigrationScopeDto>(),
-                MigrationConflictStrategy.Skip,
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Skip,
                 [new LabelSyncRepositoryPreviewDto(
                     "owner/repo-b",
@@ -229,18 +193,9 @@ public sealed class MigrationTests
         var sourceRepository = CreateRepository("owner", "repo-a");
         var targetRepository = CreateRepository("owner", "repo-b");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([sourceRepository, targetRepository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationServiceMock
-            .Setup(service => service.PreviewMigrationAsync(
-                "owner/repo-a",
-                It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
-                It.IsAny<MigrationScopeDto>(),
-                MigrationConflictStrategy.Merge,
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Merge,
                 [new LabelSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])],
                 [new MilestoneSyncRepositoryPreviewDto(
@@ -279,9 +234,7 @@ public sealed class MigrationTests
     public async Task Migration_NoRepositoriesAvailable_ShowsEmptyStateMessage()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([]);
 
         await using var ctx = CreateContext();
 
@@ -296,9 +249,7 @@ public sealed class MigrationTests
     public async Task Migration_PreviewClickedWithoutRequiredSelection_DoesNotInvokePreviewService()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
                 CreateRepository("owner", "repo-a"),
                 CreateRepository("owner", "repo-b"),
             ]);
@@ -312,12 +263,7 @@ public sealed class MigrationTests
 
         // Assert
         Assert.Empty(cut.FindAll("[data-testid='migration-preview-card']"));
-        _migrationServiceMock.Verify(service => service.PreviewMigrationAsync(
-            It.IsAny<string>(),
-            It.IsAny<IReadOnlyList<string>>(),
-            It.IsAny<MigrationScopeDto>(),
-            It.IsAny<MigrationConflictStrategy>(),
-            It.IsAny<CancellationToken>()), Times.Never);
+        _migrationService.DidNotReceive().PreviewMigrationAsync( Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<MigrationScopeDto>(), Arg.Any<MigrationConflictStrategy>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -328,18 +274,9 @@ public sealed class MigrationTests
         var targetRepository = CreateRepository("owner", "repo-b");
         var applyTaskSource = new TaskCompletionSource<MigrationResultDto>();
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([sourceRepository, targetRepository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationServiceMock
-            .Setup(service => service.PreviewMigrationAsync(
-                "owner/repo-a",
-                It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
-                It.IsAny<MigrationScopeDto>(),
-                MigrationConflictStrategy.Skip,
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Skip,
                 [new LabelSyncRepositoryPreviewDto(
                     "owner/repo-b",
@@ -349,14 +286,7 @@ public sealed class MigrationTests
                     [])],
                 [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])]));
 
-        _migrationServiceMock
-            .Setup(service => service.ApplyMigrationAsync(
-                "owner/repo-a",
-                It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
-                It.IsAny<MigrationScopeDto>(),
-                MigrationConflictStrategy.Skip,
-                It.IsAny<CancellationToken>()))
-            .Returns(applyTaskSource.Task);
+        _migrationService.ApplyMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(applyTaskSource.Task);
 
         await using var ctx = CreateContext();
 
@@ -383,12 +313,7 @@ public sealed class MigrationTests
 
         // Assert
         cut.WaitForAssertion(() => Assert.Contains("Migration completed successfully", cut.Markup));
-        _migrationServiceMock.Verify(service => service.ApplyMigrationAsync(
-            "owner/repo-a",
-            It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
-            It.IsAny<MigrationScopeDto>(),
-            MigrationConflictStrategy.Skip,
-            It.IsAny<CancellationToken>()), Times.Once);
+        _migrationService.Received(1).ApplyMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -398,18 +323,9 @@ public sealed class MigrationTests
         var sourceRepository = CreateRepository("owner", "repo-a");
         var targetRepository = CreateRepository("owner", "repo-b");
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([sourceRepository, targetRepository]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationServiceMock
-            .Setup(service => service.PreviewMigrationAsync(
-                "owner/repo-a",
-                It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
-                It.IsAny<MigrationScopeDto>(),
-                MigrationConflictStrategy.Merge,
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Merge,
                 [new LabelSyncRepositoryPreviewDto(
                     "owner/repo-b",
@@ -424,14 +340,7 @@ public sealed class MigrationTests
                     [],
                     [])]));
 
-        _migrationServiceMock
-            .Setup(service => service.ApplyMigrationAsync(
-                "owner/repo-a",
-                It.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })),
-                It.IsAny<MigrationScopeDto>(),
-                MigrationConflictStrategy.Merge,
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MigrationResultDto(
+        _migrationService.ApplyMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<CancellationToken>()).Returns(new MigrationResultDto(
                 MigrationConflictStrategy.Merge,
                 [new LabelSyncRepositoryResultDto("owner/repo-b", 1, 0, 0, 0, "GitHub label API rate limit reached")],
                 [new MilestoneSyncRepositoryResultDto("owner/repo-b", 1, 0, 0, 0, null)]));
@@ -468,8 +377,8 @@ public sealed class MigrationTests
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
         ctx.Services.AddTestHostedAuthenticationRecovery();
-        ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
-        ctx.Services.AddScoped(_ => _migrationServiceMock.Object);
+        ctx.Services.AddScoped(_ => _repositoryService);
+        ctx.Services.AddScoped(_ => _migrationService);
 
         ctx.Render<MudPopoverProvider>();
         ctx.Render<MudDialogProvider>();

--- a/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
@@ -1,8 +1,8 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
+using NSubstitute;
 using SoloDevBoard.App.Components.Features.Migration.Pages;
 using SoloDevBoard.App.Components.Shared.Components;
 using SoloDevBoard.Application.Services.Labels;
@@ -74,7 +74,7 @@ public sealed class MigrationTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationService.PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Is<MigrationScopeDto>(scope => scope.IncludeLabels && scope.IncludeMilestones), MigrationConflictStrategy.Overwrite, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Is<MigrationScopeDto>(scope => scope!.IncludeLabels && scope.IncludeMilestones), MigrationConflictStrategy.Overwrite, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Overwrite,
                 [new LabelSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])],
                 [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])]));
@@ -99,7 +99,7 @@ public sealed class MigrationTests
         // Assert
         cut.WaitForAssertion(() => Assert.Contains("Migration preview (Overwrite)", cut.Markup));
 
-        _migrationService.Received(1).PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Is<MigrationScopeDto>(scope => scope.IncludeLabels && scope.IncludeMilestones), MigrationConflictStrategy.Overwrite, Arg.Any<CancellationToken>());
+        await _migrationService.Received(1).PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Is<MigrationScopeDto>(scope => scope!.IncludeLabels && scope.IncludeMilestones), MigrationConflictStrategy.Overwrite, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -111,7 +111,7 @@ public sealed class MigrationTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationService.PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Skip,
                 [new LabelSyncRepositoryPreviewDto(
                     "owner/repo-b",
@@ -154,7 +154,7 @@ public sealed class MigrationTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationService.PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Skip,
                 [new LabelSyncRepositoryPreviewDto(
                     "owner/repo-b",
@@ -195,7 +195,7 @@ public sealed class MigrationTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationService.PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Merge,
                 [new LabelSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])],
                 [new MilestoneSyncRepositoryPreviewDto(
@@ -263,7 +263,7 @@ public sealed class MigrationTests
 
         // Assert
         Assert.Empty(cut.FindAll("[data-testid='migration-preview-card']"));
-        _migrationService.DidNotReceive().PreviewMigrationAsync( Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<MigrationScopeDto>(), Arg.Any<MigrationConflictStrategy>(), Arg.Any<CancellationToken>());
+        await _migrationService.DidNotReceive().PreviewMigrationAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<MigrationScopeDto>(), Arg.Any<MigrationConflictStrategy>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -276,7 +276,7 @@ public sealed class MigrationTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationService.PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Skip,
                 [new LabelSyncRepositoryPreviewDto(
                     "owner/repo-b",
@@ -286,7 +286,7 @@ public sealed class MigrationTests
                     [])],
                 [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])]));
 
-        _migrationService.ApplyMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(applyTaskSource.Task);
+        _migrationService.ApplyMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(applyTaskSource.Task);
 
         await using var ctx = CreateContext();
 
@@ -313,7 +313,7 @@ public sealed class MigrationTests
 
         // Assert
         cut.WaitForAssertion(() => Assert.Contains("Migration completed successfully", cut.Markup));
-        _migrationService.Received(1).ApplyMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>());
+        await _migrationService.Received(1).ApplyMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -325,7 +325,7 @@ public sealed class MigrationTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationService.PreviewMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Merge,
                 [new LabelSyncRepositoryPreviewDto(
                     "owner/repo-b",
@@ -340,7 +340,7 @@ public sealed class MigrationTests
                     [],
                     [])]));
 
-        _migrationService.ApplyMigrationAsync( "owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<CancellationToken>()).Returns(new MigrationResultDto(
+        _migrationService.ApplyMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<CancellationToken>()).Returns(new MigrationResultDto(
                 MigrationConflictStrategy.Merge,
                 [new LabelSyncRepositoryResultDto("owner/repo-b", 1, 0, 0, 0, "GitHub label API rate limit reached")],
                 [new MilestoneSyncRepositoryResultDto("owner/repo-b", 1, 0, 0, 0, null)]));

--- a/tests/App.Tests/SoloDevBoard.App.Tests/RepositoriesTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/RepositoriesTests.cs
@@ -1,8 +1,8 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
+using NSubstitute;
 using SoloDevBoard.App.Components.Features.Repositories.Pages;
 using SoloDevBoard.Application.Services.Repositories;
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/RepositoriesTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/RepositoriesTests.cs
@@ -1,6 +1,6 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
+using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
 using SoloDevBoard.App.Components.Features.Repositories.Pages;
@@ -11,16 +11,14 @@ namespace SoloDevBoard.App.Tests;
 /// <summary>Component tests for the <see cref="Repositories"/> page.</summary>
 public sealed class RepositoriesTests
 {
-    private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
+    private readonly IRepositoryService _repositoryService = Substitute.For<IRepositoryService>();
 
     [Fact]
     public async Task Repositories_InitialRender_ShowsPrimaryCommandSurface()
     {
         // Arrange
         var tcs = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
-        _repositoryServiceMock
-            .Setup(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .Returns(tcs.Task);
+        _repositoryService.GetRepositoriesAsync(Arg.Any<CancellationToken>()).Returns(tcs.Task);
 
         await using var ctx = CreateContext();
 
@@ -41,9 +39,7 @@ public sealed class RepositoriesTests
     {
         // Arrange
         var tcs = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
-        _repositoryServiceMock
-            .Setup(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .Returns(tcs.Task);
+        _repositoryService.GetRepositoriesAsync(Arg.Any<CancellationToken>()).Returns(tcs.Task);
 
         await using var ctx = CreateContext();
 
@@ -60,9 +56,8 @@ public sealed class RepositoriesTests
     public async Task Repositories_ServiceThrowsHttpRequestException_ShowsErrorMessage()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("Connection refused"));
+        _repositoryService.GetRepositoriesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<IReadOnlyList<RepositoryDto>>(new HttpRequestException("Connection refused")));
 
         await using var ctx = CreateContext();
 
@@ -82,9 +77,8 @@ public sealed class RepositoriesTests
     public async Task Repositories_ServiceThrowsUnexpectedException_ShowsGenericErrorMessage()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("Internal failure"));
+        _repositoryService.GetRepositoriesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<IReadOnlyList<RepositoryDto>>(new InvalidOperationException("Internal failure")));
 
         await using var ctx = CreateContext();
 
@@ -100,9 +94,7 @@ public sealed class RepositoriesTests
     public async Task Repositories_ServiceReturnsEmptyList_ShowsEmptyState()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<RepositoryDto>());
+        _repositoryService.GetRepositoriesAsync(Arg.Any<CancellationToken>()).Returns(Array.Empty<RepositoryDto>());
 
         await using var ctx = CreateContext();
 
@@ -128,9 +120,7 @@ public sealed class RepositoriesTests
             new(2, "my-private-repo", "owner/my-private-repo", string.Empty, string.Empty, true, false, DateTimeOffset.UnixEpoch, new DateTimeOffset(2026, 2, 20, 12, 0, 0, TimeSpan.Zero)),
         };
 
-        _repositoryServiceMock
-            .Setup(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(repositories);
+        _repositoryService.GetRepositoriesAsync(Arg.Any<CancellationToken>()).Returns(repositories);
 
         await using var ctx = CreateContext();
 
@@ -158,7 +148,7 @@ public sealed class RepositoriesTests
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
         ctx.Services.AddTestHostedAuthenticationRecovery();
-        ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
+        ctx.Services.AddScoped(_ => _repositoryService);
 
         ctx.Render<MudPopoverProvider>();
         ctx.Render<MudDialogProvider>();

--- a/tests/App.Tests/SoloDevBoard.App.Tests/SoloDevBoard.App.Tests.csproj
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/SoloDevBoard.App.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -16,8 +17,8 @@
     <PackageReference Include="bunit" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
+using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
 using SoloDevBoard.App.Components.Features.Triage.Pages;
@@ -15,18 +15,30 @@ namespace SoloDevBoard.App.Tests;
 /// <summary>Component tests for the <see cref="Triage"/> page.</summary>
 public sealed class TriageTests
 {
-    private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
-    private readonly Mock<ITriageService> _triageServiceMock = new();
-    private readonly Mock<ILabelManagerService> _labelManagerServiceMock = new();
+    private readonly IRepositoryService _repositoryService = Substitute.For<IRepositoryService>();
+    private readonly ITriageService _triageService = Substitute.For<ITriageService>();
+    private readonly ILabelManagerService _labelManagerService = Substitute.For<ILabelManagerService>();
+
+    public TriageTests()
+    {
+        _labelManagerService.GetLabelsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([
+                new LabelDto("type/story", "1d76db", "A user-facing Story delivering a discrete piece of value", "repo"),
+            ]);
+
+        _triageService.GetMilestoneOptionsAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<TriageMilestoneOptionDto>());
+
+        _triageService.GetProjectBoardOptionsAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>())
+            .Returns(new TriageProjectBoardDiscoveryDto([], 0, 0));
+    }
 
     [Fact]
     public async Task Triage_RepositoriesAreLoading_ShowsLoadingStateUntilRepositoryDataArrives()
     {
         // Arrange
         var repositoryTaskSource = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .Returns(repositoryTaskSource.Task);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns(repositoryTaskSource.Task);
 
         await using var ctx = CreateContext();
 
@@ -45,9 +57,7 @@ public sealed class TriageTests
     public async Task Triage_NoRepositoriesReturned_ShowsNoRepositoriesWarningState()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<RepositoryDto>());
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns(Array.Empty<RepositoryDto>());
 
         await using var ctx = CreateContext();
 
@@ -66,13 +76,10 @@ public sealed class TriageTests
     public async Task Triage_StartSessionFailure_ShowsErrorFeedbackRegion()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("Bad gateway", null, HttpStatusCode.BadGateway));
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<TriageSessionDto>(new HttpRequestException("Bad gateway", null, HttpStatusCode.BadGateway)));
 
         await using var ctx = CreateContext();
 
@@ -97,9 +104,7 @@ public sealed class TriageTests
     public async Task Triage_StartSessionWithEmptyQueue_ShowsSummaryStateAndEmptyQueueMessage()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var emptySession = CreateSession(
             "owner",
@@ -108,9 +113,7 @@ public sealed class TriageTests
             currentIndex: 0,
             skippedItems: []);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(emptySession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(emptySession);
 
         await using var ctx = CreateContext();
 
@@ -136,9 +139,7 @@ public sealed class TriageTests
     public async Task Triage_StartedSessionWithPullRequestCurrentItem_ShowsPullRequestVariantAndKeyboardLegend()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var pullRequestItem = new TriageItemDto(
             TriageItemTypeDto.PullRequest,
@@ -163,9 +164,7 @@ public sealed class TriageTests
             currentIndex: 0,
             skippedItems: []);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
         await using var ctx = CreateContext();
 
@@ -191,9 +190,7 @@ public sealed class TriageTests
     public async Task Triage_StartSessionClicked_LoadsFirstItemAndShowsRemainingCount()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var startedSession = CreateSession(
             "owner",
@@ -205,9 +202,7 @@ public sealed class TriageTests
             currentIndex: 0,
             skippedItems: []);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
         await using var ctx = CreateContext();
 
@@ -228,18 +223,14 @@ public sealed class TriageTests
             Assert.Contains("Remaining: 2 items", cut.Markup);
         });
 
-        _triageServiceMock.Verify(
-            service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()),
-            Times.Once);
+        _triageService.Received(1).StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Triage_NextItemClicked_MovesToNextQueueItemAndUpdatesContext()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var startedSession = CreateSession(
             "owner",
@@ -258,13 +249,9 @@ public sealed class TriageTests
             Summary = new TriageSessionSummaryDto(2, 1, 1, 0, 0, 0, 0, 0),
         };
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
-        _triageServiceMock
-            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(advancedSession);
+        _triageService.AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns(advancedSession);
 
         await using var ctx = CreateContext();
 
@@ -293,9 +280,7 @@ public sealed class TriageTests
     public async Task Triage_NextClicked_MovesToNextItemWithoutApplyingChanges()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var startedSession = CreateSession(
             "owner",
@@ -317,13 +302,9 @@ public sealed class TriageTests
             currentIndex: 1,
             skippedItems: []);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
-        _triageServiceMock
-            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(advancedSession);
+        _triageService.AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns(advancedSession);
 
         await using var ctx = CreateContext();
 
@@ -346,18 +327,14 @@ public sealed class TriageTests
             Assert.Contains("Skipped: 0 items", cut.Markup);
         });
 
-        _triageServiceMock.Verify(
-            service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+        _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Triage_NextClickedOnFinalItem_ShowsSessionCompleteWithoutProgressHeader()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var startedSession = CreateSession(
             "owner",
@@ -373,13 +350,9 @@ public sealed class TriageTests
             currentIndex: 1,
             skippedItems: []);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
-        _triageServiceMock
-            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(completedSession);
+        _triageService.AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns(completedSession);
 
         await using var ctx = CreateContext();
 
@@ -408,9 +381,7 @@ public sealed class TriageTests
     public async Task Triage_CurrentItemBodyContainsMarkdown_RendersFormattedBodyContent()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var markdownItem = new TriageItemDto(
             TriageItemTypeDto.Issue,
@@ -428,9 +399,7 @@ public sealed class TriageTests
             DateTimeOffset.UtcNow.AddDays(-2),
             DateTimeOffset.UtcNow.AddDays(-1));
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateSession("owner", "repo", [markdownItem], 0, []));
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(CreateSession("owner", "repo", [markdownItem], 0, []));
 
         await using var ctx = CreateContext();
 
@@ -456,9 +425,7 @@ public sealed class TriageTests
     public async Task Triage_CurrentItemBodyContainsRelativeAndUnsafeLinks_PreservesRelativeAndNeutralisesUnsafeHref()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var markdownItem = new TriageItemDto(
             TriageItemTypeDto.Issue,
@@ -476,9 +443,7 @@ public sealed class TriageTests
             DateTimeOffset.UtcNow.AddDays(-2),
             DateTimeOffset.UtcNow.AddDays(-1));
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateSession("owner", "repo", [markdownItem], 0, []));
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(CreateSession("owner", "repo", [markdownItem], 0, []));
 
         await using var ctx = CreateContext();
 
@@ -505,13 +470,9 @@ public sealed class TriageTests
     public async Task Triage_ApplyLabelClicked_InvokesTriageServiceAndShowsUpdatedLabels()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.GetLabelsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>()).Returns([
                 new LabelDto("type/bug", "d73a4a", "A bug or unexpected behaviour", "repo"),
             ]);
 
@@ -549,17 +510,11 @@ public sealed class TriageTests
             Summary = new TriageSessionSummaryDto(2, 1, 1, 0, 1, 0, 0, 0),
         };
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
-        _triageServiceMock
-            .Setup(service => service.ApplyLabelToCurrentItemAsync(It.IsAny<TriageSessionDto>(), "type/bug", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(labelledSession);
+        _triageService.ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), "type/bug", Arg.Any<CancellationToken>()).Returns(labelledSession);
 
-        _triageServiceMock
-            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(advancedSession);
+        _triageService.AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns(advancedSession);
 
         await using var ctx = CreateContext();
 
@@ -584,25 +539,17 @@ public sealed class TriageTests
             Assert.Contains("Applied label 'type/bug' to item #401 and moved to Item 2 of 2", cut.Markup, StringComparison.Ordinal);
         });
 
-        _triageServiceMock.Verify(
-            service => service.ApplyLabelToCurrentItemAsync(It.IsAny<TriageSessionDto>(), "type/bug", It.IsAny<CancellationToken>()),
-            Times.Once);
-        _triageServiceMock.Verify(
-            service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+        _triageService.Received(1).ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), "type/bug", Arg.Any<CancellationToken>());
+        _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Triage_ActionSurfaceShortcutL_PressedAppliesSelectedLabel()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.GetLabelsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>()).Returns([
                 new LabelDto("priority/high", "d93f0b", "Should be addressed in the current sprint or release", "repo"),
             ]);
 
@@ -613,17 +560,11 @@ public sealed class TriageTests
             currentIndex: 0,
             skippedItems: []);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
-        _triageServiceMock
-            .Setup(service => service.ApplyLabelToCurrentItemAsync(It.IsAny<TriageSessionDto>(), "priority/high", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), "priority/high", Arg.Any<CancellationToken>()).Returns(startedSession);
 
-        _triageServiceMock
-            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns(startedSession);
 
         await using var ctx = CreateContext();
 
@@ -642,25 +583,17 @@ public sealed class TriageTests
         cut.Find("[data-testid='triage-action-buttons-row']").KeyDown("l");
 
         // Assert
-        _triageServiceMock.Verify(
-            service => service.ApplyLabelToCurrentItemAsync(It.IsAny<TriageSessionDto>(), "priority/high", It.IsAny<CancellationToken>()),
-            Times.Once);
-        _triageServiceMock.Verify(
-            service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+        _triageService.Received(1).ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), "priority/high", Arg.Any<CancellationToken>());
+        _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Triage_SessionStartsWithAvailableLabels_QuickLabelDefaultsToEmptyAndApplyDisabled()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.GetLabelsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>()).Returns([
                 new LabelDto("priority/high", "d93f0b", "Should be addressed in the current sprint or release", "repo"),
                 new LabelDto("type/bug", "d73a4a", "A bug or unexpected behaviour", "repo"),
             ]);
@@ -672,9 +605,7 @@ public sealed class TriageTests
             currentIndex: 0,
             skippedItems: []);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
         await using var ctx = CreateContext();
 
@@ -694,18 +625,14 @@ public sealed class TriageTests
             Assert.True(cut.Find("[data-testid='triage-apply-label-button']").HasAttribute("disabled"));
         });
 
-        _triageServiceMock.Verify(
-            service => service.ApplyLabelToCurrentItemAsync(It.IsAny<TriageSessionDto>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+        _triageService.DidNotReceive().ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Triage_AssignMilestoneClicked_AssignsMilestoneAndShowsSuccessMessage()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var startedSession = CreateSession(
             "owner",
@@ -731,21 +658,13 @@ public sealed class TriageTests
             Summary = new TriageSessionSummaryDto(1, 0, 1, 0, 0, 1, 0, 0),
         };
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
-        _triageServiceMock
-            .Setup(service => service.GetMilestoneOptionsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new TriageMilestoneOptionDto(7, "v0.7.0")]);
+        _triageService.GetMilestoneOptionsAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns([new TriageMilestoneOptionDto(7, "v0.7.0")]);
 
-        _triageServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new TriageProjectBoardDiscoveryDto([], 0, 0));
+        _triageService.GetProjectBoardOptionsAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns(new TriageProjectBoardDiscoveryDto([], 0, 0));
 
-        _triageServiceMock
-            .Setup(service => service.AssignMilestoneToCurrentItemAsync(It.IsAny<TriageSessionDto>(), 7, "v0.7.0", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(milestoneAssignedSession);
+        _triageService.AssignMilestoneToCurrentItemAsync(Arg.Any<TriageSessionDto>(), 7, "v0.7.0", Arg.Any<CancellationToken>()).Returns(milestoneAssignedSession);
 
         await using var ctx = CreateContext();
 
@@ -772,18 +691,14 @@ public sealed class TriageTests
             Assert.Contains("Assigned milestone 'v0.7.0' to item #501", cut.Markup, StringComparison.Ordinal);
         });
 
-        _triageServiceMock.Verify(
-            service => service.AssignMilestoneToCurrentItemAsync(It.IsAny<TriageSessionDto>(), 7, "v0.7.0", It.IsAny<CancellationToken>()),
-            Times.Once);
+        _triageService.Received(1).AssignMilestoneToCurrentItemAsync(Arg.Any<TriageSessionDto>(), 7, "v0.7.0", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Triage_StartSessionWithPullRequestMilestone_PreselectsMilestoneInDropdown()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var startedSession = CreateSession(
             "owner",
@@ -817,24 +732,16 @@ public sealed class TriageTests
             Summary = new TriageSessionSummaryDto(1, 0, 1, 0, 0, 1, 0, 0),
         };
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
-        _triageServiceMock
-            .Setup(service => service.GetMilestoneOptionsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _triageService.GetMilestoneOptionsAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns([
                 new TriageMilestoneOptionDto(7, "v0.7.0"),
                 new TriageMilestoneOptionDto(8, "v0.8.0"),
             ]);
 
-        _triageServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new TriageProjectBoardDiscoveryDto([], 0, 0));
+        _triageService.GetProjectBoardOptionsAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns(new TriageProjectBoardDiscoveryDto([], 0, 0));
 
-        _triageServiceMock
-            .Setup(service => service.AssignMilestoneToCurrentItemAsync(It.IsAny<TriageSessionDto>(), 7, "v0.7.0", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(milestoneAssignedSession);
+        _triageService.AssignMilestoneToCurrentItemAsync(Arg.Any<TriageSessionDto>(), 7, "v0.7.0", Arg.Any<CancellationToken>()).Returns(milestoneAssignedSession);
 
         await using var ctx = CreateContext();
 
@@ -857,18 +764,14 @@ public sealed class TriageTests
         });
 
         // Assert
-        _triageServiceMock.Verify(
-            service => service.AssignMilestoneToCurrentItemAsync(It.IsAny<TriageSessionDto>(), 7, "v0.7.0", It.IsAny<CancellationToken>()),
-            Times.Once);
+        _triageService.Received(1).AssignMilestoneToCurrentItemAsync(Arg.Any<TriageSessionDto>(), 7, "v0.7.0", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Triage_AddToProjectBoardClicked_AddsItemAndShowsSuccessMessage()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var startedSession = CreateSession(
             "owner",
@@ -886,17 +789,11 @@ public sealed class TriageTests
             Summary = new TriageSessionSummaryDto(1, 0, 1, 0, 0, 0, 1, 0),
         };
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
-        _triageServiceMock
-            .Setup(service => service.GetMilestoneOptionsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
+        _triageService.GetMilestoneOptionsAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns([]);
 
-        _triageServiceMock
-            .Setup(service => service.GetProjectBoardOptionsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new TriageProjectBoardDiscoveryDto(
+        _triageService.GetProjectBoardOptionsAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns(new TriageProjectBoardDiscoveryDto(
             [
                 new TriageProjectBoardOptionDto(
                     "project-id",
@@ -911,16 +808,7 @@ public sealed class TriageTests
             1,
             0));
 
-        _triageServiceMock
-            .Setup(service => service.AddCurrentItemToProjectBoardAsync(
-                It.IsAny<TriageSessionDto>(),
-                "project-id",
-                "Roadmap",
-                "status-field-id",
-                "in-progress",
-                "In Progress",
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(updatedSession);
+        _triageService.AddCurrentItemToProjectBoardAsync( Arg.Any<TriageSessionDto>(), "project-id", "Roadmap", "status-field-id", "in-progress", "In Progress", Arg.Any<CancellationToken>()).Returns(updatedSession);
 
         await using var ctx = CreateContext();
 
@@ -942,25 +830,14 @@ public sealed class TriageTests
             Assert.Contains("Added item #601 to 'Roadmap' with status 'In Progress'", cut.Markup, StringComparison.Ordinal);
         });
 
-        _triageServiceMock.Verify(
-            service => service.AddCurrentItemToProjectBoardAsync(
-                It.IsAny<TriageSessionDto>(),
-                "project-id",
-                "Roadmap",
-                "status-field-id",
-                "in-progress",
-                "In Progress",
-                It.IsAny<CancellationToken>()),
-            Times.Once);
+        _triageService.Received(1).AddCurrentItemToProjectBoardAsync( Arg.Any<TriageSessionDto>(), "project-id", "Roadmap", "status-field-id", "in-progress", "In Progress", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Triage_CloseAsDuplicateClicked_ClosesCurrentItemAndAdvancesSession()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var startedSession = CreateSession(
             "owner",
@@ -988,17 +865,11 @@ public sealed class TriageTests
             Summary = new TriageSessionSummaryDto(2, 1, 1, 0, 0, 0, 0, 1),
         };
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
-        _triageServiceMock
-            .Setup(service => service.CloseCurrentItemAsDuplicateAsync(It.IsAny<TriageSessionDto>(), "#555", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(duplicateClosedSession);
+        _triageService.CloseCurrentItemAsDuplicateAsync(Arg.Any<TriageSessionDto>(), "#555", Arg.Any<CancellationToken>()).Returns(duplicateClosedSession);
 
-        _triageServiceMock
-            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(advancedSession);
+        _triageService.AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns(advancedSession);
 
         await using var ctx = CreateContext();
 
@@ -1027,21 +898,15 @@ public sealed class TriageTests
             Assert.Contains("Closed item #701 as a duplicate of '#555' and moved to Item 2 of 2", cut.Markup, StringComparison.Ordinal);
         });
 
-        _triageServiceMock.Verify(
-            service => service.CloseCurrentItemAsDuplicateAsync(It.IsAny<TriageSessionDto>(), "#555", It.IsAny<CancellationToken>()),
-            Times.Once);
-        _triageServiceMock.Verify(
-            service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+        _triageService.Received(1).CloseCurrentItemAsDuplicateAsync(Arg.Any<TriageSessionDto>(), "#555", Arg.Any<CancellationToken>());
+        _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Triage_ActionSurfaceShortcutD_PressedClosesCurrentItemAsDuplicate()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var startedSession = CreateSession(
             "owner",
@@ -1050,17 +915,11 @@ public sealed class TriageTests
             currentIndex: 0,
             skippedItems: []);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
-        _triageServiceMock
-            .Setup(service => service.CloseCurrentItemAsDuplicateAsync(It.IsAny<TriageSessionDto>(), "#556", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.CloseCurrentItemAsDuplicateAsync(Arg.Any<TriageSessionDto>(), "#556", Arg.Any<CancellationToken>()).Returns(startedSession);
 
-        _triageServiceMock
-            .Setup(service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns(startedSession);
 
         await using var ctx = CreateContext();
 
@@ -1083,21 +942,15 @@ public sealed class TriageTests
         cut.Find("[data-testid='triage-action-buttons-row']").KeyDown("d");
 
         // Assert
-        _triageServiceMock.Verify(
-            service => service.CloseCurrentItemAsDuplicateAsync(It.IsAny<TriageSessionDto>(), "#556", It.IsAny<CancellationToken>()),
-            Times.Once);
-        _triageServiceMock.Verify(
-            service => service.AdvanceSessionAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+        _triageService.Received(1).CloseCurrentItemAsDuplicateAsync(Arg.Any<TriageSessionDto>(), "#556", Arg.Any<CancellationToken>());
+        _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Triage_SkipItemClicked_RecordsSkipAndMovesToNextItem()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var startedSession = CreateSession(
             "owner",
@@ -1127,13 +980,9 @@ public sealed class TriageTests
             },
             DateTimeOffset.UtcNow);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
-        _triageServiceMock
-            .Setup(service => service.SkipCurrentItemAsync(It.IsAny<TriageSessionDto>(), "Requires broader context", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(skippedSession);
+        _triageService.SkipCurrentItemAsync(Arg.Any<TriageSessionDto>(), "Requires broader context", Arg.Any<CancellationToken>()).Returns(skippedSession);
 
         await using var ctx = CreateContext();
 
@@ -1162,18 +1011,14 @@ public sealed class TriageTests
             Assert.Contains("Skipped item #801 for later review and moved to Item 1 of 1", cut.Markup, StringComparison.Ordinal);
         });
 
-        _triageServiceMock.Verify(
-            service => service.SkipCurrentItemAsync(It.IsAny<TriageSessionDto>(), "Requires broader context", It.IsAny<CancellationToken>()),
-            Times.Once);
+        _triageService.Received(1).SkipCurrentItemAsync(Arg.Any<TriageSessionDto>(), "Requires broader context", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Triage_SessionCompleted_ShowsGroupedSummaryDetailsAndSkippedRevisitButton()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var completedSession = new TriageSessionDto(
             Guid.NewGuid(),
@@ -1196,9 +1041,7 @@ public sealed class TriageTests
             },
             DateTimeOffset.UtcNow);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(completedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(completedSession);
 
         await using var ctx = CreateContext();
 
@@ -1232,9 +1075,7 @@ public sealed class TriageTests
     public async Task Triage_SessionCompleted_MixedIssueAndPullRequestSummaryEntries_RenderTypeSpecificGitHubLinks()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var completedSession = new TriageSessionDto(
             Guid.NewGuid(),
@@ -1273,9 +1114,7 @@ public sealed class TriageTests
             },
             DateTimeOffset.UtcNow);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(completedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(completedSession);
 
         await using var ctx = CreateContext();
 
@@ -1300,9 +1139,7 @@ public sealed class TriageTests
     public async Task Triage_RevisitSkippedItemsClicked_ResumesSessionFromSkippedQueue()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
         var completedSession = new TriageSessionDto(
             Guid.NewGuid(),
@@ -1333,13 +1170,9 @@ public sealed class TriageTests
             new TriageSessionSummaryDto(1, 0, 1, 0, 0, 0, 0, 0),
             DateTimeOffset.UtcNow);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(completedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(completedSession);
 
-        _triageServiceMock
-            .Setup(service => service.RevisitSkippedItemsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(resumedSession);
+        _triageService.RevisitSkippedItemsAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>()).Returns(resumedSession);
 
         await using var ctx = CreateContext();
 
@@ -1362,9 +1195,7 @@ public sealed class TriageTests
             Assert.Contains("Skipped items were appended to the queue for review.", cut.Markup, StringComparison.Ordinal);
         });
 
-        _triageServiceMock.Verify(
-            service => service.RevisitSkippedItemsAsync(It.IsAny<TriageSessionDto>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+        _triageService.Received(1).RevisitSkippedItemsAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
     }
 
     private static async Task SelectQuickLabelAsync(IRenderedComponent<Triage> cut, string labelName)
@@ -1383,13 +1214,9 @@ public sealed class TriageTests
     public async Task Triage_QuickLabelInputShortcutL_Pressed_DoesNotApplySelectedLabel()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo")]);
 
-        _labelManagerServiceMock
-            .Setup(service => service.GetLabelsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelManagerService.GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>()).Returns([
                 new LabelDto("priority/high", "d93f0b", "Should be addressed in the current sprint or release", "repo"),
             ]);
 
@@ -1400,9 +1227,7 @@ public sealed class TriageTests
             currentIndex: 0,
             skippedItems: []);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
         await using var ctx = CreateContext();
 
@@ -1419,18 +1244,14 @@ public sealed class TriageTests
         cut.Find("[data-testid='triage-quick-label-autocomplete']").KeyDown("l");
 
         // Assert
-        _triageServiceMock.Verify(
-            service => service.ApplyLabelToCurrentItemAsync(It.IsAny<TriageSessionDto>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+        _triageService.DidNotReceive().ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Triage_RepositorySelectionClearedAfterSessionStarted_HidesActiveSessionDetails()
     {
         // Arrange
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([CreateRepository("owner", "repo-a"), CreateRepository("owner", "repo-b")]);
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo-a"), CreateRepository("owner", "repo-b")]);
 
         var startedSession = CreateSession(
             "owner",
@@ -1439,9 +1260,7 @@ public sealed class TriageTests
             currentIndex: 0,
             skippedItems: []);
 
-        _triageServiceMock
-            .Setup(service => service.StartSessionAsync("owner", "repo-a", true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(startedSession);
+        _triageService.StartSessionAsync("owner", "repo-a", true, Arg.Any<CancellationToken>()).Returns(startedSession);
 
         await using var ctx = CreateContext();
 
@@ -1521,25 +1340,14 @@ public sealed class TriageTests
 
     private BunitContext CreateContext()
     {
-        _labelManagerServiceMock
-            .SetReturnsDefault(Task.FromResult<IReadOnlyList<LabelDto>>(
-            [
-                new LabelDto("type/story", "1d76db", "A user-facing Story delivering a discrete piece of value", "repo"),
-            ]));
-
         var ctx = new BunitContext();
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
 
-        _triageServiceMock
-            .SetReturnsDefault(Task.FromResult<IReadOnlyList<TriageMilestoneOptionDto>>(Array.Empty<TriageMilestoneOptionDto>()));
-        _triageServiceMock
-            .SetReturnsDefault(Task.FromResult<IReadOnlyList<TriageProjectBoardOptionDto>>(Array.Empty<TriageProjectBoardOptionDto>()));
-
         ctx.Services.AddMudServices();
         ctx.Services.AddTestHostedAuthenticationRecovery();
-        ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
-        ctx.Services.AddScoped(_ => _triageServiceMock.Object);
-        ctx.Services.AddScoped(_ => _labelManagerServiceMock.Object);
+        ctx.Services.AddScoped(_ => _repositoryService);
+        ctx.Services.AddScoped(_ => _triageService);
+        ctx.Services.AddScoped(_ => _labelManagerService);
 
         ctx.Render<MudPopoverProvider>();
         ctx.Render<MudDialogProvider>();

--- a/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/TriageTests.cs
@@ -1,9 +1,9 @@
 using System.Net;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
+using NSubstitute;
 using SoloDevBoard.App.Components.Features.Triage.Pages;
 using SoloDevBoard.App.Components.Shared.Components;
 using SoloDevBoard.Application.Services.Labels;
@@ -223,7 +223,7 @@ public sealed class TriageTests
             Assert.Contains("Remaining: 2 items", cut.Markup);
         });
 
-        _triageService.Received(1).StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>());
+        await _triageService.Received(1).StartSessionAsync("owner", "repo", true, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -327,7 +327,7 @@ public sealed class TriageTests
             Assert.Contains("Skipped: 0 items", cut.Markup);
         });
 
-        _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
+        await _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -539,8 +539,8 @@ public sealed class TriageTests
             Assert.Contains("Applied label 'type/bug' to item #401 and moved to Item 2 of 2", cut.Markup, StringComparison.Ordinal);
         });
 
-        _triageService.Received(1).ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), "type/bug", Arg.Any<CancellationToken>());
-        _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
+        await _triageService.Received(1).ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), "type/bug", Arg.Any<CancellationToken>());
+        await _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -583,8 +583,8 @@ public sealed class TriageTests
         cut.Find("[data-testid='triage-action-buttons-row']").KeyDown("l");
 
         // Assert
-        _triageService.Received(1).ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), "priority/high", Arg.Any<CancellationToken>());
-        _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
+        await _triageService.Received(1).ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), "priority/high", Arg.Any<CancellationToken>());
+        await _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -625,7 +625,7 @@ public sealed class TriageTests
             Assert.True(cut.Find("[data-testid='triage-apply-label-button']").HasAttribute("disabled"));
         });
 
-        _triageService.DidNotReceive().ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _triageService.DidNotReceive().ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -691,7 +691,7 @@ public sealed class TriageTests
             Assert.Contains("Assigned milestone 'v0.7.0' to item #501", cut.Markup, StringComparison.Ordinal);
         });
 
-        _triageService.Received(1).AssignMilestoneToCurrentItemAsync(Arg.Any<TriageSessionDto>(), 7, "v0.7.0", Arg.Any<CancellationToken>());
+        await _triageService.Received(1).AssignMilestoneToCurrentItemAsync(Arg.Any<TriageSessionDto>(), 7, "v0.7.0", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -764,7 +764,7 @@ public sealed class TriageTests
         });
 
         // Assert
-        _triageService.Received(1).AssignMilestoneToCurrentItemAsync(Arg.Any<TriageSessionDto>(), 7, "v0.7.0", Arg.Any<CancellationToken>());
+        await _triageService.Received(1).AssignMilestoneToCurrentItemAsync(Arg.Any<TriageSessionDto>(), 7, "v0.7.0", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -808,7 +808,7 @@ public sealed class TriageTests
             1,
             0));
 
-        _triageService.AddCurrentItemToProjectBoardAsync( Arg.Any<TriageSessionDto>(), "project-id", "Roadmap", "status-field-id", "in-progress", "In Progress", Arg.Any<CancellationToken>()).Returns(updatedSession);
+        _triageService.AddCurrentItemToProjectBoardAsync(Arg.Any<TriageSessionDto>(), "project-id", "Roadmap", "status-field-id", "in-progress", "In Progress", Arg.Any<CancellationToken>()).Returns(updatedSession);
 
         await using var ctx = CreateContext();
 
@@ -830,7 +830,7 @@ public sealed class TriageTests
             Assert.Contains("Added item #601 to 'Roadmap' with status 'In Progress'", cut.Markup, StringComparison.Ordinal);
         });
 
-        _triageService.Received(1).AddCurrentItemToProjectBoardAsync( Arg.Any<TriageSessionDto>(), "project-id", "Roadmap", "status-field-id", "in-progress", "In Progress", Arg.Any<CancellationToken>());
+        await _triageService.Received(1).AddCurrentItemToProjectBoardAsync(Arg.Any<TriageSessionDto>(), "project-id", "Roadmap", "status-field-id", "in-progress", "In Progress", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -898,8 +898,8 @@ public sealed class TriageTests
             Assert.Contains("Closed item #701 as a duplicate of '#555' and moved to Item 2 of 2", cut.Markup, StringComparison.Ordinal);
         });
 
-        _triageService.Received(1).CloseCurrentItemAsDuplicateAsync(Arg.Any<TriageSessionDto>(), "#555", Arg.Any<CancellationToken>());
-        _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
+        await _triageService.Received(1).CloseCurrentItemAsDuplicateAsync(Arg.Any<TriageSessionDto>(), "#555", Arg.Any<CancellationToken>());
+        await _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -942,8 +942,8 @@ public sealed class TriageTests
         cut.Find("[data-testid='triage-action-buttons-row']").KeyDown("d");
 
         // Assert
-        _triageService.Received(1).CloseCurrentItemAsDuplicateAsync(Arg.Any<TriageSessionDto>(), "#556", Arg.Any<CancellationToken>());
-        _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
+        await _triageService.Received(1).CloseCurrentItemAsDuplicateAsync(Arg.Any<TriageSessionDto>(), "#556", Arg.Any<CancellationToken>());
+        await _triageService.Received(1).AdvanceSessionAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -1011,7 +1011,7 @@ public sealed class TriageTests
             Assert.Contains("Skipped item #801 for later review and moved to Item 1 of 1", cut.Markup, StringComparison.Ordinal);
         });
 
-        _triageService.Received(1).SkipCurrentItemAsync(Arg.Any<TriageSessionDto>(), "Requires broader context", Arg.Any<CancellationToken>());
+        await _triageService.Received(1).SkipCurrentItemAsync(Arg.Any<TriageSessionDto>(), "Requires broader context", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -1195,7 +1195,7 @@ public sealed class TriageTests
             Assert.Contains("Skipped items were appended to the queue for review.", cut.Markup, StringComparison.Ordinal);
         });
 
-        _triageService.Received(1).RevisitSkippedItemsAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
+        await _triageService.Received(1).RevisitSkippedItemsAsync(Arg.Any<TriageSessionDto>(), Arg.Any<CancellationToken>());
     }
 
     private static async Task SelectQuickLabelAsync(IRenderedComponent<Triage> cut, string labelName)
@@ -1244,7 +1244,7 @@ public sealed class TriageTests
         cut.Find("[data-testid='triage-quick-label-autocomplete']").KeyDown("l");
 
         // Assert
-        _triageService.DidNotReceive().ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _triageService.DidNotReceive().ApplyLabelToCurrentItemAsync(Arg.Any<TriageSessionDto>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/App.Tests/SoloDevBoard.App.Tests/WorkflowsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/WorkflowsTests.cs
@@ -1,8 +1,8 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
+using NSubstitute;
 using SoloDevBoard.App.Components.Features.Workflows.Pages;
 using SoloDevBoard.Application.Services.Repositories;
 using SoloDevBoard.Application.Services.Workflows;

--- a/tests/App.Tests/SoloDevBoard.App.Tests/WorkflowsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/WorkflowsTests.cs
@@ -1,6 +1,6 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
+using NSubstitute;
 using MudBlazor;
 using MudBlazor.Services;
 using SoloDevBoard.App.Components.Features.Workflows.Pages;
@@ -12,21 +12,17 @@ namespace SoloDevBoard.App.Tests;
 /// <summary>Component tests for the <see cref="Workflows"/> page.</summary>
 public sealed class WorkflowsTests
 {
-    private readonly Mock<IWorkflowTemplateService> _workflowTemplateServiceMock = new();
-    private readonly Mock<IRepositoryService> _repositoryServiceMock = new();
+    private readonly IWorkflowTemplateService _workflowTemplateService = Substitute.For<IWorkflowTemplateService>();
+    private readonly IRepositoryService _repositoryService = Substitute.For<IRepositoryService>();
 
     [Fact]
     public async Task Workflows_WhileTemplatesAreLoading_ShowsLoadingState()
     {
         // Arrange
         var templatesTask = new TaskCompletionSource<IReadOnlyList<WorkflowTemplateDto>>();
-        _workflowTemplateServiceMock
-            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
-            .Returns(templatesTask.Task);
+        _workflowTemplateService.GetTemplatesAsync(Arg.Any<CancellationToken>()).Returns(templatesTask.Task);
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateRepositories());
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns(CreateRepositories());
 
         await using var ctx = CreateContext();
 
@@ -65,9 +61,7 @@ public sealed class WorkflowsTests
     {
         // Arrange
         SetupDefaultServices();
-        _workflowTemplateServiceMock
-            .Setup(service => service.GetTemplateDetailAsync(1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateTemplateDetail());
+        _workflowTemplateService.GetTemplateDetailAsync(1, Arg.Any<CancellationToken>()).Returns(CreateTemplateDetail());
 
         await using var ctx = CreateContext();
         var cut = ctx.Render<Workflows>();
@@ -93,9 +87,7 @@ public sealed class WorkflowsTests
     {
         // Arrange
         SetupDefaultServices();
-        _workflowTemplateServiceMock
-            .Setup(service => service.GetTemplateDetailAsync(1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateTemplateDetail());
+        _workflowTemplateService.GetTemplateDetailAsync(1, Arg.Any<CancellationToken>()).Returns(CreateTemplateDetail());
 
         await using var ctx = CreateContext();
         var cut = ctx.Render<Workflows>();
@@ -119,9 +111,7 @@ public sealed class WorkflowsTests
     {
         // Arrange
         SetupDefaultServices();
-        _workflowTemplateServiceMock
-            .Setup(service => service.GetTemplateDetailAsync(1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateTemplateDetail());
+        _workflowTemplateService.GetTemplateDetailAsync(1, Arg.Any<CancellationToken>()).Returns(CreateTemplateDetail());
 
         await using var ctx = CreateContext();
         var cut = ctx.Render<Workflows>();
@@ -149,19 +139,13 @@ public sealed class WorkflowsTests
     {
         // Arrange
         SetupDefaultServices();
-        _workflowTemplateServiceMock
-            .Setup(service => service.GetTemplateDetailAsync(1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateTemplateDetail());
+        _workflowTemplateService.GetTemplateDetailAsync(1, Arg.Any<CancellationToken>()).Returns(CreateTemplateDetail());
 
-        _workflowTemplateServiceMock
-            .Setup(service => service.GetRepositoryStatusesAsync(1, It.IsAny<IReadOnlyList<string>>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _workflowTemplateService.GetRepositoryStatusesAsync(1, Arg.Any<IReadOnlyList<string>>(), Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<CancellationToken>()).Returns([
                 new WorkflowTemplateRepositoryStatusDto("owner/repo-a", WorkflowTemplateApplicationStatus.NotApplied, "Workflow file is not present in this repository."),
             ]);
 
-        _workflowTemplateServiceMock
-            .Setup(service => service.ApplyTemplateAsync(1, It.IsAny<IReadOnlyList<string>>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _workflowTemplateService.ApplyTemplateAsync(1, Arg.Any<IReadOnlyList<string>>(), Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<CancellationToken>()).Returns([
                 new WorkflowTemplateRepositoryResultDto("owner/repo-a", "Created", null),
             ]);
 
@@ -194,19 +178,13 @@ public sealed class WorkflowsTests
     {
         // Arrange
         SetupDefaultServices();
-        _workflowTemplateServiceMock
-            .Setup(service => service.GetTemplateDetailAsync(1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateTemplateDetail());
+        _workflowTemplateService.GetTemplateDetailAsync(1, Arg.Any<CancellationToken>()).Returns(CreateTemplateDetail());
 
-        _workflowTemplateServiceMock
-            .Setup(service => service.GetRepositoryStatusesAsync(1, It.IsAny<IReadOnlyList<string>>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _workflowTemplateService.GetRepositoryStatusesAsync(1, Arg.Any<IReadOnlyList<string>>(), Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<CancellationToken>()).Returns([
                 new WorkflowTemplateRepositoryStatusDto("owner/repo-a", WorkflowTemplateApplicationStatus.NotApplied, "Workflow file is not present in this repository."),
             ]);
 
-        _workflowTemplateServiceMock
-            .Setup(service => service.ApplyTemplateAsync(1, It.IsAny<IReadOnlyList<string>>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _workflowTemplateService.ApplyTemplateAsync(1, Arg.Any<IReadOnlyList<string>>(), Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<CancellationToken>()).Returns([
                 new WorkflowTemplateRepositoryResultDto("owner/repo-a", "Failed", "GitHub API request failed."),
             ]);
 
@@ -305,13 +283,9 @@ public sealed class WorkflowsTests
 
     private void SetupDefaultServices()
     {
-        _workflowTemplateServiceMock
-            .Setup(service => service.GetTemplatesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateTemplates());
+        _workflowTemplateService.GetTemplatesAsync(Arg.Any<CancellationToken>()).Returns(CreateTemplates());
 
-        _repositoryServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateRepositories());
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns(CreateRepositories());
     }
 
     private BunitContext CreateContext()
@@ -320,8 +294,8 @@ public sealed class WorkflowsTests
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
         ctx.Services.AddTestHostedAuthenticationRecovery();
-        ctx.Services.AddScoped(_ => _workflowTemplateServiceMock.Object);
-        ctx.Services.AddScoped(_ => _repositoryServiceMock.Object);
+        ctx.Services.AddScoped(_ => _workflowTemplateService);
+        ctx.Services.AddScoped(_ => _repositoryService);
 
         ctx.Render<MudPopoverProvider>();
         ctx.Render<MudDialogProvider>();

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardServiceTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Application.Services.Audit;
 using SoloDevBoard.Application.Services.GitHub;
@@ -11,14 +11,14 @@ namespace SoloDevBoard.Application.Tests;
 
 public sealed class AuditDashboardServiceTests
 {
-    private readonly Mock<IGitHubService> _gitHubServiceMock = new();
-    private readonly Mock<ICurrentUserContext> _currentUserContextMock = new();
+    private readonly IGitHubService _gitHubService = Substitute.For<IGitHubService>();
+    private readonly ICurrentUserContext _currentUserContext = Substitute.For<ICurrentUserContext>();
     private readonly AuditDashboardService _sut;
 
     public AuditDashboardServiceTests()
     {
-        _currentUserContextMock.SetupGet(context => context.OwnerLogin).Returns("owner");
-        _sut = new AuditDashboardService(_gitHubServiceMock.Object, _currentUserContextMock.Object);
+        _currentUserContext.OwnerLogin.Returns("owner");
+        _sut = new AuditDashboardService(_gitHubService, _currentUserContext);
     }
 
     [Fact]
@@ -30,18 +30,18 @@ public sealed class AuditDashboardServiceTests
             new() { Id = 1, Name = "repo-one", FullName = "owner/repo-one" },
             new() { Id = 2, Name = "repo-two", FullName = "owner/repo-two" },
         };
-        _gitHubServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(repositories);
-        _gitHubServiceMock
-            .Setup(service => service.GetIssuesAsync("owner", It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
-        _gitHubServiceMock
-            .Setup(service => service.GetPullRequestsAsync("owner", It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
-        _gitHubServiceMock
-            .Setup(service => service.GetWorkflowRunsAsync("owner", It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
+        _gitHubService
+            .GetActiveRepositoriesAsync(Arg.Any<CancellationToken>())
+            .Returns(repositories);
+        _gitHubService
+            .GetIssuesAsync("owner", Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        _gitHubService
+            .GetPullRequestsAsync("owner", Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        _gitHubService
+            .GetWorkflowRunsAsync("owner", Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([]);
 
         // Act
         var result = await _sut.GetRepositorySummaryAsync();
@@ -61,9 +61,9 @@ public sealed class AuditDashboardServiceTests
             new() { Id = 1, Number = 7, Title = "First issue", State = "open", HtmlUrl = "https://example/issue/7", CreatedAt = DateTimeOffset.UtcNow.AddDays(-3), UpdatedAt = DateTimeOffset.UtcNow },
             new() { Id = 2, Number = 8, Title = "Closed issue", State = "closed", HtmlUrl = "https://example/issue/8", CreatedAt = DateTimeOffset.UtcNow.AddDays(-10), UpdatedAt = DateTimeOffset.UtcNow },
         };
-        _gitHubServiceMock
-            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(issues);
+        _gitHubService
+            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns(issues);
 
         // Act
         var result = await _sut.GetOpenIssuesAsync("repo");
@@ -82,25 +82,25 @@ public sealed class AuditDashboardServiceTests
     {
         // Arrange
         var repos = new[] { "repo-one" };
-        _gitHubServiceMock
-            .Setup(service => service.GetIssuesAsync("owner", "repo-one", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
+        _gitHubService
+            .GetIssuesAsync("owner", "repo-one", Arg.Any<CancellationToken>())
+            .Returns(
             [
                 new Issue { Id = 1, Number = 1, State = "open", Labels = [] },
                 new Issue { Id = 2, Number = 2, State = "open", Labels = [new Label { Name = "bug" }] },
                 new Issue { Id = 3, Number = 3, State = "closed", Labels = [] },
             ]);
-        _gitHubServiceMock
-            .Setup(service => service.GetPullRequestsAsync("owner", "repo-one", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
+        _gitHubService
+            .GetPullRequestsAsync("owner", "repo-one", Arg.Any<CancellationToken>())
+            .Returns(
             [
                 new PullRequest { Id = 1, Number = 11, State = "open", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-20) },
                 new PullRequest { Id = 2, Number = 12, State = "open", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2) },
                 new PullRequest { Id = 3, Number = 13, State = "closed", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-40) },
             ]);
-        _gitHubServiceMock
-            .Setup(service => service.GetWorkflowRunsAsync("owner", "repo-one", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
+        _gitHubService
+            .GetWorkflowRunsAsync("owner", "repo-one", Arg.Any<CancellationToken>())
+            .Returns(
             [
                 new WorkflowRun { Id = 1, WorkflowName = "build", Conclusion = "failure", UpdatedAt = DateTimeOffset.UtcNow },
             ]);
@@ -129,9 +129,9 @@ public sealed class AuditDashboardServiceTests
 
         // Assert
         Assert.Empty(result);
-        _gitHubServiceMock.Verify(service => service.GetIssuesAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        _gitHubServiceMock.Verify(service => service.GetPullRequestsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        _gitHubServiceMock.Verify(service => service.GetWorkflowRunsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        await _gitHubService.DidNotReceive().GetIssuesAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _gitHubService.DidNotReceive().GetPullRequestsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _gitHubService.DidNotReceive().GetWorkflowRunsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -139,9 +139,9 @@ public sealed class AuditDashboardServiceTests
     {
         // Arrange
         var repos = new[] { "repo" };
-        _gitHubServiceMock
-            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
+        _gitHubService
+            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns(
             [
                 new Issue { Id = 1, Number = 1, State = "open", Title = "No labels", HtmlUrl = "https://example/1", Labels = [] },
                 new Issue { Id = 2, Number = 2, State = "open", Title = "Has labels", HtmlUrl = "https://example/2", Labels = [new Label { Name = "bug" }] },
@@ -162,9 +162,9 @@ public sealed class AuditDashboardServiceTests
     {
         // Arrange
         var repos = new[] { "repo" };
-        _gitHubServiceMock
-            .Setup(service => service.GetPullRequestsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
+        _gitHubService
+            .GetPullRequestsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns(
             [
                 new PullRequest { Id = 1, Number = 11, Title = "Stale", HtmlUrl = "https://example/pr/11", State = "open", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-30) },
                 new PullRequest { Id = 2, Number = 12, Title = "Fresh", HtmlUrl = "https://example/pr/12", State = "open", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2), AuthorLogin = "octo" },
@@ -184,9 +184,9 @@ public sealed class AuditDashboardServiceTests
     {
         // Arrange
         var repos = new[] { "repo" };
-        _gitHubServiceMock
-            .Setup(service => service.GetPullRequestsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
+        _gitHubService
+            .GetPullRequestsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns(
             [
                 new PullRequest { Id = 1, Number = 101, Title = "Stale", HtmlUrl = "https://example/pr/101", State = "open", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-21) },
                 new PullRequest { Id = 2, Number = 102, Title = "Recent", HtmlUrl = "https://example/pr/102", State = "open", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-4) },
@@ -206,9 +206,9 @@ public sealed class AuditDashboardServiceTests
     {
         // Arrange
         var repos = new[] { "repo" };
-        _gitHubServiceMock
-            .Setup(service => service.GetWorkflowRunsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
+        _gitHubService
+            .GetWorkflowRunsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns(
             [
                 new WorkflowRun
                 {
@@ -249,9 +249,9 @@ public sealed class AuditDashboardServiceTests
     {
         // Arrange
         var repos = new[] { "repo" };
-        _gitHubServiceMock
-            .Setup(service => service.GetWorkflowRunsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
+        _gitHubService
+            .GetWorkflowRunsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns(
             [
                 new WorkflowRun
                 {
@@ -287,15 +287,15 @@ public sealed class AuditDashboardServiceTests
     {
         // Arrange
         var repos = new[] { "another-owner/repo-one" };
-        _gitHubServiceMock
-            .Setup(service => service.GetIssuesAsync("another-owner", "repo-one", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
-        _gitHubServiceMock
-            .Setup(service => service.GetPullRequestsAsync("another-owner", "repo-one", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
-        _gitHubServiceMock
-            .Setup(service => service.GetWorkflowRunsAsync("another-owner", "repo-one", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
+        _gitHubService
+            .GetIssuesAsync("another-owner", "repo-one", Arg.Any<CancellationToken>())
+            .Returns([]);
+        _gitHubService
+            .GetPullRequestsAsync("another-owner", "repo-one", Arg.Any<CancellationToken>())
+            .Returns([]);
+        _gitHubService
+            .GetWorkflowRunsAsync("another-owner", "repo-one", Arg.Any<CancellationToken>())
+            .Returns([]);
 
         // Act
         var result = await _sut.GetAuditSummaryAsync(repos);
@@ -304,9 +304,9 @@ public sealed class AuditDashboardServiceTests
         var summary = Assert.Single(result);
         Assert.Equal("another-owner/repo-one", summary.RepositoryFullName);
 
-        _gitHubServiceMock.Verify(service => service.GetIssuesAsync("another-owner", "repo-one", It.IsAny<CancellationToken>()), Times.Once);
-        _gitHubServiceMock.Verify(service => service.GetPullRequestsAsync("another-owner", "repo-one", It.IsAny<CancellationToken>()), Times.Once);
-        _gitHubServiceMock.Verify(service => service.GetWorkflowRunsAsync("another-owner", "repo-one", It.IsAny<CancellationToken>()), Times.Once);
+        await _gitHubService.Received(1).GetIssuesAsync("another-owner", "repo-one", Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).GetPullRequestsAsync("another-owner", "repo-one", Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).GetWorkflowRunsAsync("another-owner", "repo-one", Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardServiceTests.cs
@@ -24,6 +24,7 @@ public sealed class AuditDashboardServiceTests
     [Fact]
     public async Task GetRepositorySummaryAsync_ActiveRepositoriesExist_ReturnsRepositoryAuditSummaryDtos()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var repositories = new List<Repository>
         {
@@ -31,20 +32,20 @@ public sealed class AuditDashboardServiceTests
             new() { Id = 2, Name = "repo-two", FullName = "owner/repo-two" },
         };
         _gitHubService
-            .GetActiveRepositoriesAsync(Arg.Any<CancellationToken>())
+            .GetActiveRepositoriesAsync(cancellationToken)
             .Returns(repositories);
         _gitHubService
-            .GetIssuesAsync("owner", Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .GetIssuesAsync("owner", Arg.Any<string>(), cancellationToken)
             .Returns([]);
         _gitHubService
-            .GetPullRequestsAsync("owner", Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .GetPullRequestsAsync("owner", Arg.Any<string>(), cancellationToken)
             .Returns([]);
         _gitHubService
-            .GetWorkflowRunsAsync("owner", Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .GetWorkflowRunsAsync("owner", Arg.Any<string>(), cancellationToken)
             .Returns([]);
 
         // Act
-        var result = await _sut.GetRepositorySummaryAsync();
+        var result = await _sut.GetRepositorySummaryAsync(cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -55,6 +56,7 @@ public sealed class AuditDashboardServiceTests
     [Fact]
     public async Task GetOpenIssuesAsync_ValidRepo_ReturnsMappedIssueDtos()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var issues = new List<Issue>
         {
@@ -62,11 +64,11 @@ public sealed class AuditDashboardServiceTests
             new() { Id = 2, Number = 8, Title = "Closed issue", State = "closed", HtmlUrl = "https://example/issue/8", CreatedAt = DateTimeOffset.UtcNow.AddDays(-10), UpdatedAt = DateTimeOffset.UtcNow },
         };
         _gitHubService
-            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetIssuesAsync("owner", "repo", cancellationToken)
             .Returns(issues);
 
         // Act
-        var result = await _sut.GetOpenIssuesAsync("repo");
+        var result = await _sut.GetOpenIssuesAsync("repo", cancellationToken);
 
         // Assert
         var dto = Assert.Single(result);
@@ -80,10 +82,11 @@ public sealed class AuditDashboardServiceTests
     [Fact]
     public async Task GetAuditSummaryAsync_ReposProvided_ReturnsPerRepositoryCounts()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var repos = new[] { "repo-one" };
         _gitHubService
-            .GetIssuesAsync("owner", "repo-one", Arg.Any<CancellationToken>())
+            .GetIssuesAsync("owner", "repo-one", cancellationToken)
             .Returns(
             [
                 new Issue { Id = 1, Number = 1, State = "open", Labels = [] },
@@ -91,7 +94,7 @@ public sealed class AuditDashboardServiceTests
                 new Issue { Id = 3, Number = 3, State = "closed", Labels = [] },
             ]);
         _gitHubService
-            .GetPullRequestsAsync("owner", "repo-one", Arg.Any<CancellationToken>())
+            .GetPullRequestsAsync("owner", "repo-one", cancellationToken)
             .Returns(
             [
                 new PullRequest { Id = 1, Number = 11, State = "open", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-20) },
@@ -99,14 +102,14 @@ public sealed class AuditDashboardServiceTests
                 new PullRequest { Id = 3, Number = 13, State = "closed", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-40) },
             ]);
         _gitHubService
-            .GetWorkflowRunsAsync("owner", "repo-one", Arg.Any<CancellationToken>())
+            .GetWorkflowRunsAsync("owner", "repo-one", cancellationToken)
             .Returns(
             [
                 new WorkflowRun { Id = 1, WorkflowName = "build", Conclusion = "failure", UpdatedAt = DateTimeOffset.UtcNow },
             ]);
 
         // Act
-        var result = await _sut.GetAuditSummaryAsync(repos);
+        var result = await _sut.GetAuditSummaryAsync(repos, cancellationToken);
 
         // Assert
         var summary = Assert.Single(result);
@@ -121,26 +124,28 @@ public sealed class AuditDashboardServiceTests
     [Fact]
     public async Task GetAuditSummaryAsync_EmptyRepos_ReturnsEmptyList()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         IReadOnlyList<string> repos = [];
 
         // Act
-        var result = await _sut.GetAuditSummaryAsync(repos);
+        var result = await _sut.GetAuditSummaryAsync(repos, cancellationToken);
 
         // Assert
         Assert.Empty(result);
-        await _gitHubService.DidNotReceive().GetIssuesAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await _gitHubService.DidNotReceive().GetPullRequestsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await _gitHubService.DidNotReceive().GetWorkflowRunsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _gitHubService.DidNotReceive().GetIssuesAsync(Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
+        await _gitHubService.DidNotReceive().GetPullRequestsAsync(Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
+        await _gitHubService.DidNotReceive().GetWorkflowRunsAsync(Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
     }
 
     [Fact]
     public async Task GetUnlabelledIssuesAsync_UnlabelledIssuesExist_ReturnsOnlyUnlabelledIssues()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var repos = new[] { "repo" };
         _gitHubService
-            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetIssuesAsync("owner", "repo", cancellationToken)
             .Returns(
             [
                 new Issue { Id = 1, Number = 1, State = "open", Title = "No labels", HtmlUrl = "https://example/1", Labels = [] },
@@ -149,7 +154,7 @@ public sealed class AuditDashboardServiceTests
             ]);
 
         // Act
-        var result = await _sut.GetUnlabelledIssuesAsync(repos);
+        var result = await _sut.GetUnlabelledIssuesAsync(repos, cancellationToken);
 
         // Assert
         var issue = Assert.Single(result);
@@ -160,10 +165,11 @@ public sealed class AuditDashboardServiceTests
     [Fact]
     public async Task GetStalePullRequestsAsync_StalePullRequestsExist_ReturnsOnlyStalePullRequests()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var repos = new[] { "repo" };
         _gitHubService
-            .GetPullRequestsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetPullRequestsAsync("owner", "repo", cancellationToken)
             .Returns(
             [
                 new PullRequest { Id = 1, Number = 11, Title = "Stale", HtmlUrl = "https://example/pr/11", State = "open", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-30) },
@@ -171,7 +177,7 @@ public sealed class AuditDashboardServiceTests
             ]);
 
         // Act
-        var result = await _sut.GetStalePullRequestsAsync(repos, staleDays: 14);
+        var result = await _sut.GetStalePullRequestsAsync(repos, staleDays: 14, cancellationToken);
 
         // Assert
         var pullRequest = Assert.Single(result);
@@ -182,10 +188,11 @@ public sealed class AuditDashboardServiceTests
     [Fact]
     public async Task GetStalePullRequestsAsync_DefaultThreshold_ExcludesRecentAndClosedPullRequests()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var repos = new[] { "repo" };
         _gitHubService
-            .GetPullRequestsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetPullRequestsAsync("owner", "repo", cancellationToken)
             .Returns(
             [
                 new PullRequest { Id = 1, Number = 101, Title = "Stale", HtmlUrl = "https://example/pr/101", State = "open", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-21) },
@@ -194,7 +201,7 @@ public sealed class AuditDashboardServiceTests
             ]);
 
         // Act
-        var result = await _sut.GetStalePullRequestsAsync(repos);
+        var result = await _sut.GetStalePullRequestsAsync(repos, cancellationToken: cancellationToken);
 
         // Assert
         var pullRequest = Assert.Single(result);
@@ -204,10 +211,11 @@ public sealed class AuditDashboardServiceTests
     [Fact]
     public async Task GetFailingWorkflowRunsAsync_MostRecentRunFails_ReturnsWorkflowRunDto()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var repos = new[] { "repo" };
         _gitHubService
-            .GetWorkflowRunsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetWorkflowRunsAsync("owner", "repo", cancellationToken)
             .Returns(
             [
                 new WorkflowRun
@@ -234,7 +242,7 @@ public sealed class AuditDashboardServiceTests
             ]);
 
         // Act
-        var result = await _sut.GetFailingWorkflowRunsAsync(repos);
+        var result = await _sut.GetFailingWorkflowRunsAsync(repos, cancellationToken);
 
         // Assert
         var workflowRun = Assert.Single(result);
@@ -247,10 +255,11 @@ public sealed class AuditDashboardServiceTests
     [Fact]
     public async Task GetFailingWorkflowRunsAsync_MostRecentRunIsSuccessful_ExcludesWorkflow()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var repos = new[] { "repo" };
         _gitHubService
-            .GetWorkflowRunsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetWorkflowRunsAsync("owner", "repo", cancellationToken)
             .Returns(
             [
                 new WorkflowRun
@@ -276,7 +285,7 @@ public sealed class AuditDashboardServiceTests
             ]);
 
         // Act
-        var result = await _sut.GetFailingWorkflowRunsAsync(repos);
+        var result = await _sut.GetFailingWorkflowRunsAsync(repos, cancellationToken);
 
         // Assert
         Assert.Empty(result);
@@ -285,38 +294,40 @@ public sealed class AuditDashboardServiceTests
     [Fact]
     public async Task GetAuditSummaryAsync_ReposContainDifferentOwnerPrefix_UsesProvidedOwnerForRequests()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var repos = new[] { "another-owner/repo-one" };
         _gitHubService
-            .GetIssuesAsync("another-owner", "repo-one", Arg.Any<CancellationToken>())
+            .GetIssuesAsync("another-owner", "repo-one", cancellationToken)
             .Returns([]);
         _gitHubService
-            .GetPullRequestsAsync("another-owner", "repo-one", Arg.Any<CancellationToken>())
+            .GetPullRequestsAsync("another-owner", "repo-one", cancellationToken)
             .Returns([]);
         _gitHubService
-            .GetWorkflowRunsAsync("another-owner", "repo-one", Arg.Any<CancellationToken>())
+            .GetWorkflowRunsAsync("another-owner", "repo-one", cancellationToken)
             .Returns([]);
 
         // Act
-        var result = await _sut.GetAuditSummaryAsync(repos);
+        var result = await _sut.GetAuditSummaryAsync(repos, cancellationToken);
 
         // Assert
         var summary = Assert.Single(result);
         Assert.Equal("another-owner/repo-one", summary.RepositoryFullName);
 
-        await _gitHubService.Received(1).GetIssuesAsync("another-owner", "repo-one", Arg.Any<CancellationToken>());
-        await _gitHubService.Received(1).GetPullRequestsAsync("another-owner", "repo-one", Arg.Any<CancellationToken>());
-        await _gitHubService.Received(1).GetWorkflowRunsAsync("another-owner", "repo-one", Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).GetIssuesAsync("another-owner", "repo-one", cancellationToken);
+        await _gitHubService.Received(1).GetPullRequestsAsync("another-owner", "repo-one", cancellationToken);
+        await _gitHubService.Received(1).GetWorkflowRunsAsync("another-owner", "repo-one", cancellationToken);
     }
 
     [Fact]
     public async Task GetStalePullRequestsAsync_StaleDaysIsZero_ThrowsArgumentOutOfRangeException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var repos = new[] { "repo" };
 
         // Act
-        var act = async () => await _sut.GetStalePullRequestsAsync(repos, staleDays: 0);
+        var act = async () => await _sut.GetStalePullRequestsAsync(repos, staleDays: 0, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(act);
@@ -325,11 +336,12 @@ public sealed class AuditDashboardServiceTests
     [Fact]
     public async Task GetAuditSummaryAsync_ReposIsNull_ThrowsArgumentNullException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         IReadOnlyList<string> repos = null!;
 
         // Act
-        var act = async () => await _sut.GetAuditSummaryAsync(repos);
+        var act = async () => await _sut.GetAuditSummaryAsync(repos, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentNullException>(act);

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/BoardRulesServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/BoardRulesServiceTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 using SoloDevBoard.Application.Services.BoardRules;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Domain.Entities.Triage;
@@ -8,7 +8,7 @@ namespace SoloDevBoard.Application.Tests;
 /// <summary>Tests for <see cref="BoardRulesService"/>.</summary>
 public sealed class BoardRulesServiceTests
 {
-    private readonly Mock<IGitHubService> _gitHubServiceMock = new();
+    private readonly IGitHubService _gitHubService = Substitute.For<IGitHubService>();
 
     [Fact]
     public void Constructor_GitHubServiceIsNull_ThrowsArgumentNullException()
@@ -35,27 +35,27 @@ public sealed class BoardRulesServiceTests
             Array.Empty<BoardRuleDto>(),
             new[] { "Board automation rules are not yet available through the current GitHub query model." });
 
-        _gitHubServiceMock
-            .Setup(service => service.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(expected);
+        _gitHubService
+            .GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", Arg.Any<CancellationToken>())
+            .Returns(expected);
 
-        var sut = new BoardRulesService(_gitHubServiceMock.Object);
+        var sut = new BoardRulesService(_gitHubService);
 
         // Act
         var result = await sut.GetBoardRulesAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh");
 
         // Assert
         Assert.Same(expected, result);
-        _gitHubServiceMock.Verify(service => service.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", It.IsAny<CancellationToken>()), Times.Once);
+        await _gitHubService.Received(1).GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetProjectBoardOptionsAsync_ProjectBoardsReturned_ReturnsSortedOptions()
     {
         // Arrange
-        _gitHubServiceMock
-            .Setup(service => service.GetProjectBoardsForRepositoryAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new RepositoryProjectBoardDiscoveryResult(
+        _gitHubService
+            .GetProjectBoardsForRepositoryAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns(new RepositoryProjectBoardDiscoveryResult(
             [
                 new TriageProjectBoard
                 {
@@ -77,7 +77,7 @@ public sealed class BoardRulesServiceTests
             2,
             0));
 
-        var sut = new BoardRulesService(_gitHubServiceMock.Object);
+        var sut = new BoardRulesService(_gitHubService);
 
         // Act
         var result = await sut.GetProjectBoardOptionsAsync("owner", "repo");
@@ -90,14 +90,14 @@ public sealed class BoardRulesServiceTests
         Assert.Equal("Alpha Board", result.Options[0].Title);
         Assert.Equal("owner", result.Options[0].OwnerLogin);
         Assert.Equal("PVT_beta", result.Options[1].Id);
-        _gitHubServiceMock.Verify(service => service.GetProjectBoardsForRepositoryAsync("owner", "repo", It.IsAny<CancellationToken>()), Times.Once);
+        await _gitHubService.Received(1).GetProjectBoardsForRepositoryAsync("owner", "repo", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetProjectBoardOptionsAsync_OwnerIsWhitespace_ThrowsArgumentException()
     {
         // Arrange
-        var sut = new BoardRulesService(_gitHubServiceMock.Object);
+        var sut = new BoardRulesService(_gitHubService);
 
         // Act
         var action = () => sut.GetProjectBoardOptionsAsync(" ", "repo");
@@ -110,7 +110,7 @@ public sealed class BoardRulesServiceTests
     public async Task GetBoardRulesAsync_ProjectIdIsWhitespace_ThrowsArgumentException()
     {
         // Arrange
-        var sut = new BoardRulesService(_gitHubServiceMock.Object);
+        var sut = new BoardRulesService(_gitHubService);
 
         // Act
         var action = () => sut.GetBoardRulesAsync("owner", "repo", " ");
@@ -123,11 +123,11 @@ public sealed class BoardRulesServiceTests
     public async Task GetProjectBoardOptionsAsync_NoSupportedBoards_ReturnsEmptyOptions()
     {
         // Arrange
-        _gitHubServiceMock
-            .Setup(service => service.GetProjectBoardsForRepositoryAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new RepositoryProjectBoardDiscoveryResult([], 0, 0));
+        _gitHubService
+            .GetProjectBoardsForRepositoryAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns(new RepositoryProjectBoardDiscoveryResult([], 0, 0));
 
-        var sut = new BoardRulesService(_gitHubServiceMock.Object);
+        var sut = new BoardRulesService(_gitHubService);
 
         // Act
         var result = await sut.GetProjectBoardOptionsAsync("owner", "repo");
@@ -142,9 +142,9 @@ public sealed class BoardRulesServiceTests
     public async Task GetProjectBoardOptionsAsync_PartiallyAccessibleBoards_PropagatesVisibilityCounts()
     {
         // Arrange
-        _gitHubServiceMock
-            .Setup(service => service.GetProjectBoardsForRepositoryAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new RepositoryProjectBoardDiscoveryResult(
+        _gitHubService
+            .GetProjectBoardsForRepositoryAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns(new RepositoryProjectBoardDiscoveryResult(
             [
                 new TriageProjectBoard
                 {
@@ -158,7 +158,7 @@ public sealed class BoardRulesServiceTests
             3,
             2));
 
-        var sut = new BoardRulesService(_gitHubServiceMock.Object);
+        var sut = new BoardRulesService(_gitHubService);
 
         // Act
         var result = await sut.GetProjectBoardOptionsAsync("owner", "repo");
@@ -188,7 +188,7 @@ public sealed class BoardRulesServiceTests
             [],
             []);
 
-        var sut = new BoardRulesService(_gitHubServiceMock.Object);
+        var sut = new BoardRulesService(_gitHubService);
 
         // Act
         var result = sut.CompareBoardRules(left, right);

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/BoardRulesServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/BoardRulesServiceTests.cs
@@ -26,6 +26,7 @@ public sealed class BoardRulesServiceTests
     [Fact]
     public async Task GetBoardRulesAsync_ValidRequest_ReturnsDefinitionFromGitHubService()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var expected = new BoardRulesDefinitionDto(
             "PVT_kwHOAJefG84BQ6bh",
@@ -36,25 +37,26 @@ public sealed class BoardRulesServiceTests
             new[] { "Board automation rules are not yet available through the current GitHub query model." });
 
         _gitHubService
-            .GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", Arg.Any<CancellationToken>())
+            .GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", cancellationToken)
             .Returns(expected);
 
         var sut = new BoardRulesService(_gitHubService);
 
         // Act
-        var result = await sut.GetBoardRulesAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh");
+        var result = await sut.GetBoardRulesAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", cancellationToken);
 
         // Assert
         Assert.Same(expected, result);
-        await _gitHubService.Received(1).GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", cancellationToken);
     }
 
     [Fact]
     public async Task GetProjectBoardOptionsAsync_ProjectBoardsReturned_ReturnsSortedOptions()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _gitHubService
-            .GetProjectBoardsForRepositoryAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetProjectBoardsForRepositoryAsync("owner", "repo", cancellationToken)
             .Returns(new RepositoryProjectBoardDiscoveryResult(
             [
                 new TriageProjectBoard
@@ -80,7 +82,7 @@ public sealed class BoardRulesServiceTests
         var sut = new BoardRulesService(_gitHubService);
 
         // Act
-        var result = await sut.GetProjectBoardOptionsAsync("owner", "repo");
+        var result = await sut.GetProjectBoardOptionsAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Options.Count);
@@ -90,17 +92,18 @@ public sealed class BoardRulesServiceTests
         Assert.Equal("Alpha Board", result.Options[0].Title);
         Assert.Equal("owner", result.Options[0].OwnerLogin);
         Assert.Equal("PVT_beta", result.Options[1].Id);
-        await _gitHubService.Received(1).GetProjectBoardsForRepositoryAsync("owner", "repo", Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).GetProjectBoardsForRepositoryAsync("owner", "repo", cancellationToken);
     }
 
     [Fact]
     public async Task GetProjectBoardOptionsAsync_OwnerIsWhitespace_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new BoardRulesService(_gitHubService);
 
         // Act
-        var action = () => sut.GetProjectBoardOptionsAsync(" ", "repo");
+        var action = () => sut.GetProjectBoardOptionsAsync(" ", "repo", cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -109,11 +112,12 @@ public sealed class BoardRulesServiceTests
     [Fact]
     public async Task GetBoardRulesAsync_ProjectIdIsWhitespace_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new BoardRulesService(_gitHubService);
 
         // Act
-        var action = () => sut.GetBoardRulesAsync("owner", "repo", " ");
+        var action = () => sut.GetBoardRulesAsync("owner", "repo", " ", cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -122,15 +126,16 @@ public sealed class BoardRulesServiceTests
     [Fact]
     public async Task GetProjectBoardOptionsAsync_NoSupportedBoards_ReturnsEmptyOptions()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _gitHubService
-            .GetProjectBoardsForRepositoryAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetProjectBoardsForRepositoryAsync("owner", "repo", cancellationToken)
             .Returns(new RepositoryProjectBoardDiscoveryResult([], 0, 0));
 
         var sut = new BoardRulesService(_gitHubService);
 
         // Act
-        var result = await sut.GetProjectBoardOptionsAsync("owner", "repo");
+        var result = await sut.GetProjectBoardOptionsAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Empty(result.Options);
@@ -141,9 +146,10 @@ public sealed class BoardRulesServiceTests
     [Fact]
     public async Task GetProjectBoardOptionsAsync_PartiallyAccessibleBoards_PropagatesVisibilityCounts()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _gitHubService
-            .GetProjectBoardsForRepositoryAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetProjectBoardsForRepositoryAsync("owner", "repo", cancellationToken)
             .Returns(new RepositoryProjectBoardDiscoveryResult(
             [
                 new TriageProjectBoard
@@ -161,7 +167,7 @@ public sealed class BoardRulesServiceTests
         var sut = new BoardRulesService(_gitHubService);
 
         // Act
-        var result = await sut.GetProjectBoardOptionsAsync("owner", "repo");
+        var result = await sut.GetProjectBoardOptionsAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Single(result.Options);

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelServiceTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 using SoloDevBoard.Application.Services.Labels;
 using SoloDevBoard.Domain.Entities.Labels;
 
@@ -7,7 +7,7 @@ namespace SoloDevBoard.Application.Tests;
 /// <summary>Tests for <see cref="LabelService"/>.</summary>
 public sealed class LabelServiceTests
 {
-    private readonly Mock<ILabelRepository> _labelRepositoryMock = new();
+    private readonly ILabelRepository _labelRepository = Substitute.For<ILabelRepository>();
 
     [Fact]
     public void Constructor_LabelRepositoryIsNull_ThrowsArgumentNullException()
@@ -26,14 +26,14 @@ public sealed class LabelServiceTests
     public async Task GetLabelsAsync_RepositoryReturnsLabels_ReturnsMappedLabelDtos()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "A user-facing Story delivering a discrete piece of value", RepositoryName = "repo" },
                 new Label { Name = "priority/high", Colour = "d93f0b", Description = "Should be addressed in the current sprint or release", RepositoryName = "repo" },
             ]);
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.GetLabelsAsync("owner", "repo");
@@ -48,15 +48,15 @@ public sealed class LabelServiceTests
     public async Task GetLabelsForRepositoriesAsync_MultipleRepositories_ReturnsMergedLabels()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "repo-a" }]);
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>())
+            .Returns([new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "repo-a" }]);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("owner", "repo-b", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new Label { Name = "priority/high", Colour = "d93f0b", Description = "High", RepositoryName = "repo-b" }]);
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-b", Arg.Any<CancellationToken>())
+            .Returns([new Label { Name = "priority/high", Colour = "d93f0b", Description = "High", RepositoryName = "repo-b" }]);
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.GetLabelsForRepositoriesAsync("owner", ["repo-a", "repo-b"]);
@@ -71,25 +71,25 @@ public sealed class LabelServiceTests
     public async Task GetLabelsForRepositoriesAsync_DuplicateRepositoryNames_QueriesEachRepositoryOnce()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "repo-a" }]);
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>())
+            .Returns([new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "repo-a" }]);
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.GetLabelsForRepositoriesAsync("owner", ["repo-a", "repo-a", "repo-a"]);
 
         // Assert
         Assert.Single(result);
-        _labelRepositoryMock.Verify(repository => repository.GetLabelsAsync("owner", "repo-a", It.IsAny<CancellationToken>()), Times.Once);
+        await _labelRepository.Received(1).GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetLabelsForRepositoriesAsync_OwnerIsWhitespace_ThrowsArgumentException()
     {
         // Arrange
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var action = async () => await sut.GetLabelsForRepositoriesAsync(" ", ["repo-a"]);
@@ -104,19 +104,24 @@ public sealed class LabelServiceTests
         // Arrange
         var label = new LabelDto("area/labels", "c5def5", "Label Manager feature", string.Empty);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.CreateLabelAsync("owner", It.IsAny<string>(), It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, Label value, CancellationToken _) => value with { RepositoryName = repo });
+        _labelRepository
+            .CreateLabelAsync("owner", Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var value = callInfo.ArgAt<Label>(2);
+                return value with { RepositoryName = repo };
+            });
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.CreateLabelAsync("owner", ["repo-a", "repo-b"], label);
 
         // Assert
         Assert.Equal(2, result.Count);
-        _labelRepositoryMock.Verify(repository => repository.CreateLabelAsync("owner", "repo-a", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Once);
-        _labelRepositoryMock.Verify(repository => repository.CreateLabelAsync("owner", "repo-b", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Once);
+        await _labelRepository.Received(1).CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).CreateLabelAsync("owner", "repo-b", Arg.Any<Label>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -125,31 +130,36 @@ public sealed class LabelServiceTests
         // Arrange
         var label = new LabelDto("area/labels", "c5def5", "Label Manager feature", string.Empty);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.CreateLabelAsync("owner", "repo-a", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, Label value, CancellationToken _) => value with { RepositoryName = repo });
+        _labelRepository
+            .CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var value = callInfo.ArgAt<Label>(2);
+                return value with { RepositoryName = repo };
+            });
 
-        _labelRepositoryMock
-            .Setup(repository => repository.CreateLabelAsync("owner", "repo-b", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("GitHub API failure"));
+        _labelRepository
+            .CreateLabelAsync("owner", "repo-b", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<Label>(new HttpRequestException("GitHub API failure")));
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var action = async () => await sut.CreateLabelAsync("owner", ["repo-a", "repo-b", "repo-c"], label);
 
         // Assert
         _ = await Assert.ThrowsAsync<HttpRequestException>(action);
-        _labelRepositoryMock.Verify(repository => repository.CreateLabelAsync("owner", "repo-a", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Once);
-        _labelRepositoryMock.Verify(repository => repository.CreateLabelAsync("owner", "repo-b", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Once);
-        _labelRepositoryMock.Verify(repository => repository.CreateLabelAsync("owner", "repo-c", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
+        await _labelRepository.Received(1).CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).CreateLabelAsync("owner", "repo-b", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().CreateLabelAsync("owner", "repo-c", Arg.Any<Label>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task CreateLabelAsync_LabelIsNull_ThrowsArgumentNullException()
     {
         // Arrange
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var action = async () => await sut.CreateLabelAsync("owner", ["repo-a"], null!);
@@ -162,7 +172,7 @@ public sealed class LabelServiceTests
     public async Task CreateLabelAsync_RepositoriesEmpty_ThrowsArgumentException()
     {
         // Arrange
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
         var label = new LabelDto("area/labels", "c5def5", "Label Manager feature", string.Empty);
 
         // Act
@@ -178,19 +188,24 @@ public sealed class LabelServiceTests
         // Arrange
         var updatedLabel = new LabelDto("priority/high", "d93f0b", "Should be addressed in the current sprint or release", string.Empty);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.UpdateLabelAsync("owner", It.IsAny<string>(), "priority/urgent", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, string _, Label value, CancellationToken _) => value with { RepositoryName = repo });
+        _labelRepository
+            .UpdateLabelAsync("owner", Arg.Any<string>(), "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var value = callInfo.ArgAt<Label>(3);
+                return value with { RepositoryName = repo };
+            });
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.UpdateLabelAsync("owner", ["repo-a", "repo-b"], "priority/urgent", updatedLabel);
 
         // Assert
         Assert.Equal(2, result.Count);
-        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync("owner", "repo-a", "priority/urgent", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Once);
-        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync("owner", "repo-b", "priority/urgent", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Once);
+        await _labelRepository.Received(1).UpdateLabelAsync("owner", "repo-a", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).UpdateLabelAsync("owner", "repo-b", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -199,18 +214,18 @@ public sealed class LabelServiceTests
         // Arrange
         var updatedLabel = new LabelDto("priority/high", "d93f0b", "Should be addressed in the current sprint or release", string.Empty);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.UpdateLabelAsync("owner", "repo-a", "priority/urgent", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new KeyNotFoundException("Label not found"));
+        _labelRepository
+            .UpdateLabelAsync("owner", "repo-a", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<Label>(new KeyNotFoundException("Label not found")));
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var action = async () => await sut.UpdateLabelAsync("owner", ["repo-a", "repo-b"], "priority/urgent", updatedLabel);
 
         // Assert
         _ = await Assert.ThrowsAsync<KeyNotFoundException>(action);
-        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync("owner", "repo-b", "priority/urgent", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
+        await _labelRepository.DidNotReceive().UpdateLabelAsync("owner", "repo-b", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -219,105 +234,110 @@ public sealed class LabelServiceTests
         // Arrange
         var updatedLabel = new LabelDto("priority/high", "d93f0b", "Should be addressed in the current sprint or release", string.Empty);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.UpdateLabelAsync("owner", "repo-a", "priority/urgent", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, string _, Label value, CancellationToken _) => value with { RepositoryName = repo });
+        _labelRepository
+            .UpdateLabelAsync("owner", "repo-a", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var value = callInfo.ArgAt<Label>(3);
+                return value with { RepositoryName = repo };
+            });
 
-        _labelRepositoryMock
-            .Setup(repository => repository.UpdateLabelAsync("owner", "repo-b", "priority/urgent", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("GitHub API failure"));
+        _labelRepository
+            .UpdateLabelAsync("owner", "repo-b", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<Label>(new HttpRequestException("GitHub API failure")));
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var action = async () => await sut.UpdateLabelAsync("owner", ["repo-a", "repo-b", "repo-c"], "priority/urgent", updatedLabel);
 
         // Assert
         _ = await Assert.ThrowsAsync<HttpRequestException>(action);
-        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync("owner", "repo-a", "priority/urgent", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Once);
-        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync("owner", "repo-b", "priority/urgent", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Once);
-        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync("owner", "repo-c", "priority/urgent", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
+        await _labelRepository.Received(1).UpdateLabelAsync("owner", "repo-a", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).UpdateLabelAsync("owner", "repo-b", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().UpdateLabelAsync("owner", "repo-c", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task DeleteLabelAsync_MultipleRepositories_DeletesLabelInEachRepository()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.DeleteLabelAsync("owner", It.IsAny<string>(), "status/blocked", It.IsAny<CancellationToken>()))
+        _labelRepository
+            .DeleteLabelAsync("owner", Arg.Any<string>(), "status/blocked", Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         await sut.DeleteLabelAsync("owner", ["repo-a", "repo-b"], "status/blocked");
 
         // Assert
-        _labelRepositoryMock.Verify(repository => repository.DeleteLabelAsync("owner", "repo-a", "status/blocked", It.IsAny<CancellationToken>()), Times.Once);
-        _labelRepositoryMock.Verify(repository => repository.DeleteLabelAsync("owner", "repo-b", "status/blocked", It.IsAny<CancellationToken>()), Times.Once);
+        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-a", "status/blocked", Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-b", "status/blocked", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task DeleteLabelAsync_LabelMissingInFirstRepository_ThrowsAndStopsFurtherProcessing()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.DeleteLabelAsync("owner", "repo-a", "status/blocked", It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new KeyNotFoundException("Label not found"));
+        _labelRepository
+            .DeleteLabelAsync("owner", "repo-a", "status/blocked", Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new KeyNotFoundException("Label not found")));
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var action = async () => await sut.DeleteLabelAsync("owner", ["repo-a", "repo-b"], "status/blocked");
 
         // Assert
         _ = await Assert.ThrowsAsync<KeyNotFoundException>(action);
-        _labelRepositoryMock.Verify(repository => repository.DeleteLabelAsync("owner", "repo-b", "status/blocked", It.IsAny<CancellationToken>()), Times.Never);
+        await _labelRepository.DidNotReceive().DeleteLabelAsync("owner", "repo-b", "status/blocked", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task DeleteLabelAsync_SecondRepositoryFails_ThrowsAndStopsFurtherProcessing()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.DeleteLabelAsync("owner", "repo-a", "status/blocked", It.IsAny<CancellationToken>()))
+        _labelRepository
+            .DeleteLabelAsync("owner", "repo-a", "status/blocked", Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.DeleteLabelAsync("owner", "repo-b", "status/blocked", It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("GitHub API failure"));
+        _labelRepository
+            .DeleteLabelAsync("owner", "repo-b", "status/blocked", Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new HttpRequestException("GitHub API failure")));
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var action = async () => await sut.DeleteLabelAsync("owner", ["repo-a", "repo-b", "repo-c"], "status/blocked");
 
         // Assert
         _ = await Assert.ThrowsAsync<HttpRequestException>(action);
-        _labelRepositoryMock.Verify(repository => repository.DeleteLabelAsync("owner", "repo-a", "status/blocked", It.IsAny<CancellationToken>()), Times.Once);
-        _labelRepositoryMock.Verify(repository => repository.DeleteLabelAsync("owner", "repo-b", "status/blocked", It.IsAny<CancellationToken>()), Times.Once);
-        _labelRepositoryMock.Verify(repository => repository.DeleteLabelAsync("owner", "repo-c", "status/blocked", It.IsAny<CancellationToken>()), Times.Never);
+        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-a", "status/blocked", Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-b", "status/blocked", Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().DeleteLabelAsync("owner", "repo-c", "status/blocked", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task SyncLabelsAsync_ApplyChangesFalse_ReturnsPreviewWithoutMutatingTarget()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("source-owner", "source-repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("source-owner", "source-repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "source-repo" },
                 new Label { Name = "priority/high", Colour = "d93f0b", Description = "High updated", RepositoryName = "source-repo" },
             ]);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("target-owner", "target-repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("target-owner", "target-repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "priority/high", Colour = "fbca04", Description = "High old", RepositoryName = "target-repo" },
                 new Label { Name = "status/obsolete", Colour = "ffffff", Description = "Old", RepositoryName = "target-repo" },
             ]);
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.SyncLabelsAsync("source-owner", "source-repo", "target-owner", "target-repo", applyChanges: false);
@@ -331,42 +351,53 @@ public sealed class LabelServiceTests
         Assert.Equal("status/obsolete", result.ToDelete[0].Name);
         Assert.Empty(result.Skipped);
 
-        _labelRepositoryMock.Verify(repository => repository.CreateLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
-        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
-        _labelRepositoryMock.Verify(repository => repository.DeleteLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        await _labelRepository.DidNotReceive().CreateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().DeleteLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task SyncLabelsAsync_ApplyChangesTrue_AppliesAddUpdateAndDeleteOperations()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("source-owner", "source-repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("source-owner", "source-repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "priority/high", Colour = "d93f0b", Description = "High", RepositoryName = "source-repo" },
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "source-repo" },
             ]);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("target-owner", "target-repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("target-owner", "target-repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "type/story", Colour = "ffffff", Description = "Old Story", RepositoryName = "target-repo" },
                 new Label { Name = "status/obsolete", Colour = "ffffff", Description = "Old", RepositoryName = "target-repo" },
             ]);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.UpdateLabelAsync("target-owner", "target-repo", "type/story", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, string name, Label value, CancellationToken _) => value with { Name = name, RepositoryName = repo });
+        _labelRepository
+            .UpdateLabelAsync("target-owner", "target-repo", "type/story", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var name = callInfo.ArgAt<string>(2);
+                var value = callInfo.ArgAt<Label>(3);
+                return value with { Name = name, RepositoryName = repo };
+            });
 
-        _labelRepositoryMock
-            .Setup(repository => repository.CreateLabelAsync("target-owner", "target-repo", It.Is<Label>(label => label.Name == "priority/high"), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, Label value, CancellationToken _) => value with { RepositoryName = repo });
+        _labelRepository
+            .CreateLabelAsync("target-owner", "target-repo", Arg.Is<Label>(label => label.Name == "priority/high"), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var value = callInfo.ArgAt<Label>(2);
+                return value with { RepositoryName = repo };
+            });
 
-        _labelRepositoryMock
-            .Setup(repository => repository.DeleteLabelAsync("target-owner", "target-repo", "status/obsolete", It.IsAny<CancellationToken>()))
+        _labelRepository
+            .DeleteLabelAsync("target-owner", "target-repo", "status/obsolete", Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.SyncLabelsAsync("source-owner", "source-repo", "target-owner", "target-repo", applyChanges: true);
@@ -375,9 +406,9 @@ public sealed class LabelServiceTests
         Assert.Single(result.ToAdd);
         Assert.Single(result.ToUpdate);
         Assert.Single(result.ToDelete);
-        _labelRepositoryMock.Verify(repository => repository.CreateLabelAsync("target-owner", "target-repo", It.Is<Label>(label => label.Name == "priority/high"), It.IsAny<CancellationToken>()), Times.Once);
-        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync("target-owner", "target-repo", "type/story", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Once);
-        _labelRepositoryMock.Verify(repository => repository.DeleteLabelAsync("target-owner", "target-repo", "status/obsolete", It.IsAny<CancellationToken>()), Times.Once);
+        await _labelRepository.Received(1).CreateLabelAsync("target-owner", "target-repo", Arg.Is<Label>(label => label.Name == "priority/high"), Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).UpdateLabelAsync("target-owner", "target-repo", "type/story", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).DeleteLabelAsync("target-owner", "target-repo", "status/obsolete", Arg.Any<CancellationToken>());
         Assert.Empty(result.Skipped);
     }
 
@@ -391,15 +422,15 @@ public sealed class LabelServiceTests
             new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "repo" },
         };
 
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("source-owner", "source-repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(labels);
+        _labelRepository
+            .GetLabelsAsync("source-owner", "source-repo", Arg.Any<CancellationToken>())
+            .Returns(labels);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("target-owner", "target-repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(labels);
+        _labelRepository
+            .GetLabelsAsync("target-owner", "target-repo", Arg.Any<CancellationToken>())
+            .Returns(labels);
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.SyncLabelsAsync("source-owner", "source-repo", "target-owner", "target-repo", applyChanges: true);
@@ -408,9 +439,9 @@ public sealed class LabelServiceTests
         Assert.Empty(result.ToAdd);
         Assert.Empty(result.ToUpdate);
         Assert.Empty(result.ToDelete);
-        _labelRepositoryMock.Verify(repository => repository.CreateLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
-        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
-        _labelRepositoryMock.Verify(repository => repository.DeleteLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        await _labelRepository.DidNotReceive().CreateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().DeleteLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
         Assert.Equal(2, result.Skipped.Count);
     }
 
@@ -418,27 +449,27 @@ public sealed class LabelServiceTests
     public async Task PreviewLabelSynchronisationAsync_MultipleTargets_ReturnsPerRepositoryPreviews()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("source-owner", "source-repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("source-owner", "source-repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "source-repo" },
                 new Label { Name = "priority/high", Colour = "d93f0b", Description = "High", RepositoryName = "source-repo" },
             ]);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("target-owner", "target-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("target-owner", "target-a", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "priority/high", Colour = "fbca04", Description = "Old", RepositoryName = "target-a" },
             ]);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("target-owner", "target-b", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("target-owner", "target-b", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "target-b" },
                 new Label { Name = "priority/high", Colour = "d93f0b", Description = "High", RepositoryName = "target-b" },
             ]);
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.PreviewLabelSynchronisationAsync(
@@ -455,25 +486,30 @@ public sealed class LabelServiceTests
     public async Task ApplyLabelSynchronisationAsync_TargetFails_ReturnsPartialFailureWithoutAbortingOtherTargets()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("source-owner", "source-repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("source-owner", "source-repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "source-repo" },
             ]);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("target-owner", "target-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<Label>());
+        _labelRepository
+            .GetLabelsAsync("target-owner", "target-a", Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Label>());
 
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("target-owner", "target-b", It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("GitHub API failure"));
+        _labelRepository
+            .GetLabelsAsync("target-owner", "target-b", Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<IReadOnlyList<Label>>(new HttpRequestException("GitHub API failure")));
 
-        _labelRepositoryMock
-            .Setup(repository => repository.CreateLabelAsync("target-owner", "target-a", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, Label label, CancellationToken _) => label with { RepositoryName = repo });
+        _labelRepository
+            .CreateLabelAsync("target-owner", "target-a", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var label = callInfo.ArgAt<Label>(2);
+                return label with { RepositoryName = repo };
+            });
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.ApplyLabelSynchronisationAsync(
@@ -485,33 +521,31 @@ public sealed class LabelServiceTests
         Assert.Contains(result, item => item.RepositoryFullName == "target-owner/target-a" && !item.HasError && item.CreatedCount == 1);
         Assert.Contains(result, item => item.RepositoryFullName == "target-owner/target-b" && item.HasError);
 
-        _labelRepositoryMock.Verify(
-            repository => repository.CreateLabelAsync("target-owner", "target-a", It.Is<Label>(label => label.Name == "type/story"), It.IsAny<CancellationToken>()),
-            Times.Once);
+        await _labelRepository.Received(1).CreateLabelAsync("target-owner", "target-a", Arg.Is<Label>(label => label.Name == "type/story"), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task SyncLabelsAsync_ApplyChangesAndDeleteFails_ThrowsHttpRequestException()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("source-owner", "source-repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("source-owner", "source-repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "source-repo" },
             ]);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("target-owner", "target-repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("target-owner", "target-repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "target-repo" },
                 new Label { Name = "status/obsolete", Colour = "ffffff", Description = "Old", RepositoryName = "target-repo" },
             ]);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.DeleteLabelAsync("target-owner", "target-repo", "status/obsolete", It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("GitHub API failure"));
+        _labelRepository
+            .DeleteLabelAsync("target-owner", "target-repo", "status/obsolete", Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new HttpRequestException("GitHub API failure")));
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var action = async () => await sut.SyncLabelsAsync("source-owner", "source-repo", "target-owner", "target-repo", applyChanges: true);
@@ -524,7 +558,7 @@ public sealed class LabelServiceTests
     public async Task GetRecommendedTaxonomyAsync_WhenCalled_ReturnsCanonicalTaxonomy()
     {
         // Arrange
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.GetRecommendedTaxonomyAsync();
@@ -552,7 +586,7 @@ public sealed class LabelServiceTests
     public async Task GetRecommendedLabelStrategiesAsync_WhenCalled_ReturnsBuiltInStrategies()
     {
         // Arrange
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.GetRecommendedLabelStrategiesAsync();
@@ -567,14 +601,14 @@ public sealed class LabelServiceTests
     public async Task PreviewRecommendedTaxonomyAsync_RepositoryHasMixedState_ReturnsCreateUpdateAndSkipped()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "bug", Colour = "000000", Description = "Outdated", RepositoryName = "repo-a" },
                 new Label { Name = "documentation", Colour = "0075ca", Description = "Improvements or additions to documentation", RepositoryName = "repo-a" },
             ]);
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.PreviewRecommendedTaxonomyAsync("github-default", ["owner/repo-a"]);
@@ -591,9 +625,9 @@ public sealed class LabelServiceTests
     public async Task ApplyRecommendedTaxonomyAsync_LabelAlreadyMatches_SkipsWithoutMutatingApiCalls()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "bug", Colour = "d73a4a", Description = "Something is not working", RepositoryName = "repo-a" },
                 new Label { Name = "documentation", Colour = "0075ca", Description = "Improvements or additions to documentation", RepositoryName = "repo-a" },
                 new Label { Name = "duplicate", Colour = "cfd3d7", Description = "This issue or pull request already exists", RepositoryName = "repo-a" },
@@ -605,7 +639,7 @@ public sealed class LabelServiceTests
                 new Label { Name = "wontfix", Colour = "ffffff", Description = "This will not be worked on", RepositoryName = "repo-a" },
             ]);
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a"]);
@@ -616,27 +650,32 @@ public sealed class LabelServiceTests
         Assert.Equal(0, summary.UpdatedCount);
         Assert.Equal(9, summary.SkippedCount);
         Assert.False(summary.HasError);
-        _labelRepositoryMock.Verify(repository => repository.CreateLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
-        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
+        await _labelRepository.DidNotReceive().CreateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ApplyRecommendedTaxonomyAsync_OneRepositoryFails_ReturnsErrorAndContinues()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<Label>());
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Label>());
 
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("owner", "repo-b", It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("Rate limited"));
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-b", Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<IReadOnlyList<Label>>(new HttpRequestException("Rate limited")));
 
-        _labelRepositoryMock
-            .Setup(repository => repository.CreateLabelAsync("owner", "repo-a", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, Label value, CancellationToken _) => value with { RepositoryName = repo });
+        _labelRepository
+            .CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var value = callInfo.ArgAt<Label>(2);
+                return value with { RepositoryName = repo };
+            });
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a", "owner/repo-b"]);
@@ -651,15 +690,20 @@ public sealed class LabelServiceTests
     public async Task ApplyRecommendedTaxonomyAsync_OneRepositoryHasInvalidFormat_ReturnsErrorAndContinues()
     {
         // Arrange
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("owner", "repo-a", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<Label>());
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Label>());
 
-        _labelRepositoryMock
-            .Setup(repository => repository.CreateLabelAsync("owner", "repo-a", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, Label value, CancellationToken _) => value with { RepositoryName = repo });
+        _labelRepository
+            .CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var value = callInfo.ArgAt<Label>(2);
+                return value with { RepositoryName = repo };
+            });
 
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a", "invalid-format"]);
@@ -674,7 +718,7 @@ public sealed class LabelServiceTests
     public async Task GetLabelsForRepositoriesAsync_RepositoriesEmpty_ThrowsArgumentException()
     {
         // Arrange
-        var sut = new LabelService(_labelRepositoryMock.Object);
+        var sut = new LabelService(_labelRepository);
 
         // Act
         var action = async () => await sut.GetLabelsForRepositoriesAsync("owner", []);

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelServiceTests.cs
@@ -25,9 +25,10 @@ public sealed class LabelServiceTests
     [Fact]
     public async Task GetLabelsAsync_RepositoryReturnsLabels_ReturnsMappedLabelDtos()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("owner", "repo", cancellationToken)
             .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "A user-facing Story delivering a discrete piece of value", RepositoryName = "repo" },
                 new Label { Name = "priority/high", Colour = "d93f0b", Description = "Should be addressed in the current sprint or release", RepositoryName = "repo" },
@@ -36,7 +37,7 @@ public sealed class LabelServiceTests
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.GetLabelsAsync("owner", "repo");
+        var result = await sut.GetLabelsAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -47,19 +48,20 @@ public sealed class LabelServiceTests
     [Fact]
     public async Task GetLabelsForRepositoriesAsync_MultipleRepositories_ReturnsMergedLabels()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("owner", "repo-a", cancellationToken)
             .Returns([new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "repo-a" }]);
 
         _labelRepository
-            .GetLabelsAsync("owner", "repo-b", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("owner", "repo-b", cancellationToken)
             .Returns([new Label { Name = "priority/high", Colour = "d93f0b", Description = "High", RepositoryName = "repo-b" }]);
 
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.GetLabelsForRepositoriesAsync("owner", ["repo-a", "repo-b"]);
+        var result = await sut.GetLabelsForRepositoriesAsync("owner", ["repo-a", "repo-b"], cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -70,29 +72,31 @@ public sealed class LabelServiceTests
     [Fact]
     public async Task GetLabelsForRepositoriesAsync_DuplicateRepositoryNames_QueriesEachRepositoryOnce()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("owner", "repo-a", cancellationToken)
             .Returns([new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "repo-a" }]);
 
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.GetLabelsForRepositoriesAsync("owner", ["repo-a", "repo-a", "repo-a"]);
+        var result = await sut.GetLabelsForRepositoriesAsync("owner", ["repo-a", "repo-a", "repo-a"], cancellationToken);
 
         // Assert
         Assert.Single(result);
-        await _labelRepository.Received(1).GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).GetLabelsAsync("owner", "repo-a", cancellationToken);
     }
 
     [Fact]
     public async Task GetLabelsForRepositoriesAsync_OwnerIsWhitespace_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var action = async () => await sut.GetLabelsForRepositoriesAsync(" ", ["repo-a"]);
+        var action = async () => await sut.GetLabelsForRepositoriesAsync(" ", ["repo-a"], cancellationToken);
 
         // Assert
         _ = await Assert.ThrowsAsync<ArgumentException>(action);
@@ -101,11 +105,12 @@ public sealed class LabelServiceTests
     [Fact]
     public async Task CreateLabelAsync_MultipleRepositories_CreatesLabelInEachRepository()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var label = new LabelDto("area/labels", "c5def5", "Label Manager feature", string.Empty);
 
         _labelRepository
-            .CreateLabelAsync("owner", Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .CreateLabelAsync("owner", Arg.Any<string>(), Arg.Any<Label>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -116,22 +121,23 @@ public sealed class LabelServiceTests
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.CreateLabelAsync("owner", ["repo-a", "repo-b"], label);
+        var result = await sut.CreateLabelAsync("owner", ["repo-a", "repo-b"], label, cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
-        await _labelRepository.Received(1).CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.Received(1).CreateLabelAsync("owner", "repo-b", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.Received(1).CreateLabelAsync("owner", "repo-b", Arg.Any<Label>(), cancellationToken);
     }
 
     [Fact]
     public async Task CreateLabelAsync_SecondRepositoryFails_ThrowsAndStopsFurtherProcessing()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var label = new LabelDto("area/labels", "c5def5", "Label Manager feature", string.Empty);
 
         _labelRepository
-            .CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -140,29 +146,30 @@ public sealed class LabelServiceTests
             });
 
         _labelRepository
-            .CreateLabelAsync("owner", "repo-b", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .CreateLabelAsync("owner", "repo-b", Arg.Any<Label>(), cancellationToken)
             .Returns(Task.FromException<Label>(new HttpRequestException("GitHub API failure")));
 
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var action = async () => await sut.CreateLabelAsync("owner", ["repo-a", "repo-b", "repo-c"], label);
+        var action = async () => await sut.CreateLabelAsync("owner", ["repo-a", "repo-b", "repo-c"], label, cancellationToken);
 
         // Assert
         _ = await Assert.ThrowsAsync<HttpRequestException>(action);
-        await _labelRepository.Received(1).CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.Received(1).CreateLabelAsync("owner", "repo-b", Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.DidNotReceive().CreateLabelAsync("owner", "repo-c", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.Received(1).CreateLabelAsync("owner", "repo-b", Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.DidNotReceive().CreateLabelAsync("owner", "repo-c", Arg.Any<Label>(), cancellationToken);
     }
 
     [Fact]
     public async Task CreateLabelAsync_LabelIsNull_ThrowsArgumentNullException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var action = async () => await sut.CreateLabelAsync("owner", ["repo-a"], null!);
+        var action = async () => await sut.CreateLabelAsync("owner", ["repo-a"], null!, cancellationToken);
 
         // Assert
         _ = await Assert.ThrowsAsync<ArgumentNullException>(action);
@@ -171,12 +178,13 @@ public sealed class LabelServiceTests
     [Fact]
     public async Task CreateLabelAsync_RepositoriesEmpty_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new LabelService(_labelRepository);
         var label = new LabelDto("area/labels", "c5def5", "Label Manager feature", string.Empty);
 
         // Act
-        var action = async () => await sut.CreateLabelAsync("owner", [], label);
+        var action = async () => await sut.CreateLabelAsync("owner", [], label, cancellationToken);
 
         // Assert
         _ = await Assert.ThrowsAsync<ArgumentException>(action);
@@ -185,11 +193,12 @@ public sealed class LabelServiceTests
     [Fact]
     public async Task UpdateLabelAsync_MultipleRepositories_UpdatesLabelInEachRepository()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var updatedLabel = new LabelDto("priority/high", "d93f0b", "Should be addressed in the current sprint or release", string.Empty);
 
         _labelRepository
-            .UpdateLabelAsync("owner", Arg.Any<string>(), "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .UpdateLabelAsync("owner", Arg.Any<string>(), "priority/urgent", Arg.Any<Label>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -200,42 +209,44 @@ public sealed class LabelServiceTests
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.UpdateLabelAsync("owner", ["repo-a", "repo-b"], "priority/urgent", updatedLabel);
+        var result = await sut.UpdateLabelAsync("owner", ["repo-a", "repo-b"], "priority/urgent", updatedLabel, cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
-        await _labelRepository.Received(1).UpdateLabelAsync("owner", "repo-a", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.Received(1).UpdateLabelAsync("owner", "repo-b", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).UpdateLabelAsync("owner", "repo-a", "priority/urgent", Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.Received(1).UpdateLabelAsync("owner", "repo-b", "priority/urgent", Arg.Any<Label>(), cancellationToken);
     }
 
     [Fact]
     public async Task UpdateLabelAsync_RepositoryReportsLabelMissing_ThrowsKeyNotFoundException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var updatedLabel = new LabelDto("priority/high", "d93f0b", "Should be addressed in the current sprint or release", string.Empty);
 
         _labelRepository
-            .UpdateLabelAsync("owner", "repo-a", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .UpdateLabelAsync("owner", "repo-a", "priority/urgent", Arg.Any<Label>(), cancellationToken)
             .Returns(Task.FromException<Label>(new KeyNotFoundException("Label not found")));
 
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var action = async () => await sut.UpdateLabelAsync("owner", ["repo-a", "repo-b"], "priority/urgent", updatedLabel);
+        var action = async () => await sut.UpdateLabelAsync("owner", ["repo-a", "repo-b"], "priority/urgent", updatedLabel, cancellationToken);
 
         // Assert
         _ = await Assert.ThrowsAsync<KeyNotFoundException>(action);
-        await _labelRepository.DidNotReceive().UpdateLabelAsync("owner", "repo-b", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().UpdateLabelAsync("owner", "repo-b", "priority/urgent", Arg.Any<Label>(), cancellationToken);
     }
 
     [Fact]
     public async Task UpdateLabelAsync_SecondRepositoryFails_ThrowsAndStopsFurtherProcessing()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var updatedLabel = new LabelDto("priority/high", "d93f0b", "Should be addressed in the current sprint or release", string.Empty);
 
         _labelRepository
-            .UpdateLabelAsync("owner", "repo-a", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .UpdateLabelAsync("owner", "repo-a", "priority/urgent", Arg.Any<Label>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -244,94 +255,98 @@ public sealed class LabelServiceTests
             });
 
         _labelRepository
-            .UpdateLabelAsync("owner", "repo-b", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .UpdateLabelAsync("owner", "repo-b", "priority/urgent", Arg.Any<Label>(), cancellationToken)
             .Returns(Task.FromException<Label>(new HttpRequestException("GitHub API failure")));
 
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var action = async () => await sut.UpdateLabelAsync("owner", ["repo-a", "repo-b", "repo-c"], "priority/urgent", updatedLabel);
+        var action = async () => await sut.UpdateLabelAsync("owner", ["repo-a", "repo-b", "repo-c"], "priority/urgent", updatedLabel, cancellationToken);
 
         // Assert
         _ = await Assert.ThrowsAsync<HttpRequestException>(action);
-        await _labelRepository.Received(1).UpdateLabelAsync("owner", "repo-a", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.Received(1).UpdateLabelAsync("owner", "repo-b", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.DidNotReceive().UpdateLabelAsync("owner", "repo-c", "priority/urgent", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).UpdateLabelAsync("owner", "repo-a", "priority/urgent", Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.Received(1).UpdateLabelAsync("owner", "repo-b", "priority/urgent", Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.DidNotReceive().UpdateLabelAsync("owner", "repo-c", "priority/urgent", Arg.Any<Label>(), cancellationToken);
     }
 
     [Fact]
     public async Task DeleteLabelAsync_MultipleRepositories_DeletesLabelInEachRepository()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .DeleteLabelAsync("owner", Arg.Any<string>(), "status/blocked", Arg.Any<CancellationToken>())
+            .DeleteLabelAsync("owner", Arg.Any<string>(), "status/blocked", cancellationToken)
             .Returns(Task.CompletedTask);
 
         var sut = new LabelService(_labelRepository);
 
         // Act
-        await sut.DeleteLabelAsync("owner", ["repo-a", "repo-b"], "status/blocked");
+        await sut.DeleteLabelAsync("owner", ["repo-a", "repo-b"], "status/blocked", cancellationToken);
 
         // Assert
-        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-a", "status/blocked", Arg.Any<CancellationToken>());
-        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-b", "status/blocked", Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-a", "status/blocked", cancellationToken);
+        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-b", "status/blocked", cancellationToken);
     }
 
     [Fact]
     public async Task DeleteLabelAsync_LabelMissingInFirstRepository_ThrowsAndStopsFurtherProcessing()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .DeleteLabelAsync("owner", "repo-a", "status/blocked", Arg.Any<CancellationToken>())
+            .DeleteLabelAsync("owner", "repo-a", "status/blocked", cancellationToken)
             .Returns(Task.FromException(new KeyNotFoundException("Label not found")));
 
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var action = async () => await sut.DeleteLabelAsync("owner", ["repo-a", "repo-b"], "status/blocked");
+        var action = async () => await sut.DeleteLabelAsync("owner", ["repo-a", "repo-b"], "status/blocked", cancellationToken);
 
         // Assert
         _ = await Assert.ThrowsAsync<KeyNotFoundException>(action);
-        await _labelRepository.DidNotReceive().DeleteLabelAsync("owner", "repo-b", "status/blocked", Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().DeleteLabelAsync("owner", "repo-b", "status/blocked", cancellationToken);
     }
 
     [Fact]
     public async Task DeleteLabelAsync_SecondRepositoryFails_ThrowsAndStopsFurtherProcessing()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .DeleteLabelAsync("owner", "repo-a", "status/blocked", Arg.Any<CancellationToken>())
+            .DeleteLabelAsync("owner", "repo-a", "status/blocked", cancellationToken)
             .Returns(Task.CompletedTask);
 
         _labelRepository
-            .DeleteLabelAsync("owner", "repo-b", "status/blocked", Arg.Any<CancellationToken>())
+            .DeleteLabelAsync("owner", "repo-b", "status/blocked", cancellationToken)
             .Returns(Task.FromException(new HttpRequestException("GitHub API failure")));
 
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var action = async () => await sut.DeleteLabelAsync("owner", ["repo-a", "repo-b", "repo-c"], "status/blocked");
+        var action = async () => await sut.DeleteLabelAsync("owner", ["repo-a", "repo-b", "repo-c"], "status/blocked", cancellationToken);
 
         // Assert
         _ = await Assert.ThrowsAsync<HttpRequestException>(action);
-        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-a", "status/blocked", Arg.Any<CancellationToken>());
-        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-b", "status/blocked", Arg.Any<CancellationToken>());
-        await _labelRepository.DidNotReceive().DeleteLabelAsync("owner", "repo-c", "status/blocked", Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-a", "status/blocked", cancellationToken);
+        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-b", "status/blocked", cancellationToken);
+        await _labelRepository.DidNotReceive().DeleteLabelAsync("owner", "repo-c", "status/blocked", cancellationToken);
     }
 
     [Fact]
     public async Task SyncLabelsAsync_ApplyChangesFalse_ReturnsPreviewWithoutMutatingTarget()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .GetLabelsAsync("source-owner", "source-repo", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("source-owner", "source-repo", cancellationToken)
             .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "source-repo" },
                 new Label { Name = "priority/high", Colour = "d93f0b", Description = "High updated", RepositoryName = "source-repo" },
             ]);
 
         _labelRepository
-            .GetLabelsAsync("target-owner", "target-repo", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("target-owner", "target-repo", cancellationToken)
             .Returns([
                 new Label { Name = "priority/high", Colour = "fbca04", Description = "High old", RepositoryName = "target-repo" },
                 new Label { Name = "status/obsolete", Colour = "ffffff", Description = "Old", RepositoryName = "target-repo" },
@@ -340,7 +355,7 @@ public sealed class LabelServiceTests
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.SyncLabelsAsync("source-owner", "source-repo", "target-owner", "target-repo", applyChanges: false);
+        var result = await sut.SyncLabelsAsync("source-owner", "source-repo", "target-owner", "target-repo", applyChanges: false, cancellationToken);
 
         // Assert
         Assert.Single(result.ToAdd);
@@ -351,31 +366,32 @@ public sealed class LabelServiceTests
         Assert.Equal("status/obsolete", result.ToDelete[0].Name);
         Assert.Empty(result.Skipped);
 
-        await _labelRepository.DidNotReceive().CreateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.DidNotReceive().DeleteLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().CreateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.DidNotReceive().DeleteLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
     }
 
     [Fact]
     public async Task SyncLabelsAsync_ApplyChangesTrue_AppliesAddUpdateAndDeleteOperations()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .GetLabelsAsync("source-owner", "source-repo", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("source-owner", "source-repo", cancellationToken)
             .Returns([
                 new Label { Name = "priority/high", Colour = "d93f0b", Description = "High", RepositoryName = "source-repo" },
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "source-repo" },
             ]);
 
         _labelRepository
-            .GetLabelsAsync("target-owner", "target-repo", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("target-owner", "target-repo", cancellationToken)
             .Returns([
                 new Label { Name = "type/story", Colour = "ffffff", Description = "Old Story", RepositoryName = "target-repo" },
                 new Label { Name = "status/obsolete", Colour = "ffffff", Description = "Old", RepositoryName = "target-repo" },
             ]);
 
         _labelRepository
-            .UpdateLabelAsync("target-owner", "target-repo", "type/story", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .UpdateLabelAsync("target-owner", "target-repo", "type/story", Arg.Any<Label>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -385,7 +401,7 @@ public sealed class LabelServiceTests
             });
 
         _labelRepository
-            .CreateLabelAsync("target-owner", "target-repo", Arg.Is<Label>(label => label.Name == "priority/high"), Arg.Any<CancellationToken>())
+            .CreateLabelAsync("target-owner", "target-repo", Arg.Is<Label>(label => label!.Name == "priority/high"), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -394,27 +410,28 @@ public sealed class LabelServiceTests
             });
 
         _labelRepository
-            .DeleteLabelAsync("target-owner", "target-repo", "status/obsolete", Arg.Any<CancellationToken>())
+            .DeleteLabelAsync("target-owner", "target-repo", "status/obsolete", cancellationToken)
             .Returns(Task.CompletedTask);
 
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.SyncLabelsAsync("source-owner", "source-repo", "target-owner", "target-repo", applyChanges: true);
+        var result = await sut.SyncLabelsAsync("source-owner", "source-repo", "target-owner", "target-repo", applyChanges: true, cancellationToken);
 
         // Assert
         Assert.Single(result.ToAdd);
         Assert.Single(result.ToUpdate);
         Assert.Single(result.ToDelete);
-        await _labelRepository.Received(1).CreateLabelAsync("target-owner", "target-repo", Arg.Is<Label>(label => label.Name == "priority/high"), Arg.Any<CancellationToken>());
-        await _labelRepository.Received(1).UpdateLabelAsync("target-owner", "target-repo", "type/story", Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.Received(1).DeleteLabelAsync("target-owner", "target-repo", "status/obsolete", Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).CreateLabelAsync("target-owner", "target-repo", Arg.Is<Label>(label => label!.Name == "priority/high"), cancellationToken);
+        await _labelRepository.Received(1).UpdateLabelAsync("target-owner", "target-repo", "type/story", Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.Received(1).DeleteLabelAsync("target-owner", "target-repo", "status/obsolete", cancellationToken);
         Assert.Empty(result.Skipped);
     }
 
     [Fact]
     public async Task SyncLabelsAsync_RepositoriesAlreadyAligned_ReturnsEmptyDiff()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var labels = new[]
         {
@@ -423,47 +440,48 @@ public sealed class LabelServiceTests
         };
 
         _labelRepository
-            .GetLabelsAsync("source-owner", "source-repo", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("source-owner", "source-repo", cancellationToken)
             .Returns(labels);
 
         _labelRepository
-            .GetLabelsAsync("target-owner", "target-repo", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("target-owner", "target-repo", cancellationToken)
             .Returns(labels);
 
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.SyncLabelsAsync("source-owner", "source-repo", "target-owner", "target-repo", applyChanges: true);
+        var result = await sut.SyncLabelsAsync("source-owner", "source-repo", "target-owner", "target-repo", applyChanges: true, cancellationToken);
 
         // Assert
         Assert.Empty(result.ToAdd);
         Assert.Empty(result.ToUpdate);
         Assert.Empty(result.ToDelete);
-        await _labelRepository.DidNotReceive().CreateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.DidNotReceive().DeleteLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().CreateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.DidNotReceive().DeleteLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
         Assert.Equal(2, result.Skipped.Count);
     }
 
     [Fact]
     public async Task PreviewLabelSynchronisationAsync_MultipleTargets_ReturnsPerRepositoryPreviews()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .GetLabelsAsync("source-owner", "source-repo", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("source-owner", "source-repo", cancellationToken)
             .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "source-repo" },
                 new Label { Name = "priority/high", Colour = "d93f0b", Description = "High", RepositoryName = "source-repo" },
             ]);
 
         _labelRepository
-            .GetLabelsAsync("target-owner", "target-a", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("target-owner", "target-a", cancellationToken)
             .Returns([
                 new Label { Name = "priority/high", Colour = "fbca04", Description = "Old", RepositoryName = "target-a" },
             ]);
 
         _labelRepository
-            .GetLabelsAsync("target-owner", "target-b", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("target-owner", "target-b", cancellationToken)
             .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "target-b" },
                 new Label { Name = "priority/high", Colour = "d93f0b", Description = "High", RepositoryName = "target-b" },
@@ -474,7 +492,7 @@ public sealed class LabelServiceTests
         // Act
         var result = await sut.PreviewLabelSynchronisationAsync(
             "source-owner/source-repo",
-            ["target-owner/target-a", "target-owner/target-b"]);
+            ["target-owner/target-a", "target-owner/target-b"], cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -485,23 +503,24 @@ public sealed class LabelServiceTests
     [Fact]
     public async Task ApplyLabelSynchronisationAsync_TargetFails_ReturnsPartialFailureWithoutAbortingOtherTargets()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .GetLabelsAsync("source-owner", "source-repo", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("source-owner", "source-repo", cancellationToken)
             .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "source-repo" },
             ]);
 
         _labelRepository
-            .GetLabelsAsync("target-owner", "target-a", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("target-owner", "target-a", cancellationToken)
             .Returns(Array.Empty<Label>());
 
         _labelRepository
-            .GetLabelsAsync("target-owner", "target-b", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("target-owner", "target-b", cancellationToken)
             .Returns(Task.FromException<IReadOnlyList<Label>>(new HttpRequestException("GitHub API failure")));
 
         _labelRepository
-            .CreateLabelAsync("target-owner", "target-a", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .CreateLabelAsync("target-owner", "target-a", Arg.Any<Label>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -514,41 +533,42 @@ public sealed class LabelServiceTests
         // Act
         var result = await sut.ApplyLabelSynchronisationAsync(
             "source-owner/source-repo",
-            ["target-owner/target-a", "target-owner/target-b"]);
+            ["target-owner/target-a", "target-owner/target-b"], cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
         Assert.Contains(result, item => item.RepositoryFullName == "target-owner/target-a" && !item.HasError && item.CreatedCount == 1);
         Assert.Contains(result, item => item.RepositoryFullName == "target-owner/target-b" && item.HasError);
 
-        await _labelRepository.Received(1).CreateLabelAsync("target-owner", "target-a", Arg.Is<Label>(label => label.Name == "type/story"), Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).CreateLabelAsync("target-owner", "target-a", Arg.Is<Label>(label => label!.Name == "type/story"), cancellationToken);
     }
 
     [Fact]
     public async Task SyncLabelsAsync_ApplyChangesAndDeleteFails_ThrowsHttpRequestException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .GetLabelsAsync("source-owner", "source-repo", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("source-owner", "source-repo", cancellationToken)
             .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "source-repo" },
             ]);
 
         _labelRepository
-            .GetLabelsAsync("target-owner", "target-repo", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("target-owner", "target-repo", cancellationToken)
             .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Story", RepositoryName = "target-repo" },
                 new Label { Name = "status/obsolete", Colour = "ffffff", Description = "Old", RepositoryName = "target-repo" },
             ]);
 
         _labelRepository
-            .DeleteLabelAsync("target-owner", "target-repo", "status/obsolete", Arg.Any<CancellationToken>())
+            .DeleteLabelAsync("target-owner", "target-repo", "status/obsolete", cancellationToken)
             .Returns(Task.FromException(new HttpRequestException("GitHub API failure")));
 
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var action = async () => await sut.SyncLabelsAsync("source-owner", "source-repo", "target-owner", "target-repo", applyChanges: true);
+        var action = async () => await sut.SyncLabelsAsync("source-owner", "source-repo", "target-owner", "target-repo", applyChanges: true, cancellationToken);
 
         // Assert
         _ = await Assert.ThrowsAsync<HttpRequestException>(action);
@@ -557,11 +577,12 @@ public sealed class LabelServiceTests
     [Fact]
     public async Task GetRecommendedTaxonomyAsync_WhenCalled_ReturnsCanonicalTaxonomy()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.GetRecommendedTaxonomyAsync();
+        var result = await sut.GetRecommendedTaxonomyAsync(cancellationToken);
 
         // Assert
         Assert.Contains(result, label => label.Name == "type/story" && label.Colour == "1d76db");
@@ -585,11 +606,12 @@ public sealed class LabelServiceTests
     [Fact]
     public async Task GetRecommendedLabelStrategiesAsync_WhenCalled_ReturnsBuiltInStrategies()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.GetRecommendedLabelStrategiesAsync();
+        var result = await sut.GetRecommendedLabelStrategiesAsync(cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -600,9 +622,10 @@ public sealed class LabelServiceTests
     [Fact]
     public async Task PreviewRecommendedTaxonomyAsync_RepositoryHasMixedState_ReturnsCreateUpdateAndSkipped()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("owner", "repo-a", cancellationToken)
             .Returns([
                 new Label { Name = "bug", Colour = "000000", Description = "Outdated", RepositoryName = "repo-a" },
                 new Label { Name = "documentation", Colour = "0075ca", Description = "Improvements or additions to documentation", RepositoryName = "repo-a" },
@@ -611,7 +634,7 @@ public sealed class LabelServiceTests
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.PreviewRecommendedTaxonomyAsync("github-default", ["owner/repo-a"]);
+        var result = await sut.PreviewRecommendedTaxonomyAsync("github-default", ["owner/repo-a"], cancellationToken);
 
         // Assert
         var preview = Assert.Single(result);
@@ -624,9 +647,10 @@ public sealed class LabelServiceTests
     [Fact]
     public async Task ApplyRecommendedTaxonomyAsync_LabelAlreadyMatches_SkipsWithoutMutatingApiCalls()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("owner", "repo-a", cancellationToken)
             .Returns([
                 new Label { Name = "bug", Colour = "d73a4a", Description = "Something is not working", RepositoryName = "repo-a" },
                 new Label { Name = "documentation", Colour = "0075ca", Description = "Improvements or additions to documentation", RepositoryName = "repo-a" },
@@ -642,7 +666,7 @@ public sealed class LabelServiceTests
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a"]);
+        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a"], cancellationToken);
 
         // Assert
         var summary = Assert.Single(result);
@@ -650,24 +674,25 @@ public sealed class LabelServiceTests
         Assert.Equal(0, summary.UpdatedCount);
         Assert.Equal(9, summary.SkippedCount);
         Assert.False(summary.HasError);
-        await _labelRepository.DidNotReceive().CreateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().CreateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), cancellationToken);
     }
 
     [Fact]
     public async Task ApplyRecommendedTaxonomyAsync_OneRepositoryFails_ReturnsErrorAndContinues()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("owner", "repo-a", cancellationToken)
             .Returns(Array.Empty<Label>());
 
         _labelRepository
-            .GetLabelsAsync("owner", "repo-b", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("owner", "repo-b", cancellationToken)
             .Returns(Task.FromException<IReadOnlyList<Label>>(new HttpRequestException("Rate limited")));
 
         _labelRepository
-            .CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -678,7 +703,7 @@ public sealed class LabelServiceTests
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a", "owner/repo-b"]);
+        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a", "owner/repo-b"], cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -689,13 +714,14 @@ public sealed class LabelServiceTests
     [Fact]
     public async Task ApplyRecommendedTaxonomyAsync_OneRepositoryHasInvalidFormat_ReturnsErrorAndContinues()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _labelRepository
-            .GetLabelsAsync("owner", "repo-a", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("owner", "repo-a", cancellationToken)
             .Returns(Array.Empty<Label>());
 
         _labelRepository
-            .CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .CreateLabelAsync("owner", "repo-a", Arg.Any<Label>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -706,7 +732,7 @@ public sealed class LabelServiceTests
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a", "invalid-format"]);
+        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a", "invalid-format"], cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -717,11 +743,12 @@ public sealed class LabelServiceTests
     [Fact]
     public async Task GetLabelsForRepositoriesAsync_RepositoriesEmpty_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var action = async () => await sut.GetLabelsForRepositoriesAsync("owner", []);
+        var action = async () => await sut.GetLabelsForRepositoriesAsync("owner", [], cancellationToken);
 
         // Assert
         _ = await Assert.ThrowsAsync<ArgumentException>(action);

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
@@ -15,6 +15,7 @@ public sealed class MigrationServiceTests
     [Fact]
     public async Task PreviewMigrationAsync_SkipStrategy_ReturnsCreateAndSkipOnly()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         SetupSourceAndTargetData();
         var sut = CreateSubject();
@@ -24,7 +25,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(true, true),
-            MigrationConflictStrategy.Skip);
+            MigrationConflictStrategy.Skip, cancellationToken);
 
         // Assert
         Assert.Equal(MigrationConflictStrategy.Skip, result.ConflictStrategy);
@@ -51,6 +52,7 @@ public sealed class MigrationServiceTests
     [Fact]
     public async Task PreviewMigrationAsync_OverwriteStrategy_ReturnsCreateUpdateAndDelete()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         SetupSourceAndTargetData();
         var sut = CreateSubject();
@@ -60,7 +62,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(true, true),
-            MigrationConflictStrategy.Overwrite);
+            MigrationConflictStrategy.Overwrite, cancellationToken);
 
         // Assert
         Assert.Equal(MigrationConflictStrategy.Overwrite, result.ConflictStrategy);
@@ -80,11 +82,12 @@ public sealed class MigrationServiceTests
     [Fact]
     public async Task ApplyMigrationAsync_OverwriteStrategy_AppliesLabelAndMilestoneOperations()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         SetupSourceAndTargetData();
 
         _labelRepository
-            .CreateLabelAsync("owner", "target", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .CreateLabelAsync("owner", "target", Arg.Any<Label>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -93,7 +96,7 @@ public sealed class MigrationServiceTests
             });
 
         _labelRepository
-            .UpdateLabelAsync("owner", "target", "type/story", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .UpdateLabelAsync("owner", "target", "type/story", Arg.Any<Label>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -102,15 +105,15 @@ public sealed class MigrationServiceTests
             });
 
         _labelRepository
-            .DeleteLabelAsync("owner", "target", "legacy", Arg.Any<CancellationToken>())
+            .DeleteLabelAsync("owner", "target", "legacy", cancellationToken)
             .Returns(Task.CompletedTask);
 
         _milestoneRepository
-            .CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), Arg.Any<CancellationToken>())
+            .CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), cancellationToken)
             .Returns(callInfo => callInfo.ArgAt<Milestone>(2));
 
         _milestoneRepository
-            .UpdateMilestoneAsync("owner", "target", 9, Arg.Any<Milestone>(), Arg.Any<CancellationToken>())
+            .UpdateMilestoneAsync("owner", "target", 9, Arg.Any<Milestone>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var number = callInfo.ArgAt<int>(2);
@@ -119,7 +122,7 @@ public sealed class MigrationServiceTests
             });
 
         _milestoneRepository
-            .DeleteMilestoneAsync("owner", "target", 10, Arg.Any<CancellationToken>())
+            .DeleteMilestoneAsync("owner", "target", 10, cancellationToken)
             .Returns(Task.CompletedTask);
 
         var sut = CreateSubject();
@@ -129,7 +132,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(true, true),
-            MigrationConflictStrategy.Overwrite);
+            MigrationConflictStrategy.Overwrite, cancellationToken);
 
         // Assert
         Assert.Equal(MigrationConflictStrategy.Overwrite, result.ConflictStrategy);
@@ -144,23 +147,24 @@ public sealed class MigrationServiceTests
         Assert.Equal(1, result.MilestoneResults[0].UpdatedCount);
         Assert.Equal(1, result.MilestoneResults[0].DeletedCount);
 
-        await _labelRepository.Received(1).CreateLabelAsync("owner", "target", Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.Received(1).UpdateLabelAsync("owner", "target", "type/story", Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.Received(1).DeleteLabelAsync("owner", "target", "legacy", Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).CreateLabelAsync("owner", "target", Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.Received(1).UpdateLabelAsync("owner", "target", "type/story", Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.Received(1).DeleteLabelAsync("owner", "target", "legacy", cancellationToken);
 
-        await _milestoneRepository.Received(1).CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), Arg.Any<CancellationToken>());
-        await _milestoneRepository.Received(1).UpdateMilestoneAsync("owner", "target", 9, Arg.Any<Milestone>(), Arg.Any<CancellationToken>());
-        await _milestoneRepository.Received(1).DeleteMilestoneAsync("owner", "target", 10, Arg.Any<CancellationToken>());
+        await _milestoneRepository.Received(1).CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), cancellationToken);
+        await _milestoneRepository.Received(1).UpdateMilestoneAsync("owner", "target", 9, Arg.Any<Milestone>(), cancellationToken);
+        await _milestoneRepository.Received(1).DeleteMilestoneAsync("owner", "target", 10, cancellationToken);
     }
 
     [Fact]
     public async Task ApplyMigrationAsync_SkipStrategy_DoesNotUpdateOrDeleteConflicts()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         SetupSourceAndTargetData();
 
         _labelRepository
-            .CreateLabelAsync("owner", "target", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .CreateLabelAsync("owner", "target", Arg.Any<Label>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -169,7 +173,7 @@ public sealed class MigrationServiceTests
             });
 
         _milestoneRepository
-            .CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), Arg.Any<CancellationToken>())
+            .CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), cancellationToken)
             .Returns(callInfo => callInfo.ArgAt<Milestone>(2));
 
         var sut = CreateSubject();
@@ -179,7 +183,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(true, true),
-            MigrationConflictStrategy.Skip);
+            MigrationConflictStrategy.Skip, cancellationToken);
 
         // Assert
         Assert.Single(result.LabelResults);
@@ -194,10 +198,10 @@ public sealed class MigrationServiceTests
         Assert.Equal(0, result.MilestoneResults[0].DeletedCount);
         Assert.Equal(1, result.MilestoneResults[0].SkippedCount);
 
-        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.DidNotReceive().DeleteLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await _milestoneRepository.DidNotReceive().UpdateMilestoneAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<Milestone>(), Arg.Any<CancellationToken>());
-        await _milestoneRepository.DidNotReceive().DeleteMilestoneAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.DidNotReceive().DeleteLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
+        await _milestoneRepository.DidNotReceive().UpdateMilestoneAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<Milestone>(), cancellationToken);
+        await _milestoneRepository.DidNotReceive().DeleteMilestoneAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), cancellationToken);
     }
 
     private MigrationService CreateSubject()
@@ -206,6 +210,7 @@ public sealed class MigrationServiceTests
     [Fact]
     public async Task PreviewMigrationAsync_LabelsOnly_DoesNotReturnMilestonePreviews()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         SetupSourceAndTargetData();
         var sut = CreateSubject();
@@ -215,7 +220,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(true, false),
-            MigrationConflictStrategy.Merge);
+            MigrationConflictStrategy.Merge, cancellationToken);
 
         // Assert
         Assert.Single(result.LabelPreviews);
@@ -225,11 +230,12 @@ public sealed class MigrationServiceTests
     [Fact]
     public async Task ApplyMigrationAsync_MilestonesOnly_DoesNotRunLabelOperations()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         SetupSourceAndTargetData();
 
         _milestoneRepository
-            .CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), Arg.Any<CancellationToken>())
+            .CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), cancellationToken)
             .Returns(callInfo => callInfo.ArgAt<Milestone>(2));
 
         var sut = CreateSubject();
@@ -239,20 +245,21 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(false, true),
-            MigrationConflictStrategy.Skip);
+            MigrationConflictStrategy.Skip, cancellationToken);
 
         // Assert
         Assert.Empty(result.LabelResults);
         Assert.Single(result.MilestoneResults);
 
-        await _labelRepository.DidNotReceive().CreateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
-        await _labelRepository.DidNotReceive().DeleteLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().CreateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.DidNotReceive().DeleteLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
     }
 
     [Fact]
     public async Task PreviewMigrationAsync_NoScopeSelected_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         SetupSourceAndTargetData();
         var sut = CreateSubject();
@@ -262,7 +269,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(false, false),
-            MigrationConflictStrategy.Skip);
+            MigrationConflictStrategy.Skip, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -271,6 +278,7 @@ public sealed class MigrationServiceTests
     [Fact]
     public async Task ApplyMigrationAsync_TargetRepositoriesContainOnlySource_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         SetupSourceAndTargetData();
         var sut = CreateSubject();
@@ -280,7 +288,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/source"],
             new MigrationScopeDto(true, true),
-            MigrationConflictStrategy.Skip);
+            MigrationConflictStrategy.Skip, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -289,19 +297,20 @@ public sealed class MigrationServiceTests
     [Fact]
     public async Task ApplyMigrationAsync_MultipleTargetsOneLabelOperationFails_ReturnsPartialFailureAndContinues()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         SetupSourceAndTargetData();
 
         _labelRepository
-            .GetLabelsAsync("owner", "failing", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("owner", "failing", cancellationToken)
             .Returns(Task.FromException<IReadOnlyList<Label>>(new HttpRequestException("label operation failed")));
 
         _milestoneRepository
-            .GetMilestonesAsync("owner", "failing", Arg.Any<CancellationToken>())
+            .GetMilestonesAsync("owner", "failing", cancellationToken)
             .Returns([]);
 
         _labelRepository
-            .CreateLabelAsync("owner", "target", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .CreateLabelAsync("owner", "target", Arg.Any<Label>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -310,11 +319,11 @@ public sealed class MigrationServiceTests
             });
 
         _milestoneRepository
-            .CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), Arg.Any<CancellationToken>())
+            .CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), cancellationToken)
             .Returns(callInfo => callInfo.ArgAt<Milestone>(2));
 
         _milestoneRepository
-            .CreateMilestoneAsync("owner", "failing", Arg.Any<Milestone>(), Arg.Any<CancellationToken>())
+            .CreateMilestoneAsync("owner", "failing", Arg.Any<Milestone>(), cancellationToken)
             .Returns(callInfo => callInfo.ArgAt<Milestone>(2));
 
         var sut = CreateSubject();
@@ -324,7 +333,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target", "owner/failing"],
             new MigrationScopeDto(true, true),
-            MigrationConflictStrategy.Skip);
+            MigrationConflictStrategy.Skip, cancellationToken);
 
         // Assert
         Assert.Equal(2, result.LabelResults.Count);
@@ -350,11 +359,12 @@ public sealed class MigrationServiceTests
     [Fact]
     public async Task ApplyMigrationAsync_UpdateFailsAfterCreate_ReturnsErrorWithPartialProgressCounts()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         SetupSourceAndTargetData();
 
         _labelRepository
-            .CreateLabelAsync("owner", "target", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .CreateLabelAsync("owner", "target", Arg.Any<Label>(), cancellationToken)
             .Returns(callInfo =>
             {
                 var repo = callInfo.ArgAt<string>(1);
@@ -363,7 +373,7 @@ public sealed class MigrationServiceTests
             });
 
         _labelRepository
-            .UpdateLabelAsync("owner", "target", "type/story", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .UpdateLabelAsync("owner", "target", "type/story", Arg.Any<Label>(), cancellationToken)
             .Returns(Task.FromException<Label>(new HttpRequestException("update failed")));
 
         var sut = CreateSubject();
@@ -373,7 +383,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(true, false),
-            MigrationConflictStrategy.Overwrite);
+            MigrationConflictStrategy.Overwrite, cancellationToken);
 
         // Assert
         var labelResult = Assert.Single(result.LabelResults);

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 using SoloDevBoard.Application.Services.Labels;
 using SoloDevBoard.Application.Services.Migration;
 using SoloDevBoard.Domain.Entities.Labels;
@@ -9,8 +9,8 @@ namespace SoloDevBoard.Application.Tests;
 /// <summary>Tests for <see cref="MigrationService"/>.</summary>
 public sealed class MigrationServiceTests
 {
-    private readonly Mock<ILabelRepository> _labelRepositoryMock = new();
-    private readonly Mock<IMilestoneRepository> _milestoneRepositoryMock = new();
+    private readonly ILabelRepository _labelRepository = Substitute.For<ILabelRepository>();
+    private readonly IMilestoneRepository _milestoneRepository = Substitute.For<IMilestoneRepository>();
 
     [Fact]
     public async Task PreviewMigrationAsync_SkipStrategy_ReturnsCreateAndSkipOnly()
@@ -83,28 +83,43 @@ public sealed class MigrationServiceTests
         // Arrange
         SetupSourceAndTargetData();
 
-        _labelRepositoryMock
-            .Setup(repository => repository.CreateLabelAsync("owner", "target", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, Label label, CancellationToken _) => label with { RepositoryName = repo });
+        _labelRepository
+            .CreateLabelAsync("owner", "target", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var label = callInfo.ArgAt<Label>(2);
+                return label with { RepositoryName = repo };
+            });
 
-        _labelRepositoryMock
-            .Setup(repository => repository.UpdateLabelAsync("owner", "target", "type/story", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, string _, Label label, CancellationToken _) => label with { RepositoryName = repo });
+        _labelRepository
+            .UpdateLabelAsync("owner", "target", "type/story", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var label = callInfo.ArgAt<Label>(3);
+                return label with { RepositoryName = repo };
+            });
 
-        _labelRepositoryMock
-            .Setup(repository => repository.DeleteLabelAsync("owner", "target", "legacy", It.IsAny<CancellationToken>()))
+        _labelRepository
+            .DeleteLabelAsync("owner", "target", "legacy", Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 
-        _milestoneRepositoryMock
-            .Setup(repository => repository.CreateMilestoneAsync("owner", "target", It.IsAny<Milestone>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string _, Milestone milestone, CancellationToken _) => milestone);
+        _milestoneRepository
+            .CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => callInfo.ArgAt<Milestone>(2));
 
-        _milestoneRepositoryMock
-            .Setup(repository => repository.UpdateMilestoneAsync("owner", "target", 9, It.IsAny<Milestone>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string _, int number, Milestone milestone, CancellationToken _) => milestone with { Number = number });
+        _milestoneRepository
+            .UpdateMilestoneAsync("owner", "target", 9, Arg.Any<Milestone>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var number = callInfo.ArgAt<int>(2);
+                var milestone = callInfo.ArgAt<Milestone>(3);
+                return milestone with { Number = number };
+            });
 
-        _milestoneRepositoryMock
-            .Setup(repository => repository.DeleteMilestoneAsync("owner", "target", 10, It.IsAny<CancellationToken>()))
+        _milestoneRepository
+            .DeleteMilestoneAsync("owner", "target", 10, Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 
         var sut = CreateSubject();
@@ -129,13 +144,13 @@ public sealed class MigrationServiceTests
         Assert.Equal(1, result.MilestoneResults[0].UpdatedCount);
         Assert.Equal(1, result.MilestoneResults[0].DeletedCount);
 
-        _labelRepositoryMock.Verify(repository => repository.CreateLabelAsync("owner", "target", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Once);
-        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync("owner", "target", "type/story", It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Once);
-        _labelRepositoryMock.Verify(repository => repository.DeleteLabelAsync("owner", "target", "legacy", It.IsAny<CancellationToken>()), Times.Once);
+        await _labelRepository.Received(1).CreateLabelAsync("owner", "target", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).UpdateLabelAsync("owner", "target", "type/story", Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.Received(1).DeleteLabelAsync("owner", "target", "legacy", Arg.Any<CancellationToken>());
 
-        _milestoneRepositoryMock.Verify(repository => repository.CreateMilestoneAsync("owner", "target", It.IsAny<Milestone>(), It.IsAny<CancellationToken>()), Times.Once);
-        _milestoneRepositoryMock.Verify(repository => repository.UpdateMilestoneAsync("owner", "target", 9, It.IsAny<Milestone>(), It.IsAny<CancellationToken>()), Times.Once);
-        _milestoneRepositoryMock.Verify(repository => repository.DeleteMilestoneAsync("owner", "target", 10, It.IsAny<CancellationToken>()), Times.Once);
+        await _milestoneRepository.Received(1).CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), Arg.Any<CancellationToken>());
+        await _milestoneRepository.Received(1).UpdateMilestoneAsync("owner", "target", 9, Arg.Any<Milestone>(), Arg.Any<CancellationToken>());
+        await _milestoneRepository.Received(1).DeleteMilestoneAsync("owner", "target", 10, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -144,13 +159,18 @@ public sealed class MigrationServiceTests
         // Arrange
         SetupSourceAndTargetData();
 
-        _labelRepositoryMock
-            .Setup(repository => repository.CreateLabelAsync("owner", "target", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, Label label, CancellationToken _) => label with { RepositoryName = repo });
+        _labelRepository
+            .CreateLabelAsync("owner", "target", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var label = callInfo.ArgAt<Label>(2);
+                return label with { RepositoryName = repo };
+            });
 
-        _milestoneRepositoryMock
-            .Setup(repository => repository.CreateMilestoneAsync("owner", "target", It.IsAny<Milestone>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string _, Milestone milestone, CancellationToken _) => milestone);
+        _milestoneRepository
+            .CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => callInfo.ArgAt<Milestone>(2));
 
         var sut = CreateSubject();
 
@@ -174,14 +194,14 @@ public sealed class MigrationServiceTests
         Assert.Equal(0, result.MilestoneResults[0].DeletedCount);
         Assert.Equal(1, result.MilestoneResults[0].SkippedCount);
 
-        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
-        _labelRepositoryMock.Verify(repository => repository.DeleteLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        _milestoneRepositoryMock.Verify(repository => repository.UpdateMilestoneAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Milestone>(), It.IsAny<CancellationToken>()), Times.Never);
-        _milestoneRepositoryMock.Verify(repository => repository.DeleteMilestoneAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().DeleteLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _milestoneRepository.DidNotReceive().UpdateMilestoneAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<Milestone>(), Arg.Any<CancellationToken>());
+        await _milestoneRepository.DidNotReceive().DeleteMilestoneAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
     private MigrationService CreateSubject()
-        => new(_labelRepositoryMock.Object, _milestoneRepositoryMock.Object);
+        => new(_labelRepository, _milestoneRepository);
 
     [Fact]
     public async Task PreviewMigrationAsync_LabelsOnly_DoesNotReturnMilestonePreviews()
@@ -208,9 +228,9 @@ public sealed class MigrationServiceTests
         // Arrange
         SetupSourceAndTargetData();
 
-        _milestoneRepositoryMock
-            .Setup(repository => repository.CreateMilestoneAsync("owner", "target", It.IsAny<Milestone>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string _, Milestone milestone, CancellationToken _) => milestone);
+        _milestoneRepository
+            .CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => callInfo.ArgAt<Milestone>(2));
 
         var sut = CreateSubject();
 
@@ -225,9 +245,9 @@ public sealed class MigrationServiceTests
         Assert.Empty(result.LabelResults);
         Assert.Single(result.MilestoneResults);
 
-        _labelRepositoryMock.Verify(repository => repository.CreateLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
-        _labelRepositoryMock.Verify(repository => repository.UpdateLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Label>(), It.IsAny<CancellationToken>()), Times.Never);
-        _labelRepositoryMock.Verify(repository => repository.DeleteLabelAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        await _labelRepository.DidNotReceive().CreateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), Arg.Any<CancellationToken>());
+        await _labelRepository.DidNotReceive().DeleteLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -272,25 +292,30 @@ public sealed class MigrationServiceTests
         // Arrange
         SetupSourceAndTargetData();
 
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("owner", "failing", It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("label operation failed"));
+        _labelRepository
+            .GetLabelsAsync("owner", "failing", Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<IReadOnlyList<Label>>(new HttpRequestException("label operation failed")));
 
-        _milestoneRepositoryMock
-            .Setup(repository => repository.GetMilestonesAsync("owner", "failing", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
+        _milestoneRepository
+            .GetMilestonesAsync("owner", "failing", Arg.Any<CancellationToken>())
+            .Returns([]);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.CreateLabelAsync("owner", "target", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, Label label, CancellationToken _) => label with { RepositoryName = repo });
+        _labelRepository
+            .CreateLabelAsync("owner", "target", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var label = callInfo.ArgAt<Label>(2);
+                return label with { RepositoryName = repo };
+            });
 
-        _milestoneRepositoryMock
-            .Setup(repository => repository.CreateMilestoneAsync("owner", "target", It.IsAny<Milestone>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string _, Milestone milestone, CancellationToken _) => milestone);
+        _milestoneRepository
+            .CreateMilestoneAsync("owner", "target", Arg.Any<Milestone>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => callInfo.ArgAt<Milestone>(2));
 
-        _milestoneRepositoryMock
-            .Setup(repository => repository.CreateMilestoneAsync("owner", "failing", It.IsAny<Milestone>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string _, Milestone milestone, CancellationToken _) => milestone);
+        _milestoneRepository
+            .CreateMilestoneAsync("owner", "failing", Arg.Any<Milestone>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => callInfo.ArgAt<Milestone>(2));
 
         var sut = CreateSubject();
 
@@ -328,13 +353,18 @@ public sealed class MigrationServiceTests
         // Arrange
         SetupSourceAndTargetData();
 
-        _labelRepositoryMock
-            .Setup(repository => repository.CreateLabelAsync("owner", "target", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, string repo, Label label, CancellationToken _) => label with { RepositoryName = repo });
+        _labelRepository
+            .CreateLabelAsync("owner", "target", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var repo = callInfo.ArgAt<string>(1);
+                var label = callInfo.ArgAt<Label>(2);
+                return label with { RepositoryName = repo };
+            });
 
-        _labelRepositoryMock
-            .Setup(repository => repository.UpdateLabelAsync("owner", "target", "type/story", It.IsAny<Label>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("update failed"));
+        _labelRepository
+            .UpdateLabelAsync("owner", "target", "type/story", Arg.Any<Label>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<Label>(new HttpRequestException("update failed")));
 
         var sut = CreateSubject();
 
@@ -355,30 +385,30 @@ public sealed class MigrationServiceTests
 
     private void SetupSourceAndTargetData()
     {
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("owner", "source", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("owner", "source", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "type/story", Colour = "1d76db", Description = "Source story", RepositoryName = "source" },
                 new Label { Name = "priority/high", Colour = "d93f0b", Description = "Source high", RepositoryName = "source" },
             ]);
 
-        _labelRepositoryMock
-            .Setup(repository => repository.GetLabelsAsync("owner", "target", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _labelRepository
+            .GetLabelsAsync("owner", "target", Arg.Any<CancellationToken>())
+            .Returns([
                 new Label { Name = "type/story", Colour = "ffffff", Description = "Target story", RepositoryName = "target" },
                 new Label { Name = "legacy", Colour = "cfd3d7", Description = "Legacy", RepositoryName = "target" },
             ]);
 
-        _milestoneRepositoryMock
-            .Setup(repository => repository.GetMilestonesAsync("owner", "source", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _milestoneRepository
+            .GetMilestonesAsync("owner", "source", Arg.Any<CancellationToken>())
+            .Returns([
                 new Milestone { Id = 1, Number = 1, Title = "Sprint 1", Description = "Source sprint 1", State = "open", DueOn = DateTimeOffset.Parse("2026-04-01T00:00:00Z") },
                 new Milestone { Id = 2, Number = 2, Title = "Sprint 2", Description = "Source sprint 2", State = "open", DueOn = null },
             ]);
 
-        _milestoneRepositoryMock
-            .Setup(repository => repository.GetMilestonesAsync("owner", "target", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _milestoneRepository
+            .GetMilestonesAsync("owner", "target", Arg.Any<CancellationToken>())
+            .Returns([
                 new Milestone { Id = 9, Number = 9, Title = "Sprint 1", Description = "Target sprint 1", State = "open", DueOn = DateTimeOffset.Parse("2026-03-20T00:00:00Z") },
                 new Milestone { Id = 10, Number = 10, Title = "Legacy", Description = "Legacy milestone", State = "open", DueOn = null },
             ]);

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/RepositoryServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/RepositoryServiceTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Application.Services.Repositories;
 using SoloDevBoard.Domain.Entities.Repositories;
@@ -8,7 +8,7 @@ namespace SoloDevBoard.Application.Tests;
 /// <summary>Tests for <see cref="RepositoryService"/>.</summary>
 public sealed class RepositoryServiceTests
 {
-    private readonly Mock<IGitHubService> _gitHubServiceMock = new();
+    private readonly IGitHubService _gitHubService = Substitute.For<IGitHubService>();
 
     [Fact]
     public async Task GetRepositoriesAsync_GitHubServiceReturnsRepositories_ReturnsRepositories()
@@ -20,11 +20,11 @@ public sealed class RepositoryServiceTests
             new() { Id = 2, Name = "repo-two", FullName = "owner/repo-two" },
         };
 
-        _gitHubServiceMock
-            .Setup(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(expectedRepositories);
+        _gitHubService
+            .GetRepositoriesAsync(Arg.Any<CancellationToken>())
+            .Returns(expectedRepositories);
 
-        var sut = new RepositoryService(_gitHubServiceMock.Object);
+        var sut = new RepositoryService(_gitHubService);
 
         // Act
         var result = await sut.GetRepositoriesAsync();
@@ -32,7 +32,7 @@ public sealed class RepositoryServiceTests
         // Assert
         Assert.Equal(2, result.Count);
         Assert.Equal("repo-one", result[0].Name);
-        _gitHubServiceMock.Verify(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        await _gitHubService.Received(1).GetRepositoriesAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -42,9 +42,9 @@ public sealed class RepositoryServiceTests
         var createdAt = new DateTimeOffset(2025, 1, 2, 3, 4, 5, TimeSpan.Zero);
         var updatedAt = new DateTimeOffset(2026, 2, 3, 4, 5, 6, TimeSpan.Zero);
 
-        _gitHubServiceMock
-            .Setup(service => service.GetRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _gitHubService
+            .GetRepositoriesAsync(Arg.Any<CancellationToken>())
+            .Returns([
                 new Repository
                 {
                     Id = 42,
@@ -59,7 +59,7 @@ public sealed class RepositoryServiceTests
                 },
             ]);
 
-        var sut = new RepositoryService(_gitHubServiceMock.Object);
+        var sut = new RepositoryService(_gitHubService);
 
         // Act
         var result = await sut.GetRepositoriesAsync();
@@ -82,17 +82,17 @@ public sealed class RepositoryServiceTests
     {
         // Arrange
         var cancellationTokenSource = new CancellationTokenSource();
-        _gitHubServiceMock
-            .Setup(service => service.GetRepositoriesAsync(cancellationTokenSource.Token))
-            .ReturnsAsync([]);
+        _gitHubService
+            .GetRepositoriesAsync(cancellationTokenSource.Token)
+            .Returns([]);
 
-        var sut = new RepositoryService(_gitHubServiceMock.Object);
+        var sut = new RepositoryService(_gitHubService);
 
         // Act
         _ = await sut.GetRepositoriesAsync(cancellationTokenSource.Token);
 
         // Assert
-        _gitHubServiceMock.Verify(service => service.GetRepositoriesAsync(cancellationTokenSource.Token), Times.Once);
+        await _gitHubService.Received(1).GetRepositoriesAsync(cancellationTokenSource.Token);
     }
 
     [Fact]
@@ -104,11 +104,11 @@ public sealed class RepositoryServiceTests
             new() { Id = 1, Name = "repo-one", FullName = "owner/repo-one", IsArchived = false },
         };
 
-        _gitHubServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(expectedRepositories);
+        _gitHubService
+            .GetActiveRepositoriesAsync(Arg.Any<CancellationToken>())
+            .Returns(expectedRepositories);
 
-        var sut = new RepositoryService(_gitHubServiceMock.Object);
+        var sut = new RepositoryService(_gitHubService);
 
         // Act
         var result = await sut.GetActiveRepositoriesAsync();
@@ -116,7 +116,7 @@ public sealed class RepositoryServiceTests
         // Assert
         Assert.Single(result);
         Assert.Equal("repo-one", result[0].Name);
-        _gitHubServiceMock.Verify(service => service.GetActiveRepositoriesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        await _gitHubService.Received(1).GetActiveRepositoriesAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -124,16 +124,16 @@ public sealed class RepositoryServiceTests
     {
         // Arrange
         var cancellationTokenSource = new CancellationTokenSource();
-        _gitHubServiceMock
-            .Setup(service => service.GetActiveRepositoriesAsync(cancellationTokenSource.Token))
-            .ReturnsAsync([]);
+        _gitHubService
+            .GetActiveRepositoriesAsync(cancellationTokenSource.Token)
+            .Returns([]);
 
-        var sut = new RepositoryService(_gitHubServiceMock.Object);
+        var sut = new RepositoryService(_gitHubService);
 
         // Act
         _ = await sut.GetActiveRepositoriesAsync(cancellationTokenSource.Token);
 
         // Assert
-        _gitHubServiceMock.Verify(service => service.GetActiveRepositoriesAsync(cancellationTokenSource.Token), Times.Once);
+        await _gitHubService.Received(1).GetActiveRepositoriesAsync(cancellationTokenSource.Token);
     }
 }

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/RepositoryServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/RepositoryServiceTests.cs
@@ -13,6 +13,7 @@ public sealed class RepositoryServiceTests
     [Fact]
     public async Task GetRepositoriesAsync_GitHubServiceReturnsRepositories_ReturnsRepositories()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var expectedRepositories = new List<Repository>
         {
@@ -21,29 +22,30 @@ public sealed class RepositoryServiceTests
         };
 
         _gitHubService
-            .GetRepositoriesAsync(Arg.Any<CancellationToken>())
+            .GetRepositoriesAsync(cancellationToken)
             .Returns(expectedRepositories);
 
         var sut = new RepositoryService(_gitHubService);
 
         // Act
-        var result = await sut.GetRepositoriesAsync();
+        var result = await sut.GetRepositoriesAsync(cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
         Assert.Equal("repo-one", result[0].Name);
-        await _gitHubService.Received(1).GetRepositoriesAsync(Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).GetRepositoriesAsync(cancellationToken);
     }
 
     [Fact]
     public async Task GetRepositoriesAsync_GitHubServiceReturnsRepository_MapsAllFieldsToRepositoryDto()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var createdAt = new DateTimeOffset(2025, 1, 2, 3, 4, 5, TimeSpan.Zero);
         var updatedAt = new DateTimeOffset(2026, 2, 3, 4, 5, 6, TimeSpan.Zero);
 
         _gitHubService
-            .GetRepositoriesAsync(Arg.Any<CancellationToken>())
+            .GetRepositoriesAsync(cancellationToken)
             .Returns([
                 new Repository
                 {
@@ -62,7 +64,7 @@ public sealed class RepositoryServiceTests
         var sut = new RepositoryService(_gitHubService);
 
         // Act
-        var result = await sut.GetRepositoriesAsync();
+        var result = await sut.GetRepositoriesAsync(cancellationToken);
 
         // Assert
         var dto = Assert.Single(result);
@@ -80,6 +82,7 @@ public sealed class RepositoryServiceTests
     [Fact]
     public async Task GetRepositoriesAsync_WhenCalled_PassesCancellationTokenToGitHubService()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var cancellationTokenSource = new CancellationTokenSource();
         _gitHubService
@@ -98,6 +101,7 @@ public sealed class RepositoryServiceTests
     [Fact]
     public async Task GetActiveRepositoriesAsync_GitHubServiceReturnsRepositories_ReturnsRepositories()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var expectedRepositories = new List<Repository>
         {
@@ -105,23 +109,24 @@ public sealed class RepositoryServiceTests
         };
 
         _gitHubService
-            .GetActiveRepositoriesAsync(Arg.Any<CancellationToken>())
+            .GetActiveRepositoriesAsync(cancellationToken)
             .Returns(expectedRepositories);
 
         var sut = new RepositoryService(_gitHubService);
 
         // Act
-        var result = await sut.GetActiveRepositoriesAsync();
+        var result = await sut.GetActiveRepositoriesAsync(cancellationToken);
 
         // Assert
         Assert.Single(result);
         Assert.Equal("repo-one", result[0].Name);
-        await _gitHubService.Received(1).GetActiveRepositoriesAsync(Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).GetActiveRepositoriesAsync(cancellationToken);
     }
 
     [Fact]
     public async Task GetActiveRepositoriesAsync_WhenCalled_PassesCancellationTokenToGitHubService()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var cancellationTokenSource = new CancellationTokenSource();
         _gitHubService

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/SoloDevBoard.Application.Tests.csproj
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/SoloDevBoard.Application.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -10,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Application.Services.Triage;
 using SoloDevBoard.Domain.Entities.Labels;
@@ -9,7 +9,7 @@ namespace SoloDevBoard.Application.Tests;
 /// <summary>Tests for <see cref="TriageService"/>.</summary>
 public sealed class TriageServiceTests
 {
-    private readonly Mock<IGitHubService> _gitHubServiceMock = new();
+    private readonly IGitHubService _gitHubService = Substitute.For<IGitHubService>();
 
     [Fact]
     public void Constructor_GitHubServiceIsNull_ThrowsArgumentNullException()
@@ -28,7 +28,7 @@ public sealed class TriageServiceTests
     public async Task StartSessionAsync_OwnerIsWhitespace_ThrowsArgumentException()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
 
         // Act
         var action = async () => _ = await sut.StartSessionAsync(" ", "repo");
@@ -41,7 +41,7 @@ public sealed class TriageServiceTests
     public async Task StartSessionAsync_RepositoryIsWhitespace_ThrowsArgumentException()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
 
         // Act
         var action = async () => _ = await sut.StartSessionAsync("owner", " ");
@@ -54,15 +54,15 @@ public sealed class TriageServiceTests
     public async Task StartSessionAsync_IssuesOnly_BuildsIssueQueueAndInitialProgress()
     {
         // Arrange
-        _gitHubServiceMock
-            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
+        _gitHubService
+            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns(
             [
                 new Issue { Id = 1, Number = 11, Title = "Older", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2) },
                 new Issue { Id = 2, Number = 12, Title = "Newer", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1) },
             ]);
 
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
 
         // Act
         var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: false);
@@ -78,26 +78,26 @@ public sealed class TriageServiceTests
         Assert.Equal(2, result.Progress.TotalItems);
         Assert.Equal(0, result.Progress.ProcessedItems);
         Assert.Equal(2, result.Progress.RemainingItems);
-        _gitHubServiceMock.Verify(service => service.GetPullRequestsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        await _gitHubService.DidNotReceive().GetPullRequestsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task StartSessionAsync_IncludePullRequests_CombinesIssuesAndPullRequests()
     {
         // Arrange
-        _gitHubServiceMock
-            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _gitHubService
+            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new Issue { Id = 1, Number = 11, Title = "Issue", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2) },
             ]);
 
-        _gitHubServiceMock
-            .Setup(service => service.GetPullRequestsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _gitHubService
+            .GetPullRequestsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new PullRequest { Id = 2, Number = 21, Title = "Pull request", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1) },
             ]);
 
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
 
         // Act
         var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true);
@@ -112,15 +112,15 @@ public sealed class TriageServiceTests
     public async Task StartSessionAsync_IncludePullRequestsWithLabelledPullRequest_ExcludesLabelledPullRequestFromQueue()
     {
         // Arrange
-        _gitHubServiceMock
-            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _gitHubService
+            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new Issue { Id = 1, Number = 11, Title = "Issue", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2), Labels = [] },
             ]);
 
-        _gitHubServiceMock
-            .Setup(service => service.GetPullRequestsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _gitHubService
+            .GetPullRequestsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new PullRequest
                 {
                     Id = 2,
@@ -139,7 +139,7 @@ public sealed class TriageServiceTests
                 },
             ]);
 
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
 
         // Act
         var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true);
@@ -155,20 +155,20 @@ public sealed class TriageServiceTests
     public async Task StartSessionAsync_IncludePullRequestsWithMixedItems_OrdersQueueByUpdatedAtAcrossItemTypes()
     {
         // Arrange
-        _gitHubServiceMock
-            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _gitHubService
+            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new Issue { Id = 1, Number = 11, Title = "Older issue", UpdatedAt = DateTimeOffset.Parse("2026-03-01T10:00:00Z"), Labels = [] },
                 new Issue { Id = 2, Number = 12, Title = "Newer issue", UpdatedAt = DateTimeOffset.Parse("2026-03-03T10:00:00Z"), Labels = [] },
             ]);
 
-        _gitHubServiceMock
-            .Setup(service => service.GetPullRequestsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _gitHubService
+            .GetPullRequestsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new PullRequest { Id = 3, Number = 21, Title = "Middle pull request", UpdatedAt = DateTimeOffset.Parse("2026-03-02T10:00:00Z"), Labels = [] },
             ]);
 
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
 
         // Act
         var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true);
@@ -187,13 +187,13 @@ public sealed class TriageServiceTests
     public async Task StartSessionAsync_IncludePullRequestsWithMilestoneOnPullRequest_PreservesMilestoneDetails()
     {
         // Arrange
-        _gitHubServiceMock
-            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
+        _gitHubService
+            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns([]);
 
-        _gitHubServiceMock
-            .Setup(service => service.GetPullRequestsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _gitHubService
+            .GetPullRequestsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new PullRequest
                 {
                     Id = 3,
@@ -209,7 +209,7 @@ public sealed class TriageServiceTests
                 },
             ]);
 
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
 
         // Act
         var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true);
@@ -225,14 +225,14 @@ public sealed class TriageServiceTests
     public async Task StartSessionAsync_LabelledIssuePresent_ExcludesLabelledIssueFromQueue()
     {
         // Arrange
-        _gitHubServiceMock
-            .Setup(service => service.GetIssuesAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _gitHubService
+            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new Issue { Id = 1, Number = 11, Title = "Unlabelled", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2), Labels = [] },
                 new Issue { Id = 2, Number = 12, Title = "Labelled", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1), Labels = [new Label { Name = "priority/high" }] },
             ]);
 
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
 
         // Act
         var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: false);
@@ -246,7 +246,7 @@ public sealed class TriageServiceTests
     public async Task AdvanceSessionAsync_QueueHasItems_IncrementsCurrentIndex()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 2, currentIndex: 0);
 
         // Act
@@ -262,7 +262,7 @@ public sealed class TriageServiceTests
     public async Task SkipCurrentItemAsync_ActiveItemExists_AddsSkippedItemAndMovesForward()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 2, currentIndex: 0);
 
         // Act
@@ -283,7 +283,7 @@ public sealed class TriageServiceTests
     public async Task RevisitSkippedItemsAsync_SkippedItemsExist_ClearsSkippedList()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var queue = new[]
         {
             new TriageItemDto(TriageItemTypeDto.Issue, 1, 11, "owner/repo", "Item 1", string.Empty, string.Empty, "open", "mark", [], null, string.Empty, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
@@ -318,7 +318,7 @@ public sealed class TriageServiceTests
     public async Task RevisitSkippedItemsAsync_SkippedItemStillPresentInQueue_MovesItemToQueueEnd()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var itemOne = new TriageItemDto(TriageItemTypeDto.Issue, 1, 11, "owner/repo", "Item 1", string.Empty, string.Empty, "open", "mark", [], null, string.Empty, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
         var itemTwo = new TriageItemDto(TriageItemTypeDto.Issue, 2, 12, "owner/repo", "Item 2", string.Empty, string.Empty, "open", "mark", [], null, string.Empty, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
 
@@ -349,7 +349,7 @@ public sealed class TriageServiceTests
     public async Task ApplyLabelToCurrentItemAsync_ActiveItemExists_AppliesLabelAndRecordsAction()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
         // Act
@@ -363,16 +363,14 @@ public sealed class TriageServiceTests
         Assert.Contains("type/story", result.ActionHistory[0].Detail, StringComparison.Ordinal);
         Assert.Equal(1, result.Summary.LabelsAppliedCount);
 
-        _gitHubServiceMock.Verify(
-            service => service.ApplyLabelsToTriageItemAsync("owner", "repo", 1, It.Is<IReadOnlyList<string>>(labels => labels.Count == 1 && labels[0] == "type/story"), It.IsAny<CancellationToken>()),
-            Times.Once);
+        await _gitHubService.Received(1).ApplyLabelsToTriageItemAsync("owner", "repo", 1, Arg.Is<IReadOnlyList<string>>(labels => labels.Count == 1 && labels[0] == "type/story"), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ApplyLabelToCurrentItemAsync_LabelAlreadyAssigned_DoesNotDuplicateAssignedLabel()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var existingLabelItem = new TriageItemDto(
             TriageItemTypeDto.Issue,
             1,
@@ -409,16 +407,14 @@ public sealed class TriageServiceTests
         Assert.Single(result.Queue[0].Labels);
         Assert.Equal("priority/high", result.Queue[0].Labels[0]);
 
-        _gitHubServiceMock.Verify(
-            service => service.ApplyLabelsToTriageItemAsync("owner", "repo", 99, It.Is<IReadOnlyList<string>>(labels => labels.Count == 1 && labels[0] == "priority/high"), It.IsAny<CancellationToken>()),
-            Times.Once);
+        await _gitHubService.Received(1).ApplyLabelsToTriageItemAsync("owner", "repo", 99, Arg.Is<IReadOnlyList<string>>(labels => labels.Count == 1 && labels[0] == "priority/high"), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ApplyLabelToCurrentItemAsync_InvalidRepositoryScope_ThrowsArgumentException()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var invalidScopeItem = new TriageItemDto(
             TriageItemTypeDto.Issue,
             1,
@@ -459,14 +455,14 @@ public sealed class TriageServiceTests
     public async Task GetMilestoneOptionsAsync_MilestonesReturned_ReturnsSortedOptions()
     {
         // Arrange
-        _gitHubServiceMock
-            .Setup(service => service.GetMilestonesAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
+        _gitHubService
+            .GetMilestonesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns([
                 new SoloDevBoard.Domain.Entities.Milestones.Milestone { Number = 3, Title = "v0.3.0" },
                 new SoloDevBoard.Domain.Entities.Milestones.Milestone { Number = 1, Title = "v0.1.0" },
             ]);
 
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
         // Act
@@ -483,9 +479,9 @@ public sealed class TriageServiceTests
     public async Task GetProjectBoardOptionsAsync_ProjectBoardsReturned_ReturnsSortedOptions()
     {
         // Arrange
-        _gitHubServiceMock
-            .Setup(service => service.GetProjectBoardsForRepositoryAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new RepositoryProjectBoardDiscoveryResult(
+        _gitHubService
+            .GetProjectBoardsForRepositoryAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns(new RepositoryProjectBoardDiscoveryResult(
             [
                 new TriageProjectBoard
                 {
@@ -514,7 +510,7 @@ public sealed class TriageServiceTests
             2,
             0));
 
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
         // Act
@@ -532,7 +528,7 @@ public sealed class TriageServiceTests
     public async Task AssignMilestoneToCurrentItemAsync_ValidMilestone_AssignsMilestoneAndRecordsAction()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
         // Act
@@ -545,20 +541,18 @@ public sealed class TriageServiceTests
         Assert.Equal(TriageActionTypeDto.MilestoneAssigned, result.ActionHistory[0].ActionType);
         Assert.Equal(1, result.Summary.MilestonesAssignedCount);
 
-        _gitHubServiceMock.Verify(
-            service => service.AssignMilestoneToTriageItemAsync("owner", "repo", 1, 12, It.IsAny<CancellationToken>()),
-            Times.Once);
+        await _gitHubService.Received(1).AssignMilestoneToTriageItemAsync("owner", "repo", 1, 12, Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task AddCurrentItemToProjectBoardAsync_ValidInput_AddsItemAndUpdatesStatusAndRecordsAction()
     {
         // Arrange
-        _gitHubServiceMock
-            .Setup(service => service.AddTriageItemToProjectBoardAsync("owner", "repo", 1, "project-id", It.IsAny<CancellationToken>()))
-            .ReturnsAsync("project-item-id");
+        _gitHubService
+            .AddTriageItemToProjectBoardAsync("owner", "repo", 1, "project-id", Arg.Any<CancellationToken>())
+            .Returns("project-item-id");
 
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
         // Act
@@ -577,19 +571,15 @@ public sealed class TriageServiceTests
         Assert.Contains("In Progress", result.ActionHistory[0].Detail, StringComparison.Ordinal);
         Assert.Equal(1, result.Summary.ProjectAssignmentsCount);
 
-        _gitHubServiceMock.Verify(
-            service => service.AddTriageItemToProjectBoardAsync("owner", "repo", 1, "project-id", It.IsAny<CancellationToken>()),
-            Times.Once);
-        _gitHubServiceMock.Verify(
-            service => service.UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress", It.IsAny<CancellationToken>()),
-            Times.Once);
+        await _gitHubService.Received(1).AddTriageItemToProjectBoardAsync("owner", "repo", 1, "project-id", Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task AddCurrentItemToProjectBoardAsync_InvalidRepositoryScope_ThrowsArgumentException()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var invalidScopeItem = new TriageItemDto(
             TriageItemTypeDto.Issue,
             1,
@@ -636,7 +626,7 @@ public sealed class TriageServiceTests
     public async Task CloseCurrentItemAsDuplicateAsync_ActiveIssueExists_ClosesDuplicateAndRecordsAction()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
         // Act
@@ -648,33 +638,31 @@ public sealed class TriageServiceTests
         Assert.Contains("#123", result.ActionHistory[0].Detail, StringComparison.Ordinal);
         Assert.Equal(1, result.Summary.DuplicateClosuresCount);
 
-        _gitHubServiceMock.Verify(
-            service => service.CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 1, "#123", It.IsAny<CancellationToken>()),
-            Times.Once);
+        await _gitHubService.Received(1).CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 1, "#123", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task CloseCurrentItemAsDuplicateAsync_DuplicateLabelExists_AppliesCanonicalDuplicateLabel()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
-        _gitHubServiceMock
-            .Setup(service => service.CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 1, "#123", It.IsAny<CancellationToken>()))
+        _gitHubService
+            .CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 1, "#123", Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 
-        _gitHubServiceMock
-            .Setup(service => service.GetLabelsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { new Label { Name = "duplicate" } });
+        _gitHubService
+            .GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns(new[] { new Label { Name = "duplicate" } });
 
-        _gitHubServiceMock
-            .Setup(service => service.ApplyLabelsToTriageItemAsync(
+        _gitHubService
+            .ApplyLabelsToTriageItemAsync(
                 "owner",
                 "repo",
                 1,
-                It.Is<IReadOnlyList<string>>(labels => labels.SequenceEqual(new[] { "duplicate" })),
-                It.IsAny<CancellationToken>()))
+                Arg.Is<IReadOnlyList<string>>(labels => labels.SequenceEqual(new[] { "duplicate" })),
+                Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 
         // Act
@@ -686,29 +674,29 @@ public sealed class TriageServiceTests
         Assert.Contains("Applied label 'duplicate'", result.ActionHistory[0].Detail, StringComparison.Ordinal);
         Assert.Equal(1, result.Summary.DuplicateClosuresCount);
 
-        _gitHubServiceMock.Verify(service => service.GetLabelsAsync("owner", "repo", It.IsAny<CancellationToken>()), Times.Once);
-        _gitHubServiceMock.Verify(service => service.ApplyLabelsToTriageItemAsync(
+        await _gitHubService.Received(1).GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).ApplyLabelsToTriageItemAsync(
             "owner",
             "repo",
             1,
-            It.Is<IReadOnlyList<string>>(labels => labels.SequenceEqual(new[] { "duplicate" })),
-            It.IsAny<CancellationToken>()), Times.Once);
+            Arg.Is<IReadOnlyList<string>>(labels => labels.SequenceEqual(new[] { "duplicate" })),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task CloseCurrentItemAsDuplicateAsync_DuplicateLabelMissing_DoesNotApplyLabel()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
-        _gitHubServiceMock
-            .Setup(service => service.CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 1, "#123", It.IsAny<CancellationToken>()))
+        _gitHubService
+            .CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 1, "#123", Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 
-        _gitHubServiceMock
-            .Setup(service => service.GetLabelsAsync("owner", "repo", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<Label>());
+        _gitHubService
+            .GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Label>());
 
         // Act
         var result = await sut.CloseCurrentItemAsDuplicateAsync(session, "#123");
@@ -719,15 +707,15 @@ public sealed class TriageServiceTests
         Assert.Contains("No canonical duplicate label was available", result.ActionHistory[0].Detail, StringComparison.Ordinal);
         Assert.Equal(1, result.Summary.DuplicateClosuresCount);
 
-        _gitHubServiceMock.Verify(service => service.GetLabelsAsync("owner", "repo", It.IsAny<CancellationToken>()), Times.Once);
-        _gitHubServiceMock.Verify(service => service.ApplyLabelsToTriageItemAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()), Times.Never);
+        await _gitHubService.Received(1).GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>());
+        await _gitHubService.DidNotReceive().ApplyLabelsToTriageItemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task CloseCurrentItemAsDuplicateAsync_ActivePullRequestExists_ClosesPullRequestDuplicate()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var pullRequestItem = new TriageItemDto(
             TriageItemTypeDto.PullRequest,
             21,
@@ -761,22 +749,20 @@ public sealed class TriageServiceTests
         _ = await sut.CloseCurrentItemAsDuplicateAsync(session, "https://github.com/owner/repo/pull/20");
 
         // Assert
-        _gitHubServiceMock.Verify(
-            service => service.CloseTriageItemAsDuplicateAsync(
-                "owner",
-                "repo",
-                GitHubTriageItemType.PullRequest,
-                21,
-                "https://github.com/owner/repo/pull/20",
-                It.IsAny<CancellationToken>()),
-            Times.Once);
+        await _gitHubService.Received(1).CloseTriageItemAsDuplicateAsync(
+            "owner",
+            "repo",
+            GitHubTriageItemType.PullRequest,
+            21,
+            "https://github.com/owner/repo/pull/20",
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public void BuildSessionSummary_ActionHistoryIncludesAllActionTypes_ReturnsComputedCounts()
     {
         // Arrange
-        var sut = new TriageService(_gitHubServiceMock.Object);
+        var sut = new TriageService(_gitHubService);
         var actions = new[]
         {
             new TriageActionDto(TriageActionTypeDto.LabelApplied, TriageItemTypeDto.Issue, 1, "owner/repo", string.Empty, DateTimeOffset.UtcNow),

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/TriageServiceTests.cs
@@ -27,11 +27,12 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task StartSessionAsync_OwnerIsWhitespace_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
 
         // Act
-        var action = async () => _ = await sut.StartSessionAsync(" ", "repo");
+        var action = async () => _ = await sut.StartSessionAsync(" ", "repo", cancellationToken: cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -40,11 +41,12 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task StartSessionAsync_RepositoryIsWhitespace_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
 
         // Act
-        var action = async () => _ = await sut.StartSessionAsync("owner", " ");
+        var action = async () => _ = await sut.StartSessionAsync("owner", " ", cancellationToken: cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -53,9 +55,10 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task StartSessionAsync_IssuesOnly_BuildsIssueQueueAndInitialProgress()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _gitHubService
-            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetIssuesAsync("owner", "repo", cancellationToken)
             .Returns(
             [
                 new Issue { Id = 1, Number = 11, Title = "Older", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2) },
@@ -65,7 +68,7 @@ public sealed class TriageServiceTests
         var sut = new TriageService(_gitHubService);
 
         // Act
-        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: false);
+        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: false, cancellationToken);
 
         // Assert
         Assert.Equal("owner", result.OwnerLogin);
@@ -78,21 +81,22 @@ public sealed class TriageServiceTests
         Assert.Equal(2, result.Progress.TotalItems);
         Assert.Equal(0, result.Progress.ProcessedItems);
         Assert.Equal(2, result.Progress.RemainingItems);
-        await _gitHubService.DidNotReceive().GetPullRequestsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _gitHubService.DidNotReceive().GetPullRequestsAsync(Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
     }
 
     [Fact]
     public async Task StartSessionAsync_IncludePullRequests_CombinesIssuesAndPullRequests()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _gitHubService
-            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetIssuesAsync("owner", "repo", cancellationToken)
             .Returns([
                 new Issue { Id = 1, Number = 11, Title = "Issue", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2) },
             ]);
 
         _gitHubService
-            .GetPullRequestsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetPullRequestsAsync("owner", "repo", cancellationToken)
             .Returns([
                 new PullRequest { Id = 2, Number = 21, Title = "Pull request", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1) },
             ]);
@@ -100,7 +104,7 @@ public sealed class TriageServiceTests
         var sut = new TriageService(_gitHubService);
 
         // Act
-        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true);
+        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true, cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Queue.Count);
@@ -111,15 +115,16 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task StartSessionAsync_IncludePullRequestsWithLabelledPullRequest_ExcludesLabelledPullRequestFromQueue()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _gitHubService
-            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetIssuesAsync("owner", "repo", cancellationToken)
             .Returns([
                 new Issue { Id = 1, Number = 11, Title = "Issue", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2), Labels = [] },
             ]);
 
         _gitHubService
-            .GetPullRequestsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetPullRequestsAsync("owner", "repo", cancellationToken)
             .Returns([
                 new PullRequest
                 {
@@ -142,7 +147,7 @@ public sealed class TriageServiceTests
         var sut = new TriageService(_gitHubService);
 
         // Act
-        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true);
+        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true, cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Queue.Count);
@@ -154,16 +159,17 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task StartSessionAsync_IncludePullRequestsWithMixedItems_OrdersQueueByUpdatedAtAcrossItemTypes()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _gitHubService
-            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetIssuesAsync("owner", "repo", cancellationToken)
             .Returns([
                 new Issue { Id = 1, Number = 11, Title = "Older issue", UpdatedAt = DateTimeOffset.Parse("2026-03-01T10:00:00Z"), Labels = [] },
                 new Issue { Id = 2, Number = 12, Title = "Newer issue", UpdatedAt = DateTimeOffset.Parse("2026-03-03T10:00:00Z"), Labels = [] },
             ]);
 
         _gitHubService
-            .GetPullRequestsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetPullRequestsAsync("owner", "repo", cancellationToken)
             .Returns([
                 new PullRequest { Id = 3, Number = 21, Title = "Middle pull request", UpdatedAt = DateTimeOffset.Parse("2026-03-02T10:00:00Z"), Labels = [] },
             ]);
@@ -171,7 +177,7 @@ public sealed class TriageServiceTests
         var sut = new TriageService(_gitHubService);
 
         // Act
-        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true);
+        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true, cancellationToken);
 
         // Assert
         Assert.Equal(3, result.Queue.Count);
@@ -186,13 +192,14 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task StartSessionAsync_IncludePullRequestsWithMilestoneOnPullRequest_PreservesMilestoneDetails()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _gitHubService
-            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetIssuesAsync("owner", "repo", cancellationToken)
             .Returns([]);
 
         _gitHubService
-            .GetPullRequestsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetPullRequestsAsync("owner", "repo", cancellationToken)
             .Returns([
                 new PullRequest
                 {
@@ -212,7 +219,7 @@ public sealed class TriageServiceTests
         var sut = new TriageService(_gitHubService);
 
         // Act
-        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true);
+        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: true, cancellationToken);
 
         // Assert
         var pullRequest = Assert.Single(result.Queue);
@@ -224,9 +231,10 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task StartSessionAsync_LabelledIssuePresent_ExcludesLabelledIssueFromQueue()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _gitHubService
-            .GetIssuesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetIssuesAsync("owner", "repo", cancellationToken)
             .Returns([
                 new Issue { Id = 1, Number = 11, Title = "Unlabelled", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2), Labels = [] },
                 new Issue { Id = 2, Number = 12, Title = "Labelled", UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1), Labels = [new Label { Name = "priority/high" }] },
@@ -235,7 +243,7 @@ public sealed class TriageServiceTests
         var sut = new TriageService(_gitHubService);
 
         // Act
-        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: false);
+        var result = await sut.StartSessionAsync("owner", "repo", includePullRequests: false, cancellationToken);
 
         // Assert
         Assert.Single(result.Queue);
@@ -245,12 +253,13 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task AdvanceSessionAsync_QueueHasItems_IncrementsCurrentIndex()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 2, currentIndex: 0);
 
         // Act
-        var result = await sut.AdvanceSessionAsync(session);
+        var result = await sut.AdvanceSessionAsync(session, cancellationToken);
 
         // Assert
         Assert.Equal(1, result.CurrentIndex);
@@ -261,12 +270,13 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task SkipCurrentItemAsync_ActiveItemExists_AddsSkippedItemAndMovesForward()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 2, currentIndex: 0);
 
         // Act
-        var result = await sut.SkipCurrentItemAsync(session, "Needs follow-up");
+        var result = await sut.SkipCurrentItemAsync(session, "Needs follow-up", cancellationToken);
 
         // Assert
         Assert.Equal(0, result.CurrentIndex);
@@ -282,6 +292,7 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task RevisitSkippedItemsAsync_SkippedItemsExist_ClearsSkippedList()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
         var queue = new[]
@@ -307,7 +318,7 @@ public sealed class TriageServiceTests
             DateTimeOffset.UtcNow);
 
         // Act
-        var result = await sut.RevisitSkippedItemsAsync(session);
+        var result = await sut.RevisitSkippedItemsAsync(session, cancellationToken);
 
         // Assert
         Assert.Empty(result.SkippedItems);
@@ -317,6 +328,7 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task RevisitSkippedItemsAsync_SkippedItemStillPresentInQueue_MovesItemToQueueEnd()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
         var itemOne = new TriageItemDto(TriageItemTypeDto.Issue, 1, 11, "owner/repo", "Item 1", string.Empty, string.Empty, "open", "mark", [], null, string.Empty, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
@@ -336,7 +348,7 @@ public sealed class TriageServiceTests
             DateTimeOffset.UtcNow);
 
         // Act
-        var result = await sut.RevisitSkippedItemsAsync(session);
+        var result = await sut.RevisitSkippedItemsAsync(session, cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Queue.Count);
@@ -348,12 +360,13 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task ApplyLabelToCurrentItemAsync_ActiveItemExists_AppliesLabelAndRecordsAction()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
         // Act
-        var result = await sut.ApplyLabelToCurrentItemAsync(session, "type/story");
+        var result = await sut.ApplyLabelToCurrentItemAsync(session, "type/story", cancellationToken);
 
         // Assert
         Assert.Single(result.Queue[0].Labels);
@@ -363,12 +376,13 @@ public sealed class TriageServiceTests
         Assert.Contains("type/story", result.ActionHistory[0].Detail, StringComparison.Ordinal);
         Assert.Equal(1, result.Summary.LabelsAppliedCount);
 
-        await _gitHubService.Received(1).ApplyLabelsToTriageItemAsync("owner", "repo", 1, Arg.Is<IReadOnlyList<string>>(labels => labels.Count == 1 && labels[0] == "type/story"), Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).ApplyLabelsToTriageItemAsync("owner", "repo", 1, Arg.Is<IReadOnlyList<string>>(labels => labels!.Count == 1 && labels[0] == "type/story"), cancellationToken);
     }
 
     [Fact]
     public async Task ApplyLabelToCurrentItemAsync_LabelAlreadyAssigned_DoesNotDuplicateAssignedLabel()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
         var existingLabelItem = new TriageItemDto(
@@ -401,18 +415,19 @@ public sealed class TriageServiceTests
             DateTimeOffset.UtcNow);
 
         // Act
-        var result = await sut.ApplyLabelToCurrentItemAsync(session, "priority/high");
+        var result = await sut.ApplyLabelToCurrentItemAsync(session, "priority/high", cancellationToken);
 
         // Assert
         Assert.Single(result.Queue[0].Labels);
         Assert.Equal("priority/high", result.Queue[0].Labels[0]);
 
-        await _gitHubService.Received(1).ApplyLabelsToTriageItemAsync("owner", "repo", 99, Arg.Is<IReadOnlyList<string>>(labels => labels.Count == 1 && labels[0] == "priority/high"), Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).ApplyLabelsToTriageItemAsync("owner", "repo", 99, Arg.Is<IReadOnlyList<string>>(labels => labels!.Count == 1 && labels[0] == "priority/high"), cancellationToken);
     }
 
     [Fact]
     public async Task ApplyLabelToCurrentItemAsync_InvalidRepositoryScope_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
         var invalidScopeItem = new TriageItemDto(
@@ -445,7 +460,7 @@ public sealed class TriageServiceTests
             DateTimeOffset.UtcNow);
 
         // Act
-        var action = async () => _ = await sut.ApplyLabelToCurrentItemAsync(session, "type/story");
+        var action = async () => _ = await sut.ApplyLabelToCurrentItemAsync(session, "type/story", cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -454,9 +469,10 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task GetMilestoneOptionsAsync_MilestonesReturned_ReturnsSortedOptions()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _gitHubService
-            .GetMilestonesAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetMilestonesAsync("owner", "repo", cancellationToken)
             .Returns([
                 new SoloDevBoard.Domain.Entities.Milestones.Milestone { Number = 3, Title = "v0.3.0" },
                 new SoloDevBoard.Domain.Entities.Milestones.Milestone { Number = 1, Title = "v0.1.0" },
@@ -466,7 +482,7 @@ public sealed class TriageServiceTests
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
         // Act
-        var result = await sut.GetMilestoneOptionsAsync(session);
+        var result = await sut.GetMilestoneOptionsAsync(session, cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -478,9 +494,10 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task GetProjectBoardOptionsAsync_ProjectBoardsReturned_ReturnsSortedOptions()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _gitHubService
-            .GetProjectBoardsForRepositoryAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetProjectBoardsForRepositoryAsync("owner", "repo", cancellationToken)
             .Returns(new RepositoryProjectBoardDiscoveryResult(
             [
                 new TriageProjectBoard
@@ -514,7 +531,7 @@ public sealed class TriageServiceTests
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
         // Act
-        var result = await sut.GetProjectBoardOptionsAsync(session);
+        var result = await sut.GetProjectBoardOptionsAsync(session, cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Options.Count);
@@ -527,12 +544,13 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task AssignMilestoneToCurrentItemAsync_ValidMilestone_AssignsMilestoneAndRecordsAction()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
         // Act
-        var result = await sut.AssignMilestoneToCurrentItemAsync(session, 12, "v1.2.0");
+        var result = await sut.AssignMilestoneToCurrentItemAsync(session, 12, "v1.2.0", cancellationToken);
 
         // Assert
         Assert.Equal(12, result.Queue[0].MilestoneNumber);
@@ -541,15 +559,16 @@ public sealed class TriageServiceTests
         Assert.Equal(TriageActionTypeDto.MilestoneAssigned, result.ActionHistory[0].ActionType);
         Assert.Equal(1, result.Summary.MilestonesAssignedCount);
 
-        await _gitHubService.Received(1).AssignMilestoneToTriageItemAsync("owner", "repo", 1, 12, Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).AssignMilestoneToTriageItemAsync("owner", "repo", 1, 12, cancellationToken);
     }
 
     [Fact]
     public async Task AddCurrentItemToProjectBoardAsync_ValidInput_AddsItemAndUpdatesStatusAndRecordsAction()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _gitHubService
-            .AddTriageItemToProjectBoardAsync("owner", "repo", 1, "project-id", Arg.Any<CancellationToken>())
+            .AddTriageItemToProjectBoardAsync("owner", "repo", 1, "project-id", cancellationToken)
             .Returns("project-item-id");
 
         var sut = new TriageService(_gitHubService);
@@ -562,7 +581,7 @@ public sealed class TriageServiceTests
             "Roadmap",
             "status-field-id",
             "in-progress",
-            "In Progress");
+            "In Progress", cancellationToken);
 
         // Assert
         Assert.Single(result.ActionHistory);
@@ -571,13 +590,14 @@ public sealed class TriageServiceTests
         Assert.Contains("In Progress", result.ActionHistory[0].Detail, StringComparison.Ordinal);
         Assert.Equal(1, result.Summary.ProjectAssignmentsCount);
 
-        await _gitHubService.Received(1).AddTriageItemToProjectBoardAsync("owner", "repo", 1, "project-id", Arg.Any<CancellationToken>());
-        await _gitHubService.Received(1).UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress", Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).AddTriageItemToProjectBoardAsync("owner", "repo", 1, "project-id", cancellationToken);
+        await _gitHubService.Received(1).UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress", cancellationToken);
     }
 
     [Fact]
     public async Task AddCurrentItemToProjectBoardAsync_InvalidRepositoryScope_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
         var invalidScopeItem = new TriageItemDto(
@@ -616,7 +636,7 @@ public sealed class TriageServiceTests
             "Roadmap",
             "status-field-id",
             "in-progress",
-            "In Progress");
+            "In Progress", cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -625,12 +645,13 @@ public sealed class TriageServiceTests
     [Fact]
     public async Task CloseCurrentItemAsDuplicateAsync_ActiveIssueExists_ClosesDuplicateAndRecordsAction()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
         // Act
-        var result = await sut.CloseCurrentItemAsDuplicateAsync(session, "#123");
+        var result = await sut.CloseCurrentItemAsDuplicateAsync(session, "#123", cancellationToken);
 
         // Assert
         Assert.Single(result.ActionHistory);
@@ -638,22 +659,23 @@ public sealed class TriageServiceTests
         Assert.Contains("#123", result.ActionHistory[0].Detail, StringComparison.Ordinal);
         Assert.Equal(1, result.Summary.DuplicateClosuresCount);
 
-        await _gitHubService.Received(1).CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 1, "#123", Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 1, "#123", cancellationToken);
     }
 
     [Fact]
     public async Task CloseCurrentItemAsDuplicateAsync_DuplicateLabelExists_AppliesCanonicalDuplicateLabel()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
         _gitHubService
-            .CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 1, "#123", Arg.Any<CancellationToken>())
+            .CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 1, "#123", cancellationToken)
             .Returns(Task.CompletedTask);
 
         _gitHubService
-            .GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("owner", "repo", cancellationToken)
             .Returns(new[] { new Label { Name = "duplicate" } });
 
         _gitHubService
@@ -661,12 +683,12 @@ public sealed class TriageServiceTests
                 "owner",
                 "repo",
                 1,
-                Arg.Is<IReadOnlyList<string>>(labels => labels.SequenceEqual(new[] { "duplicate" })),
-                Arg.Any<CancellationToken>())
+                Arg.Is<IReadOnlyList<string>>(labels => labels!.SequenceEqual(new[] { "duplicate" })),
+                cancellationToken)
             .Returns(Task.CompletedTask);
 
         // Act
-        var result = await sut.CloseCurrentItemAsDuplicateAsync(session, "#123");
+        var result = await sut.CloseCurrentItemAsDuplicateAsync(session, "#123", cancellationToken);
 
         // Assert
         Assert.Single(result.ActionHistory);
@@ -674,32 +696,33 @@ public sealed class TriageServiceTests
         Assert.Contains("Applied label 'duplicate'", result.ActionHistory[0].Detail, StringComparison.Ordinal);
         Assert.Equal(1, result.Summary.DuplicateClosuresCount);
 
-        await _gitHubService.Received(1).GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).GetLabelsAsync("owner", "repo", cancellationToken);
         await _gitHubService.Received(1).ApplyLabelsToTriageItemAsync(
             "owner",
             "repo",
             1,
-            Arg.Is<IReadOnlyList<string>>(labels => labels.SequenceEqual(new[] { "duplicate" })),
-            Arg.Any<CancellationToken>());
+            Arg.Is<IReadOnlyList<string>>(labels => labels!.SequenceEqual(new[] { "duplicate" })),
+            cancellationToken);
     }
 
     [Fact]
     public async Task CloseCurrentItemAsDuplicateAsync_DuplicateLabelMissing_DoesNotApplyLabel()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
         var session = CreateSession(queueCount: 1, currentIndex: 0);
 
         _gitHubService
-            .CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 1, "#123", Arg.Any<CancellationToken>())
+            .CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 1, "#123", cancellationToken)
             .Returns(Task.CompletedTask);
 
         _gitHubService
-            .GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>())
+            .GetLabelsAsync("owner", "repo", cancellationToken)
             .Returns(Array.Empty<Label>());
 
         // Act
-        var result = await sut.CloseCurrentItemAsDuplicateAsync(session, "#123");
+        var result = await sut.CloseCurrentItemAsDuplicateAsync(session, "#123", cancellationToken);
 
         // Assert
         Assert.Single(result.ActionHistory);
@@ -707,13 +730,14 @@ public sealed class TriageServiceTests
         Assert.Contains("No canonical duplicate label was available", result.ActionHistory[0].Detail, StringComparison.Ordinal);
         Assert.Equal(1, result.Summary.DuplicateClosuresCount);
 
-        await _gitHubService.Received(1).GetLabelsAsync("owner", "repo", Arg.Any<CancellationToken>());
-        await _gitHubService.DidNotReceive().ApplyLabelsToTriageItemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+        await _gitHubService.Received(1).GetLabelsAsync("owner", "repo", cancellationToken);
+        await _gitHubService.DidNotReceive().ApplyLabelsToTriageItemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<IReadOnlyList<string>>(), cancellationToken);
     }
 
     [Fact]
     public async Task CloseCurrentItemAsDuplicateAsync_ActivePullRequestExists_ClosesPullRequestDuplicate()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = new TriageService(_gitHubService);
         var pullRequestItem = new TriageItemDto(
@@ -746,7 +770,7 @@ public sealed class TriageServiceTests
             DateTimeOffset.UtcNow);
 
         // Act
-        _ = await sut.CloseCurrentItemAsDuplicateAsync(session, "https://github.com/owner/repo/pull/20");
+        _ = await sut.CloseCurrentItemAsDuplicateAsync(session, "https://github.com/owner/repo/pull/20", cancellationToken);
 
         // Assert
         await _gitHubService.Received(1).CloseTriageItemAsDuplicateAsync(
@@ -755,7 +779,7 @@ public sealed class TriageServiceTests
             GitHubTriageItemType.PullRequest,
             21,
             "https://github.com/owner/repo/pull/20",
-            Arg.Any<CancellationToken>());
+            cancellationToken);
     }
 
     [Fact]

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/WorkflowTemplateServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/WorkflowTemplateServiceTests.cs
@@ -25,11 +25,12 @@ public sealed class WorkflowTemplateServiceTests
     [Fact]
     public async Task GetTemplatesAsync_ReturnsBuiltInTemplates()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = CreateSut();
 
         // Act
-        var result = await sut.GetTemplatesAsync();
+        var result = await sut.GetTemplatesAsync(cancellationToken);
 
         // Assert
         Assert.Equal(3, result.Count);
@@ -41,11 +42,12 @@ public sealed class WorkflowTemplateServiceTests
     [Fact]
     public async Task GetTemplatesAsync_ReturnsTemplateMetadata()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = CreateSut();
 
         // Act
-        var result = await sut.GetTemplatesAsync();
+        var result = await sut.GetTemplatesAsync(cancellationToken);
         var ciTemplate = result.Single(template => template.Name == ".NET CI");
 
         // Assert
@@ -58,11 +60,12 @@ public sealed class WorkflowTemplateServiceTests
     [Fact]
     public async Task GetTemplateDetailAsync_ReturnsParametersAndYamlPreview()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = CreateSut();
 
         // Act
-        var result = await sut.GetTemplateDetailAsync(1);
+        var result = await sut.GetTemplateDetailAsync(1, cancellationToken);
 
         // Assert
         Assert.Equal(".NET CI", result.Name);
@@ -74,11 +77,12 @@ public sealed class WorkflowTemplateServiceTests
     [Fact]
     public async Task GetTemplateDetailAsync_UnknownTemplate_ThrowsKeyNotFoundException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = CreateSut();
 
         // Act
-        var action = () => sut.GetTemplateDetailAsync(999);
+        var action = () => sut.GetTemplateDetailAsync(999, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<KeyNotFoundException>(action);
@@ -87,15 +91,16 @@ public sealed class WorkflowTemplateServiceTests
     [Fact]
     public async Task GetRepositoryStatusesAsync_MissingWorkflowFile_ReturnsNotAppliedStatus()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _workflowFileRepository
-            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", cancellationToken)
             .Returns((WorkflowFile?)null);
 
         var sut = CreateSut();
 
         // Act
-        var result = await sut.GetRepositoryStatusesAsync(1, ["owner/repo-a"], new Dictionary<string, string>());
+        var result = await sut.GetRepositoryStatusesAsync(1, ["owner/repo-a"], new Dictionary<string, string>(), cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -105,11 +110,12 @@ public sealed class WorkflowTemplateServiceTests
     [Fact]
     public async Task GetRepositoryStatusesAsync_MatchingWorkflowFile_ReturnsAppliedStatus()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var canonicalYaml = await GetRenderedCiYamlAsync();
 
         _workflowFileRepository
-            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", cancellationToken)
             .Returns(new WorkflowFile
             {
                 Path = ".github/workflows/ci.yml",
@@ -120,7 +126,7 @@ public sealed class WorkflowTemplateServiceTests
         var sut = CreateSut();
 
         // Act
-        var result = await sut.GetRepositoryStatusesAsync(1, ["owner/repo-a"], new Dictionary<string, string>());
+        var result = await sut.GetRepositoryStatusesAsync(1, ["owner/repo-a"], new Dictionary<string, string>(), cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -130,9 +136,10 @@ public sealed class WorkflowTemplateServiceTests
     [Fact]
     public async Task GetRepositoryStatusesAsync_DifferentWorkflowFile_ReturnsDriftedStatus()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _workflowFileRepository
-            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", cancellationToken)
             .Returns(new WorkflowFile
             {
                 Path = ".github/workflows/ci.yml",
@@ -143,7 +150,7 @@ public sealed class WorkflowTemplateServiceTests
         var sut = CreateSut();
 
         // Act
-        var result = await sut.GetRepositoryStatusesAsync(1, ["owner/repo-a"], new Dictionary<string, string>());
+        var result = await sut.GetRepositoryStatusesAsync(1, ["owner/repo-a"], new Dictionary<string, string>(), cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -153,11 +160,12 @@ public sealed class WorkflowTemplateServiceTests
     [Fact]
     public async Task GetRepositoryStatusesAsync_RequiredParameterMissing_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = CreateSut();
 
         // Act
-        var action = () => sut.GetRepositoryStatusesAsync(1, ["owner/repo-a"], new Dictionary<string, string> { ["mainBranch"] = "   " });
+        var action = () => sut.GetRepositoryStatusesAsync(1, ["owner/repo-a"], new Dictionary<string, string> { ["mainBranch"] = "   " }, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -166,15 +174,16 @@ public sealed class WorkflowTemplateServiceTests
     [Fact]
     public async Task ApplyTemplateAsync_MissingWorkflowFile_CreatesWorkflowFile()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _workflowFileRepository
-            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", cancellationToken)
             .Returns((WorkflowFile?)null);
 
         var sut = CreateSut();
 
         // Act
-        var result = await sut.ApplyTemplateAsync(1, ["owner/repo-a"], new Dictionary<string, string>());
+        var result = await sut.ApplyTemplateAsync(1, ["owner/repo-a"], new Dictionary<string, string>(), cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -184,20 +193,21 @@ public sealed class WorkflowTemplateServiceTests
             Arg.Is("owner"),
             Arg.Is("repo-a"),
             Arg.Is(".github/workflows/ci.yml"),
-            Arg.Is<string>(content => content.Contains("name: CI", StringComparison.Ordinal)),
+            Arg.Is<string>(content => content!.Contains("name: CI", StringComparison.Ordinal)),
             Arg.Is<string?>(sha => sha == null),
             Arg.Any<string>(),
-            Arg.Any<CancellationToken>());
+            cancellationToken);
     }
 
     [Fact]
     public async Task ApplyTemplateAsync_MatchingWorkflowFile_SkipsRepository()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var canonicalYaml = await GetRenderedCiYamlAsync();
 
         _workflowFileRepository
-            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", cancellationToken)
             .Returns(new WorkflowFile
             {
                 Path = ".github/workflows/ci.yml",
@@ -208,7 +218,7 @@ public sealed class WorkflowTemplateServiceTests
         var sut = CreateSut();
 
         // Act
-        var result = await sut.ApplyTemplateAsync(1, ["owner/repo-a"], new Dictionary<string, string>());
+        var result = await sut.ApplyTemplateAsync(1, ["owner/repo-a"], new Dictionary<string, string>(), cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -220,15 +230,16 @@ public sealed class WorkflowTemplateServiceTests
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string>(),
-            Arg.Any<CancellationToken>());
+            cancellationToken);
     }
 
     [Fact]
     public async Task ApplyTemplateAsync_CustomParameterValues_RenderInWorkflowContent()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _workflowFileRepository
-            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", cancellationToken)
             .Returns((WorkflowFile?)null);
 
         var sut = CreateSut();
@@ -241,35 +252,36 @@ public sealed class WorkflowTemplateServiceTests
             {
                 ["mainBranch"] = "develop",
                 ["dotnetVersion"] = "9.0.x",
-            });
+            }, cancellationToken);
 
         // Assert
         await _workflowFileRepository.Received(1).CreateOrUpdateWorkflowFileAsync(
             Arg.Is("owner"),
             Arg.Is("repo-a"),
             Arg.Is(".github/workflows/ci.yml"),
-            Arg.Is<string>(content => content.Contains("- develop", StringComparison.Ordinal) && content.Contains("9.0.x", StringComparison.Ordinal)),
+            Arg.Is<string>(content => content!.Contains("- develop", StringComparison.Ordinal) && content.Contains("9.0.x", StringComparison.Ordinal)),
             Arg.Is<string?>(sha => sha == null),
             Arg.Any<string>(),
-            Arg.Any<CancellationToken>());
+            cancellationToken);
     }
 
     [Fact]
     public async Task ApplyTemplateAsync_OneRepositoryFails_ReturnsErrorAndContinues()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         _workflowFileRepository
-            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", cancellationToken)
             .Returns((WorkflowFile?)null);
 
         _workflowFileRepository
-            .GetWorkflowFileAsync("owner", "repo-b", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .GetWorkflowFileAsync("owner", "repo-b", ".github/workflows/ci.yml", cancellationToken)
             .Returns(Task.FromException<WorkflowFile?>(new HttpRequestException("Rate limited")));
 
         var sut = CreateSut();
 
         // Act
-        var result = await sut.ApplyTemplateAsync(1, ["owner/repo-a", "owner/repo-b"], new Dictionary<string, string>());
+        var result = await sut.ApplyTemplateAsync(1, ["owner/repo-a", "owner/repo-b"], new Dictionary<string, string>(), cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -282,11 +294,12 @@ public sealed class WorkflowTemplateServiceTests
     [InlineData("   ")]
     public async Task ApplyTemplateAsync_EmptyRepositoryList_ThrowsArgumentException(string repository)
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = CreateSut();
 
         // Act
-        var action = () => sut.ApplyTemplateAsync(1, [repository], new Dictionary<string, string>());
+        var action = () => sut.ApplyTemplateAsync(1, [repository], new Dictionary<string, string>(), cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -295,11 +308,12 @@ public sealed class WorkflowTemplateServiceTests
     [Fact]
     public async Task ApplyTemplateAsync_InvalidRepositoryFormat_ReturnsErrorResult()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = CreateSut();
 
         // Act
-        var result = await sut.ApplyTemplateAsync(1, ["invalid-repo"], new Dictionary<string, string>());
+        var result = await sut.ApplyTemplateAsync(1, ["invalid-repo"], new Dictionary<string, string>(), cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -313,7 +327,7 @@ public sealed class WorkflowTemplateServiceTests
     private static async Task<string> GetRenderedCiYamlAsync()
     {
         var sut = new WorkflowTemplateService(Substitute.For<IWorkflowFileRepository>());
-        var detail = await sut.GetTemplateDetailAsync(1);
+        var detail = await sut.GetTemplateDetailAsync(1, TestContext.Current.CancellationToken);
         return detail.YamlPreview;
     }
 }

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/WorkflowTemplateServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/WorkflowTemplateServiceTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 using SoloDevBoard.Application.Services.Workflows;
 using SoloDevBoard.Domain.Entities.Workflows;
 
@@ -7,7 +7,7 @@ namespace SoloDevBoard.Application.Tests;
 /// <summary>Tests for <see cref="WorkflowTemplateService"/>.</summary>
 public sealed class WorkflowTemplateServiceTests
 {
-    private readonly Mock<IWorkflowFileRepository> _workflowFileRepositoryMock = new();
+    private readonly IWorkflowFileRepository _workflowFileRepository = Substitute.For<IWorkflowFileRepository>();
 
     [Fact]
     public void Constructor_WorkflowFileRepositoryIsNull_ThrowsArgumentNullException()
@@ -88,9 +88,9 @@ public sealed class WorkflowTemplateServiceTests
     public async Task GetRepositoryStatusesAsync_MissingWorkflowFile_ReturnsNotAppliedStatus()
     {
         // Arrange
-        _workflowFileRepositoryMock
-            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
-            .ReturnsAsync((WorkflowFile?)null);
+        _workflowFileRepository
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .Returns((WorkflowFile?)null);
 
         var sut = CreateSut();
 
@@ -108,9 +108,9 @@ public sealed class WorkflowTemplateServiceTests
         // Arrange
         var canonicalYaml = await GetRenderedCiYamlAsync();
 
-        _workflowFileRepositoryMock
-            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new WorkflowFile
+        _workflowFileRepository
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .Returns(new WorkflowFile
             {
                 Path = ".github/workflows/ci.yml",
                 Content = canonicalYaml,
@@ -131,9 +131,9 @@ public sealed class WorkflowTemplateServiceTests
     public async Task GetRepositoryStatusesAsync_DifferentWorkflowFile_ReturnsDriftedStatus()
     {
         // Arrange
-        _workflowFileRepositoryMock
-            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new WorkflowFile
+        _workflowFileRepository
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .Returns(new WorkflowFile
             {
                 Path = ".github/workflows/ci.yml",
                 Content = "name: Custom CI",
@@ -167,9 +167,9 @@ public sealed class WorkflowTemplateServiceTests
     public async Task ApplyTemplateAsync_MissingWorkflowFile_CreatesWorkflowFile()
     {
         // Arrange
-        _workflowFileRepositoryMock
-            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
-            .ReturnsAsync((WorkflowFile?)null);
+        _workflowFileRepository
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .Returns((WorkflowFile?)null);
 
         var sut = CreateSut();
 
@@ -180,16 +180,14 @@ public sealed class WorkflowTemplateServiceTests
         Assert.Single(result);
         Assert.Equal("Created", result[0].Action);
         Assert.False(result[0].HasError);
-        _workflowFileRepositoryMock.Verify(
-            repository => repository.CreateOrUpdateWorkflowFileAsync(
-                "owner",
-                "repo-a",
-                ".github/workflows/ci.yml",
-                It.Is<string>(content => content.Contains("name: CI", StringComparison.Ordinal)),
-                null,
-                It.IsAny<string>(),
-                It.IsAny<CancellationToken>()),
-            Times.Once);
+        await _workflowFileRepository.Received(1).CreateOrUpdateWorkflowFileAsync(
+            Arg.Is("owner"),
+            Arg.Is("repo-a"),
+            Arg.Is(".github/workflows/ci.yml"),
+            Arg.Is<string>(content => content.Contains("name: CI", StringComparison.Ordinal)),
+            Arg.Is<string?>(sha => sha == null),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -198,9 +196,9 @@ public sealed class WorkflowTemplateServiceTests
         // Arrange
         var canonicalYaml = await GetRenderedCiYamlAsync();
 
-        _workflowFileRepositoryMock
-            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new WorkflowFile
+        _workflowFileRepository
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .Returns(new WorkflowFile
             {
                 Path = ".github/workflows/ci.yml",
                 Content = canonicalYaml,
@@ -215,25 +213,23 @@ public sealed class WorkflowTemplateServiceTests
         // Assert
         Assert.Single(result);
         Assert.Equal("Skipped", result[0].Action);
-        _workflowFileRepositoryMock.Verify(
-            repository => repository.CreateOrUpdateWorkflowFileAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>(),
-                It.IsAny<string>(),
-                It.IsAny<string>(),
-                It.IsAny<string?>(),
-                It.IsAny<string>(),
-                It.IsAny<CancellationToken>()),
-            Times.Never);
+        await _workflowFileRepository.DidNotReceive().CreateOrUpdateWorkflowFileAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ApplyTemplateAsync_CustomParameterValues_RenderInWorkflowContent()
     {
         // Arrange
-        _workflowFileRepositoryMock
-            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
-            .ReturnsAsync((WorkflowFile?)null);
+        _workflowFileRepository
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .Returns((WorkflowFile?)null);
 
         var sut = CreateSut();
 
@@ -248,29 +244,27 @@ public sealed class WorkflowTemplateServiceTests
             });
 
         // Assert
-        _workflowFileRepositoryMock.Verify(
-            repository => repository.CreateOrUpdateWorkflowFileAsync(
-                "owner",
-                "repo-a",
-                ".github/workflows/ci.yml",
-                It.Is<string>(content => content.Contains("- develop", StringComparison.Ordinal) && content.Contains("9.0.x", StringComparison.Ordinal)),
-                null,
-                It.IsAny<string>(),
-                It.IsAny<CancellationToken>()),
-            Times.Once);
+        await _workflowFileRepository.Received(1).CreateOrUpdateWorkflowFileAsync(
+            Arg.Is("owner"),
+            Arg.Is("repo-a"),
+            Arg.Is(".github/workflows/ci.yml"),
+            Arg.Is<string>(content => content.Contains("- develop", StringComparison.Ordinal) && content.Contains("9.0.x", StringComparison.Ordinal)),
+            Arg.Is<string?>(sha => sha == null),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ApplyTemplateAsync_OneRepositoryFails_ReturnsErrorAndContinues()
     {
         // Arrange
-        _workflowFileRepositoryMock
-            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
-            .ReturnsAsync((WorkflowFile?)null);
+        _workflowFileRepository
+            .GetWorkflowFileAsync("owner", "repo-a", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .Returns((WorkflowFile?)null);
 
-        _workflowFileRepositoryMock
-            .Setup(repository => repository.GetWorkflowFileAsync("owner", "repo-b", ".github/workflows/ci.yml", It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("Rate limited"));
+        _workflowFileRepository
+            .GetWorkflowFileAsync("owner", "repo-b", ".github/workflows/ci.yml", Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<WorkflowFile?>(new HttpRequestException("Rate limited")));
 
         var sut = CreateSut();
 
@@ -314,11 +308,11 @@ public sealed class WorkflowTemplateServiceTests
     }
 
     private WorkflowTemplateService CreateSut()
-        => new(_workflowFileRepositoryMock.Object);
+        => new(_workflowFileRepository);
 
     private static async Task<string> GetRenderedCiYamlAsync()
     {
-        var sut = new WorkflowTemplateService(new Mock<IWorkflowFileRepository>().Object);
+        var sut = new WorkflowTemplateService(Substitute.For<IWorkflowFileRepository>());
         var detail = await sut.GetTemplateDetailAsync(1);
         return detail.YamlPreview;
     }

--- a/tests/Domain.Tests/SoloDevBoard.Domain.Tests/SoloDevBoard.Domain.Tests.csproj
+++ b/tests/Domain.Tests/SoloDevBoard.Domain.Tests/SoloDevBoard.Domain.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -10,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/tests/E2E/README.md
+++ b/tests/E2E/README.md
@@ -1,0 +1,34 @@
+# SoloDevBoard end-to-end tests
+
+Playwright tests for key user journeys. These complement unit and bUnit component tests — they validate complete workflows in a real browser rather than replacing isolated unit coverage.
+
+## Prerequisites
+
+- Node.js 20 or later.
+- A running SoloDevBoard instance (see below).
+
+## Local run
+
+Start the app on HTTP (plain HTTP avoids dev-certificate issues in headless environments):
+
+```bash
+ASPNETCORE_URLS=http://localhost:5080 \
+  ASPNETCORE_ENVIRONMENT=Development \
+  GitHubAuth__PersonalAccessToken=local-e2e-placeholder \
+  GitHubAuth__OwnerLogin=local-test-user \
+  HostedAdmissionControl__Enabled=false \
+  dotnet run --project src/App/SoloDevBoard.App --no-launch-profile
+```
+
+In a second terminal:
+
+```bash
+cd tests/E2E
+npm ci
+npx playwright install --with-deps chromium
+PLAYWRIGHT_BASE_URL=http://localhost:5080 npm test
+```
+
+## CI
+
+The `e2e` job in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) starts the app with placeholder auth configuration and runs the smoke tests.

--- a/tests/E2E/package-lock.json
+++ b/tests/E2E/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "solodevboard-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "solodevboard-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/E2E/package.json
+++ b/tests/E2E/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "solodevboard-e2e",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0"
+  }
+}

--- a/tests/E2E/playwright.config.ts
+++ b/tests/E2E/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5080',
+    trace: 'on-first-retry',
+  },
+});

--- a/tests/E2E/tests/smoke.spec.ts
+++ b/tests/E2E/tests/smoke.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('health endpoint returns healthy', async ({ request }) => {
+  const response = await request.get('/health');
+  expect(response.ok()).toBeTruthy();
+  await expect(response.text()).resolves.toContain('Healthy');
+});
+
+test('home page renders dashboard navigation', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle(/Home — SoloDevBoard/);
+  await expect(page.getByRole('navigation')).toBeVisible();
+});

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubAuthHandlerTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubAuthHandlerTests.cs
@@ -11,6 +11,7 @@ public sealed class GitHubAuthHandlerTests
     [Fact]
     public async Task SendAsync_ValidAccessToken_AddsBearerAuthorisationHeader()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var currentUserContext = Substitute.For<ICurrentUserContext>();
         currentUserContext.GetAccessToken().Returns("test-token");
@@ -23,7 +24,7 @@ public sealed class GitHubAuthHandlerTests
         using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/user");
 
         // Act
-        _ = await invoker.SendAsync(request, CancellationToken.None);
+        _ = await invoker.SendAsync(request, cancellationToken);
 
         // Assert
         Assert.NotNull(terminalHandler.LastRequest);
@@ -36,6 +37,7 @@ public sealed class GitHubAuthHandlerTests
     [Fact]
     public async Task SendAsync_EmptyAccessToken_ThrowsInvalidOperationException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var currentUserContext = Substitute.For<ICurrentUserContext>();
         currentUserContext.GetAccessToken().Returns(string.Empty);
@@ -48,7 +50,7 @@ public sealed class GitHubAuthHandlerTests
         using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/user");
 
         // Act
-        var act = async () => _ = await invoker.SendAsync(request, CancellationToken.None);
+        var act = async () => _ = await invoker.SendAsync(request, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
@@ -57,6 +59,7 @@ public sealed class GitHubAuthHandlerTests
     [Fact]
     public async Task SendAsync_WhitespaceAccessToken_ThrowsInvalidOperationException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var currentUserContext = Substitute.For<ICurrentUserContext>();
         currentUserContext.GetAccessToken().Returns("   ");
@@ -69,7 +72,7 @@ public sealed class GitHubAuthHandlerTests
         using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/user");
 
         // Act
-        var act = async () => _ = await invoker.SendAsync(request, CancellationToken.None);
+        var act = async () => _ = await invoker.SendAsync(request, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
@@ -78,6 +81,7 @@ public sealed class GitHubAuthHandlerTests
     [Fact]
     public async Task SendAsync_NullAccessToken_ThrowsInvalidOperationException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var currentUserContext = Substitute.For<ICurrentUserContext>();
         currentUserContext.GetAccessToken().Returns((string)null!);
@@ -90,7 +94,7 @@ public sealed class GitHubAuthHandlerTests
         using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/user");
 
         // Act
-        var act = async () => _ = await invoker.SendAsync(request, CancellationToken.None);
+        var act = async () => _ = await invoker.SendAsync(request, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
@@ -99,6 +103,7 @@ public sealed class GitHubAuthHandlerTests
     [Fact]
     public async Task SendAsync_HostedModeUnauthorizedResponse_ThrowsHostedAuthenticationRequiredException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var currentUserContext = Substitute.For<ICurrentUserContext>();
         currentUserContext.GetAccessToken().Returns("revoked-token");
@@ -111,7 +116,7 @@ public sealed class GitHubAuthHandlerTests
         using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/user");
 
         // Act
-        var act = async () => _ = await invoker.SendAsync(request, CancellationToken.None);
+        var act = async () => _ = await invoker.SendAsync(request, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<HostedAuthenticationRequiredException>(act);
@@ -120,6 +125,7 @@ public sealed class GitHubAuthHandlerTests
     [Fact]
     public async Task SendAsync_PatModeUnauthorizedResponse_ReturnsUnauthorizedResponse()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var currentUserContext = Substitute.For<ICurrentUserContext>();
         currentUserContext.GetAccessToken().Returns("pat-token");
@@ -132,7 +138,7 @@ public sealed class GitHubAuthHandlerTests
         using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/user");
 
         // Act
-        using var response = await invoker.SendAsync(request, CancellationToken.None);
+        using var response = await invoker.SendAsync(request, cancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubAuthHandlerTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubAuthHandlerTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Infrastructure.GitHub;
 
@@ -12,11 +12,11 @@ public sealed class GitHubAuthHandlerTests
     public async Task SendAsync_ValidAccessToken_AddsBearerAuthorisationHeader()
     {
         // Arrange
-        var currentUserContextMock = new Mock<ICurrentUserContext>();
-        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns("test-token");
+        var currentUserContext = Substitute.For<ICurrentUserContext>();
+        currentUserContext.GetAccessToken().Returns("test-token");
 
         var terminalHandler = new TerminalHandler();
-        using var handler = CreateHandler(currentUserContextMock.Object);
+        using var handler = CreateHandler(currentUserContext);
         handler.InnerHandler = terminalHandler;
 
         using var invoker = new HttpMessageInvoker(handler);
@@ -30,18 +30,18 @@ public sealed class GitHubAuthHandlerTests
         Assert.NotNull(terminalHandler.LastRequest!.Headers.Authorization);
         Assert.Equal("Bearer", terminalHandler.LastRequest.Headers.Authorization!.Scheme);
         Assert.Equal("test-token", terminalHandler.LastRequest.Headers.Authorization.Parameter);
-        currentUserContextMock.Verify(context => context.GetAccessToken(), Times.Once);
+        currentUserContext.Received(1).GetAccessToken();
     }
 
     [Fact]
     public async Task SendAsync_EmptyAccessToken_ThrowsInvalidOperationException()
     {
         // Arrange
-        var currentUserContextMock = new Mock<ICurrentUserContext>();
-        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns(string.Empty);
+        var currentUserContext = Substitute.For<ICurrentUserContext>();
+        currentUserContext.GetAccessToken().Returns(string.Empty);
 
         var terminalHandler = new TerminalHandler();
-        using var handler = CreateHandler(currentUserContextMock.Object);
+        using var handler = CreateHandler(currentUserContext);
         handler.InnerHandler = terminalHandler;
 
         using var invoker = new HttpMessageInvoker(handler);
@@ -58,11 +58,11 @@ public sealed class GitHubAuthHandlerTests
     public async Task SendAsync_WhitespaceAccessToken_ThrowsInvalidOperationException()
     {
         // Arrange
-        var currentUserContextMock = new Mock<ICurrentUserContext>();
-        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns("   ");
+        var currentUserContext = Substitute.For<ICurrentUserContext>();
+        currentUserContext.GetAccessToken().Returns("   ");
 
         var terminalHandler = new TerminalHandler();
-        using var handler = CreateHandler(currentUserContextMock.Object);
+        using var handler = CreateHandler(currentUserContext);
         handler.InnerHandler = terminalHandler;
 
         using var invoker = new HttpMessageInvoker(handler);
@@ -79,11 +79,11 @@ public sealed class GitHubAuthHandlerTests
     public async Task SendAsync_NullAccessToken_ThrowsInvalidOperationException()
     {
         // Arrange
-        var currentUserContextMock = new Mock<ICurrentUserContext>();
-        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns((string)null!);
+        var currentUserContext = Substitute.For<ICurrentUserContext>();
+        currentUserContext.GetAccessToken().Returns((string)null!);
 
         var terminalHandler = new TerminalHandler();
-        using var handler = CreateHandler(currentUserContextMock.Object);
+        using var handler = CreateHandler(currentUserContext);
         handler.InnerHandler = terminalHandler;
 
         using var invoker = new HttpMessageInvoker(handler);
@@ -100,11 +100,11 @@ public sealed class GitHubAuthHandlerTests
     public async Task SendAsync_HostedModeUnauthorizedResponse_ThrowsHostedAuthenticationRequiredException()
     {
         // Arrange
-        var currentUserContextMock = new Mock<ICurrentUserContext>();
-        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns("revoked-token");
+        var currentUserContext = Substitute.For<ICurrentUserContext>();
+        currentUserContext.GetAccessToken().Returns("revoked-token");
 
         var terminalHandler = new TerminalHandler(HttpStatusCode.Unauthorized);
-        using var handler = CreateHandler(currentUserContextMock.Object, hostedSignInEnabled: true);
+        using var handler = CreateHandler(currentUserContext, hostedSignInEnabled: true);
         handler.InnerHandler = terminalHandler;
 
         using var invoker = new HttpMessageInvoker(handler);
@@ -121,11 +121,11 @@ public sealed class GitHubAuthHandlerTests
     public async Task SendAsync_PatModeUnauthorizedResponse_ReturnsUnauthorizedResponse()
     {
         // Arrange
-        var currentUserContextMock = new Mock<ICurrentUserContext>();
-        currentUserContextMock.Setup(context => context.GetAccessToken()).Returns("pat-token");
+        var currentUserContext = Substitute.For<ICurrentUserContext>();
+        currentUserContext.GetAccessToken().Returns("pat-token");
 
         var terminalHandler = new TerminalHandler(HttpStatusCode.Unauthorized);
-        using var handler = CreateHandler(currentUserContextMock.Object, hostedSignInEnabled: false);
+        using var handler = CreateHandler(currentUserContext, hostedSignInEnabled: false);
         handler.InnerHandler = terminalHandler;
 
         using var invoker = new HttpMessageInvoker(handler);

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubLabelRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubLabelRepositoryTests.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Domain.Entities.Labels;
 using SoloDevBoard.Infrastructure.GitHub;
@@ -171,13 +171,13 @@ public sealed class GitHubLabelRepositoryTests
     public async Task GetLabelsAsync_CurrentUserTokenMissing_ThrowsInvalidOperationException()
     {
         // Arrange
-        var currentUserContextMock = new Mock<ICurrentUserContext>();
-        currentUserContextMock
-            .Setup(context => context.GetAccessToken())
-            .Throws(new InvalidOperationException("Token missing."));
+        var currentUserContext = Substitute.For<ICurrentUserContext>();
+        currentUserContext
+            .When(x => x.GetAccessToken())
+            .Throw(new InvalidOperationException("Token missing."));
 
         var authHandler = new GitHubAuthHandler(
-            currentUserContextMock.Object,
+            currentUserContext,
             Options.Create(new GitHubAuthOptions()))
         {
             InnerHandler = new QueueMessageHandler([new HttpResponseMessage(HttpStatusCode.OK)]),
@@ -188,12 +188,12 @@ public sealed class GitHubLabelRepositoryTests
             BaseAddress = new Uri("https://api.github.com"),
         };
 
-        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
-        httpClientFactoryMock
-            .Setup(factory => factory.CreateClient(GitHubService.GitHubApiClientName))
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory
+            .CreateClient(GitHubService.GitHubApiClientName)
             .Returns(client);
 
-        var sut = new GitHubLabelRepository(httpClientFactoryMock.Object);
+        var sut = new GitHubLabelRepository(httpClientFactory);
 
         // Act / Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
@@ -202,13 +202,13 @@ public sealed class GitHubLabelRepositoryTests
 
     private static GitHubLabelRepository CreateSubject(HttpMessageHandler handler)
     {
-        var currentUserContextMock = new Mock<ICurrentUserContext>();
-        currentUserContextMock
-            .Setup(context => context.GetAccessToken())
+        var currentUserContext = Substitute.For<ICurrentUserContext>();
+        currentUserContext
+            .GetAccessToken()
             .Returns("test-token");
 
         var authHandler = new GitHubAuthHandler(
-            currentUserContextMock.Object,
+            currentUserContext,
             Options.Create(new GitHubAuthOptions()))
         {
             InnerHandler = handler,
@@ -219,12 +219,12 @@ public sealed class GitHubLabelRepositoryTests
             BaseAddress = new Uri("https://api.github.com"),
         };
 
-        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
-        httpClientFactoryMock
-            .Setup(factory => factory.CreateClient(GitHubService.GitHubApiClientName))
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory
+            .CreateClient(GitHubService.GitHubApiClientName)
             .Returns(client);
 
-        return new GitHubLabelRepository(httpClientFactoryMock.Object);
+        return new GitHubLabelRepository(httpClientFactory);
     }
 
     private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json)

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubLabelRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubLabelRepositoryTests.cs
@@ -16,6 +16,7 @@ public sealed class GitHubLabelRepositoryTests
     [Fact]
     public async Task GetLabelsAsync_ValidResponse_ReturnsMappedLabels()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -35,7 +36,7 @@ public sealed class GitHubLabelRepositoryTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetLabelsAsync("owner", "repo");
+        var result = await sut.GetLabelsAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -53,6 +54,7 @@ public sealed class GitHubLabelRepositoryTests
     [Fact]
     public async Task CreateLabelAsync_ValidLabel_PostsPayloadAndReturnsLabel()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -71,7 +73,7 @@ public sealed class GitHubLabelRepositoryTests
         var label = new Label { Name = "bug", Colour = "d73a4a", Description = "Something is not working" };
 
         // Act
-        var result = await sut.CreateLabelAsync("owner", "repo", label);
+        var result = await sut.CreateLabelAsync("owner", "repo", label, cancellationToken);
 
         // Assert
         Assert.Equal("bug", result.Name);
@@ -82,7 +84,7 @@ public sealed class GitHubLabelRepositoryTests
         Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
         Assert.Equal("https://api.github.com/repos/owner/repo/labels", handler.Requests[0].RequestUri!.ToString());
 
-        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync(cancellationToken);
         using var document = JsonDocument.Parse(payload);
         Assert.Equal("bug", document.RootElement.GetProperty("name").GetString());
         Assert.Equal("d73a4a", document.RootElement.GetProperty("color").GetString());
@@ -92,6 +94,7 @@ public sealed class GitHubLabelRepositoryTests
     [Fact]
     public async Task UpdateLabelAsync_ValidLabel_SendsPatchPayloadWithNewName()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -110,7 +113,7 @@ public sealed class GitHubLabelRepositoryTests
         var label = new Label { Name = "enhancement", Colour = "a2eeef", Description = "Feature request" };
 
         // Act
-        var result = await sut.UpdateLabelAsync("owner", "repo", "feature", label);
+        var result = await sut.UpdateLabelAsync("owner", "repo", "feature", label, cancellationToken);
 
         // Assert
         Assert.Equal("enhancement", result.Name);
@@ -120,7 +123,7 @@ public sealed class GitHubLabelRepositoryTests
         Assert.Equal(HttpMethod.Patch, handler.Requests[0].Method);
         Assert.Equal("https://api.github.com/repos/owner/repo/labels/feature", handler.Requests[0].RequestUri!.ToString());
 
-        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync(cancellationToken);
         using var document = JsonDocument.Parse(payload);
         Assert.Equal("enhancement", document.RootElement.GetProperty("new_name").GetString());
         Assert.Equal("a2eeef", document.RootElement.GetProperty("color").GetString());
@@ -130,6 +133,7 @@ public sealed class GitHubLabelRepositoryTests
     [Fact]
     public async Task DeleteLabelAsync_ValidLabelName_SendsDeleteRequest()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler([
             new HttpResponseMessage(HttpStatusCode.NoContent),
@@ -138,7 +142,7 @@ public sealed class GitHubLabelRepositoryTests
         var sut = CreateSubject(handler);
 
         // Act
-        await sut.DeleteLabelAsync("owner", "repo", "bug");
+        await sut.DeleteLabelAsync("owner", "repo", "bug", cancellationToken);
 
         // Assert
         Assert.Single(handler.Requests);
@@ -149,6 +153,7 @@ public sealed class GitHubLabelRepositoryTests
     [Fact]
     public async Task CreateLabelAsync_ApiReturnsBadRequest_ThrowsHttpRequestException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler([
             new HttpResponseMessage(HttpStatusCode.BadRequest)
@@ -161,7 +166,7 @@ public sealed class GitHubLabelRepositoryTests
 
         // Act / Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            async () => _ = await sut.CreateLabelAsync("owner", "repo", new Label { Name = "bug", Colour = "d73a4a" }));
+            async () => _ = await sut.CreateLabelAsync("owner", "repo", new Label { Name = "bug", Colour = "d73a4a" }, cancellationToken));
 
         Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
         Assert.Contains("GitHub API request failed", exception.Message, StringComparison.Ordinal);
@@ -170,6 +175,7 @@ public sealed class GitHubLabelRepositoryTests
     [Fact]
     public async Task GetLabelsAsync_CurrentUserTokenMissing_ThrowsInvalidOperationException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var currentUserContext = Substitute.For<ICurrentUserContext>();
         currentUserContext
@@ -197,7 +203,7 @@ public sealed class GitHubLabelRepositoryTests
 
         // Act / Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => _ = await sut.GetLabelsAsync("owner", "repo"));
+            async () => _ = await sut.GetLabelsAsync("owner", "repo", cancellationToken));
     }
 
     private static GitHubLabelRepository CreateSubject(HttpMessageHandler handler)

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubMilestoneRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubMilestoneRepositoryTests.cs
@@ -16,6 +16,7 @@ public sealed class GitHubMilestoneRepositoryTests
     [Fact]
     public async Task GetMilestonesAsync_ValidResponse_ReturnsMappedMilestones()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -40,7 +41,7 @@ public sealed class GitHubMilestoneRepositoryTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetMilestonesAsync("owner", "repo");
+        var result = await sut.GetMilestonesAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -60,6 +61,7 @@ public sealed class GitHubMilestoneRepositoryTests
     [Fact]
     public async Task CreateMilestoneAsync_ValidMilestone_PostsPayloadAndReturnsMilestone()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -91,7 +93,7 @@ public sealed class GitHubMilestoneRepositoryTests
         };
 
         // Act
-        var result = await sut.CreateMilestoneAsync("owner", "repo", milestone);
+        var result = await sut.CreateMilestoneAsync("owner", "repo", milestone, cancellationToken);
 
         // Assert
         Assert.Equal(321, result.Id);
@@ -101,7 +103,7 @@ public sealed class GitHubMilestoneRepositoryTests
         Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
         Assert.Equal("https://api.github.com/repos/owner/repo/milestones", handler.Requests[0].RequestUri!.ToString());
 
-        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync(cancellationToken);
         using var document = JsonDocument.Parse(payload);
         Assert.Equal("Sprint 8", document.RootElement.GetProperty("title").GetString());
         Assert.Equal("open", document.RootElement.GetProperty("state").GetString());
@@ -111,6 +113,7 @@ public sealed class GitHubMilestoneRepositoryTests
     [Fact]
     public async Task UpdateMilestoneAsync_ValidMilestone_SendsPatchPayload()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -141,7 +144,7 @@ public sealed class GitHubMilestoneRepositoryTests
         };
 
         // Act
-        var result = await sut.UpdateMilestoneAsync("owner", "repo", 8, milestone);
+        var result = await sut.UpdateMilestoneAsync("owner", "repo", 8, milestone, cancellationToken);
 
         // Assert
         Assert.Equal("Updated description", result.Description);
@@ -149,7 +152,7 @@ public sealed class GitHubMilestoneRepositoryTests
         Assert.Equal(HttpMethod.Patch, handler.Requests[0].Method);
         Assert.Equal("https://api.github.com/repos/owner/repo/milestones/8", handler.Requests[0].RequestUri!.ToString());
 
-        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync(cancellationToken);
         using var document = JsonDocument.Parse(payload);
         Assert.False(document.RootElement.TryGetProperty("due_on", out _));
     }
@@ -157,6 +160,7 @@ public sealed class GitHubMilestoneRepositoryTests
     [Fact]
     public async Task DeleteMilestoneAsync_ValidNumber_SendsDeleteRequest()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler([
             new HttpResponseMessage(HttpStatusCode.NoContent),
@@ -165,7 +169,7 @@ public sealed class GitHubMilestoneRepositoryTests
         var sut = CreateSubject(handler);
 
         // Act
-        await sut.DeleteMilestoneAsync("owner", "repo", 8);
+        await sut.DeleteMilestoneAsync("owner", "repo", 8, cancellationToken);
 
         // Assert
         Assert.Single(handler.Requests);
@@ -176,6 +180,7 @@ public sealed class GitHubMilestoneRepositoryTests
     [Fact]
     public async Task GetMilestonesAsync_NonSuccessResponse_ThrowsHttpRequestException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler([
             CreateJsonResponse(HttpStatusCode.Forbidden, "{ \"message\": \"Forbidden\" }"),
@@ -184,7 +189,7 @@ public sealed class GitHubMilestoneRepositoryTests
         var sut = CreateSubject(handler);
 
         // Act
-        var action = async () => await sut.GetMilestonesAsync("owner", "repo");
+        var action = async () => await sut.GetMilestonesAsync("owner", "repo", cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<HttpRequestException>(action);
@@ -193,6 +198,7 @@ public sealed class GitHubMilestoneRepositoryTests
     [Fact]
     public async Task CreateMilestoneAsync_NonSuccessResponse_ThrowsHttpRequestException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler([
             CreateJsonResponse(HttpStatusCode.UnprocessableEntity, "{ \"message\": \"Validation Failed\" }"),
@@ -207,7 +213,7 @@ public sealed class GitHubMilestoneRepositoryTests
         };
 
         // Act
-        var action = async () => await sut.CreateMilestoneAsync("owner", "repo", milestone);
+        var action = async () => await sut.CreateMilestoneAsync("owner", "repo", milestone, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<HttpRequestException>(action);
@@ -216,6 +222,7 @@ public sealed class GitHubMilestoneRepositoryTests
     [Fact]
     public async Task UpdateMilestoneAsync_MilestoneNumberIsZero_ThrowsArgumentOutOfRangeException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = CreateSubject(new QueueMessageHandler([]));
         var milestone = new Milestone
@@ -226,7 +233,7 @@ public sealed class GitHubMilestoneRepositoryTests
         };
 
         // Act
-        var action = async () => await sut.UpdateMilestoneAsync("owner", "repo", 0, milestone);
+        var action = async () => await sut.UpdateMilestoneAsync("owner", "repo", 0, milestone, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(action);
@@ -235,11 +242,12 @@ public sealed class GitHubMilestoneRepositoryTests
     [Fact]
     public async Task DeleteMilestoneAsync_RepositoryIsWhitespace_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = CreateSubject(new QueueMessageHandler([]));
 
         // Act
-        var action = async () => await sut.DeleteMilestoneAsync("owner", " ", 8);
+        var action = async () => await sut.DeleteMilestoneAsync("owner", " ", 8, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -248,11 +256,12 @@ public sealed class GitHubMilestoneRepositoryTests
     [Fact]
     public async Task CreateMilestoneAsync_MilestoneIsNull_ThrowsArgumentNullException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = CreateSubject(new QueueMessageHandler([]));
 
         // Act
-        var action = async () => await sut.CreateMilestoneAsync("owner", "repo", null!);
+        var action = async () => await sut.CreateMilestoneAsync("owner", "repo", null!, cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentNullException>(action);

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubMilestoneRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubMilestoneRepositoryTests.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Domain.Entities.Milestones;
 using SoloDevBoard.Infrastructure.GitHub;
@@ -260,13 +260,13 @@ public sealed class GitHubMilestoneRepositoryTests
 
     private static GitHubMilestoneRepository CreateSubject(HttpMessageHandler handler)
     {
-        var currentUserContextMock = new Mock<ICurrentUserContext>();
-        currentUserContextMock
-            .Setup(context => context.GetAccessToken())
+        var currentUserContext = Substitute.For<ICurrentUserContext>();
+        currentUserContext
+            .GetAccessToken()
             .Returns("test-token");
 
         var authHandler = new GitHubAuthHandler(
-            currentUserContextMock.Object,
+            currentUserContext,
             Options.Create(new GitHubAuthOptions()))
         {
             InnerHandler = handler,
@@ -277,12 +277,12 @@ public sealed class GitHubMilestoneRepositoryTests
             BaseAddress = new Uri("https://api.github.com"),
         };
 
-        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
-        httpClientFactoryMock
-            .Setup(factory => factory.CreateClient(GitHubService.GitHubApiClientName))
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory
+            .CreateClient(GitHubService.GitHubApiClientName)
             .Returns(client);
 
-        return new GitHubMilestoneRepository(httpClientFactoryMock.Object);
+        return new GitHubMilestoneRepository(httpClientFactory);
     }
 
     private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json)

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubPatOwnerLoginResolverTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubPatOwnerLoginResolverTests.cs
@@ -9,6 +9,7 @@ public sealed class GitHubPatOwnerLoginResolverTests
     [Fact]
     public async Task ResolveAsync_ValidPat_ReturnsAuthenticatedLogin()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new StubHttpMessageHandler(static (_, _) =>
             Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
@@ -25,7 +26,7 @@ public sealed class GitHubPatOwnerLoginResolverTests
         var sut = new GitHubPatOwnerLoginResolver(factory, new TestAppVersionService(), NullLogger<GitHubPatOwnerLoginResolver>.Instance);
 
         // Act
-        var result = await sut.ResolveAsync("ghp_test-token");
+        var result = await sut.ResolveAsync("ghp_test-token", cancellationToken);
 
         // Assert
         Assert.Equal("markheydon", result);
@@ -39,6 +40,7 @@ public sealed class GitHubPatOwnerLoginResolverTests
     [Fact]
     public async Task ResolveAsync_InvalidPat_ThrowsInvalidOperationException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new StubHttpMessageHandler(static (_, _) =>
             Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
@@ -55,7 +57,7 @@ public sealed class GitHubPatOwnerLoginResolverTests
         var sut = new GitHubPatOwnerLoginResolver(factory, new TestAppVersionService(), NullLogger<GitHubPatOwnerLoginResolver>.Instance);
 
         // Act
-        var act = () => sut.ResolveAsync("invalid-token");
+        var act = () => sut.ResolveAsync("invalid-token", cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -13,6 +13,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetRepositoriesAsync_AuthenticatedUser_UsesUserReposEndpoint()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -38,7 +39,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetRepositoriesAsync();
+        var result = await sut.GetRepositoriesAsync(cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -51,6 +52,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetRepositoriesAsync_EmptyResponse_ReturnsEmptyList()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -60,7 +62,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetRepositoriesAsync();
+        var result = await sut.GetRepositoriesAsync(cancellationToken);
 
         // Assert
         Assert.Empty(result);
@@ -71,6 +73,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetRepositoriesAsync_MultiplePages_ReturnsMappedRepositories()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -114,7 +117,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetRepositoriesAsync("owner");
+        var result = await sut.GetRepositoriesAsync("owner", cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -129,6 +132,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetActiveRepositoriesAsync_MultiplePages_ExcludesArchivedRepositories()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -172,7 +176,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetActiveRepositoriesAsync("owner");
+        var result = await sut.GetActiveRepositoriesAsync("owner", cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -187,6 +191,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetIssuesAsync_ResponseContainsPullRequests_FiltersPullRequests()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -234,7 +239,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetIssuesAsync("owner", "repo");
+        var result = await sut.GetIssuesAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -248,6 +253,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetIssuesAsync_ResponseContainsLargeId_MapsWithoutJsonOverflow()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -273,7 +279,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetIssuesAsync("owner", "repo");
+        var result = await sut.GetIssuesAsync("owner", "repo", cancellationToken);
 
         // Assert
         var issue = Assert.Single(result);
@@ -285,6 +291,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetPullRequestsAsync_ValidResponse_ReturnsMappedPullRequests()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -325,7 +332,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetPullRequestsAsync("owner", "repo");
+        var result = await sut.GetPullRequestsAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -343,6 +350,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetWorkflowRunsAsync_ValidResponse_ReturnsMappedWorkflowRuns()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -370,7 +378,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetWorkflowRunsAsync("owner", "repo");
+        var result = await sut.GetWorkflowRunsAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -388,6 +396,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetWorkflowRunsAsync_EmptyWrapper_ReturnsEmptyList()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -401,7 +410,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetWorkflowRunsAsync("owner", "repo");
+        var result = await sut.GetWorkflowRunsAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Empty(result);
@@ -412,6 +421,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetWorkflowRunsAsync_NonSuccessStatusCode_ThrowsHttpRequestException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -421,7 +431,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var act = async () => _ = await sut.GetWorkflowRunsAsync("owner", "repo");
+        var act = async () => _ = await sut.GetWorkflowRunsAsync("owner", "repo", cancellationToken);
 
         // Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(act);
@@ -431,28 +441,31 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetWorkflowRunsAsync_OwnerIsWhitespace_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = CreateSubject(new QueueMessageHandler([]));
 
         // Act / Assert
         await Assert.ThrowsAsync<ArgumentException>(
-            async () => _ = await sut.GetWorkflowRunsAsync(" ", "repo"));
+            async () => _ = await sut.GetWorkflowRunsAsync(" ", "repo", cancellationToken));
     }
 
     [Fact]
     public async Task GetWorkflowRunsAsync_RepoIsWhitespace_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = CreateSubject(new QueueMessageHandler([]));
 
         // Act / Assert
         await Assert.ThrowsAsync<ArgumentException>(
-            async () => _ = await sut.GetWorkflowRunsAsync("owner", " "));
+            async () => _ = await sut.GetWorkflowRunsAsync("owner", " ", cancellationToken));
     }
 
     [Fact]
     public async Task GetMilestonesAsync_ValidResponse_ReturnsMappedMilestones()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -477,7 +490,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetMilestonesAsync("owner", "repo");
+        var result = await sut.GetMilestonesAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -490,6 +503,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetLabelsAsync_ValidResponse_ReturnsMappedLabels()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -509,7 +523,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetLabelsAsync("owner", "repo");
+        var result = await sut.GetLabelsAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -520,6 +534,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetLabelsAsync_MojibakeDescription_RepairsDescription()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -539,7 +554,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetLabelsAsync("owner", "repo");
+        var result = await sut.GetLabelsAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -549,6 +564,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task CreateLabelAsync_ValidLabel_PostsCorrectPayload()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -565,7 +581,7 @@ public sealed class GitHubServiceTests
         var label = new Label { Name = "bug", Colour = "d73a4a", Description = "Something is not working" };
 
         // Act
-        var result = await sut.CreateLabelAsync("owner", "repo", label);
+        var result = await sut.CreateLabelAsync("owner", "repo", label, cancellationToken);
 
         // Assert
         Assert.Equal(label, result);
@@ -573,7 +589,7 @@ public sealed class GitHubServiceTests
         Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
         Assert.Equal("https://api.github.com/repos/owner/repo/labels", handler.Requests[0].RequestUri!.ToString());
 
-        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync(cancellationToken);
         using var document = JsonDocument.Parse(payload);
         Assert.Equal("bug", document.RootElement.GetProperty("name").GetString());
         Assert.Equal("d73a4a", document.RootElement.GetProperty("color").GetString());
@@ -583,6 +599,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task UpdateLabelAsync_ValidLabel_SendsPatchPayloadWithNewName()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -599,7 +616,7 @@ public sealed class GitHubServiceTests
         var updatedLabel = new Label { Name = "enhancement", Colour = "a2eeef", Description = "Feature request" };
 
         // Act
-        var result = await sut.UpdateLabelAsync("owner", "repo", "feature", updatedLabel);
+        var result = await sut.UpdateLabelAsync("owner", "repo", "feature", updatedLabel, cancellationToken);
 
         // Assert
         Assert.Equal(updatedLabel, result);
@@ -607,7 +624,7 @@ public sealed class GitHubServiceTests
         Assert.Equal(HttpMethod.Patch, handler.Requests[0].Method);
         Assert.Equal("https://api.github.com/repos/owner/repo/labels/feature", handler.Requests[0].RequestUri!.ToString());
 
-        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync(cancellationToken);
         using var document = JsonDocument.Parse(payload);
         Assert.Equal("enhancement", document.RootElement.GetProperty("new_name").GetString());
         Assert.Equal("a2eeef", document.RootElement.GetProperty("color").GetString());
@@ -617,6 +634,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task DeleteLabelAsync_ValidLabelName_SendsDeleteRequest()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler([
             new HttpResponseMessage(HttpStatusCode.NoContent),
@@ -624,7 +642,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        await sut.DeleteLabelAsync("owner", "repo", "bug");
+        await sut.DeleteLabelAsync("owner", "repo", "bug", cancellationToken);
 
         // Assert
         Assert.Single(handler.Requests);
@@ -635,6 +653,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetRepositoriesAsync_ApiReturnsUnauthorised_ThrowsHttpRequestException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler([
             new HttpResponseMessage(HttpStatusCode.Unauthorized)
@@ -646,7 +665,7 @@ public sealed class GitHubServiceTests
 
         // Act / Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-          async () => _ = await sut.GetRepositoriesAsync("owner"));
+          async () => _ = await sut.GetRepositoriesAsync("owner", cancellationToken));
 
         Assert.Equal(HttpStatusCode.Unauthorized, exception.StatusCode);
     }
@@ -654,6 +673,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task CreateLabelAsync_ApiReturnsBadRequest_ThrowsHttpRequestException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler([
             new HttpResponseMessage(HttpStatusCode.BadRequest)
@@ -666,7 +686,7 @@ public sealed class GitHubServiceTests
 
         // Act / Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(
-            async () => _ = await sut.CreateLabelAsync("owner", "repo", label));
+            async () => _ = await sut.CreateLabelAsync("owner", "repo", label, cancellationToken));
 
         Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
         Assert.Contains("GitHub API request failed", exception.Message, StringComparison.Ordinal);
@@ -675,6 +695,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task ApplyLabelsToTriageItemAsync_ValidLabels_PutsLabelsPayload()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler([
             new HttpResponseMessage(HttpStatusCode.OK)
@@ -686,14 +707,14 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        await sut.ApplyLabelsToTriageItemAsync("owner", "repo", 42, ["type/story", "priority/high"]);
+        await sut.ApplyLabelsToTriageItemAsync("owner", "repo", 42, ["type/story", "priority/high"], cancellationToken);
 
         // Assert
         Assert.Single(handler.Requests);
         Assert.Equal(HttpMethod.Put, handler.Requests[0].Method);
         Assert.Equal("https://api.github.com/repos/owner/repo/issues/42/labels", handler.Requests[0].RequestUri!.ToString());
 
-        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync(cancellationToken);
         using var document = JsonDocument.Parse(payload);
         var labels = document.RootElement.GetProperty("labels");
         Assert.Equal(2, labels.GetArrayLength());
@@ -704,6 +725,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task ApplyLabelsToTriageItemAsync_DuplicateAndWhitespaceLabels_NormalisesPayload()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler([
             new HttpResponseMessage(HttpStatusCode.OK)
@@ -715,11 +737,11 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        await sut.ApplyLabelsToTriageItemAsync("owner", "repo", 42, [" priority/high ", "", "type/story", "priority/high"]);
+        await sut.ApplyLabelsToTriageItemAsync("owner", "repo", 42, [" priority/high ", "", "type/story", "priority/high"], cancellationToken);
 
         // Assert
         Assert.Single(handler.Requests);
-        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync(cancellationToken);
         using var document = JsonDocument.Parse(payload);
         var labels = document.RootElement.GetProperty("labels");
         Assert.Equal(2, labels.GetArrayLength());
@@ -730,11 +752,12 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task ApplyLabelsToTriageItemAsync_ItemNumberIsNotPositive_ThrowsArgumentOutOfRangeException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var sut = CreateSubject(new QueueMessageHandler([]));
 
         // Act
-        var action = async () => await sut.ApplyLabelsToTriageItemAsync("owner", "repo", 0, ["type/story"]);
+        var action = async () => await sut.ApplyLabelsToTriageItemAsync("owner", "repo", 0, ["type/story"], cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(action);
@@ -743,6 +766,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task AssignMilestoneToTriageItemAsync_NullMilestone_SendsPatchWithNullMilestone()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler([
             new HttpResponseMessage(HttpStatusCode.OK)
@@ -754,14 +778,14 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        await sut.AssignMilestoneToTriageItemAsync("owner", "repo", 77, null);
+        await sut.AssignMilestoneToTriageItemAsync("owner", "repo", 77, null, cancellationToken);
 
         // Assert
         Assert.Single(handler.Requests);
         Assert.Equal(HttpMethod.Patch, handler.Requests[0].Method);
         Assert.Equal("https://api.github.com/repos/owner/repo/issues/77", handler.Requests[0].RequestUri!.ToString());
 
-        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync(cancellationToken);
         using var document = JsonDocument.Parse(payload);
         Assert.Equal(JsonValueKind.Null, document.RootElement.GetProperty("milestone").ValueKind);
     }
@@ -769,6 +793,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task AddTriageItemToProjectBoardAsync_ValidResponses_ReturnsCreatedProjectItemId()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -794,7 +819,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.AddTriageItemToProjectBoardAsync("owner", "repo", 55, "PVT_kwHOAJefG84BQ6bh");
+        var result = await sut.AddTriageItemToProjectBoardAsync("owner", "repo", 55, "PVT_kwHOAJefG84BQ6bh", cancellationToken);
 
         // Assert
         Assert.Equal("PVTI_lAHOAJefG84BQ6bhzgnrX1A", result);
@@ -808,6 +833,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task AddTriageItemToProjectBoardAsync_GraphQlErrorsPresent_ThrowsHttpRequestException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -837,7 +863,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var action = async () => _ = await sut.AddTriageItemToProjectBoardAsync("owner", "repo", 55, "project-id");
+        var action = async () => _ = await sut.AddTriageItemToProjectBoardAsync("owner", "repo", 55, "project-id", cancellationToken);
 
         // Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(action);
@@ -847,6 +873,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetProjectBoardsForRepositoryAsync_StatusFieldPresent_ReturnsProjectBoardOptions()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -885,7 +912,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo");
+        var result = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Single(result.SupportedProjectBoards);
@@ -901,6 +928,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetProjectBoardsForRepositoryAsync_GraphQlErrorsPresent_ThrowsHttpRequestException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -921,7 +949,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var action = async () => _ = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo");
+        var action = async () => _ = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo", cancellationToken);
 
         // Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(action);
@@ -931,6 +959,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetProjectBoardsForRepositoryAsync_InaccessibleNodeWithAccessibleProject_ReturnsAccessibleProjectBoards()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -973,7 +1002,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo");
+        var result = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Single(result.SupportedProjectBoards);
@@ -985,6 +1014,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetBoardRulesDefinitionAsync_ProjectBoardFound_ReturnsBoardRulesDefinitionDto()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -1017,7 +1047,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh");
+        var result = await sut.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", cancellationToken);
 
         // Assert
         Assert.Equal("PVT_kwHOAJefG84BQ6bh", result.ProjectId);
@@ -1030,6 +1060,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetBoardRulesDefinitionAsync_ProjectBoardNotFound_ReturnsUnavailableDetail()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -1046,7 +1077,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh");
+        var result = await sut.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", cancellationToken);
 
         // Assert
         Assert.Equal("PVT_kwHOAJefG84BQ6bh", result.ProjectId);
@@ -1057,6 +1088,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetBoardRulesDefinitionAsync_StatusFieldMissing_ReturnsStatusFieldUnsupportedDetail()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -1080,7 +1112,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh");
+        var result = await sut.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", cancellationToken);
 
         // Assert
         Assert.Equal("PVT_kwHOAJefG84BQ6bh", result.ProjectId);
@@ -1091,6 +1123,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetBoardRulesDefinitionAsync_GraphQlErrorsPresent_ThrowsHttpRequestException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -1111,7 +1144,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var action = async () => _ = await sut.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh");
+        var action = async () => _ = await sut.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", cancellationToken);
 
         // Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(action);
@@ -1121,12 +1154,13 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetBoardRulesDefinitionAsync_OwnerIsWhitespace_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler([]);
         var sut = CreateSubject(handler);
 
         // Act
-        var action = async () => _ = await sut.GetBoardRulesDefinitionAsync(" ", "repo", "PVT_kwHOAJefG84BQ6bh");
+        var action = async () => _ = await sut.GetBoardRulesDefinitionAsync(" ", "repo", "PVT_kwHOAJefG84BQ6bh", cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -1135,6 +1169,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetBoardRulesDefinitionAsync_StatusFieldWithEmptyOptions_ReturnsEmptyColumnsWithUnsupportedDetail()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -1164,7 +1199,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh");
+        var result = await sut.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_kwHOAJefG84BQ6bh", cancellationToken);
 
         // Assert
         Assert.Empty(result.Columns);
@@ -1175,12 +1210,13 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetProjectBoardsForRepositoryAsync_OwnerIsWhitespace_ThrowsArgumentException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler([]);
         var sut = CreateSubject(handler);
 
         // Act
-        var action = async () => _ = await sut.GetProjectBoardsForRepositoryAsync(" ", "repo");
+        var action = async () => _ = await sut.GetProjectBoardsForRepositoryAsync(" ", "repo", cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -1189,6 +1225,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task GetProjectBoardsForRepositoryAsync_BoardWithoutStatusField_IsExcludedFromSupportedBoards()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -1226,7 +1263,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var result = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo");
+        var result = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo", cancellationToken);
 
         // Assert
         Assert.Empty(result.SupportedProjectBoards);
@@ -1237,6 +1274,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task UpdateProjectBoardItemStatusAsync_ValidResponse_PostsGraphQlMutation()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -1257,14 +1295,14 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        await sut.UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress");
+        await sut.UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress", cancellationToken);
 
         // Assert
         Assert.Single(handler.Requests);
         Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
         Assert.Equal("https://api.github.com/graphql", handler.Requests[0].RequestUri!.ToString());
 
-        var payload = await handler.Requests[0].Content!.ReadAsStringAsync();
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync(cancellationToken);
         using var document = JsonDocument.Parse(payload);
         var variables = document.RootElement.GetProperty("variables");
         Assert.Equal("project-id", variables.GetProperty("projectId").GetString());
@@ -1276,6 +1314,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task UpdateProjectBoardItemStatusAsync_GraphQlErrorsPresent_ThrowsHttpRequestException()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -1296,7 +1335,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var action = async () => await sut.UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress");
+        var action = async () => await sut.UpdateProjectBoardItemStatusAsync("project-id", "project-item-id", "status-field-id", "in-progress", cancellationToken);
 
         // Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(action);
@@ -1306,6 +1345,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task CloseTriageItemAsDuplicateAsync_Issue_PostsCommentAndClosesIssue()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -1322,7 +1362,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        await sut.CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 99, "#12");
+        await sut.CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 99, "#12", cancellationToken);
 
         // Assert
         Assert.Equal(2, handler.Requests.Count);
@@ -1335,6 +1375,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task CloseTriageItemAsDuplicateAsync_PullRequest_PostsCommentAndClosesPullRequest()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -1351,7 +1392,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        await sut.CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.PullRequest, 100, "#22");
+        await sut.CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.PullRequest, 100, "#22", cancellationToken);
 
         // Assert
         Assert.Equal(2, handler.Requests.Count);
@@ -1364,6 +1405,7 @@ public sealed class GitHubServiceTests
     [Fact]
     public async Task CloseTriageItemAsDuplicateAsync_CommentRequestFails_ThrowsAndDoesNotAttemptCloseRequest()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var handler = new QueueMessageHandler(
         [
@@ -1376,7 +1418,7 @@ public sealed class GitHubServiceTests
         var sut = CreateSubject(handler);
 
         // Act
-        var action = async () => await sut.CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 99, "#12");
+        var action = async () => await sut.CloseTriageItemAsDuplicateAsync("owner", "repo", GitHubTriageItemType.Issue, 99, "#12", cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<HttpRequestException>(action);

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
-using Moq;
+using NSubstitute;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Domain.Entities.Labels;
 using SoloDevBoard.Infrastructure.GitHub;
@@ -1391,12 +1391,12 @@ public sealed class GitHubServiceTests
             BaseAddress = new Uri("https://api.github.com"),
         };
 
-        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
-        httpClientFactoryMock
-            .Setup(factory => factory.CreateClient(GitHubService.GitHubApiClientName))
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory
+            .CreateClient(GitHubService.GitHubApiClientName)
             .Returns(client);
 
-        return new GitHubService(httpClientFactoryMock.Object);
+        return new GitHubService(httpClientFactory);
     }
 
     private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json, string? linkHeader = null)

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/HostedAdmissionControlMiddlewareTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/HostedAdmissionControlMiddlewareTests.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 using SoloDevBoard.Infrastructure.Identity;
 
 namespace SoloDevBoard.Infrastructure.Tests;
@@ -141,15 +141,14 @@ public sealed class HostedAdmissionControlMiddlewareTests
         new(
             next,
             Options.Create(admissionOptions ?? new HostedAdmissionControlOptions { Enabled = true }),
-            Mock.Of<ILogger<HostedAdmissionControlMiddleware>>());
+            Substitute.For<ILogger<HostedAdmissionControlMiddleware>>());
 
     private static IHostedAdmissionEvaluator CreateEvaluator(HostedAdmissionDecision decision)
     {
-        var evaluator = new Mock<IHostedAdmissionEvaluator>();
-        evaluator.Setup(static evaluator => evaluator.Evaluate(It.IsAny<ClaimsPrincipal>()))
-            .Returns(decision);
+        var evaluator = Substitute.For<IHostedAdmissionEvaluator>();
+        evaluator.Evaluate(Arg.Any<ClaimsPrincipal>()).Returns(decision);
 
-        return evaluator.Object;
+        return evaluator;
     }
 
     private static DefaultHttpContext CreateHttpContext(bool isAuthenticated, string? acceptHeader)

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/HostedAdmissionControlMiddlewareTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/HostedAdmissionControlMiddlewareTests.cs
@@ -16,6 +16,7 @@ public sealed class HostedAdmissionControlMiddlewareTests
     [Fact]
     public async Task InvokeAsync_DeniedHtmlRequest_RedirectsToAuthErrorPage()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var context = CreateHttpContext(isAuthenticated: true, acceptHeader: "text/html");
         var nextCalled = false;
@@ -40,6 +41,7 @@ public sealed class HostedAdmissionControlMiddlewareTests
     [Fact]
     public async Task InvokeAsync_DeniedJsonRequest_ReturnsProblemDetails()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var context = CreateHttpContext(isAuthenticated: true, acceptHeader: "application/json");
         var nextCalled = false;
@@ -61,7 +63,8 @@ public sealed class HostedAdmissionControlMiddlewareTests
         context.Response.Body.Position = 0;
         var problemDetails = await JsonSerializer.DeserializeAsync<ProblemDetails>(
             context.Response.Body,
-            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+            new JsonSerializerOptions(JsonSerializerDefaults.Web),
+            cancellationToken);
 
         Assert.NotNull(problemDetails);
         Assert.Equal(StatusCodes.Status403Forbidden, problemDetails.Status);
@@ -72,6 +75,7 @@ public sealed class HostedAdmissionControlMiddlewareTests
     [Fact]
     public async Task InvokeAsync_AllowedUser_InvokesNextMiddleware()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var context = CreateHttpContext(isAuthenticated: true, acceptHeader: "text/html");
         var nextCalled = false;
@@ -93,6 +97,7 @@ public sealed class HostedAdmissionControlMiddlewareTests
     [Fact]
     public async Task InvokeAsync_UnauthenticatedUser_ChallengesSignIn()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var context = CreateHttpContext(isAuthenticated: false, acceptHeader: "text/html");
         ConfigureAuthentication(context);
@@ -116,6 +121,7 @@ public sealed class HostedAdmissionControlMiddlewareTests
     [Fact]
     public async Task InvokeAsync_DisabledAdmissionControl_InvokesNextMiddleware()
     {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         // Arrange
         var context = CreateHttpContext(isAuthenticated: true, acceptHeader: "text/html");
         var nextCalled = false;

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests.csproj
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -10,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates SoloDevBoard to the newly formalised testing standard (DEC-016).

- **xUnit v3**: All four test projects upgraded (`xunit.v3` 3.2.2, `<OutputType>Exe</OutputType>`).
- **NSubstitute**: Replaces Moq across 20 test files; DEC-004 superseded.
- **Playwright E2E**: New `tests/E2E/` project with smoke tests and a CI job.
- **Documentation**: AGENTS.md, DECISIONS.md, skills, contracts, CONTRIBUTING, dependabot, and PM runbook updated.

## CI fixes (latest commit)

- Applied `dotnet format` fixes (whitespace, import ordering) that caused the Build and Test job to fail.
- Replaced E2E health-check `for` loop with `until` loop to fix actionlint shellcheck SC2034.
- Fixed xUnit1051 by passing `TestContext.Current.CancellationToken` in Application and Infrastructure tests.
- Fixed CS4014 by awaiting NSubstitute `Received()`/`DidNotReceive()` on async methods in App tests.
- Fixed CS8602/CS8604 nullable warnings in `Arg.Is<>` expression-tree lambdas.

## Test results

- `dotnet test SoloDevBoard.slnx` — **371 passed**, 0 failed.
- `dotnet build --no-incremental` — **0 warnings**.
- Playwright smoke tests — **2 passed**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5666b2b6-df37-4ad7-ae7a-0a895b3b09dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5666b2b6-df37-4ad7-ae7a-0a895b3b09dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

