### PR TITLE
test(e2e): expand Playwright coverage with user journey specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           global-json-file: global.json
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: npm
@@ -75,32 +75,47 @@ jobs:
           npm ci
           npx playwright install --with-deps chromium
 
-      - name: Run Playwright smoke tests
+      - name: Run Playwright E2E tests
         env:
           PLAYWRIGHT_BASE_URL: http://localhost:5080
         run: |
+          APP_LOG="$(mktemp)"
+          echo "Application logs are captured in: $APP_LOG"
+
           ASPNETCORE_URLS=http://localhost:5080 \
             ASPNETCORE_ENVIRONMENT=Development \
             GitHubAuth__PersonalAccessToken=ci-e2e-placeholder \
             GitHubAuth__OwnerLogin=ci-test-user \
             HostedAdmissionControl__Enabled=false \
-            dotnet run --project src/App/SoloDevBoard.App --no-launch-profile --no-build &
+            dotnet run --project src/App/SoloDevBoard.App --no-launch-profile --no-build \
+            >>"$APP_LOG" 2>&1 &
           APP_PID=$!
 
           ATTEMPTS=0
           until curl -sf http://localhost:5080/health > /dev/null; do
             ATTEMPTS=$((ATTEMPTS + 1))
             if [ "$ATTEMPTS" -ge 60 ]; then
-              echo "Application failed to become healthy within 120 seconds."
+              echo "::error::SoloDevBoard did not become healthy within 120 seconds."
+              echo "Application log:"
+              cat "$APP_LOG"
               kill "$APP_PID" || true
               exit 1
             fi
             sleep 2
           done
 
+          echo "Application is healthy. Running Playwright E2E suite..."
           cd tests/E2E
           PLAYWRIGHT_HTML_OPEN=never npm test
           TEST_EXIT=$?
 
-          kill $APP_PID || true
-          exit $TEST_EXIT
+          kill "$APP_PID" || true
+
+          if [ "$TEST_EXIT" -ne 0 ]; then
+            echo "::error::Playwright E2E suite failed with exit code $TEST_EXIT."
+            echo "Application log:"
+            cat "$APP_LOG"
+            exit "$TEST_EXIT"
+          fi
+
+          echo "Playwright E2E suite passed."

--- a/tests/E2E/.gitignore
+++ b/tests/E2E/.gitignore
@@ -1,0 +1,3 @@
+/test-results/
+/playwright-report/
+/blob-report/

--- a/tests/E2E/README.md
+++ b/tests/E2E/README.md
@@ -44,4 +44,4 @@ PLAYWRIGHT_BASE_URL=http://localhost:5080 npm test
 
 ## CI
 
-The `e2e` job in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) starts the app with placeholder auth configuration and runs the full Playwright suite.
+The `e2e` job in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) starts the app with placeholder auth configuration, captures application logs separately from Playwright output, and runs the full Playwright suite.

--- a/tests/E2E/README.md
+++ b/tests/E2E/README.md
@@ -2,6 +2,19 @@
 
 Playwright tests for key user journeys. These complement unit and bUnit component tests — they validate complete workflows in a real browser rather than replacing isolated unit coverage.
 
+## Test coverage
+
+| Spec | What it validates |
+|------|-------------------|
+| `smoke.spec.ts` | Health endpoint and home page render |
+| `navigation.spec.ts` | Home feature cards and drawer navigation to all primary routes |
+| `about.spec.ts` | About page metadata via the shell menu |
+| `labels.spec.ts` | Label Manager shell, tabs, and empty-repository state |
+| `workflows.spec.ts` | Built-in template browse/filter/select and repository error state |
+| `triage.spec.ts` | Triage shell and no-repositories alert without a live GitHub connection |
+
+Tests are designed to pass in CI with placeholder auth (`GitHubAuth__PersonalAccessToken=ci-e2e-placeholder`). Repository-dependent features assert empty or error states rather than live GitHub data.
+
 ## Prerequisites
 
 - Node.js 20 or later.
@@ -31,4 +44,4 @@ PLAYWRIGHT_BASE_URL=http://localhost:5080 npm test
 
 ## CI
 
-The `e2e` job in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) starts the app with placeholder auth configuration and runs the smoke tests.
+The `e2e` job in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) starts the app with placeholder auth configuration and runs the full Playwright suite.

