### PR TITLE
Enable production health endpoints for Azure Container Apps monitoring (#106)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -213,7 +213,7 @@ The AppHost registers the readiness probe path for the `app` resource:
 .WithHttpHealthCheck("/health")
 ```
 
-Aspire applies this as the Container App HTTP probe during `aspire deploy`. No manual Bicep or portal configuration is required for the default deployment path.
+Aspire applies this as the Container App HTTP probe during `aspire deploy`. No manual Bicep or portal configuration is required for the default deployment path. Aspire wires `/health` as the platform probe; `/alive` remains available for manual liveness checks but is not configured as a separate ACA probe in the default AppHost model.
 
 After deployment, verify probes from the Azure portal:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -185,6 +185,53 @@ See [Azure Deployment Costs](user-guide/azure-costs.md) for cost guidance.
 
 ---
 
+## Health checks and Container Apps probes
+
+SoloDevBoard exposes two HTTP health endpoints via `SoloDevBoard.ServiceDefaults`:
+
+| Endpoint | Purpose | Checks included |
+|---|---|---|
+| `GET /health` | **Readiness** — the app can accept traffic after startup | All registered health checks |
+| `GET /alive` | **Liveness** — the process is responsive | Checks tagged `live` only (the built-in `self` check) |
+
+Both endpoints return `200 OK` with a `Healthy` body when checks pass. They are excluded from distributed tracing to reduce noise (see [Observability](user-guide/observability.md)).
+
+### Liveness versus readiness design
+
+| Probe type | Endpoint | Rationale |
+|---|---|---|
+| **Liveness** | `/alive` | Confirms the ASP.NET Core host is running. A failure here indicates the container should be restarted. |
+| **Readiness** | `/health` | Confirms the app finished startup and can serve requests. Used by Azure Container Apps after scale-from-zero and during deployments. |
+
+SoloDevBoard deliberately does **not** include GitHub API or other external dependency checks in health probes. External outages should surface as application errors and telemetry, not as container restarts or traffic withdrawal.
+
+### Azure Container Apps configuration
+
+The AppHost registers the readiness probe path for the `app` resource:
+
+```csharp
+.WithHttpHealthCheck("/health")
+```
+
+Aspire applies this as the Container App HTTP probe during `aspire deploy`. No manual Bicep or portal configuration is required for the default deployment path.
+
+After deployment, verify probes from the Azure portal:
+
+1. Open the Container App resource created by Aspire.
+2. Select **Containers** → your revision → **Health probes**.
+3. Confirm the HTTP probe targets `/health`.
+
+To test manually against the deployed FQDN:
+
+```bash
+curl -sf "https://<container-app-fqdn>/health"
+curl -sf "https://<container-app-fqdn>/alive"
+```
+
+The CD workflow and Playwright smoke tests also call `/health` during CI to confirm the app is ready before browser tests run.
+
+---
+
 ## Teardown
 
 To remove Aspire-managed resources:

--- a/docs/user-guide/observability.md
+++ b/docs/user-guide/observability.md
@@ -47,7 +47,7 @@ SoloDevBoard exposes operational health endpoints for container orchestration an
 | `GET /health` | Readiness | After deployment, scale-from-zero, or when verifying the app can accept traffic |
 | `GET /alive` | Liveness | When confirming the process is responsive (no external dependency checks) |
 
-Both endpoints are available in all environments, including production Azure Container Apps. They return `Healthy` when checks pass and do not require authentication.
+Both endpoints are available in all environments, including production Azure Container Apps. They return `Healthy` when checks pass and do not require authentication, including when hosted admission control is enabled.
 
 The AppHost wires `/health` as the Container App HTTP probe via `.WithHttpHealthCheck("/health")`. See [Deployment — Health checks and Container Apps probes](../deployment.md#health-checks-and-container-apps-probes) for probe design rationale and verification steps.
 

--- a/docs/user-guide/observability.md
+++ b/docs/user-guide/observability.md
@@ -38,6 +38,21 @@ See [Deployment](../deployment.md) for the full operator guide.
 
 ---
 
+## Health endpoints
+
+SoloDevBoard exposes operational health endpoints for container orchestration and post-deploy smoke checks:
+
+| Endpoint | Type | When to use |
+|---|---|---|
+| `GET /health` | Readiness | After deployment, scale-from-zero, or when verifying the app can accept traffic |
+| `GET /alive` | Liveness | When confirming the process is responsive (no external dependency checks) |
+
+Both endpoints are available in all environments, including production Azure Container Apps. They return `Healthy` when checks pass and do not require authentication.
+
+The AppHost wires `/health` as the Container App HTTP probe via `.WithHttpHealthCheck("/health")`. See [Deployment — Health checks and Container Apps probes](../deployment.md#health-checks-and-container-apps-probes) for probe design rationale and verification steps.
+
+---
+
 ## Structured logging
 
 Server-side logging follows these conventions:

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -219,7 +219,7 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Complete Azure infrastructure baseline via Bicep (App Service, Key Vault, managed identity). _(#104 — superseded by ADR-0018 Aspire ACA migration.)_
 - [x] Migrate production deployment to Aspire Azure Container Apps with scale-to-zero. _(ADR-0018.)_
 - [x] Configure OIDC authentication for GitHub Actions deployment to Azure (no long-lived credentials). _(#105)_
-- [ ] Add health check endpoints for Azure Container Apps monitoring. _(#106)_
+- [x] Add health check endpoints for Azure Container Apps monitoring. _(#106 — readiness `/health`, liveness `/alive`, ACA probe via AppHost `WithHttpHealthCheck`)_
 - [ ] Implement response caching for GitHub API calls to respect rate limits. _(#108)_
 - [x] Configure structured logging and Application Insights telemetry. _(#107)_
 - [x] Set up Dependabot for automated dependency updates. _(#109)_

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/Identity/HostedAdmissionControlMiddleware.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/Identity/HostedAdmissionControlMiddleware.cs
@@ -114,6 +114,11 @@ public sealed class HostedAdmissionControlMiddleware(
             return true;
         }
 
+        if (path.StartsWithSegments("/health") || path.StartsWithSegments("/alive"))
+        {
+            return true;
+        }
+
         if (path.StartsWithSegments("/_framework") || path.StartsWithSegments("/_content"))
         {
             return true;

--- a/src/SoloDevBoard.AppHost/README.md
+++ b/src/SoloDevBoard.AppHost/README.md
@@ -67,6 +67,10 @@ Application Insights is deploy-time only. Local telemetry uses the Aspire dashbo
 
 Deployment uses `aspire deploy` to Azure Container Apps with scale-to-zero. Application Insights and structured logging are provisioned automatically. See [docs/deployment.md](../docs/deployment.md) and [docs/user-guide/observability.md](../docs/user-guide/observability.md) for the full operator guide.
 
+### Health probes
+
+The `app` resource registers `GET /health` as the Container App readiness probe (`.WithHttpHealthCheck("/health")`). A separate `GET /alive` liveness endpoint is also available. Neither probe calls GitHub or other external dependencies — see [Health checks and Container Apps probes](../docs/deployment.md#health-checks-and-container-apps-probes) for the design rationale.
+
 ### Key Vault-backed auth secrets
 
 In publish/deploy mode, hosted authentication secrets are persisted in an Aspire-provisioned `auth-secrets` Key Vault and injected into the Container App as Key Vault references — not plain-text app settings. This applies to:

--- a/src/SoloDevBoard.AppHost/README.md
+++ b/src/SoloDevBoard.AppHost/README.md
@@ -69,7 +69,7 @@ Deployment uses `aspire deploy` to Azure Container Apps with scale-to-zero. Appl
 
 ### Health probes
 
-The `app` resource registers `GET /health` as the Container App readiness probe (`.WithHttpHealthCheck("/health")`). A separate `GET /alive` liveness endpoint is also available. Neither probe calls GitHub or other external dependencies — see [Health checks and Container Apps probes](../docs/deployment.md#health-checks-and-container-apps-probes) for the design rationale.
+The `app` resource registers `GET /health` as the Container App readiness probe (`.WithHttpHealthCheck("/health")`). A separate `GET /alive` liveness endpoint is also available for manual checks but is not wired as an additional ACA probe in the default AppHost model. Neither probe calls GitHub or other external dependencies — see [Health checks and Container Apps probes](../docs/deployment.md#health-checks-and-container-apps-probes) for the design rationale.
 
 ### Key Vault-backed auth secrets
 

--- a/src/SoloDevBoard.ServiceDefaults/Extensions.cs
+++ b/src/SoloDevBoard.ServiceDefaults/Extensions.cs
@@ -158,25 +158,20 @@ public static class Extensions
     }
 
     /// <summary>
-    /// Maps default health and liveness endpoints for development environments.
+    /// Maps default readiness and liveness health endpoints for operational monitoring.
     /// </summary>
     /// <param name="app">The web application to configure.</param>
     /// <returns>The configured web application.</returns>
     public static WebApplication MapDefaultEndpoints(this WebApplication app)
     {
-        // Adding health checks endpoints to applications in non-development environments has security implications.
-        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
-        if (app.Environment.IsDevelopment())
-        {
-            // All health checks must pass for app to be considered ready to accept traffic after starting
-            app.MapHealthChecks(HealthEndpointPath);
+        // All health checks must pass for app to be considered ready to accept traffic after starting.
+        app.MapHealthChecks(HealthEndpointPath);
 
-            // Only health checks tagged with the "live" tag must pass for app to be considered alive
-            app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
-            {
-                Predicate = r => r.Tags.Contains("live")
-            });
-        }
+        // Only health checks tagged with the "live" tag must pass for app to be considered alive.
+        app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
+        {
+            Predicate = r => r.Tags.Contains("live")
+        });
 
         return app;
     }

--- a/src/SoloDevBoard.ServiceDefaults/Extensions.cs
+++ b/src/SoloDevBoard.ServiceDefaults/Extensions.cs
@@ -164,6 +164,8 @@ public static class Extensions
     /// <returns>The configured web application.</returns>
     public static WebApplication MapDefaultEndpoints(this WebApplication app)
     {
+        // Expose health endpoints in all environments so container orchestrators (for example, Azure Container Apps)
+        // can probe readiness. Only the built-in "self" check is registered, so responses reveal no dependency detail.
         // All health checks must pass for app to be considered ready to accept traffic after starting.
         app.MapHealthChecks(HealthEndpointPath);
 

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/HostedAdmissionControlMiddlewareTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/HostedAdmissionControlMiddlewareTests.cs
@@ -141,6 +141,28 @@ public sealed class HostedAdmissionControlMiddlewareTests
         Assert.True(nextCalled);
     }
 
+    [Theory]
+    [InlineData("/health")]
+    [InlineData("/alive")]
+    public async Task InvokeAsync_UnauthenticatedHealthEndpoint_InvokesNextMiddleware(string requestPath)
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        var context = CreateHttpContext(isAuthenticated: false, acceptHeader: "text/html");
+        context.Request.Path = requestPath;
+        var nextCalled = false;
+        var middleware = CreateMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+        var evaluator = CreateEvaluator(new HostedAdmissionDecision(false, "Hosted request is not authenticated."));
+
+        await middleware.InvokeAsync(context, evaluator);
+
+        Assert.True(nextCalled);
+    }
+
     private static HostedAdmissionControlMiddleware CreateMiddleware(
         RequestDelegate next,
         HostedAdmissionControlOptions? admissionOptions = null) =>

--- a/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/HealthEndpointTests.cs
+++ b/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/HealthEndpointTests.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+
+namespace SoloDevBoard.ServiceDefaults.Tests;
+
+public sealed class HealthEndpointTests
+{
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Production")]
+    public async Task MapDefaultEndpoints_InConfiguredEnvironment_ExposesHealthyReadinessAndLivenessEndpoints(string environment)
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = environment,
+        });
+        builder.AddDefaultHealthChecks();
+
+        var app = builder.Build();
+        app.MapDefaultEndpoints();
+
+        await app.StartAsync(cancellationToken);
+        try
+        {
+            var baseAddress = new Uri(app.Urls.First());
+            using var client = new HttpClient { BaseAddress = baseAddress };
+
+            var healthResponse = await client.GetAsync("/health", cancellationToken);
+            var aliveResponse = await client.GetAsync("/alive", cancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, healthResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, aliveResponse.StatusCode);
+
+            var healthBody = await healthResponse.Content.ReadAsStringAsync(cancellationToken);
+            var aliveBody = await aliveResponse.Content.ReadAsStringAsync(cancellationToken);
+
+            Assert.Contains("Healthy", healthBody, StringComparison.Ordinal);
+            Assert.Contains("Healthy", aliveBody, StringComparison.Ordinal);
+        }
+        finally
+        {
+            await app.StopAsync(cancellationToken);
+        }
+    }
+}

--- a/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests.csproj
+++ b/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />


### PR DESCRIPTION
## Summary of Changes

Enable `/health` (readiness) and `/alive` (liveness) health endpoints in all environments so Azure Container Apps probes work in production. The ServiceDefaults scaffolding and AppHost `WithHttpHealthCheck(/health)` wiring were already present, but endpoints were previously gated to Development only.

Documentation covers probe design (no external dependency checks), ACA configuration via Aspire, and operator verification steps.

## Related Issue(s)

Closes #106

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and `docs/index.md` has been updated

## Screenshots (if applicable)

N/A — infrastructure and documentation only.

## Additional Notes

- `/health` is the ACA readiness probe path configured by the AppHost.
- `/alive` provides a liveness check using only the built-in `self` check.
- GitHub API availability is intentionally excluded from health probes to avoid false unhealthy states during external outages.