### PR TITLE
Implement GitHub API response caching for #108.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -268,6 +268,13 @@ Located at `src/App/SoloDevBoard.App/appsettings.json`. The relevant sections ar
       "AllowedUserLogins": "",
       "AllowedOrganisationLogins": "",
       "HostedOrganisationLoginsClaimType": "solo-dev-board.github.organisation-logins"
+   },
+   "GitHub": {
+      "Cache": {
+         "RepositoriesTtlSeconds": 60,
+         "LabelsTtlSeconds": 300,
+         "MilestonesTtlSeconds": 300
+      }
    }
 }
 ```
@@ -289,6 +296,9 @@ Located at `src/App/SoloDevBoard.App/appsettings.json`. The relevant sections ar
 - `HostedAdmissionControl:AllowedUserLogins`: Comma-separated permitted GitHub user logins for hosted access.
 - `HostedAdmissionControl:AllowedOrganisationLogins`: Comma-separated permitted GitHub organisation logins for hosted access.
 - `HostedAdmissionControl:HostedOrganisationLoginsClaimType`: Claim type used to extract organisation logins from authentication claims.
+- `GitHub:Cache:RepositoriesTtlSeconds`: Absolute cache lifetime in seconds for repository catalogue responses (default `60`).
+- `GitHub:Cache:LabelsTtlSeconds`: Absolute cache lifetime in seconds for label catalogue responses (default `300`).
+- `GitHub:Cache:MilestonesTtlSeconds`: Absolute cache lifetime in seconds for milestone catalogue responses (default `300`).
 
 Leave `PersonalAccessToken` empty in `appsettings.json` and supply it via an environment variable or user secrets instead.
 
@@ -315,6 +325,9 @@ Leave `PersonalAccessToken` empty in `appsettings.json` and supply it via an env
 | `HostedAdmissionControl__AllowedUserLogins` | Comma-separated list of allowed GitHub user logins |
 | `HostedAdmissionControl__AllowedOrganisationLogins` | Comma-separated list of allowed GitHub organisation logins |
 | `HostedAdmissionControl__HostedOrganisationLoginsClaimType` | Claim type for organisation logins (string) |
+| `GitHub__Cache__RepositoriesTtlSeconds` | Cache lifetime in seconds for repository catalogue responses |
+| `GitHub__Cache__LabelsTtlSeconds` | Cache lifetime in seconds for label catalogue responses |
+| `GitHub__Cache__MilestonesTtlSeconds` | Cache lifetime in seconds for milestone catalogue responses |
 
 To set PAT-only values for the **legacy `dotnet run` path** (without Aspire), use .NET User Secrets on the app project. Only the PAT is required; owner login is resolved automatically:
 

--- a/plan/DECISIONS.md
+++ b/plan/DECISIONS.md
@@ -171,6 +171,15 @@ A formal migration to GitHub Spec Kit is planned — see [`plan/SPEC_KIT_MIGRATI
 
 ---
 