--- a/tests/E2E/fixtures/navigation.ts
+++ b/tests/E2E/fixtures/navigation.ts
@@ -1,0 +1,31 @@
+import { expect, type Page } from '@playwright/test';
+
+export const featureRoutes = [
+  { navLabel: 'Audit Dashboard', path: '/audit-dashboard', title: /Audit Dashboard/ },
+  { navLabel: 'Repositories', path: '/repositories', title: /Repositories/ },
+  { navLabel: 'Migrate', path: '/migrate', title: /One-Click Migration/ },
+  { navLabel: 'Labels', path: '/labels', title: /Label Manager/ },
+  { navLabel: 'Board Rules', path: '/board-rules', title: /Board Rules Visualiser/ },
+  { navLabel: 'Triage', path: '/triage', title: /Triage UI/ },
+  { navLabel: 'Workflows', path: '/workflows', title: /Workflow Templates/ },
+] as const;
+
+async function ensureDrawerOpen(page: Page): Promise<void> {
+  const drawer = page.locator('#nav-drawer');
+  const firstNavLink = drawer.getByRole('link').first();
+
+  if (!(await firstNavLink.isVisible())) {
+    await page.getByRole('banner').getByRole('button').first().click();
+    await expect(firstNavLink).toBeVisible();
+  }
+}
+
+export async function navigateViaDrawer(page: Page, label: string): Promise<void> {
+  await ensureDrawerOpen(page);
+
+  const link = page.locator('#nav-drawer').getByRole('link', { name: label, exact: true });
+  await expect(link).toBeVisible();
+
+  // MudBlazor drawer transforms can leave links outside Playwright's clickable viewport.
+  await link.evaluate((element) => (element as HTMLAnchorElement).click());
+}

--- a/tests/E2E/playwright.config.ts
+++ b/tests/E2E/playwright.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5080',
     trace: 'on-first-retry',
+    viewport: { width: 1400, height: 900 },
   },
 });

--- a/tests/E2E/tests/about.spec.ts
+++ b/tests/E2E/tests/about.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('about page shows deployment metadata from the shell menu', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'More options' }).click();
+  await page.getByRole('link', { name: 'About' }).click();
+
+  await expect(page).toHaveURL(/\/about$/);
+  await expect(page).toHaveTitle(/About/);
+  await expect(page.getByTestId('about-application-name')).toContainText('SoloDevBoard');
+  await expect(page.getByTestId('about-version')).not.toBeEmpty();
+  await expect(page.getByTestId('about-dotnet-version')).toHaveText(/\d+\.\d+/);
+  await expect(page.getByTestId('about-repository-link')).toHaveAttribute('href', /github\.com/);
+});

--- a/tests/E2E/tests/labels.spec.ts
+++ b/tests/E2E/tests/labels.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Label Manager shell', () => {
+  test('page renders taxonomy controls before any repository data is available', async ({ page }) => {
+    await page.goto('/labels');
+
+    await expect(page).toHaveTitle(/Label Manager/);
+    await expect(page.getByRole('heading', { name: 'Label Manager' })).toBeVisible();
+    await expect(page.getByTestId('label-manager-tab-strip')).toBeVisible();
+    await expect(page.getByTestId('new-label-button')).toBeDisabled();
+    await expect(page.getByTestId('load-labels-button')).toBeDisabled();
+    await expect(page.getByText('No active repositories are available for label analysis.')).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('label manager tabs remain available across taxonomy modes', async ({ page }) => {
+    await page.goto('/labels');
+
+    await expect(page.getByRole('tab', { name: 'Labels' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Recommended taxonomy' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Synchronise' })).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Recommended taxonomy' }).click();
+    await expect(page.getByRole('heading', { name: 'Apply recommended taxonomy' })).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Synchronise' }).click();
+    await expect(page.getByRole('heading', { name: 'Synchronise labels' })).toBeVisible();
+  });
+});

