### PR TITLE
Add automated status label sync for issues and pull requests.

### DIFF
--- a/.agents/workflows/README.md
+++ b/.agents/workflows/README.md
@@ -23,6 +23,7 @@ Orchestration, rituals, and step-by-step guidance live in [`plan/PM_RUNBOOK.md`]
 | Validate implementation and open PR | "Verify issue #N", "Create PR for issue #N", `/verify-and-create-pr` | `verify-and-create-pr` | `verify` |
 | Audit code against conventions | "Code review PR #N", "Review PR #N for conventions", `/code-review` | `code-review` | `code-review` |
 | Weekly milestone health | "Run the weekly PM review", `/weekly-pm-review` | `weekly-pm-review` | `pm-orchestrator` |
+| Status label hygiene | "Clean up status labels", `/sync-status-labels` | `sync-status-labels` | `repo-github-gh-cli` |
 
 **Rule:** Never use bare "Review issue #N" for code-review, or bare "Review PR #N" for verify. The word **verify** = gate + PR; **code review** = conventions audit.
 
@@ -36,5 +37,6 @@ Orchestration, rituals, and step-by-step guidance live in [`plan/PM_RUNBOOK.md`]
 | [verify-and-create-pr](verify-and-create-pr.md) | "Verify issue #N", "Create PR for issue #N" | `verify` | — | Stage 3: Verify and PR |
 | [address-pr-review-comments](address-pr-review-comments.md) | "Address PR review comments on PR #N" | `delivery` | — | PR Review Comment Loop |
 | [weekly-pm-review](weekly-pm-review.md) | "Run the weekly PM review" | `pm-orchestrator` | — | Weekly Operating Rhythm |
+| [sync-status-labels](sync-status-labels.md) | "Clean up status labels", `/sync-status-labels` | `repo-github-gh-cli` | — | Weekly Board Hygiene Audit |
 | [code-review](code-review.md) | "Code review PR #N" | `code-review` | — | — |
 | [docs-update](docs-update.md) | "Refresh documentation for X" | `tech-writer` | `documentation-writer` | — |

--- a/.agents/workflows/sync-status-labels.md
+++ b/.agents/workflows/sync-status-labels.md
@@ -1,0 +1,36 @@
+# Sync Status Labels
+
+**Contract:** [`.agents/skills/repo-github-gh-cli/SKILL.md`](../skills/repo-github-gh-cli/SKILL.md) (label safety rules)
+**Runbook:** [`plan/PROJECT_BOARD_DESIGN.md`](../../plan/PROJECT_BOARD_DESIGN.md) — Weekly Board Hygiene Audit
+
+## Easy-to-miss specifics
+
+- **Dry-run first** — always run `node .github/scripts/sync-status-labels.mjs --dry-run` and present the report.
+- **Apply only on explicit user confirmation** — then re-run with `--apply`.
+- **Re-run dry-run after apply** — confirm zero remaining violations.
+- **Do not touch** `type/`, `priority/`, `area/`, or `size/` labels.
+- **Scope:** `markheydon/solo-dev-board` only unless the user names another repo.
+- **CI already auto-applies** — the Roadmap Sync workflow runs `sync-status-labels.mjs --apply` before `roadmap-sync.mjs` on schedule, `workflow_dispatch`, and issue events. Manual invocation is for on-demand inspection and ad-hoc fixes; do not trigger CI from the agent unless the user explicitly asks for `workflow_dispatch`.
+
+## Repair rules
+
+Canonical `status/*` labels are defined in [`plan/LABEL_STRATEGY.md`](../../plan/LABEL_STRATEGY.md).
+
+### Closed issues and PRs
+
+| Condition | Action |
+|-----------|--------|
+| Closed, not duplicate | Remove every `status/*` except `status/done`; add `status/done` if missing. |
+| Closed as duplicate | Remove all `status/*` labels; do not add `status/done`. |
+
+### Open issues and PRs
+
+| Condition | Action |
+|-----------|--------|
+| Open with `status/done` | Remove `status/done`; set `status/in-review` if the item has an open linked PR, otherwise `status/todo`. |
+| Open with multiple `status/*` labels | Keep the most advanced label (`in-review` > `in-progress` > `blocked` > `todo`); remove the rest. |
+| Open with no `status/*` label | Report only — do not auto-add. |
+
+## Invocation
+
+Natural language: "Clean up status labels", "Fix status/done drift on closed issues", `/sync-status-labels`