+### DEC-018: GitHub API response caching in Infrastructure
+
+**Status:** Active  
+**Date:** 2026-07-25  
+**Legacy:** [ADR-0005](../adr/archive/0005-github-api-strategy.md)  
+**Summary:** Cache read-heavy GitHub catalogue responses (repositories, labels, milestones) in Infrastructure using scoped `IMemoryCache` keys tied to the current user's owner login. Invalidate label and milestone catalogue entries on corresponding CRUD mutations. Reject Application-layer DTO caching, distributed cache for this tranche, and caching issues, pull requests, workflow runs, or GraphQL project board queries until a follow-up performance pass.
+
+---
+
 ## Superseded legacy (archive only)
 
 | Legacy ADR | Superseded by | Notes |

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -220,7 +220,7 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Migrate production deployment to Aspire Azure Container Apps with scale-to-zero. _(ADR-0018.)_
 - [x] Configure OIDC authentication for GitHub Actions deployment to Azure (no long-lived credentials). _(#105)_
 - [x] Add health check endpoints for Azure Container Apps monitoring. _(#106 — readiness `/health`, liveness `/alive`, ACA probe via AppHost `WithHttpHealthCheck`)_
-- [ ] Implement response caching for GitHub API calls to respect rate limits. _(#108)_
+- [x] Implement response caching for GitHub API calls to respect rate limits. _(#108)_
 - [x] Configure structured logging and Application Insights telemetry. _(#107)_
 - [x] Set up Dependabot for automated dependency updates. _(#109)_
 - [ ] Formalise and document PAT-only local trusted mode and self-hoster deployment path. _(#247, #248)_

--- a/src/App/SoloDevBoard.App/appsettings.json
+++ b/src/App/SoloDevBoard.App/appsettings.json
@@ -24,6 +24,13 @@
     "AllowedOrganisationLogins": "",
     "HostedOrganisationLoginsClaimType": "solo-dev-board.github.organisation-logins"
   },
+  "GitHub": {
+    "Cache": {
+      "RepositoriesTtlSeconds": 60,
+      "LabelsTtlSeconds": 300,
+      "MilestonesTtlSeconds": 300
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/Common/InfrastructureServiceExtensions.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/Common/InfrastructureServiceExtensions.cs
@@ -31,6 +31,28 @@ public static class InfrastructureServiceExtensions
         ArgumentNullException.ThrowIfNull(configuration);
 
         services.Configure<GitHubAuthOptions>(configuration.GetSection(GitHubAuthOptions.SectionName));
+        services.AddOptions<GitHubCacheOptions>()
+            .Bind(configuration.GetSection(GitHubCacheOptions.SectionName))
+            .PostConfigure(static options =>
+            {
+                if (options.RepositoriesTtlSeconds == 0)
+                {
+                    options.RepositoriesTtlSeconds = 60;
+                }
+
+                if (options.LabelsTtlSeconds == 0)
+                {
+                    options.LabelsTtlSeconds = 300;
+                }
+
+                if (options.MilestonesTtlSeconds == 0)
+                {
+                    options.MilestonesTtlSeconds = 300;
+                }
+            })
+            .ValidateOnStart();
+        services.AddSingleton<IValidateOptions<GitHubCacheOptions>, GitHubCacheOptionsValidator>();
+        services.AddMemoryCache();
         services.Configure<HostedAdmissionControlOptions>(configuration.GetSection(HostedAdmissionControlOptions.SectionName));
         services.AddSingleton<ResolvedPatOwnerLogin>();
         services.AddSingleton<GitHubPatOwnerLoginResolver>();
@@ -70,6 +92,7 @@ public static class InfrastructureServiceExtensions
             })
             .AddHttpMessageHandler<GitHubAuthHandler>();
 
+        services.AddScoped<GitHubResponseCache>();
         services.AddScoped<IGitHubService, GitHubService>();
         services.AddScoped<ILabelRepository, GitHubLabelRepository>();
         services.AddScoped<IMilestoneRepository, GitHubMilestoneRepository>();

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubCacheOptions.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubCacheOptions.cs
@@ -1,0 +1,17 @@
+namespace SoloDevBoard.Infrastructure.GitHub;
+
+/// <summary>Configuration options for GitHub API response caching.</summary>
+public sealed class GitHubCacheOptions
+{
+    /// <summary>Configuration section name for GitHub response cache settings.</summary>
+    public const string SectionName = "GitHub:Cache";
+
+    /// <summary>Absolute cache lifetime in seconds for repository catalogue responses.</summary>
+    public int RepositoriesTtlSeconds { get; set; } = 60;
+
+    /// <summary>Absolute cache lifetime in seconds for label catalogue responses.</summary>
+    public int LabelsTtlSeconds { get; set; } = 300;
+
+    /// <summary>Absolute cache lifetime in seconds for milestone catalogue responses.</summary>
+    public int MilestonesTtlSeconds { get; set; } = 300;
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubCacheOptionsValidator.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubCacheOptionsValidator.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Options;
+
+namespace SoloDevBoard.Infrastructure.GitHub;
+
+/// <summary>Validates <see cref="GitHubCacheOptions"/> at application startup.</summary>
+public sealed class GitHubCacheOptionsValidator : IValidateOptions<GitHubCacheOptions>
+{
+    /// <inheritdoc/>
+    public ValidateOptionsResult Validate(string? name, GitHubCacheOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        List<string> failures = [];
+
+        if (options.RepositoriesTtlSeconds < 1)
+        {
+            failures.Add($"{nameof(GitHubCacheOptions.RepositoriesTtlSeconds)} must be at least 1 second.");
+        }
+
+        if (options.LabelsTtlSeconds < 1)
+        {
+            failures.Add($"{nameof(GitHubCacheOptions.LabelsTtlSeconds)} must be at least 1 second.");
+        }
+
+        if (options.MilestonesTtlSeconds < 1)
+        {
+            failures.Add($"{nameof(GitHubCacheOptions.MilestonesTtlSeconds)} must be at least 1 second.");
+        }
+
+        return failures.Count > 0
+            ? ValidateOptionsResult.Fail(failures)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubResponseCache.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubResponseCache.cs
@@ -1,0 +1,157 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using SoloDevBoard.Application.Identity;
+
+namespace SoloDevBoard.Infrastructure.GitHub;
+
+/// <summary>
+/// Provides scoped in-memory caching for read-heavy GitHub API catalogue responses.
+/// Cache keys are scoped by the current user's owner login so hosted sessions do not share data.
+/// </summary>
+public sealed class GitHubResponseCache
+{
+    private readonly IMemoryCache _memoryCache;
+    private readonly ICurrentUserContext _currentUserContext;
+    private readonly GitHubCacheOptions _options;
+
+    /// <summary>Initialises a new instance of the <see cref="GitHubResponseCache"/> class.</summary>
+    /// <param name="memoryCache">The memory cache used to store GitHub API responses.</param>
+    /// <param name="currentUserContext">The current user context used to scope cache keys.</param>
+    /// <param name="options">Cache lifetime configuration.</param>
+    public GitHubResponseCache(
+        IMemoryCache memoryCache,
+        ICurrentUserContext currentUserContext,
+        IOptions<GitHubCacheOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(memoryCache);
+        ArgumentNullException.ThrowIfNull(currentUserContext);
+        ArgumentNullException.ThrowIfNull(options);
+
+        _memoryCache = memoryCache;
+        _currentUserContext = currentUserContext;
+        _options = options.Value;
+    }
+
+    /// <summary>Gets or creates a cached repository catalogue for the authenticated user.</summary>
+    /// <typeparam name="T">The cached item type.</typeparam>
+    /// <param name="factory">The factory used to load the catalogue when the cache misses.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The cached or freshly loaded catalogue.</returns>
+    public Task<IReadOnlyList<T>> GetOrCreateUserRepositoriesAsync<T>(
+        Func<CancellationToken, Task<IReadOnlyList<T>>> factory,
+        CancellationToken cancellationToken = default)
+        => GetOrCreateAsync(BuildUserRepositoriesKey(), _options.RepositoriesTtlSeconds, factory, cancellationToken);
+
+    /// <summary>Gets or creates a cached repository catalogue for the specified owner.</summary>
+    /// <typeparam name="T">The cached item type.</typeparam>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="factory">The factory used to load the catalogue when the cache misses.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The cached or freshly loaded catalogue.</returns>
+    public Task<IReadOnlyList<T>> GetOrCreateOwnerRepositoriesAsync<T>(
+        string owner,
+        Func<CancellationToken, Task<IReadOnlyList<T>>> factory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+
+        return GetOrCreateAsync(BuildOwnerRepositoriesKey(owner), _options.RepositoriesTtlSeconds, factory, cancellationToken);
+    }
+
+    /// <summary>Gets or creates a cached label catalogue for the specified repository.</summary>
+    /// <typeparam name="T">The cached item type.</typeparam>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="factory">The factory used to load the catalogue when the cache misses.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The cached or freshly loaded catalogue.</returns>
+    public Task<IReadOnlyList<T>> GetOrCreateLabelsAsync<T>(
+        string owner,
+        string repo,
+        Func<CancellationToken, Task<IReadOnlyList<T>>> factory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        return GetOrCreateAsync(BuildLabelsKey(owner, repo), _options.LabelsTtlSeconds, factory, cancellationToken);
+    }
+
+    /// <summary>Gets or creates a cached milestone catalogue for the specified repository.</summary>
+    /// <typeparam name="T">The cached item type.</typeparam>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="factory">The factory used to load the catalogue when the cache misses.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The cached or freshly loaded catalogue.</returns>
+    public Task<IReadOnlyList<T>> GetOrCreateMilestonesAsync<T>(
+        string owner,
+        string repo,
+        Func<CancellationToken, Task<IReadOnlyList<T>>> factory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        return GetOrCreateAsync(BuildMilestonesKey(owner, repo), _options.MilestonesTtlSeconds, factory, cancellationToken);
+    }
+
+    /// <summary>Removes the cached label catalogue for the specified repository.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    public void InvalidateLabels(string owner, string repo)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        _memoryCache.Remove(BuildLabelsKey(owner, repo));
+    }
+
+    /// <summary>Removes the cached milestone catalogue for the specified repository.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    public void InvalidateMilestones(string owner, string repo)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        _memoryCache.Remove(BuildMilestonesKey(owner, repo));
+    }
+
+    private string BuildUserRepositoriesKey()
+        => $"gh:{NormalizeKeySegment(_currentUserContext.OwnerLogin)}:repos:user";
+
+    private string BuildOwnerRepositoriesKey(string owner)
+        => $"gh:{NormalizeKeySegment(_currentUserContext.OwnerLogin)}:repos:owner:{NormalizeKeySegment(owner)}";
+
+    private string BuildLabelsKey(string owner, string repo)
+        => $"gh:{NormalizeKeySegment(_currentUserContext.OwnerLogin)}:labels:{NormalizeKeySegment(owner)}:{NormalizeKeySegment(repo)}";
+
+    private string BuildMilestonesKey(string owner, string repo)
+        => $"gh:{NormalizeKeySegment(_currentUserContext.OwnerLogin)}:milestones:{NormalizeKeySegment(owner)}:{NormalizeKeySegment(repo)}";
+
+    private static string NormalizeKeySegment(string value) => value.ToLowerInvariant();
+
+    private async Task<IReadOnlyList<T>> GetOrCreateAsync<T>(
+        string key,
+        int ttlSeconds,
+        Func<CancellationToken, Task<IReadOnlyList<T>>> factory,
+        CancellationToken cancellationToken)
+    {
+        var cached = await _memoryCache.GetOrCreateAsync(
+            key,
+            async entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(ttlSeconds);
+                var result = await factory(cancellationToken).ConfigureAwait(false);
+                return CopyCatalogue(result);
+            }).ConfigureAwait(false);
+
+        return CopyCatalogue(cached);
+    }
+
+    private static T[] CopyCatalogue<T>(IReadOnlyList<T>? catalogue)
+        => catalogue is null || catalogue.Count == 0
+            ? Array.Empty<T>()
+            : catalogue.ToArray();
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
@@ -18,26 +18,34 @@ public sealed class GitHubService : IGitHubService
     public const string GitHubApiClientName = "GitHubApiClient";
 
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly GitHubResponseCache _responseCache;
 
     /// <summary>Initialises a new instance of the <see cref="GitHubService"/> class.</summary>
     /// <param name="httpClientFactory">The factory used to create named <see cref="HttpClient"/> instances.</param>
-    public GitHubService(IHttpClientFactory httpClientFactory)
+    /// <param name="responseCache">The cache used for read-heavy GitHub API catalogue responses.</param>
+    public GitHubService(IHttpClientFactory httpClientFactory, GitHubResponseCache responseCache)
     {
         _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _responseCache = responseCache ?? throw new ArgumentNullException(nameof(responseCache));
     }
 
     /// <inheritdoc/>
     public async Task<IReadOnlyList<Repository>> GetRepositoriesAsync(CancellationToken cancellationToken = default)
     {
-        var client = CreateAuthenticatedClient();
-        const string endpoint = "/user/repos?sort=updated&per_page=100";
-        return await GetPagedAsync<RepositoryResponseDto, Repository>(
-                client,
-                endpoint,
-                static dto => dto.ToDomain(),
-            JsonOptions,
-                cancellationToken)
-            .ConfigureAwait(false);
+        return await _responseCache.GetOrCreateUserRepositoriesAsync(
+            async ct =>
+            {
+                var client = CreateAuthenticatedClient();
+                const string endpoint = "/user/repos?sort=updated&per_page=100";
+                return await GetPagedAsync<RepositoryResponseDto, Repository>(
+                        client,
+                        endpoint,
+                        static dto => dto.ToDomain(),
+                        JsonOptions,
+                        ct)
+                    .ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -54,15 +62,21 @@ public sealed class GitHubService : IGitHubService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
 
-        var client = CreateAuthenticatedClient();
-        var endpoint = $"/users/{Uri.EscapeDataString(owner)}/repos?per_page=100";
-        return await GetPagedAsync<RepositoryResponseDto, Repository>(
-                client,
-                endpoint,
-                static dto => dto.ToDomain(),
-            JsonOptions,
-                cancellationToken)
-            .ConfigureAwait(false);
+        return await _responseCache.GetOrCreateOwnerRepositoriesAsync(
+            owner,
+            async ct =>
+            {
+                var client = CreateAuthenticatedClient();
+                var endpoint = $"/users/{Uri.EscapeDataString(owner)}/repos?per_page=100";
+                return await GetPagedAsync<RepositoryResponseDto, Repository>(
+                        client,
+                        endpoint,
+                        static dto => dto.ToDomain(),
+                        JsonOptions,
+                        ct)
+                    .ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -142,17 +156,22 @@ public sealed class GitHubService : IGitHubService
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
 
-        var client = CreateAuthenticatedClient();
-        var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/milestones?state=all&per_page=100";
-        var milestones = await GetPagedAsync<MilestoneResponseDto, Milestone>(
-                client,
-                endpoint,
-                static dto => dto.ToDomain(),
-            JsonOptions,
-                cancellationToken)
-            .ConfigureAwait(false);
-
-        return milestones;
+        return await _responseCache.GetOrCreateMilestonesAsync(
+            owner,
+            repo,
+            async ct =>
+            {
+                var client = CreateAuthenticatedClient();
+                var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/milestones?state=all&per_page=100";
+                return await GetPagedAsync<MilestoneResponseDto, Milestone>(
+                        client,
+                        endpoint,
+                        static dto => dto.ToDomain(),
+                        JsonOptions,
+                        ct)
+                    .ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -161,17 +180,22 @@ public sealed class GitHubService : IGitHubService
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
 
-        var client = CreateAuthenticatedClient();
-        var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels?per_page=100";
-        var labels = await GetPagedAsync<LabelResponseDto, Label>(
-                client,
-                endpoint,
-                static dto => dto.ToDomain(),
-            JsonOptions,
-                cancellationToken)
-            .ConfigureAwait(false);
-
-        return labels;
+        return await _responseCache.GetOrCreateLabelsAsync(
+            owner,
+            repo,
+            async ct =>
+            {
+                var client = CreateAuthenticatedClient();
+                var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels?per_page=100";
+                return await GetPagedAsync<LabelResponseDto, Label>(
+                        client,
+                        endpoint,
+                        dto => dto.ToDomain(repo),
+                        JsonOptions,
+                        ct)
+                    .ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -190,7 +214,9 @@ public sealed class GitHubService : IGitHubService
         var created = await response.Content.ReadFromJsonAsync<LabelResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
             ?? throw CreateInvalidResponseException("Label response was empty.", endpoint);
 
-        return created.ToDomain();
+        _responseCache.InvalidateLabels(owner, repo);
+
+        return created.ToDomain(repo);
     }
 
     /// <inheritdoc/>
@@ -215,7 +241,9 @@ public sealed class GitHubService : IGitHubService
         var updated = await response.Content.ReadFromJsonAsync<LabelResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
             ?? throw CreateInvalidResponseException("Label response was empty.", endpoint);
 
-        return updated.ToDomain();
+        _responseCache.InvalidateLabels(owner, repo);
+
+        return updated.ToDomain(repo);
     }
 
     /// <inheritdoc/>
@@ -230,6 +258,8 @@ public sealed class GitHubService : IGitHubService
 
         using var response = await client.DeleteAsync(endpoint, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+
+        _responseCache.InvalidateLabels(owner, repo);
     }
 
     /// <inheritdoc/>
@@ -1059,6 +1089,14 @@ public sealed class GitHubService : IGitHubService
             Name = Name,
             Colour = Colour,
             Description = RepairCommonMojibake(Description),
+        };
+
+        public Label ToDomain(string repoName) => new()
+        {
+            Name = Name,
+            Colour = Colour,
+            Description = RepairCommonMojibake(Description),
+            RepositoryName = repoName,
         };
     }
 

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/Labels/GitHubLabelRepository.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/Labels/GitHubLabelRepository.cs
@@ -18,11 +18,15 @@ public sealed class GitHubLabelRepository : ILabelRepository
     };
 
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly GitHubResponseCache _responseCache;
+
     /// <summary>Initialises a new instance of the <see cref="GitHubLabelRepository"/> class.</summary>
     /// <param name="httpClientFactory">The factory used to create named <see cref="HttpClient"/> instances.</param>
-    public GitHubLabelRepository(IHttpClientFactory httpClientFactory)
+    /// <param name="responseCache">The cache used for read-heavy GitHub API catalogue responses.</param>
+    public GitHubLabelRepository(IHttpClientFactory httpClientFactory, GitHubResponseCache responseCache)
     {
         _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _responseCache = responseCache ?? throw new ArgumentNullException(nameof(responseCache));
     }
 
     /// <inheritdoc/>
@@ -31,16 +35,23 @@ public sealed class GitHubLabelRepository : ILabelRepository
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
 
-        var client = CreateClient();
-        var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels?per_page=100";
+        return await _responseCache.GetOrCreateLabelsAsync(
+            owner,
+            repo,
+            async ct =>
+            {
+                var client = CreateClient();
+                var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/labels?per_page=100";
 
-        return await GitHubService.GetPagedAsync<LabelResponseDto, Label>(
-                client,
-                endpoint,
-            dto => dto.ToDomain(repo),
-            JsonOptions,
-                cancellationToken)
-            .ConfigureAwait(false);
+                return await GitHubService.GetPagedAsync<LabelResponseDto, Label>(
+                        client,
+                        endpoint,
+                        dto => dto.ToDomain(repo),
+                        JsonOptions,
+                        ct)
+                    .ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -58,6 +69,8 @@ public sealed class GitHubLabelRepository : ILabelRepository
 
         var created = await response.Content.ReadFromJsonAsync<LabelResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
             ?? throw GitHubService.CreateInvalidResponseException("Label response was empty.", endpoint);
+
+        _responseCache.InvalidateLabels(owner, repo);
 
         return created.ToDomain(repo);
     }
@@ -84,6 +97,8 @@ public sealed class GitHubLabelRepository : ILabelRepository
         var updated = await response.Content.ReadFromJsonAsync<LabelResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
             ?? throw GitHubService.CreateInvalidResponseException("Label response was empty.", endpoint);
 
+        _responseCache.InvalidateLabels(owner, repo);
+
         return updated.ToDomain(repo);
     }
 
@@ -99,6 +114,8 @@ public sealed class GitHubLabelRepository : ILabelRepository
 
         using var response = await client.DeleteAsync(endpoint, cancellationToken).ConfigureAwait(false);
         await GitHubService.EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+
+        _responseCache.InvalidateLabels(owner, repo);
     }
 
     private HttpClient CreateClient()

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/Milestones/GitHubMilestoneRepository.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/Milestones/GitHubMilestoneRepository.cs
@@ -19,12 +19,15 @@ public sealed class GitHubMilestoneRepository : IMilestoneRepository
     };
 
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly GitHubResponseCache _responseCache;
 
     /// <summary>Initialises a new instance of the <see cref="GitHubMilestoneRepository"/> class.</summary>
     /// <param name="httpClientFactory">The factory used to create named <see cref="HttpClient"/> instances.</param>
-    public GitHubMilestoneRepository(IHttpClientFactory httpClientFactory)
+    /// <param name="responseCache">The cache used for read-heavy GitHub API catalogue responses.</param>
+    public GitHubMilestoneRepository(IHttpClientFactory httpClientFactory, GitHubResponseCache responseCache)
     {
         _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _responseCache = responseCache ?? throw new ArgumentNullException(nameof(responseCache));
     }
 
     /// <inheritdoc/>
@@ -33,16 +36,23 @@ public sealed class GitHubMilestoneRepository : IMilestoneRepository
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
 
-        var client = CreateClient();
-        var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/milestones?state=all&per_page=100";
+        return await _responseCache.GetOrCreateMilestonesAsync(
+            owner,
+            repo,
+            async ct =>
+            {
+                var client = CreateClient();
+                var endpoint = $"/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/milestones?state=all&per_page=100";
 
-        return await GitHubService.GetPagedAsync<MilestoneResponseDto, Milestone>(
-                client,
-                endpoint,
-                static dto => dto.ToDomain(),
-                JsonOptions,
-                cancellationToken)
-            .ConfigureAwait(false);
+                return await GitHubService.GetPagedAsync<MilestoneResponseDto, Milestone>(
+                        client,
+                        endpoint,
+                        static dto => dto.ToDomain(),
+                        JsonOptions,
+                        ct)
+                    .ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -60,6 +70,8 @@ public sealed class GitHubMilestoneRepository : IMilestoneRepository
 
         var created = await response.Content.ReadFromJsonAsync<MilestoneResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
             ?? throw GitHubService.CreateInvalidResponseException("Milestone response was empty.", endpoint);
+
+        _responseCache.InvalidateMilestones(owner, repo);
 
         return created.ToDomain();
     }
@@ -90,6 +102,8 @@ public sealed class GitHubMilestoneRepository : IMilestoneRepository
         var updated = await response.Content.ReadFromJsonAsync<MilestoneResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
             ?? throw GitHubService.CreateInvalidResponseException("Milestone response was empty.", endpoint);
 
+        _responseCache.InvalidateMilestones(owner, repo);
+
         return updated.ToDomain();
     }
 
@@ -108,6 +122,8 @@ public sealed class GitHubMilestoneRepository : IMilestoneRepository
 
         using var response = await client.DeleteAsync(endpoint, cancellationToken).ConfigureAwait(false);
         await GitHubService.EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+
+        _responseCache.InvalidateMilestones(owner, repo);
     }
 
     private HttpClient CreateClient()

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubApiCachingTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubApiCachingTests.cs
@@ -1,0 +1,489 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using SoloDevBoard.Application.Identity;
+using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Infrastructure.GitHub;
+using SoloDevBoard.Infrastructure.Labels;
+using SoloDevBoard.Infrastructure.Milestones;
+
+namespace SoloDevBoard.Infrastructure.Tests;
+
+/// <summary>Tests for GitHub API response caching behaviour in Infrastructure.</summary>
+public sealed class GitHubApiCachingTests
+{
+    [Fact]
+    public async Task GetRepositoriesAsync_CalledTwice_UsesCacheOnSecondCall()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "id": 1,
+                    "name": "repo-one",
+                    "full_name": "owner/repo-one",
+                    "description": "First repo",
+                    "html_url": "https://github.com/owner/repo-one",
+                    "private": false,
+                    "archived": false,
+                    "created_at": "2026-03-01T10:00:00Z",
+                    "updated_at": "2026-03-02T11:00:00Z"
+                  }
+                ]
+                """),
+        ]);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var sut = CreateGitHubService(handler, memoryCache);
+
+        // Act
+        var first = await sut.GetRepositoriesAsync(cancellationToken);
+        var second = await sut.GetRepositoriesAsync(cancellationToken);
+
+        // Assert
+        Assert.Single(first);
+        Assert.Single(second);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task GetLabelsAsync_CalledTwice_UsesCacheOnSecondCall()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "name": "enhancement",
+                    "color": "a2eeef",
+                    "description": null
+                  }
+                ]
+                """),
+        ]);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var sut = CreateGitHubService(handler, memoryCache);
+
+        // Act
+        await sut.GetLabelsAsync("owner", "repo", cancellationToken);
+        await sut.GetLabelsAsync("owner", "repo", cancellationToken);
+
+        // Assert
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task GetMilestonesAsync_CalledTwice_UsesCacheOnSecondCall()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "id": 300,
+                    "number": 10,
+                    "title": "v0.2.0",
+                    "description": null,
+                    "state": "open",
+                    "due_on": null,
+                    "open_issues": 3,
+                    "closed_issues": 1
+                  }
+                ]
+                """),
+        ]);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var sut = CreateGitHubService(handler, memoryCache);
+
+        // Act
+        await sut.GetMilestonesAsync("owner", "repo", cancellationToken);
+        await sut.GetMilestonesAsync("owner", "repo", cancellationToken);
+
+        // Assert
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task GetLabelsAsync_DifferentOwnerLogins_DoNotShareCachedData()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "name": "user-a-label",
+                    "color": "a2eeef",
+                    "description": null
+                  }
+                ]
+                """),
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "name": "user-b-label",
+                    "color": "d73a4a",
+                    "description": null
+                  }
+                ]
+                """),
+        ]);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var userAContext = GitHubCachingTestSupport.CreateCurrentUserContext("user-a");
+        var userBContext = GitHubCachingTestSupport.CreateCurrentUserContext("user-b");
+        var userAService = CreateGitHubService(handler, memoryCache, userAContext);
+        var userBService = CreateGitHubService(handler, memoryCache, userBContext);
+
+        // Act
+        var userALabels = await userAService.GetLabelsAsync("owner", "repo", cancellationToken);
+        var userBLabels = await userBService.GetLabelsAsync("owner", "repo", cancellationToken);
+
+        // Assert
+        Assert.Equal("user-a-label", userALabels[0].Name);
+        Assert.Equal("user-b-label", userBLabels[0].Name);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task GetLabelsAsync_MixedCaseOwnerAndRepo_UsesSingleCacheEntry()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "name": "enhancement",
+                    "color": "a2eeef",
+                    "description": null
+                  }
+                ]
+                """),
+        ]);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var sut = CreateGitHubService(handler, memoryCache);
+
+        // Act
+        await sut.GetLabelsAsync("Owner", "Repo", cancellationToken);
+        await sut.GetLabelsAsync("owner", "repo", cancellationToken);
+
+        // Assert
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task GetLabelsAsync_ReturnedCatalogueIsDefensiveCopy()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "name": "enhancement",
+                    "color": "a2eeef",
+                    "description": null
+                  }
+                ]
+                """),
+        ]);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var sut = CreateGitHubService(handler, memoryCache);
+
+        // Act
+        var first = await sut.GetLabelsAsync("owner", "repo", cancellationToken);
+        var second = await sut.GetLabelsAsync("owner", "repo", cancellationToken);
+
+        // Assert
+        Assert.NotSame(first, second);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task GetLabelsAsync_RepositoryAndServiceShareCacheKey_UsesSingleHttpRequest()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "name": "enhancement",
+                    "color": "a2eeef",
+                    "description": null
+                  }
+                ]
+                """),
+        ]);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var currentUserContext = GitHubCachingTestSupport.CreateCurrentUserContext();
+        var responseCache = GitHubCachingTestSupport.CreateResponseCache(memoryCache, currentUserContext);
+        var labelRepository = CreateLabelRepository(handler, responseCache, currentUserContext);
+        var gitHubService = CreateGitHubService(handler, memoryCache, currentUserContext);
+
+        // Act
+        var repositoryLabels = await labelRepository.GetLabelsAsync("owner", "repo", cancellationToken);
+        var serviceLabels = await gitHubService.GetLabelsAsync("owner", "repo", cancellationToken);
+
+        // Assert
+        Assert.Single(repositoryLabels);
+        Assert.Single(serviceLabels);
+        Assert.Equal("repo", repositoryLabels[0].RepositoryName);
+        Assert.Equal("repo", serviceLabels[0].RepositoryName);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task CreateLabelAsync_AfterCachedGetLabels_RefetchesLabelsOnNextRead()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "name": "enhancement",
+                    "color": "a2eeef",
+                    "description": null
+                  }
+                ]
+                """),
+            CreateJsonResponse(
+                HttpStatusCode.Created,
+                """
+                {
+                  "name": "bug",
+                  "color": "d73a4a",
+                  "description": "Something is not working"
+                }
+                """),
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "name": "enhancement",
+                    "color": "a2eeef",
+                    "description": null
+                  },
+                  {
+                    "name": "bug",
+                    "color": "d73a4a",
+                    "description": "Something is not working"
+                  }
+                ]
+                """),
+        ]);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var currentUserContext = GitHubCachingTestSupport.CreateCurrentUserContext();
+        var responseCache = GitHubCachingTestSupport.CreateResponseCache(memoryCache, currentUserContext);
+        var sut = CreateLabelRepository(handler, responseCache, currentUserContext);
+
+        // Act
+        await sut.GetLabelsAsync("owner", "repo", cancellationToken);
+        await sut.CreateLabelAsync("owner", "repo", new Label { Name = "bug", Colour = "d73a4a", Description = "Something is not working" }, cancellationToken);
+        var refreshed = await sut.GetLabelsAsync("owner", "repo", cancellationToken);
+
+        // Assert
+        Assert.Equal(2, refreshed.Count);
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+        Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
+        Assert.Equal(HttpMethod.Get, handler.Requests[2].Method);
+    }
+
+    [Fact]
+    public async Task DeleteMilestoneAsync_AfterCachedGetMilestones_RefetchesMilestonesOnNextRead()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "id": 123,
+                    "number": 7,
+                    "title": "Sprint 7",
+                    "description": "Milestone description",
+                    "state": "open",
+                    "due_on": null,
+                    "open_issues": 2,
+                    "closed_issues": 5
+                  }
+                ]
+                """),
+            new HttpResponseMessage(HttpStatusCode.NoContent),
+            CreateJsonResponse(HttpStatusCode.OK, "[]"),
+        ]);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var currentUserContext = GitHubCachingTestSupport.CreateCurrentUserContext();
+        var responseCache = GitHubCachingTestSupport.CreateResponseCache(memoryCache, currentUserContext);
+        var sut = CreateMilestoneRepository(handler, responseCache, currentUserContext);
+
+        // Act
+        await sut.GetMilestonesAsync("owner", "repo", cancellationToken);
+        await sut.DeleteMilestoneAsync("owner", "repo", 7, cancellationToken);
+        var refreshed = await sut.GetMilestonesAsync("owner", "repo", cancellationToken);
+
+        // Assert
+        Assert.Empty(refreshed);
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+        Assert.Equal(HttpMethod.Delete, handler.Requests[1].Method);
+        Assert.Equal(HttpMethod.Get, handler.Requests[2].Method);
+    }
+
+    private static GitHubService CreateGitHubService(
+        HttpMessageHandler handler,
+        IMemoryCache memoryCache,
+        ICurrentUserContext? currentUserContext = null)
+    {
+        var context = currentUserContext ?? GitHubCachingTestSupport.CreateCurrentUserContext();
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory
+            .CreateClient(GitHubService.GitHubApiClientName)
+            .Returns(new HttpClient(handler) { BaseAddress = new Uri("https://api.github.com") });
+
+        var responseCache = GitHubCachingTestSupport.CreateResponseCache(memoryCache, context);
+        return new GitHubService(httpClientFactory, responseCache);
+    }
+
+    private static GitHubLabelRepository CreateLabelRepository(
+        HttpMessageHandler handler,
+        GitHubResponseCache responseCache,
+        ICurrentUserContext currentUserContext)
+    {
+        var authHandler = new GitHubAuthHandler(
+            currentUserContext,
+            Options.Create(new GitHubAuthOptions()))
+        {
+            InnerHandler = handler,
+        };
+
+        var client = new HttpClient(authHandler)
+        {
+            BaseAddress = new Uri("https://api.github.com"),
+        };
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory
+            .CreateClient(GitHubService.GitHubApiClientName)
+            .Returns(client);
+
+        return new GitHubLabelRepository(httpClientFactory, responseCache);
+    }
+
+    private static GitHubMilestoneRepository CreateMilestoneRepository(
+        HttpMessageHandler handler,
+        GitHubResponseCache responseCache,
+        ICurrentUserContext currentUserContext)
+    {
+        var authHandler = new GitHubAuthHandler(
+            currentUserContext,
+            Options.Create(new GitHubAuthOptions()))
+        {
+            InnerHandler = handler,
+        };
+
+        var client = new HttpClient(authHandler)
+        {
+            BaseAddress = new Uri("https://api.github.com"),
+        };
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory
+            .CreateClient(GitHubService.GitHubApiClientName)
+            .Returns(client);
+
+        return new GitHubMilestoneRepository(httpClientFactory, responseCache);
+    }
+
+    private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json)
+    {
+        return new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+    }
+
+    private sealed class QueueMessageHandler(IEnumerable<HttpResponseMessage> responses) : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new(responses);
+
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(await CloneRequestAsync(request, cancellationToken).ConfigureAwait(false));
+
+            if (_responses.Count == 0)
+            {
+                throw new InvalidOperationException("No mocked responses are left in the queue.");
+            }
+
+            return _responses.Dequeue();
+        }
+
+        private static async Task<HttpRequestMessage> CloneRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri);
+
+            foreach (var header in request.Headers)
+            {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            if (request.Content is not null)
+            {
+                var content = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                var mediaType = request.Content.Headers.ContentType?.MediaType ?? "application/json";
+                clone.Content = new StringContent(content, Encoding.UTF8, mediaType);
+            }
+
+            return clone;
+        }
+    }
+}

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubCacheOptionsValidatorTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubCacheOptionsValidatorTests.cs
@@ -1,0 +1,40 @@
+using SoloDevBoard.Infrastructure.GitHub;
+
+namespace SoloDevBoard.Infrastructure.Tests;
+
+/// <summary>Tests for <see cref="GitHubCacheOptionsValidator"/>.</summary>
+public sealed class GitHubCacheOptionsValidatorTests
+{
+    private readonly GitHubCacheOptionsValidator _sut = new();
+
+    [Fact]
+    public void Validate_DefaultOptions_ReturnsSuccess()
+    {
+        // Arrange
+        var options = new GitHubCacheOptions();
+
+        // Act
+        var result = _sut.Validate(null, options);
+
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+
+    [Theory]
+    [InlineData(nameof(GitHubCacheOptions.RepositoriesTtlSeconds), 0)]
+    [InlineData(nameof(GitHubCacheOptions.LabelsTtlSeconds), -1)]
+    [InlineData(nameof(GitHubCacheOptions.MilestonesTtlSeconds), -5)]
+    public void Validate_InvalidTtl_ReturnsFailure(string propertyName, int invalidValue)
+    {
+        // Arrange
+        var options = new GitHubCacheOptions();
+        typeof(GitHubCacheOptions).GetProperty(propertyName)!.SetValue(options, invalidValue);
+
+        // Act
+        var result = _sut.Validate(null, options);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Contains(propertyName, result.FailureMessage, StringComparison.Ordinal);
+    }
+}

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubCachingTestSupport.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubCachingTestSupport.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using SoloDevBoard.Application.Identity;
+using SoloDevBoard.Infrastructure.GitHub;
+
+namespace SoloDevBoard.Infrastructure.Tests;
+
+/// <summary>Shared helpers for GitHub API caching tests.</summary>
+internal static class GitHubCachingTestSupport
+{
+    /// <summary>Creates a <see cref="GitHubResponseCache"/> for unit tests.</summary>
+    /// <param name="memoryCache">Optional memory cache instance to share between collaborators.</param>
+    /// <param name="currentUserContext">Optional current user context for cache key scoping.</param>
+    /// <param name="options">Optional cache lifetime configuration.</param>
+    /// <returns>A configured response cache instance.</returns>
+    internal static GitHubResponseCache CreateResponseCache(
+        IMemoryCache? memoryCache = null,
+        ICurrentUserContext? currentUserContext = null,
+        GitHubCacheOptions? options = null)
+    {
+        var context = currentUserContext ?? CreateCurrentUserContext();
+
+        return new GitHubResponseCache(
+            memoryCache ?? new MemoryCache(new MemoryCacheOptions()),
+            context,
+            Options.Create(options ?? new GitHubCacheOptions()));
+    }
+
+    /// <summary>Creates a substitute current user context for Infrastructure tests.</summary>
+    /// <param name="ownerLogin">The owner login used to scope cache keys.</param>
+    /// <param name="token">The access token returned by <see cref="ICurrentUserContext.GetAccessToken"/>.</param>
+    /// <returns>A configured substitute current user context.</returns>
+    internal static ICurrentUserContext CreateCurrentUserContext(string ownerLogin = "test-user", string token = "test-token")
+    {
+        var context = Substitute.For<ICurrentUserContext>();
+        context.OwnerLogin.Returns(ownerLogin);
+        context.GetAccessToken().Returns(token);
+        return context;
+    }
+}

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubLabelRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubLabelRepositoryTests.cs
@@ -199,7 +199,7 @@ public sealed class GitHubLabelRepositoryTests
             .CreateClient(GitHubService.GitHubApiClientName)
             .Returns(client);
 
-        var sut = new GitHubLabelRepository(httpClientFactory);
+        var sut = new GitHubLabelRepository(httpClientFactory, GitHubCachingTestSupport.CreateResponseCache());
 
         // Act / Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
@@ -208,11 +208,7 @@ public sealed class GitHubLabelRepositoryTests
 
     private static GitHubLabelRepository CreateSubject(HttpMessageHandler handler)
     {
-        var currentUserContext = Substitute.For<ICurrentUserContext>();
-        currentUserContext
-            .GetAccessToken()
-            .Returns("test-token");
-
+        var currentUserContext = GitHubCachingTestSupport.CreateCurrentUserContext();
         var authHandler = new GitHubAuthHandler(
             currentUserContext,
             Options.Create(new GitHubAuthOptions()))
@@ -230,7 +226,8 @@ public sealed class GitHubLabelRepositoryTests
             .CreateClient(GitHubService.GitHubApiClientName)
             .Returns(client);
 
-        return new GitHubLabelRepository(httpClientFactory);
+        var responseCache = GitHubCachingTestSupport.CreateResponseCache(memoryCache: null, currentUserContext);
+        return new GitHubLabelRepository(httpClientFactory, responseCache);
     }
 
     private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json)

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubMilestoneRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubMilestoneRepositoryTests.cs
@@ -3,7 +3,6 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Domain.Entities.Milestones;
 using SoloDevBoard.Infrastructure.GitHub;
 using SoloDevBoard.Infrastructure.Milestones;
@@ -269,10 +268,7 @@ public sealed class GitHubMilestoneRepositoryTests
 
     private static GitHubMilestoneRepository CreateSubject(HttpMessageHandler handler)
     {
-        var currentUserContext = Substitute.For<ICurrentUserContext>();
-        currentUserContext
-            .GetAccessToken()
-            .Returns("test-token");
+        var currentUserContext = GitHubCachingTestSupport.CreateCurrentUserContext();
 
         var authHandler = new GitHubAuthHandler(
             currentUserContext,
@@ -291,7 +287,8 @@ public sealed class GitHubMilestoneRepositoryTests
             .CreateClient(GitHubService.GitHubApiClientName)
             .Returns(client);
 
-        return new GitHubMilestoneRepository(httpClientFactory);
+        var responseCache = GitHubCachingTestSupport.CreateResponseCache(memoryCache: null, currentUserContext);
+        return new GitHubMilestoneRepository(httpClientFactory, responseCache);
     }
 
     private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json)

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -578,7 +578,7 @@ public sealed class GitHubServiceTests
         ]);
 
         var sut = CreateSubject(handler);
-        var label = new Label { Name = "bug", Colour = "d73a4a", Description = "Something is not working" };
+        var label = new Label { Name = "bug", Colour = "d73a4a", Description = "Something is not working", RepositoryName = "repo" };
 
         // Act
         var result = await sut.CreateLabelAsync("owner", "repo", label, cancellationToken);
@@ -613,7 +613,7 @@ public sealed class GitHubServiceTests
         ]);
 
         var sut = CreateSubject(handler);
-        var updatedLabel = new Label { Name = "enhancement", Colour = "a2eeef", Description = "Feature request" };
+        var updatedLabel = new Label { Name = "enhancement", Colour = "a2eeef", Description = "Feature request", RepositoryName = "repo" };
 
         // Act
         var result = await sut.UpdateLabelAsync("owner", "repo", "feature", updatedLabel, cancellationToken);
@@ -1438,7 +1438,8 @@ public sealed class GitHubServiceTests
             .CreateClient(GitHubService.GitHubApiClientName)
             .Returns(client);
 
-        return new GitHubService(httpClientFactory);
+        var responseCache = GitHubCachingTestSupport.CreateResponseCache();
+        return new GitHubService(httpClientFactory, responseCache);
     }
 
     private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json, string? linkHeader = null)

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/InfrastructureServiceExtensionsTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/InfrastructureServiceExtensionsTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Application.Services.Common;
 using SoloDevBoard.Infrastructure.Common;
@@ -58,6 +59,45 @@ public sealed class InfrastructureServiceExtensionsTests
 
         // Assert
         Assert.IsType<SingleUserCurrentUserContext>(currentUserContext);
+    }
+
+    [Fact]
+    public void AddInfrastructureServices_RegistersGitHubResponseCache()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder().Build();
+        var services = new ServiceCollection();
+        services.AddSingleton<IAppVersionService>(new TestAppVersionService());
+
+        // Act
+        services.AddInfrastructureServices(configuration);
+        using var serviceProvider = services.BuildServiceProvider();
+        using var scope = serviceProvider.CreateScope();
+
+        // Assert
+        Assert.NotNull(scope.ServiceProvider.GetService<Microsoft.Extensions.Caching.Memory.IMemoryCache>());
+        Assert.NotNull(scope.ServiceProvider.GetService<GitHubResponseCache>());
+    }
+
+    [Fact]
+    public void AddInfrastructureServices_InvalidGitHubCacheTtl_ThrowsOnStartup()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{GitHubCacheOptions.SectionName}:{nameof(GitHubCacheOptions.RepositoriesTtlSeconds)}"] = "-1",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IAppVersionService>(new TestAppVersionService());
+        services.AddInfrastructureServices(configuration);
+
+        // Act / Assert
+        using var serviceProvider = services.BuildServiceProvider();
+        Assert.Throws<OptionsValidationException>(
+            () => _ = serviceProvider.GetRequiredService<IOptions<GitHubCacheOptions>>().Value);
     }
 }
 


### PR DESCRIPTION
## Summary of Changes

Adds scoped in-memory caching for read-heavy GitHub catalogue API calls (repositories, labels, and milestones) in Infrastructure, with configurable TTLs and cache invalidation on label and milestone mutations. Documents new `GitHub:Cache` configuration in `docs/getting-started.md`.

## Related Issue(s)

Closes #108

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and `docs/index.md` has been updated

## Screenshots (if applicable)

N/A — infrastructure-only change.

## Additional Notes

Implements ADR-0005 caching guidance. Cache keys are scoped per authenticated user owner login.