--- a/tests/E2E/tests/navigation.spec.ts
+++ b/tests/E2E/tests/navigation.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { featureRoutes, navigateViaDrawer } from '../fixtures/navigation';
+
+test.describe('Feature navigation', () => {
+  test('home dashboard lists all feature entry points', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Open Label Manager' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Open Triage UI' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Open Workflow Templates' })).toBeVisible();
+  });
+
+  test('home feature cards navigate to the matching feature page', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('link', { name: 'Open Label Manager' }).click();
+    await expect(page).toHaveURL(/\/labels$/);
+    await expect(page).toHaveTitle(/Label Manager/);
+
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Open Workflow Templates' }).click();
+    await expect(page).toHaveURL(/\/workflows$/);
+    await expect(page).toHaveTitle(/Workflow Templates/);
+  });
+
+  test('drawer navigation reaches each primary feature route', async ({ page }) => {
+    await page.goto('/');
+
+    for (const feature of featureRoutes) {
+      await navigateViaDrawer(page, feature.navLabel);
+      await expect(page).toHaveURL(new RegExp(`${feature.path}$`));
+      await expect(page).toHaveTitle(feature.title);
+    }
+  });
+});

--- a/tests/E2E/tests/triage.spec.ts
+++ b/tests/E2E/tests/triage.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Triage shell', () => {
+  test('page shows the not-started region without repository data', async ({ page }) => {
+    await page.goto('/triage');
+
+    await expect(page).toHaveTitle(/Triage UI/);
+    await expect(page.getByRole('heading', { name: 'Triage UI' })).toBeVisible();
+    await expect(page.getByTestId('triage-not-started-region')).toBeVisible();
+    await expect(page.getByTestId('triage-no-repositories-alert')).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/tests/E2E/tests/workflows.spec.ts
+++ b/tests/E2E/tests/workflows.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Workflow template browser', () => {
+  test('built-in templates load and can be filtered and selected', async ({ page }) => {
+    await page.goto('/workflows');
+
+    await expect(page.getByTestId('workflow-template-browser-region')).toBeVisible();
+    await expect(page.getByTestId('workflow-templates-loading-state')).toBeHidden({ timeout: 15_000 });
+    await expect(page.getByTestId('workflow-template-grid')).toBeVisible();
+    await expect(page.getByTestId('workflow-template-card-1')).toBeVisible();
+
+    await page.getByRole('searchbox', { name: 'Search templates by name, category, or tags' }).fill('.NET CI');
+    await expect(page.getByRole('heading', { name: '.NET CI' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Dependabot Auto-Merge' })).toBeHidden();
+
+    await page.getByTestId('workflow-template-select-1').click();
+    await expect(page.getByTestId('workflow-template-detail-region')).not.toContainText(
+      'Select a template to review YAML',
+    );
+    await expect(page.getByTestId('workflow-template-select-1')).toHaveText('Selected');
+  });
+
+  test('repository selector surfaces an error without a live GitHub connection', async ({ page }) => {
+    await page.goto('/workflows');
+
+    await expect(page.getByTestId('workflow-repositories-loading-state')).toBeHidden({ timeout: 15_000 });
+    await expect(page.getByTestId('workflow-repositories-error-state')).toBeVisible();
+    await expect(page.getByText('Unable to load repositories')).toBeVisible();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Continues the testing standards migration (post-PR #303) by expanding Playwright E2E coverage beyond smoke tests. Adds journey specs for navigation, about, labels, workflows, and triage that pass in CI without a live GitHub PAT.

Also cleans up the E2E CI job so application logs (GitHub 401s, ASP.NET warnings) are captured separately from Playwright output, avoiding confusion with test failures. Bumps `actions/setup-node` v4 → v7 (supersedes Dependabot #304).

## Related Issue(s)

Follow-on from testing standards migration (DEC-016). No dedicated issue — user requested bypass of issue ceremony for this phase.

## Type of Change

- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**

## Additional Notes

- **11 Playwright tests** (up from 2 smoke tests): navigation drawer loop, home cards, about metadata, label manager tabs, workflow template browse/filter/select, triage empty state, and repository error states.
- Shared `fixtures/navigation.ts` handles MudBlazor drawer quirks (programmatic anchor click when transforms leave links outside Playwright's clickable viewport).
- Desktop viewport (`1400×900`) set in `playwright.config.ts` for stable drawer behaviour.
- All journeys assert against placeholder-auth empty/error states — no live GitHub data required.
- **CI log cleanup:** app stdout/stderr redirected to a temp file; Playwright output stays clean; app log dumped only on health-check or test failure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5666b2b6-df37-4ad7-ae7a-0a895b3b09dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5666b2b6-df37-4ad7-ae7a-0a895b3b09dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