--- a/.cursor/commands/sync-status-labels.md
+++ b/.cursor/commands/sync-status-labels.md
@@ -1,0 +1,3 @@
+# Sync Status Labels
+
+Follow [`.agents/workflows/sync-status-labels.md`](.agents/workflows/sync-status-labels.md).

--- a/.github/prompts/sync-status-labels.prompt.md
+++ b/.github/prompts/sync-status-labels.prompt.md
@@ -1,0 +1,6 @@
+---
+name: Sync Status Labels
+description: Audit and repair drift on status/* labels for GitHub issues and pull requests.
+---
+
+Follow [`.agents/workflows/sync-status-labels.md`](../../.agents/workflows/sync-status-labels.md).

--- a/.github/scripts/sync-status-labels.mjs
+++ b/.github/scripts/sync-status-labels.mjs
@@ -1,0 +1,338 @@
+const apiBaseUrl = 'https://api.github.com';
+const owner = 'markheydon';
+const repo = 'solo-dev-board';
+
+const statusLabels = [
+    'status/todo',
+    'status/in-progress',
+    'status/blocked',
+    'status/in-review',
+    'status/done',
+];
+
+const statusPrecedence = [
+    'status/in-review',
+    'status/in-progress',
+    'status/blocked',
+    'status/todo',
+];
+
+const applyChanges = process.argv.includes('--apply');
+const dryRun = !applyChanges;
+
+const token =
+    process.env.ROADMAP_PROJECT_TOKEN ??
+    process.env.GH_TOKEN ??
+    process.env.GITHUB_TOKEN ??
+    null;
+
+if (!token) {
+    throw new Error('A GitHub token is required. Set ROADMAP_PROJECT_TOKEN, GH_TOKEN, or GITHUB_TOKEN.');
+}
+
+await main();
+
+async function main() {
+    const [issues, pullRequests, openLinkedIssueNumbers] = await Promise.all([
+        fetchIssuesAsync(),
+        fetchPullRequestsAsync(),
+        fetchOpenLinkedIssueNumbersAsync(),
+    ]);
+
+    const items = [
+        ...issues.map(issue => ({ kind: 'issue', item: issue })),
+        ...pullRequests.map(pullRequest => ({ kind: 'pr', item: pullRequest })),
+    ];
+
+    const repairs = [];
+
+    for (const { kind, item } of items) {
+        const plan = planRepair(kind, item, openLinkedIssueNumbers);
+
+        if (!plan) {
+            continue;
+        }
+
+        repairs.push({ kind, item, plan });
+    }
+
+    printReport(repairs);
+
+    if (repairs.length === 0) {
+        console.log('No status label repairs required.');
+        return;
+    }
+
+    if (dryRun) {
+        console.log(`Dry run complete. ${repairs.length} item(s) would be updated. Re-run with --apply to mutate labels.`);
+        process.exitCode = 1;
+        return;
+    }
+
+    for (const repair of repairs) {
+        if (repair.plan.reportOnly) {
+            continue;
+        }
+
+        await applyRepairAsync(repair);
+    }
+
+    console.log(`Applied status label repairs to ${repairs.filter(repair => !repair.plan.reportOnly).length} item(s).`);
+
+    const [refreshedIssues, refreshedPullRequests, refreshedOpenLinkedIssueNumbers] = await Promise.all([
+        fetchIssuesAsync(),
+        fetchPullRequestsAsync(),
+        fetchOpenLinkedIssueNumbersAsync(),
+    ]);
+
+    const refreshedItems = [
+        ...refreshedIssues.map(issue => ({ kind: 'issue', item: issue })),
+        ...refreshedPullRequests.map(pullRequest => ({ kind: 'pr', item: pullRequest })),
+    ];
+
+    const remainingRepairs = refreshedItems
+        .map(({ kind, item }) => {
+            const plan = planRepair(kind, item, refreshedOpenLinkedIssueNumbers);
+            return plan ? { kind, item, plan } : null;
+        })
+        .filter(Boolean)
+        .filter(repair => !repair.plan.reportOnly);
+
+    if (remainingRepairs.length > 0) {
+        console.error(`Status label sync finished with ${remainingRepairs.length} remaining repair(s).`);
+        process.exitCode = 1;
+    }
+}
+
+function planRepair(kind, item, openLinkedIssueNumbers) {
+    const currentStatusLabels = getCurrentStatusLabels(item);
+    const isClosed = item.state === 'closed';
+    const isDuplicate = kind === 'issue' && item.state_reason === 'duplicate';
+
+    if (isClosed) {
+        if (isDuplicate) {
+            if (currentStatusLabels.length === 0) {
+                return null;
+            }
+
+            return {
+                reportOnly: false,
+                remove: [...currentStatusLabels],
+                add: [],
+                action: 'remove all status/* (closed duplicate)',
+            };
+        }
+
+        const extras = currentStatusLabels.filter(label => label !== 'status/done');
+        const missingDone = !currentStatusLabels.includes('status/done');
+
+        if (extras.length === 0 && !missingDone) {
+            return null;
+        }
+
+        return {
+            reportOnly: false,
+            remove: extras,
+            add: missingDone ? ['status/done'] : [],
+            action: missingDone ? 'set status/done only' : 'remove stale status/* labels; keep status/done',
+        };
+    }
+
+    if (currentStatusLabels.length === 0) {
+        return {
+            reportOnly: true,
+            remove: [],
+            add: [],
+            action: 'report missing status/* label (manual triage required)',
+        };
+    }
+
+    if (currentStatusLabels.includes('status/done')) {
+        const replacement = kind === 'pr' || openLinkedIssueNumbers.has(item.number)
+            ? 'status/in-review'
+            : 'status/todo';
+
+        return {
+            reportOnly: false,
+            remove: currentStatusLabels.filter(label => label !== replacement),
+            add: currentStatusLabels.includes(replacement) ? [] : [replacement],
+            action: `replace status/done with ${replacement}`,
+        };
+    }
+
+    if (currentStatusLabels.length > 1) {
+        const keeper = pickHighestPrecedenceLabel(currentStatusLabels);
+
+        return {
+            reportOnly: false,
+            remove: currentStatusLabels.filter(label => label !== keeper),
+            add: [],
+            action: `keep ${keeper}; remove duplicate status/* labels`,
+        };
+    }
+
+    return null;
+}
+
+function pickHighestPrecedenceLabel(labels) {
+    for (const label of statusPrecedence) {
+        if (labels.includes(label)) {
+            return label;
+        }
+    }
+
+    return labels[0];
+}
+
+function getCurrentStatusLabels(item) {
+    const labelNames = (item.labels ?? []).map(label => label.name);
+    return labelNames.filter(label => statusLabels.includes(label));
+}
+
+function printReport(repairs) {
+    if (repairs.length === 0) {
+        return;
+    }
+
+    console.log('');
+    console.log('number\ttype\tstate\tcurrent status/*\taction');
+    console.log('------\t----\t-----\t----------------\t------');
+
+    for (const repair of repairs) {
+        const current = getCurrentStatusLabels(repair.item);
+        const currentText = current.length > 0 ? current.join(', ') : '(none)';
+
+        console.log(
+            `${repair.item.number}\t${repair.kind}\t${repair.item.state}\t${currentText}\t${repair.plan.action}`,
+        );
+    }
+
+    console.log('');
+}
+
+async function applyRepairAsync({ kind, item, plan }) {
+    for (const label of plan.remove) {
+        await restAsync(
+            `/repos/${owner}/${repo}/issues/${item.number}/labels/${encodeURIComponent(label)}`,
+            { method: 'DELETE' },
+        );
+    }
+
+    if (plan.add.length > 0) {
+        await restAsync(`/repos/${owner}/${repo}/issues/${item.number}/labels`, {
+            method: 'POST',
+            body: JSON.stringify({ labels: plan.add }),
+        });
+    }
+
+    console.log(`Updated ${kind} #${item.number}: ${plan.action}`);
+}
+
+async function fetchIssuesAsync() {
+    const issues = [];
+    let page = 1;
+
+    while (true) {
+        const pageIssues = await restAsync(`/repos/${owner}/${repo}/issues?state=all&per_page=100&page=${page}`);
+        const issuesOnly = pageIssues.filter(issue => !issue.pull_request);
+
+        issues.push(...issuesOnly);
+
+        if (pageIssues.length < 100) {
+            break;
+        }
+
+        page += 1;
+    }
+
+    return issues;
+}
+
+async function fetchPullRequestsAsync() {
+    const pullRequests = [];
+    let page = 1;
+
+    while (true) {
+        const pagePullRequests = await restAsync(`/repos/${owner}/${repo}/pulls?state=all&per_page=100&page=${page}`);
+        const issueBackedPullRequests = await Promise.all(
+            pagePullRequests.map(async pullRequest => {
+                const issue = await restAsync(`/repos/${owner}/${repo}/issues/${pullRequest.number}`);
+                return {
+                    number: pullRequest.number,
+                    state: pullRequest.state,
+                    state_reason: null,
+                    labels: issue.labels ?? [],
+                };
+            }),
+        );
+
+        pullRequests.push(...issueBackedPullRequests);
+
+        if (pagePullRequests.length < 100) {
+            break;
+        }
+
+        page += 1;
+    }
+
+    return pullRequests;
+}
+
+async function fetchOpenLinkedIssueNumbersAsync() {
+    const linkedIssueNumbers = new Set();
+    let page = 1;
+
+    while (true) {
+        const pagePullRequests = await restAsync(`/repos/${owner}/${repo}/pulls?state=open&per_page=100&page=${page}`);
+
+        for (const pullRequest of pagePullRequests) {
+            const timeline = await restAsync(
+                `/repos/${owner}/${repo}/issues/${pullRequest.number}/timeline?per_page=100`,
+            );
+
+            for (const event of timeline) {
+                if (event.event === 'cross-referenced' && event.source?.issue?.number) {
+                    linkedIssueNumbers.add(event.source.issue.number);
+                }
+            }
+
+            const bodyMatches = pullRequest.body?.matchAll(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi) ?? [];
+
+            for (const match of bodyMatches) {
+                linkedIssueNumbers.add(Number.parseInt(match[1], 10));
+            }
+        }
+
+        if (pagePullRequests.length < 100) {
+            break;
+        }
+
+        page += 1;
+    }
+
+    return linkedIssueNumbers;
+}
+
+async function restAsync(path, options = {}) {
+    const response = await fetch(`${apiBaseUrl}${path}`, {
+        method: options.method ?? 'GET',
+        headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'User-Agent': 'solo-dev-board-sync-status-labels',
+            'X-GitHub-Api-Version': '2022-11-28',
+            ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+        },
+        body: options.body,
+    });
+
+    if (response.status === 204) {
+        return null;
+    }
+
+    if (!response.ok) {
+        throw new Error(`REST request failed (${response.status}) for ${path}: ${await response.text()}`);
+    }
+
+    return response.json();
+}

--- a/.github/workflows/roadmap-sync.yml
+++ b/.github/workflows/roadmap-sync.yml
@@ -17,6 +17,8 @@ on:
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 concurrency:
   group: roadmap-sync
@@ -48,6 +50,11 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: "24"
+
+      - name: Sync status labels
+        env:
+          ROADMAP_PROJECT_TOKEN: ${{ secrets.ROADMAP_PROJECT_TOKEN }}
+        run: node .github/scripts/sync-status-labels.mjs --apply
 
       - name: Sync roadmap board
         env:

--- a/plan/PROJECT_BOARD_DESIGN.md
+++ b/plan/PROJECT_BOARD_DESIGN.md
@@ -94,6 +94,7 @@ The following automation rules are configured on the board. These are documented
 ### Weekly Board Hygiene Audit
 - **Trigger:** Weekly PM review, or any time the roadmap view appears inconsistent.
 - **Action:** Backfill missing Start Date / Target Date values for active or done items, correct invalid date pairs, remove stray pull request cards, and add missing planned issues back to the roadmap board.
+- **Status labels:** `.github/scripts/sync-status-labels.mjs` runs automatically before `roadmap-sync.mjs` in the Roadmap Sync workflow (nightly schedule, `workflow_dispatch`, and issue events). Use `/sync-status-labels` for on-demand inspection and ad-hoc repairs.
 
 ---
 


### PR DESCRIPTION
## Summary of Changes

Adds automated repair for drift on `status/*` labels across GitHub issues and pull requests.

- New script: `.github/scripts/sync-status-labels.mjs` (dry-run by default, `--apply` to mutate).
- New workflow and `/sync-status-labels` Cursor command for on-demand inspection and ad-hoc fixes.
- Roadmap Sync CI now runs status label repair before `roadmap-sync.mjs` on the existing schedule, `workflow_dispatch`, and issue events.
- Validated locally against the repository (36 items repaired; follow-up dry-run clean).

## Related Issue(s)

Ad-hoc hygiene automation — no linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`) — not applicable (Node.js automation script only)
- [ ] I have added or updated tests to cover my changes — not applicable (AppHost/script automation per project policy)
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and `docs/index.md` has been updated — hygiene tooling; no user-facing feature

## Screenshots (if applicable)

N/A

## Additional Notes

Repair rules:
- Closed items (not duplicate) → `status/done` only.
- Closed duplicates → remove all `status/*` labels.
- Open items with multiple `status/*` labels → keep the most advanced label.
- Open items with `status/done` → replace with `status/in-review` (if linked open PR) or `status/todo`.