### PR TITLE
fix/key vault secret reference names

### DIFF
--- a/src/SoloDevBoard.AppHost/AppHost.cs
+++ b/src/SoloDevBoard.AppHost/AppHost.cs
@@ -43,14 +43,14 @@ if (builder.ExecutionContext.IsPublishMode)
 {
     var authSecretsVault = builder.AddAzureKeyVault("auth-secrets");
 
-    authSecretsVault.AddSecret("auth-gh-pat", "gh-pat", githubPat);
-    authSecretsVault.AddSecret("auth-gh-app-client-secret", "gh-app-client-secret", ghAppClientSecret);
+    authSecretsVault.AddSecret("gh-pat", githubPat);
+    authSecretsVault.AddSecret("gh-app-client-secret", ghAppClientSecret);
 
     app = app
         .WithRoleAssignments(authSecretsVault, KeyVaultBuiltInRole.KeyVaultSecretsUser)
         .WithReference(authSecretsVault)
-        .WithEnvironment("GitHubAuth__PersonalAccessToken", authSecretsVault.GetSecret("auth-gh-pat"))
-        .WithEnvironment("GitHubAuth__HostedGitHubAppClientSecret", authSecretsVault.GetSecret("auth-gh-app-client-secret"))
+        .WithEnvironment("GitHubAuth__PersonalAccessToken", authSecretsVault.GetSecret("gh-pat"))
+        .WithEnvironment("GitHubAuth__HostedGitHubAppClientSecret", authSecretsVault.GetSecret("gh-app-client-secret"))
         .WithReference(builder.AddAzureApplicationInsights("app-insights"));
 }
 else

--- a/src/SoloDevBoard.AppHost/AppHost.cs
+++ b/src/SoloDevBoard.AppHost/AppHost.cs
@@ -43,8 +43,8 @@ if (builder.ExecutionContext.IsPublishMode)
 {
     var authSecretsVault = builder.AddAzureKeyVault("auth-secrets");
 
-    authSecretsVault.AddSecret("gh-pat", githubPat);
-    authSecretsVault.AddSecret("gh-app-client-secret", ghAppClientSecret);
+    authSecretsVault.AddSecret("auth-gh-pat", "gh-pat", githubPat);
+    authSecretsVault.AddSecret("auth-gh-app-client-secret", "gh-app-client-secret", ghAppClientSecret);
 
     app = app
         .WithRoleAssignments(authSecretsVault, KeyVaultBuiltInRole.KeyVaultSecretsUser)


### PR DESCRIPTION
## Summary of Changes

Fixes a deploy regression where `aspire deploy` failed at `provision-app-containerapp` with `ResourceNotFound` because `GetSecret()` was passed Aspire resource names instead of Azure Key Vault secret names.

`AddSecret(auth-gh-pat, gh-pat, ...)` stores the secret as `gh-pat` in Key Vault, but the Container App referenced `GetSecret(auth-gh-pat)`. Aspire resolves `GetSecret(secretName)` against the vault secret name, not the Aspire resource name.

## Related Issue(s)

- Fixes regression introduced by #310
- Relates to #250 — [Enabler] Persist hosted auth material via Key Vault-backed patterns

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [ ] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and `docs/index.md` has been updated

## Screenshots (if applicable)

N/A — AppHost configuration fix only.

## Additional Notes

Verified locally with `aspire deploy --environment Development` — `provision-app-containerapp` succeeds and the Container App starts with Key Vault-backed auth secret references.

Correct pattern:

```csharp
authSecretsVault.AddSecret(auth-gh-pat, gh-pat, githubPat);
.WithEnvironment(GitHubAuth__PersonalAccessToken, authSecretsVault.GetSecret(gh-pat))
```

The first `AddSecret` argument is the Aspire resource name (must not collide with parameter names). `GetSecret` must use the Key Vault secret name (second argument).