### PR TITLE
[Enabler] Add structured logging and Application Insights telemetry (#107)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,8 @@
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="1.5.2" />
     <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="13.4.6" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
     <PackageVersion Include="MessagePack" Version="3.1.8" />
     <PackageVersion Include="MudBlazor" Version="9.7.0" />
     <PackageVersion Include="Markdig" Version="1.3.2" />

--- a/SoloDevBoard.slnx
+++ b/SoloDevBoard.slnx
@@ -6,12 +6,12 @@
     <Project Path="src/Infrastructure/SoloDevBoard.Infrastructure/SoloDevBoard.Infrastructure.csproj" />
     <Project Path="src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj" />
     <Project Path="src/SoloDevBoard.ServiceDefaults/SoloDevBoard.ServiceDefaults.csproj" />
-    <Project Path="tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests.csproj" />
     <Project Path="tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/App.Tests/SoloDevBoard.App.Tests/SoloDevBoard.App.Tests.csproj" />
     <Project Path="tests/Application.Tests/SoloDevBoard.Application.Tests/SoloDevBoard.Application.Tests.csproj" />
     <Project Path="tests/Domain.Tests/SoloDevBoard.Domain.Tests/SoloDevBoard.Domain.Tests.csproj" />
+    <Project Path="tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests.csproj" />
   </Folder>
 </Solution>

--- a/SoloDevBoard.slnx
+++ b/SoloDevBoard.slnx
@@ -6,6 +6,7 @@
     <Project Path="src/Infrastructure/SoloDevBoard.Infrastructure/SoloDevBoard.Infrastructure.csproj" />
     <Project Path="src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj" />
     <Project Path="src/SoloDevBoard.ServiceDefaults/SoloDevBoard.ServiceDefaults.csproj" />
+    <Project Path="tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests.csproj" />
     <Project Path="tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -125,6 +125,7 @@ The CD workflow (`.github/workflows/cd.yml`) runs `aspire deploy` with OIDC auth
 2. Open **Actions → CD - Deploy to Azure → Run workflow**.
 3. After a successful run, note the deployed Container App FQDN from the workflow output or Azure portal.
 4. Register the GitHub App callback URL: `https://<fqdn>/auth/callback`.
+5. Open the provisioned Application Insights resource to confirm telemetry is flowing (see [Observability guide](user-guide/observability.md)).
 
 ### Enable automatic deploys
 
@@ -172,7 +173,8 @@ Aspire generates and applies Bicep at deploy time. A typical deployment includes
 | Azure Container Apps environment | Hosts the containerised app (Consumption profile) |
 | Container App (`app`) | Runs SoloDevBoard (scale-to-zero enabled) |
 | Azure Container Registry | Stores built container images |
-| Log Analytics workspace | Container and environment logs |
+| Application Insights | Application logs, metrics, and distributed traces |
+| Log Analytics workspace | Container platform logs and Application Insights backing store |
 | Aspire dashboard | Optional operational dashboard (Aspire default) |
 | Managed identities | Image pull and runtime authentication |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -340,7 +340,7 @@ In production, secret AppHost parameters are supplied from the GitHub `productio
 
 ## Deploying to Azure
 
-SoloDevBoard deploys to Azure Container Apps via Aspire. See the [Deployment guide](deployment.md) for prerequisites, one-time OIDC bootstrap, GitHub Environment configuration, and first deploy steps.
+SoloDevBoard deploys to Azure Container Apps via Aspire. See the [Deployment guide](deployment.md) for prerequisites, one-time OIDC bootstrap, GitHub Environment configuration, and first deploy steps. For logs, metrics, and traces after deployment, see the [Observability guide](user-guide/observability.md).
 
 Summary:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ It is built with the solo developer in mind: opinionated defaults, minimal confi
 - 👤 [Hosted Authentication Guide](user-guide/hosted-authentication.md) — hosted sign-in, operator allow-lists, and fallback modes for production deployments.
 - ℹ️ [About Guide](user-guide/about.md) — overview of the About page, version information, and repository link.
 - 💰 [Azure Deployment Costs](user-guide/azure-costs.md) — guide to resource charges, SKUs, and cost optimisation for self-hosted Azure deployments.
+- 📊 [Observability](user-guide/observability.md) — structured logging, Application Insights telemetry, and operational diagnostics.
 
 ---
 

--- a/docs/user-guide/azure-costs.md
+++ b/docs/user-guide/azure-costs.md
@@ -4,14 +4,15 @@ Self-hosting SoloDevBoard on Azure incurs charges for the resources Aspire provi
 
 ## Resources Deployed
 
-Aspire deploys the following Azure resources (see [Deployment guide](../deployment.md)):
+Aspire deploys the following Azure resources (see [Deployment guide](../deployment.md) and [Observability guide](observability.md)):
 
 | Resource | Purpose | Pricing model |
 |---|---|---|
 | Azure Container Apps environment | Hosts containerised workloads on the Consumption profile | Environment + per-use compute |
 | Container App (`app`) | SoloDevBoard Blazor Server application | Consumption (vCPU-seconds, memory, requests) |
 | Azure Container Registry (Basic) | Stores built container images | Fixed monthly (Basic tier) |
-| Log Analytics workspace | Container and environment logs | Per GB ingested |
+| Log Analytics workspace | Container platform logs and Application Insights backing store | Per GB ingested |
+| Application Insights | Application logs, metrics, and traces | Per GB ingested (linked workspace) |
 | Managed identities | Image pull and runtime auth | No direct charge |
 
 ## Cost profile with scale-to-zero

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -24,6 +24,7 @@ The SoloDevBoard user guide provides detailed documentation for available featur
 - [About](about.md) — Application version, runtime environment, and repository link.
 - [Azure Deployment Costs](azure-costs.md) — Understand Azure resource charges, SKUs, and cost optimisation for SoloDevBoard deployments.
 - [Hosted Authentication](hosted-authentication.md) — Guide to hosted sign-in, operator allow-lists, and fallback modes for production deployments.
+- [Observability](observability.md) — Structured logging, Application Insights telemetry, and operational diagnostics for hosted deployments.
 
 ## Coming Soon
 

--- a/docs/user-guide/observability.md
+++ b/docs/user-guide/observability.md
@@ -1,0 +1,144 @@
+---
+layout: page
+title: Observability
+parent: User Guide
+nav_order: 12
+---
+
+# Observability and Telemetry
+
+SoloDevBoard emits structured logs, metrics, and distributed traces so operators can diagnose production behaviour without relying on ad hoc console output.
+
+---
+
+## What is collected
+
+| Signal | Source | Production destination |
+|---|---|---|
+| **Logs** | `ILogger` categories across the Blazor Server app and infrastructure layer | Azure Application Insights (via OpenTelemetry) and Container Apps stdout (JSON) |
+| **Metrics** | ASP.NET Core, HTTP client, and .NET runtime instrumentation | Azure Application Insights |
+| **Traces** | ASP.NET Core requests and outbound HTTP calls | Azure Application Insights |
+
+Local development uses the Aspire dashboard via the OTLP exporter. Azure deployments use Application Insights provisioned by the AppHost.
+
+---
+
+## Provisioning (Azure)
+
+Aspire provisions observability resources during `aspire deploy`:
+
+| Resource | Purpose |
+|---|---|
+| **Application Insights** (`app-insights`) | APM, logs, metrics, and traces for the `app` container |
+| **Log Analytics workspace** | Backing store for Application Insights telemetry and Container Apps platform logs |
+
+The AppHost wires the Application Insights connection string into the `app` resource as `APPLICATIONINSIGHTS_CONNECTION_STRING`. No manual secret mapping is required in the CD workflow.
+
+See [Deployment](../deployment.md) for the full operator guide.
+
+---
+
+## Structured logging
+
+Server-side logging follows these conventions:
+
+- Use `ILogger<T>` with [message templates](https://learn.microsoft.com/dotnet/core/extensions/logging#log-message-template-format) and named placeholders (for example, `LogWarning("Hosted admission denied. Reason: {Reason}", decision.Reason)`).
+- Default log level is `Information`; ASP.NET Core framework noise is suppressed to `Warning` in production.
+- Non-development environments write JSON-formatted logs to stdout so Container Apps log ingestion can query fields such as `LogLevel`, `Category`, and `Message`.
+- OpenTelemetry logging exports formatted messages and scopes to Application Insights when a connection string is present.
+
+### Recommended log levels
+
+| Category | Production level | Notes |
+|---|---|---|
+| `Default` | Information | Application events |
+| `Microsoft.AspNetCore` | Warning | Suppress routine request noise |
+| `System.Net.Http.HttpClient` | Warning | Suppress per-request HTTP client traces |
+
+Adjust levels in `appsettings.Production.json` when investigating a specific subsystem.
+
+---
+
+## Sensitive data handling
+
+Telemetry must never contain credentials, tokens, cookies, or personal data beyond what is required for operations.
+
+### Never log or emit in telemetry
+
+- GitHub personal access tokens, OAuth codes, client secrets, or installation tokens.
+- `Authorization`, `Cookie`, or `Set-Cookie` header values.
+- Full OAuth callback URLs containing `code`, `state`, `token`, `access_token`, `refresh_token`, or `client_secret` query parameters.
+
+### Built-in safeguards
+
+SoloDevBoard applies the following defaults in `SoloDevBoard.ServiceDefaults`:
+
+- **URL redaction:** Sensitive query-string keys are replaced with `[Redacted]` before request URLs are attached to trace spans.
+- **Header deny-list:** `Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`, and `X-GitHub-Api-Version` are documented as prohibited telemetry attributes.
+- **Health-check exclusion:** `/health` and `/alive` requests are excluded from distributed tracing to reduce noise.
+
+When adding new logging or custom span enrichment, follow the same rules. Prefer opaque identifiers (for example, repository owner/name) over secrets.
+
+---
+
+## Operational usage
+
+### Azure portal
+
+1. Open the Application Insights resource created by your deployment (named with the `app-insights` Aspire resource prefix).
+2. Use **Logs** to query `traces`, `requests`, `exceptions`, and `customEvents` tables.
+3. Use **Investigate → Failures** for error spikes and **Performance** for slow requests.
+
+Example Kusto query for recent errors:
+
+```kusto
+exceptions
+| where timestamp > ago(24h)
+| order by timestamp desc
+| take 50
+```
+
+Example query for hosted sign-in warnings:
+
+```kusto
+traces
+| where timestamp > ago(24h)
+| where message contains "Hosted sign-in failed"
+| order by timestamp desc
+```
+
+### Container Apps stdout logs
+
+When Application Insights is unavailable (for example, during a misconfiguration investigation), query the Log Analytics workspace linked to the Container Apps environment:
+
+```kusto
+ContainerAppConsoleLogs_CL
+| where TimeGenerated > ago(1h)
+| where ContainerAppName_s == "app"
+| order by TimeGenerated desc
+```
+
+Stdout entries are JSON when `ASPNETCORE_ENVIRONMENT` is not `Development`.
+
+### Local development
+
+Run the AppHost and open the Aspire dashboard:
+
+```bash
+aspire start --apphost src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
+```
+
+Structured logs, traces, and metrics for the `app` resource appear in the dashboard via OTLP. Application Insights export is inactive locally unless you provide a connection string.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| No telemetry in Application Insights | Deploy predates App Insights wiring, or connection string missing | Redeploy with current AppHost; verify `APPLICATIONINSIGHTS_CONNECTION_STRING` on the Container App |
+| Duplicate telemetry | Both OTLP and Application Insights exporters active | Expected during local runs with a connection string; production should rely on Application Insights |
+| High log volume / cost | Verbose categories left enabled | Restore production log levels; review Log Analytics ingestion in Cost Management |
+| OAuth codes visible in traces | Custom enrichment bypassing redaction | Use `TelemetryRedaction.RedactHttpUrl` before attaching URLs to spans |
+
+For deployment prerequisites and environment configuration, see [Deployment](../deployment.md) and [Azure Deployment Costs](azure-costs.md).

--- a/docs/user-guide/observability.md
+++ b/docs/user-guide/observability.md
@@ -73,11 +73,12 @@ Telemetry must never contain credentials, tokens, cookies, or personal data beyo
 
 SoloDevBoard applies the following defaults in `SoloDevBoard.ServiceDefaults`:
 
-- **URL redaction:** Sensitive query-string keys are replaced with `[Redacted]` before request URLs are attached to trace spans.
-- **Header deny-list:** `Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`, and `X-GitHub-Api-Version` are documented as prohibited telemetry attributes.
+- **Inbound URL redaction:** Known OAuth-related query-string keys are replaced with `[Redacted]` on ASP.NET Core request spans before `url.full` is set.
+- **Outbound URL redaction:** Outbound `HttpClient` spans rely on the OpenTelemetry HTTP instrumenter's default behaviour, which redacts all query-string values.
+- **Header tag stripping:** If sensitive request header tags (`Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`) are present on a span, they are removed at enrichment time.
 - **Health-check exclusion:** `/health` and `/alive` requests are excluded from distributed tracing to reduce noise.
 
-When adding new logging or custom span enrichment, follow the same rules. Prefer opaque identifiers (for example, repository owner/name) over secrets.
+When adding new logging or custom span enrichment, follow the same rules. Prefer opaque identifiers (for example, repository owner/name) over secrets. Do not add custom enrichment that copies request headers into telemetry.
 
 ---
 

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -221,7 +221,7 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Configure OIDC authentication for GitHub Actions deployment to Azure (no long-lived credentials). _(#105)_
 - [ ] Add health check endpoints for Azure Container Apps monitoring. _(#106)_
 - [ ] Implement response caching for GitHub API calls to respect rate limits. _(#108)_
-- [ ] Configure structured logging and Application Insights telemetry. _(#107)_
+- [x] Configure structured logging and Application Insights telemetry. _(#107)_
 - [x] Set up Dependabot for automated dependency updates. _(#109)_
 - [ ] Formalise and document PAT-only local trusted mode and self-hoster deployment path. _(#247, #248, #249)_
 - [x] Implement hosted authentication session boundaries and per-request user context for GitHub App-first hosted mode. _(#103, #112; implemented on 2026-03-13, see plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md.)_

--- a/src/App/SoloDevBoard.App/appsettings.Production.json
+++ b/src/App/SoloDevBoard.App/appsettings.Production.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.Hosting.Diagnostics": "Warning",
+      "System.Net.Http.HttpClient": "Warning"
+    }
+  }
+}

--- a/src/SoloDevBoard.AppHost/AppHost.cs
+++ b/src/SoloDevBoard.AppHost/AppHost.cs
@@ -2,6 +2,8 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureContainerAppEnvironment("aca");
 
+var appInsights = builder.AddAzureApplicationInsights("app-insights");
+
 var hostedSignInEnabled = builder.AddParameter("hosted-sign-in-enabled")
     .WithDescription("Enable GitHub App hosted sign-in at /auth/sign-in. When false, PAT mode is used (default).");
 
@@ -24,6 +26,7 @@ var allowedOrgLogins = builder.AddParameter("allowed-org-logins")
     .WithDescription("Comma-separated GitHub organisation logins for hosted admission. Use '-' when using allowed-user-logins instead, or in PAT mode.");
 
 var app = builder.AddProject<Projects.SoloDevBoard_App>("app")
+    .WithReference(appInsights)
     .WithHttpHealthCheck("/health")
     .WithExternalHttpEndpoints()
     .WithEnvironment("GitHubAuth__HostedSignInEnabled", hostedSignInEnabled)

--- a/src/SoloDevBoard.AppHost/README.md
+++ b/src/SoloDevBoard.AppHost/README.md
@@ -63,7 +63,7 @@ Open the `app` resource URL shown by `aspire describe`.
 
 ## Production deployment
 
-Deployment uses `aspire deploy` to Azure Container Apps with scale-to-zero. See [docs/deployment.md](../docs/deployment.md) for the full operator guide.
+Deployment uses `aspire deploy` to Azure Container Apps with scale-to-zero. Application Insights and structured logging are provisioned automatically. See [docs/deployment.md](../docs/deployment.md) and [docs/user-guide/observability.md](../docs/user-guide/observability.md) for the full operator guide.
 
 Preview deployment steps:
 

--- a/src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
+++ b/src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Azure.AppContainers" />
+    <PackageReference Include="Aspire.Hosting.Azure.ApplicationInsights" />
     <PackageReference Include="MessagePack" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" VersionOverride="10.0.9" />
     <ProjectReference Include="..\App\SoloDevBoard.App\SoloDevBoard.App.csproj" />

--- a/src/SoloDevBoard.ServiceDefaults/Extensions.cs
+++ b/src/SoloDevBoard.ServiceDefaults/Extensions.cs
@@ -68,6 +68,7 @@ public static class Extensions
     {
         if (!builder.Environment.IsDevelopment())
         {
+            builder.Logging.ClearProviders();
             builder.Logging.AddJsonConsole(options =>
             {
                 options.IncludeScopes = true;
@@ -111,18 +112,12 @@ public static class Extensions
 
                         options.EnrichWithHttpRequest = (activity, request) =>
                         {
-                            EnrichHttpRequestActivity(activity, request.GetDisplayUrl());
+                            EnrichInboundHttpRequestActivity(activity, request.GetDisplayUrl());
                         };
                     })
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()
-                    .AddHttpClientInstrumentation(options =>
-                    {
-                        options.EnrichWithHttpRequestMessage = (activity, request) =>
-                        {
-                            EnrichHttpRequestActivity(activity, request.RequestUri?.ToString());
-                        };
-                    });
+                    .AddHttpClientInstrumentation();
             });
 
         builder.AddOpenTelemetryExporters();
@@ -186,7 +181,7 @@ public static class Extensions
         return app;
     }
 
-    private static void EnrichHttpRequestActivity(Activity activity, string? url)
+    private static void EnrichInboundHttpRequestActivity(Activity activity, string? url)
     {
         if (string.IsNullOrWhiteSpace(url))
         {
@@ -196,5 +191,6 @@ public static class Extensions
         var redactedUrl = TelemetryRedaction.RedactHttpUrl(url);
         activity.SetTag("url.full", redactedUrl);
         activity.SetTag("http.url", redactedUrl);
+        TelemetryRedaction.StripSensitiveHeaderTags(activity);
     }
 }

--- a/src/SoloDevBoard.ServiceDefaults/Extensions.cs
+++ b/src/SoloDevBoard.ServiceDefaults/Extensions.cs
@@ -1,11 +1,15 @@
+using System.Diagnostics;
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
+using SoloDevBoard.ServiceDefaults.Telemetry;
 
 namespace Microsoft.Extensions.Hosting;
 
@@ -19,6 +23,7 @@ public static class Extensions
 {
     private const string HealthEndpointPath = "/health";
     private const string AlivenessEndpointPath = "/alive";
+    private const string ApplicationInsightsConnectionStringKey = "APPLICATIONINSIGHTS_CONNECTION_STRING";
 
     /// <summary>
     /// Adds default service configuration for resilience, service discovery, health checks, and OpenTelemetry.
@@ -28,6 +33,7 @@ public static class Extensions
     /// <returns>The configured host builder.</returns>
     public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
     {
+        builder.ConfigureStructuredLogging();
         builder.ConfigureOpenTelemetry();
 
         builder.AddDefaultHealthChecks();
@@ -48,6 +54,27 @@ public static class Extensions
         // {
         //     options.AllowedSchemes = ["https"];
         // });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures structured console logging for non-development environments.
+    /// </summary>
+    /// <typeparam name="TBuilder">The host builder type.</typeparam>
+    /// <param name="builder">The host builder to configure.</param>
+    /// <returns>The configured host builder.</returns>
+    public static TBuilder ConfigureStructuredLogging<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        if (!builder.Environment.IsDevelopment())
+        {
+            builder.Logging.AddJsonConsole(options =>
+            {
+                options.IncludeScopes = true;
+                options.TimestampFormat = "yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'";
+                options.UseUtcTimestamp = true;
+            });
+        }
 
         return builder;
     }
@@ -77,14 +104,25 @@ public static class Extensions
             {
                 tracing.AddSource(builder.Environment.ApplicationName)
                     .AddAspNetCoreInstrumentation(options =>
-                        // Exclude health check requests from tracing
+                    {
                         options.Filter = context =>
                             !context.Request.Path.StartsWithSegments(HealthEndpointPath)
-                            && !context.Request.Path.StartsWithSegments(AlivenessEndpointPath)
-                    )
+                            && !context.Request.Path.StartsWithSegments(AlivenessEndpointPath);
+
+                        options.EnrichWithHttpRequest = (activity, request) =>
+                        {
+                            EnrichHttpRequestActivity(activity, request.GetDisplayUrl());
+                        };
+                    })
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()
-                    .AddHttpClientInstrumentation();
+                    .AddHttpClientInstrumentation(options =>
+                    {
+                        options.EnrichWithHttpRequestMessage = (activity, request) =>
+                        {
+                            EnrichHttpRequestActivity(activity, request.RequestUri?.ToString());
+                        };
+                    });
             });
 
         builder.AddOpenTelemetryExporters();
@@ -101,12 +139,10 @@ public static class Extensions
             builder.Services.AddOpenTelemetry().UseOtlpExporter();
         }
 
-        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
-        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
-        //{
-        //    builder.Services.AddOpenTelemetry()
-        //       .UseAzureMonitor();
-        //}
+        if (!string.IsNullOrWhiteSpace(builder.Configuration[ApplicationInsightsConnectionStringKey]))
+        {
+            builder.Services.AddOpenTelemetry().UseAzureMonitor();
+        }
 
         return builder;
     }
@@ -148,5 +184,17 @@ public static class Extensions
         }
 
         return app;
+    }
+
+    private static void EnrichHttpRequestActivity(Activity activity, string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return;
+        }
+
+        var redactedUrl = TelemetryRedaction.RedactHttpUrl(url);
+        activity.SetTag("url.full", redactedUrl);
+        activity.SetTag("http.url", redactedUrl);
     }
 }

--- a/src/SoloDevBoard.ServiceDefaults/SoloDevBoard.ServiceDefaults.csproj
+++ b/src/SoloDevBoard.ServiceDefaults/SoloDevBoard.ServiceDefaults.csproj
@@ -12,6 +12,7 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />

--- a/src/SoloDevBoard.ServiceDefaults/TelemetryRedaction.cs
+++ b/src/SoloDevBoard.ServiceDefaults/TelemetryRedaction.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace SoloDevBoard.ServiceDefaults.Telemetry;
+
+/// <summary>
+/// Redacts sensitive values from telemetry and log enrichment payloads.
+/// </summary>
+public static class TelemetryRedaction
+{
+    /// <summary>
+    /// HTTP request headers that must never be copied into telemetry attributes.
+    /// </summary>
+    public static IReadOnlySet<string> SensitiveRequestHeaders { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "Authorization",
+        "Cookie",
+        "Set-Cookie",
+        "X-Api-Key",
+        "X-GitHub-Api-Version",
+    };
+
+    /// <summary>
+    /// Query-string keys that must be redacted from request URLs in telemetry.
+    /// </summary>
+    public static IReadOnlySet<string> SensitiveQueryKeys { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "code",
+        "state",
+        "token",
+        "access_token",
+        "refresh_token",
+        "client_secret",
+    };
+
+    /// <summary>
+    /// Redacts sensitive query-string values from an HTTP URL before it is attached to telemetry.
+    /// </summary>
+    /// <param name="url">The URL to redact.</param>
+    /// <returns>A URL with sensitive query values replaced by a redaction marker.</returns>
+    public static string RedactHttpUrl(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var absoluteUri))
+        {
+            return url;
+        }
+
+        if (string.IsNullOrEmpty(absoluteUri.Query))
+        {
+            return url;
+        }
+
+        var query = QueryHelpers.ParseQuery(absoluteUri.Query);
+        var redactedPairs = new List<string>(query.Count);
+
+        foreach (var pair in query)
+        {
+            var value = SensitiveQueryKeys.Contains(pair.Key) ? "[Redacted]" : pair.Value.ToString();
+            redactedPairs.Add($"{Uri.EscapeDataString(pair.Key)}={Uri.EscapeDataString(value)}");
+        }
+
+        var builder = new UriBuilder(absoluteUri)
+        {
+            Query = string.Join('&', redactedPairs),
+        };
+
+        return builder.Uri.ToString();
+    }
+}

--- a/src/SoloDevBoard.ServiceDefaults/TelemetryRedaction.cs
+++ b/src/SoloDevBoard.ServiceDefaults/TelemetryRedaction.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.AspNetCore.WebUtilities;
 
 namespace SoloDevBoard.ServiceDefaults.Telemetry;
@@ -16,11 +17,10 @@ public static class TelemetryRedaction
         "Cookie",
         "Set-Cookie",
         "X-Api-Key",
-        "X-GitHub-Api-Version",
     };
 
     /// <summary>
-    /// Query-string keys that must be redacted from request URLs in telemetry.
+    /// Query-string keys that must be redacted from inbound ASP.NET Core request URLs in telemetry.
     /// </summary>
     public static IReadOnlySet<string> SensitiveQueryKeys { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
@@ -44,30 +44,81 @@ public static class TelemetryRedaction
             return string.Empty;
         }
 
-        if (!Uri.TryCreate(url, UriKind.Absolute, out var absoluteUri))
+        if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            || url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            if (Uri.TryCreate(url, UriKind.Absolute, out var absoluteUri))
+            {
+                return RedactAbsoluteUri(absoluteUri);
+            }
+
+            return url;
+        }
+
+        // Path-only URLs are not emitted by ASP.NET Core GetDisplayUrl(), but redact them defensively
+        // in case custom enrichment passes a relative value.
+        return RedactRelativeUrl(url);
+    }
+
+    /// <summary>
+    /// Removes sensitive HTTP request header tags from a trace activity when present.
+    /// </summary>
+    /// <param name="activity">The activity to sanitise.</param>
+    public static void StripSensitiveHeaderTags(Activity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+
+        foreach (var header in SensitiveRequestHeaders)
+        {
+            activity.SetTag($"http.request.header.{header.ToLowerInvariant()}", null);
+        }
+    }
+
+    private static string RedactRelativeUrl(string url)
+    {
+        var queryIndex = url.IndexOf('?', StringComparison.Ordinal);
+        if (queryIndex < 0)
         {
             return url;
         }
 
+        var path = url[..queryIndex];
+        var redactedQuery = RedactQueryString(url[(queryIndex + 1)..]);
+        return string.IsNullOrEmpty(redactedQuery) ? path : $"{path}?{redactedQuery}";
+    }
+
+    private static string RedactAbsoluteUri(Uri absoluteUri)
+    {
         if (string.IsNullOrEmpty(absoluteUri.Query))
         {
-            return url;
+            return absoluteUri.ToString();
         }
 
-        var query = QueryHelpers.ParseQuery(absoluteUri.Query);
-        var redactedPairs = new List<string>(query.Count);
+        var redactedQuery = RedactQueryString(absoluteUri.Query.TrimStart('?'));
+        var builder = new UriBuilder(absoluteUri)
+        {
+            Query = redactedQuery,
+        };
 
-        foreach (var pair in query)
+        return builder.Uri.ToString();
+    }
+
+    private static string RedactQueryString(string query)
+    {
+        var parsedQuery = QueryHelpers.ParseQuery(query);
+        if (parsedQuery.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var redactedPairs = new List<string>(parsedQuery.Count);
+
+        foreach (var pair in parsedQuery)
         {
             var value = SensitiveQueryKeys.Contains(pair.Key) ? "[Redacted]" : pair.Value.ToString();
             redactedPairs.Add($"{Uri.EscapeDataString(pair.Key)}={Uri.EscapeDataString(value)}");
         }
 
-        var builder = new UriBuilder(absoluteUri)
-        {
-            Query = string.Join('&', redactedPairs),
-        };
-
-        return builder.Uri.ToString();
+        return string.Join('&', redactedPairs);
     }
 }

--- a/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests.csproj
+++ b/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SoloDevBoard.ServiceDefaults\SoloDevBoard.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/TelemetryRedactionTests.cs
+++ b/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/TelemetryRedactionTests.cs
@@ -1,0 +1,51 @@
+using SoloDevBoard.ServiceDefaults.Telemetry;
+
+namespace SoloDevBoard.ServiceDefaults.Tests;
+
+public sealed class TelemetryRedactionTests
+{
+    [Fact]
+    public void RedactHttpUrl_NoQuery_ReturnsOriginalUrl()
+    {
+        const string url = "https://example.com/auth/sign-in";
+
+        var redacted = TelemetryRedaction.RedactHttpUrl(url);
+
+        Assert.Equal(url, redacted);
+    }
+
+    [Fact]
+    public void RedactHttpUrl_SensitiveQueryKeys_ReplacesValuesWithRedactionMarker()
+    {
+        const string url = "https://example.com/auth/callback?code=secret-code&state=opaque-state&returnUrl=%2F";
+
+        var redacted = TelemetryRedaction.RedactHttpUrl(url);
+
+        Assert.Contains("code=%5BRedacted%5D", redacted, StringComparison.Ordinal);
+        Assert.Contains("state=%5BRedacted%5D", redacted, StringComparison.Ordinal);
+        Assert.Contains("returnUrl=%2F", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret-code", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("opaque-state", redacted, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RedactHttpUrl_NullOrWhitespace_ReturnsEmpty(string? url)
+    {
+        var redacted = TelemetryRedaction.RedactHttpUrl(url);
+
+        Assert.Equal(string.Empty, redacted);
+    }
+
+    [Fact]
+    public void RedactHttpUrl_RelativeUrl_ReturnsOriginalValue()
+    {
+        const string url = "/auth/callback?code=secret";
+
+        var redacted = TelemetryRedaction.RedactHttpUrl(url);
+
+        Assert.Equal(url, redacted);
+    }
+}

--- a/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/TelemetryRedactionTests.cs
+++ b/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/TelemetryRedactionTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using SoloDevBoard.ServiceDefaults.Telemetry;
 
 namespace SoloDevBoard.ServiceDefaults.Tests;
@@ -40,12 +41,29 @@ public sealed class TelemetryRedactionTests
     }
 
     [Fact]
-    public void RedactHttpUrl_RelativeUrl_ReturnsOriginalValue()
+    public void RedactHttpUrl_RelativeUrl_RedactsSensitiveQueryKeys()
     {
-        const string url = "/auth/callback?code=secret";
+        const string url = "/auth/callback?code=secret&returnUrl=%2F";
 
         var redacted = TelemetryRedaction.RedactHttpUrl(url);
 
-        Assert.Equal(url, redacted);
+        Assert.Equal("/auth/callback?code=%5BRedacted%5D&returnUrl=%2F", redacted);
+        Assert.DoesNotContain("secret", redacted, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StripSensitiveHeaderTags_RemovesKnownSensitiveHeaderTags()
+    {
+        using var activity = new Activity("test");
+        activity.Start();
+        activity.SetTag("http.request.header.authorization", "Bearer secret");
+        activity.SetTag("http.request.header.cookie", "session=opaque");
+        activity.SetTag("http.request.header.user-agent", "SoloDevBoard/1.0");
+
+        TelemetryRedaction.StripSensitiveHeaderTags(activity);
+
+        Assert.Null(activity.GetTagItem("http.request.header.authorization"));
+        Assert.Null(activity.GetTagItem("http.request.header.cookie"));
+        Assert.Equal("SoloDevBoard/1.0", activity.GetTagItem("http.request.header.user-agent"));
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Adds production observability for SoloDevBoard by provisioning Azure Application Insights through the AppHost, enabling the Azure Monitor OpenTelemetry exporter, and documenting operational telemetry usage.

## Related Issue(s)

Closes #107

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)
- [x] 📝 Documentation (updates to docs, comments, or README)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and `docs/index.md` has been updated

## Additional Notes

### Implementation

- **AppHost:** Adds `AddAzureApplicationInsights("app-insights")` and references it from the `app` project so `APPLICATIONINSIGHTS_CONNECTION_STRING` is injected at deploy time.
- **ServiceDefaults:** Enables `UseAzureMonitor()` when the connection string is present; adds JSON structured logging for non-development environments; redacts sensitive OAuth query parameters from inbound ASP.NET Core trace URLs.
- **Documentation:** New `docs/user-guide/observability.md` covering logging conventions, sensitive-data rules, and operational Kusto queries. Deployment and cost docs updated accordingly.
- **Tests:** New `SoloDevBoard.ServiceDefaults.Tests` project with unit tests for URL redaction and header tag stripping.

### Review feedback addressed

- **HttpClient enrichment removed** — outbound spans now rely on the OpenTelemetry HTTP instrumenter's default query redaction (stricter than selective key redaction).
- **Duplicate console providers fixed** — `ClearProviders()` before `AddJsonConsole()` in non-development environments.
- **Sensitive header handling enforced** — `StripSensitiveHeaderTags()` removes known sensitive `http.request.header.*` tags at enrichment time; docs updated to match runtime behaviour.
- **Solution layout** — `SoloDevBoard.ServiceDefaults.Tests` moved under `/tests/` in `SoloDevBoard.slnx`.
- **Relative URL redaction** — path-only URLs are redacted defensively; test updated accordingly.
- **Getting started cross-link** — observability guide linked from deployment section.

### Definition of Done mapping

- Application logging requirements defined for server-side execution.
- Application Insights provisioning and configuration requirements captured.
- Sensitive data handling expectations for telemetry defined and enforced.
- Documentation identifies how logs and telemetry are expected to be used operationally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8a578eb-677f-409a-90a8-b189c18f0b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8a578eb-677f-409a-90a8-b189c18f0b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

