### PR TITLE
chore: standardise Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,70 +1,110 @@
 version: 2
 updates:
-  - package-ecosystem: "nuget"
-    directory: "/"
+  - package-ecosystem: nuget
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: weekly
+      day: monday
       time: "04:00"
-      timezone: "Europe/London"
+      timezone: Europe/London
     open-pull-requests-limit: 5
     labels:
-      - "dependencies"
+      - dependencies
     assignees:
-      - "markheydon"
+      - markheydon
     groups:
-      microsoft-extensions:
-        patterns:
-          - "Microsoft.Extensions.*"
-        update-types:
-          - "minor"
-          - "patch"
-      azure:
-        patterns:
-          - "Azure.*"
-        update-types:
-          - "minor"
-          - "patch"
-      opentelemetry:
-        patterns:
-          - "OpenTelemetry.*"
-        update-types:
-          - "minor"
-          - "patch"
       test-packages:
         patterns:
-          - "bunit"
-          - "coverlet.collector"
-          - "Microsoft.NET.Test.Sdk"
-          - "NSubstitute"
-          - "xunit.v3"
-          - "xunit.*"
+          - bunit
+          - coverlet.*
+          - Microsoft.NET.Test.Sdk
+          - Moq
+          - NSubstitute
+          - xunit.*
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
+      microsoft-extensions:
+        patterns:
+          - Microsoft.Extensions.*
+        update-types:
+          - minor
+          - patch
+      azure:
+        patterns:
+          - Azure.*
+        update-types:
+          - minor
+          - patch
+      opentelemetry:
+        patterns:
+          - OpenTelemetry.*
+        update-types:
+          - minor
+          - patch
       analyzers:
         patterns:
-          - ".*analyzers.*"
-          - "Microsoft.CodeAnalysis.*"
+          - "*[Aa]nalyzers*"
+          - Microsoft.CodeAnalysis.*
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
       other:
         patterns:
           - "*"
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
 
-  - package-ecosystem: "github-actions"
-    directory: "/.github/workflows"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: weekly
+      day: monday
       time: "04:00"
-      timezone: "Europe/London"
+      timezone: Europe/London
     open-pull-requests-limit: 5
     labels:
-      - "dependencies"
+      - dependencies
     assignees:
-      - "markheydon"
+      - markheydon
+
+  - package-ecosystem: devcontainers
+    directory: /.devcontainer
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    assignees:
+      - markheydon
+    groups:
+      devcontainers:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /tests/E2E
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    assignees:
+      - markheydon
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `.github/dependabot.yml` to a minimal, consistent configuration aligned with repository policy.

## Changes

- **NuGet** (`/`): Retains logical grouping for test packages, Microsoft.Extensions, Azure, OpenTelemetry, and analyzers; adds `Moq`, `NSubstitute`, and `coverlet.*` to test grouping.
- **GitHub Actions** (`/`): Corrects directory to `/` per GitHub documentation.
- **Dev containers** (`/.devcontainer`): Added with patch/minor grouping.
- **npm** (`/tests/E2E`): Added for Playwright E2E dependencies with patch/minor grouping.

## Scheduling

Weekly on Monday at 04:00 Europe/London for all ecosystems.

## Policy

- Labels: `dependencies` only.
- Assignee: `markheydon`.
- Open PR limit: 5 per ecosystem.
- No `dotnet-sdk` ecosystem (intentionally excluded).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6625b40f-c689-449d-a189-5adb61a584a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6625b40f-c689-449d-a189-5adb61a584a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

