### PR TITLE
Add implementation preflight to delivery workflow

### DIFF
--- a/.agents/contracts/delivery.md
+++ b/.agents/contracts/delivery.md
@@ -1,7 +1,7 @@
 ---
 role: Delivery
-description: Implements planned GitHub issues, creates tests, updates documentation, and prepares work for review.
-triggers: Implement issue #N; build feature X; fix bug #N
+description: Runs implementation preflight and implements planned GitHub issues, creates tests, updates documentation, and prepares work for review.
+triggers: Implement issue #N; preflight issue #N; build feature X; fix bug #N
 ---
 
 # Delivery Agent
@@ -29,6 +29,7 @@ Use after planning is complete.
 Examples:
 
 - Implement issue #123
+- Preflight issue #123
 - Build Label Manager UI
 - Fix bug #42
 - Implement issues #100 and #101
@@ -37,17 +38,64 @@ Examples:
 
 ## Responsibilities
 
-### 1. Verify Readiness
+### 1. Implementation Preflight
 
-Perform a lightweight readiness check:
+Run implementation preflight **before** creating a feature branch or writing code. This is a technical discovery phase — not a repeat of PM planning.
 
-- Issue exists
-- Issue is open
+#### Step 1: Load context
+
+- Load the issue: `gh issue view <N> --json title,body,state,labels`
+- Parse the `## Implementation References` section from the issue body
+- Load the parent issue if referenced
+- Read linked artefacts: wireframe path, test issue, feature plan doc under `plan/`, and related `DEC-NNN` entries in `plan/DECISIONS.md`
+- If `## Implementation References` is missing, fall back gracefully:
+  - Infer wireframe from `area/` label and [`plan/wireframes/README.md`](../../plan/wireframes/README.md)
+  - Load parent context from GitHub sub-issue relationships when available
+
+#### Step 2: Validate product readiness
+
+- Issue exists and is open
 - Acceptance criteria or implementation notes exist
+- For page-producing UI work (`area/*` excluding `area/infrastructure` and `area/docs`): wireframe must be linked and readable
+- For `type/enabler`: `## Implementation Notes` must exist beyond acceptance criteria alone
+- Unresolved blockers: escalate to PM Orchestrator; do not code
 
-Assume issues created via planning workflows are ready for implementation.
+Assume issues created via planning workflows are product-ready. Escalate only when a prerequisite is genuinely missing.
 
-Escalate only if implementation is genuinely blocked.
+#### Step 3: Codebase discovery
+
+Explore the feature area using the `area/` label (see [implement-issue workflow](../workflows/implement-issue.md) for path hints). Identify services, components, and tests to reuse. Produce a touch map of likely files and projects.
+
+Invoke `dotnet-best-practices` for all issues. Invoke `mudblazor` for UI work during the sketch.
+
+#### Step 4: Implementation sketch
+
+Produce a short summary:
+
+- Approach (1–3 sentences)
+- Files and projects to change (touch map)
+- Test placement (projects and scenarios; recap from linked test issue when present)
+- Risks or blockers
+
+#### Step 5: Proceed gate
+
+Present the **Preflight Complete** output (see Output Contract) before continuing.
+
+| Condition | Action |
+|-----------|--------|
+| `size/xs`, `size/s`, or `type/bug` | Auto-continue to feature branch |
+| `size/m`, `size/l`, `size/xl`, or `type/enabler` | Pause for user confirmation before coding |
+| Missing acceptance criteria, missing wireframe on page-producing UI, or unresolved blocker | Escalate; do not code |
+
+**Standalone preflight:** When invoked via `preflight-issue` workflow only, always pause after **Preflight Complete** — do not create a branch or write code.
+
+#### Preflight boundaries
+
+Do NOT during preflight:
+
+- Re-run `breakdown-plan` or PM Orchestrator planning
+- Create or update GitHub issues
+- Update `plan/SCOPE.md` or other planning documents
 
 ---
 
@@ -254,6 +302,7 @@ Escalate to the user if:
 
 Implementation is complete when:
 
+- Implementation preflight completed and proceed gate satisfied
 - Acceptance criteria are implemented
 - Build succeeds
 - Tests pass
@@ -265,7 +314,21 @@ Implementation is complete when:
 
 ## Output Contract
 
-Provide:
+After preflight, before coding, provide:
+
+```text
+Preflight Complete
+
+Issue: #123
+Context loaded: [wireframe, parent #X, test #Y, DEC-NNN]
+Touch map: [file list]
+Approach: [1-3 sentences]
+Tests: [projects + scenarios]
+Risks: [none | list]
+Proceeding: [auto | awaiting confirmation]
+```
+
+When implementation finishes, provide:
 
 ```text
 Implementation Complete

--- a/.agents/contracts/pm-orchestrator.md
+++ b/.agents/contracts/pm-orchestrator.md
@@ -59,6 +59,13 @@ Invoke this when you need to:
   - `status/todo` for new items
 - Use markdown templates from `.agents/skills/repo-github-issues/references/templates.md`
 - **Note:** Markdown templates mirror YAML issue forms (`.github/ISSUE_TEMPLATE/*.yml`) which define the canonical structure
+- Every story, enabler, and test issue body must include an `## Implementation References` section with:
+  - **Wireframe:** path under `plan/wireframes/` (for page-producing UI) or `N/A`
+  - **Parent issue:** `#N` (feature or epic)
+  - **Test issue:** `#N` or `N/A`
+  - **Related decisions:** `DEC-NNN` entries or `N/A`
+  - **Feature plan doc:** path under `plan/` or `N/A`
+- For `type/enabler` issues, include an `## Implementation Notes` section (technical approach, layers affected, dependencies)
 - Assign to current milestone if applicable
 - **Assign to `markheydon`** — all issues must be assigned at creation (see repo-github-project skill Event 1)
 - Note parent/child sub-issue hierarchy (Epic→Feature→Story/Enabler/Test) and any blocking relationships — GitHub CLI cannot set either; produce a **Manual Linking Required** table in the handoff for the user to set via the GitHub UI
@@ -118,6 +125,8 @@ When complete, this agent produces:
 ### Artefacts Created
 - GitHub issues with full metadata (labels, milestones, acceptance criteria)
 - Technical plan (Epic/Feature/Story breakdown) in issue descriptions
+- `## Implementation References` section in every story, enabler, and test issue body
+- `## Implementation Notes` section in every enabler issue body
 - Wireframe artefact in `plan/wireframes/` for any page-producing feature or page refresh
 - Test issues linked to feature issues
 - Dependency relationships established
@@ -154,7 +163,7 @@ Planning is complete when:
 - ✅ Work item selected from GitHub Issues / Project #8 and scope validated
 - ✅ Technical plan produced via `breakdown-plan`
 - ✅ Wireframe created and referenced for any page-producing feature or page refresh
-- ✅ GitHub issues created with correct labels/milestones
+- ✅ GitHub issues created with correct labels/milestones and Implementation References sections
 - ✅ Test strategy defined via `breakdown-test`
 - ✅ Dependencies and acceptance criteria documented
 - ✅ All created issues added to project board with Phase/Priority/Status/dates set

--- a/.agents/skills/_REGISTRY.md
+++ b/.agents/skills/_REGISTRY.md
@@ -35,7 +35,7 @@ Skills not listed as active or optional companion should be removed from `.agent
 SoloDevBoard defines specialised role contracts for daily PM workflows. These orchestrate skills and enforce quality gates.
 
 - `pm-orchestrator`: GitHub Issues / Project #8 selection → scope validation → technical planning (breakdown-plan) → GitHub issue setup
-- `delivery`: Implementation execution → tests → docs → decision log (if needed)
+- `delivery`: Implementation preflight → code → tests → docs → decision log (if needed)
 - `verify`: Quality validation → PR creation → issue closure → release impact assessment
 
 **Role contracts:** `.agents/contracts/*.md`  
@@ -49,7 +49,8 @@ Reusable workflows for daily PM operations (canonical definitions in `.agents/wo
 
 - `daily-start`: Morning status check → issue and project board health → blocker identification → next action recommendation
 - `plan-next-issue`: GitHub Issues / Project #8 selection → scope validation → breakdown-plan → GitHub issue creation
-- `implement-issue`: Implementation → tests → docs → decision log
+- `preflight-issue`: Implementation preflight only (context, codebase discovery, sketch) — no coding
+- `implement-issue`: Preflight → implementation → tests → docs → decision log
 - `verify-and-create-pr`: Quality gates → PR creation → issue closure
 - `address-pr-review-comments`: PR review feedback → thread replies → resolved conversations
 - `weekly-pm-review`: Milestone health → velocity trends → release confidence → top 3 priorities
@@ -61,7 +62,7 @@ Reusable workflows for daily PM operations (canonical definitions in `.agents/wo
 
 ## Tool entry points
 
-Cursor slash commands and Copilot prompts are thin discovery layers only. Example: `/implement-issue` → [`.agents/workflows/implement-issue.md`](../../.agents/workflows/implement-issue.md) → [`.agents/contracts/delivery.md`](../../.agents/contracts/delivery.md)
+Cursor slash commands and Copilot prompts are thin discovery layers only. Examples: `/preflight-issue` → [`.agents/workflows/preflight-issue.md`](../../.agents/workflows/preflight-issue.md) → [`.agents/contracts/delivery.md`](../../.agents/contracts/delivery.md); `/implement-issue` → [`.agents/workflows/implement-issue.md`](../../.agents/workflows/implement-issue.md) → [`.agents/contracts/delivery.md`](../../.agents/contracts/delivery.md)
 
 ## Canonical Sources
 

--- a/.agents/skills/repo-github-issues/references/TEMPLATE_SYNC.md
+++ b/.agents/skills/repo-github-issues/references/TEMPLATE_SYNC.md
@@ -77,9 +77,9 @@ The following **must** stay synchronised across formats:
 
 | YAML Template | Markdown Template | Key Fields | Default Labels |
 |---------------|-------------------|------------|----------------|
-| `bug.yml` | Bug Report | Description, Steps to Reproduce, Expected Behaviour, Actual Behaviour, Environment, Logs/Screenshots | `type/bug`, `priority/high` |
-| `feature.yml` | Feature/User Story | Description, User Story, Acceptance Criteria, Related Epic/Milestone, Area | `type/story` (user story), `type/feature` (feature grouping), `priority/medium`, optionally `area/*` |
-| `chore.yml` | Chore/Technical Debt | Description, Motivation/Context, Definition of Done, Area | `type/chore`, `priority/low`, optionally `area/*` |
+| `bug.yml` | Bug Report | Description, Steps to Reproduce, Expected/Actual Behaviour, Environment, Logs/Screenshots, Implementation References | `type/bug`, `priority/high` |
+| `feature.yml` | Feature/User Story | Description, User Story, Acceptance Criteria, Related Epic/Milestone, Area, Implementation References, Implementation Notes | `type/story` (user story), `type/feature` (feature grouping), `priority/medium`, optionally `area/*` |
+| `chore.yml` | Chore/Technical Debt | Description, Motivation/Context, Definition of Done, Area, Implementation References | `type/chore`, `priority/low`, optionally `area/*` |
 
 ---
 

--- a/.agents/skills/repo-github-issues/references/templates.md
+++ b/.agents/skills/repo-github-issues/references/templates.md
@@ -38,6 +38,14 @@
 
 ## Relevant Logs or Screenshots
 [Paste any relevant log output or attach screenshots]
+
+## Implementation References
+- **Wireframe:** N/A
+- **Parent issue:** N/A
+- **Test issue:** N/A
+- **Related decisions:** N/A
+- **Feature plan doc:** plan/... or N/A
+- **Failing code area:** src/... (path or feature area)
 ```
 
 **Note:** All text must be written in **UK English** (behaviour, colour, organise, etc.).
@@ -69,6 +77,16 @@
 
 ## Related Epic / Milestone
 [Which epic or milestone does this belong to? e.g. Phase 2 — Label Manager]
+
+## Implementation References
+- **Wireframe:** plan/wireframes/... or N/A
+- **Parent issue:** #N
+- **Test issue:** #N or N/A
+- **Related decisions:** DEC-NNN or N/A
+- **Feature plan doc:** plan/... or N/A
+
+## Implementation Notes
+[For `type/enabler` issues only: technical approach, layers affected, dependencies. Omit for stories.]
 
 ## Additional Context
 [Any other context, screenshots, or links relevant to this feature request]
@@ -103,6 +121,13 @@ Examples:
 
 ## Area
 [Which area of the codebase does this relate to? dashboard, migration, labels, board-rules, triage, workflows, infrastructure, docs]
+
+## Implementation References
+- **Wireframe:** N/A
+- **Parent issue:** #N
+- **Test issue:** N/A
+- **Related decisions:** DEC-NNN or N/A
+- **Feature plan doc:** plan/... or N/A
 ```
 
 **Note:** All text must be written in **UK English** (behaviour, colour, organise, etc.).
@@ -121,6 +146,13 @@ For very simple issues or quick tasks:
 - [ ] [Task 1]
 - [ ] [Task 2]
 - [ ] [Task 3]
+
+## Implementation References
+- **Wireframe:** N/A
+- **Parent issue:** #N or N/A
+- **Test issue:** N/A
+- **Related decisions:** N/A
+- **Feature plan doc:** N/A
 ```
 
 **Note:** Even simple issues should have at least `type/` and `priority/` labels applied.

--- a/.agents/skills/repo-pm-feature-workflow/SKILL.md
+++ b/.agents/skills/repo-pm-feature-workflow/SKILL.md
@@ -19,14 +19,16 @@ Run a deterministic feature workflow so the user can act as product manager whil
 4. For any feature that will result in a new page, a new major page region, or a substantive page refresh, create a wireframe in `plan/wireframes/` and update `plan/wireframes/README.md` before implementation begins.
 5. Create or update GitHub issues with `repo-github-issues` (use `repo-github-gh-cli` for bulk changes), then sync each issue to the project board with `repo-github-project` skill.
 6. Trigger quality planning with `breakdown-test`.
-7. Implement using repository standards (`dotnet-best-practices`, and `mudblazor` for UI work), with MudBlazor components and utility classes preferred over custom CSS or raw HTML.
-8. Record architectural decisions via `repo-decision-log` when introduced.
-9. Update user-facing documentation and index links.
-10. Verify completion gates and then close issue states.
+7. Run implementation preflight (load context, codebase discovery, sketch). For `size/l+` or enablers, consider standalone `preflight-issue` first.
+8. Implement using repository standards (`dotnet-best-practices`, and `mudblazor` for UI work), with MudBlazor components and utility classes preferred over custom CSS or raw HTML.
+9. Record architectural decisions via `repo-decision-log` when introduced.
+10. Update user-facing documentation and index links.
+11. Verify completion gates and then close issue states.
 
 ## Mandatory Gates
 
 - Do not code before planning artefacts and issue records are complete.
+- Do not start coding before implementation preflight completes (context loaded, touch map produced, proceed gate satisfied).
 - Do not start page-producing UI implementation until the planning wireframe exists and is referenced by the relevant issue or artefact.
 - Do not close work before tests and documentation updates are complete.
 - Any scope change must update `plan/SCOPE.md` and `plan/IMPLEMENTATION_PLAN.md`, and create or update the corresponding GitHub Issue.
@@ -34,7 +36,7 @@ Run a deterministic feature workflow so the user can act as product manager whil
 
 ## Required Artefacts Per Feature
 
-- GitHub Issue create/update + Project #8 sync
+- GitHub Issue create/update + Project #8 sync (including `## Implementation References` in issue bodies)
 - Scope update when needed: `plan/SCOPE.md`
 - Wireframe: `plan/wireframes/*.md` and `plan/wireframes/README.md` for any page-producing feature or substantive page refresh
 - Decision log when needed: `plan/DECISIONS.md`

--- a/.agents/workflows/README.md
+++ b/.agents/workflows/README.md
@@ -21,6 +21,7 @@ Orchestration, rituals, and step-by-step guidance live in [`plan/PM_RUNBOOK.md`]
 | User intent | Trigger phrases | Workflow | Contract |
 |-------------|-----------------|----------|----------|
 | Validate implementation and open PR | "Verify issue #N", "Create PR for issue #N", `/verify-and-create-pr` | `verify-and-create-pr` | `verify` |
+| Preflight before implementation | "Preflight issue #N", `/preflight-issue` | `preflight-issue` | `delivery` |
 | Audit code against conventions | "Code review PR #N", "Review PR #N for conventions", `/code-review` | `code-review` | `code-review` |
 | Weekly milestone health | "Run the weekly PM review", `/weekly-pm-review` | `weekly-pm-review` | `pm-orchestrator` |
 | Status label hygiene | "Clean up status labels", `/sync-status-labels` | `sync-status-labels` | `repo-github-gh-cli` |
@@ -33,6 +34,7 @@ Orchestration, rituals, and step-by-step guidance live in [`plan/PM_RUNBOOK.md`]
 |----------|--------------------------|----------|----------------|-----------------|
 | [daily-start](daily-start.md) | "Run the daily start workflow" | `pm-orchestrator` | `repo-github-project` (optional) | Morning Ritual |
 | [plan-next-issue](plan-next-issue.md) | "Plan the next item" | `pm-orchestrator` | `breakdown-plan`, `breakdown-test`, `repo-github-issues`, `repo-github-project` | Stage 1: Planning |
+| [preflight-issue](preflight-issue.md) | "Preflight issue #N" | `delivery` | `dotnet-best-practices`, `mudblazor` (on demand) | Stage 2: Implementation (preflight) |
 | [implement-issue](implement-issue.md) | "Implement issue #N" | `delivery` | `dotnet-best-practices`, `mudblazor`, etc. (on demand) | Stage 2: Implementation |
 | [verify-and-create-pr](verify-and-create-pr.md) | "Verify issue #N", "Create PR for issue #N" | `verify` | — | Stage 3: Verify and PR |
 | [address-pr-review-comments](address-pr-review-comments.md) | "Address PR review comments on PR #N" | `delivery` | — | PR Review Comment Loop |

--- a/.agents/workflows/implement-issue.md
+++ b/.agents/workflows/implement-issue.md
@@ -6,8 +6,26 @@
 
 ## Easy-to-miss specifics
 
-- Load the issue first: `gh issue view <N> --json title,body,state,labels`.
-- Consult skills when relevant — do not require reading every skill up front.
+- **Preflight is mandatory** and runs before the feature branch — see Implementation Preflight in the Delivery contract.
+- Load the issue first: `gh issue view <N> --json title,body,state,labels` (labels are required for the proceed gate).
+- Parse the `## Implementation References` section from the issue body.
+- For UI work, read the linked wireframe from [`plan/wireframes/`](../../plan/wireframes/).
+- Invoke `dotnet-best-practices` during preflight for all issues; invoke `mudblazor` for UI issues.
+- Apply the tiered proceed gate: auto-continue for `size/xs`, `size/s`, and `type/bug`; pause for `size/m+` and all `type/enabler` issues.
+- Consult other skills when relevant — do not require reading every skill up front.
+
+### Area label → codebase hints
+
+| `area/` label | Primary paths |
+|---------------|---------------|
+| `area/labels` | `src/App/.../Features/Labels/`, `src/Application/.../Services/Labels/`, `tests/` |
+| `area/dashboard` | `src/App/.../Features/Audit/`, `src/Application/.../Services/Audit/` |
+| `area/migration` | `src/App/.../Features/Migration/`, `src/Application/.../Services/Migration/` |
+| `area/triage` | `src/App/.../Features/Triage/`, `src/Application/.../Services/Triage/` |
+| `area/board-rules` | `src/App/.../Features/BoardRules/`, `src/Application/.../Services/BoardRules/` |
+| `area/workflows` | `src/App/.../Features/Workflows/`, `src/Application/.../Services/Workflows/` |
+| `area/infrastructure` | `src/Infrastructure/`, `src/SoloDevBoard.AppHost/` |
+| `area/docs` | `docs/`, `plan/` |
 
 ## Invocation
 

--- a/.agents/workflows/preflight-issue.md
+++ b/.agents/workflows/preflight-issue.md
@@ -1,0 +1,17 @@
+# Preflight Issue
+
+**Contract:** [`.agents/contracts/delivery.md`](../contracts/delivery.md) (Implementation Preflight section only)
+**Runbook:** [`plan/PM_RUNBOOK.md`](../../plan/PM_RUNBOOK.md) — Stage 2: Implementation (preflight sub-step)
+**Skills (on demand):** `dotnet-best-practices`, `mudblazor`
+
+## Easy-to-miss specifics
+
+- Run preflight only — do not create a feature branch or write code.
+- Follow Implementation Preflight in the Delivery contract (load context, validate readiness, codebase discovery, sketch).
+- Area label → codebase hints: see [implement-issue workflow](implement-issue.md).
+- Always pause after the **Preflight Complete** output, even for `size/xs` and `size/s` issues.
+- End with: "Ready to implement — run `/implement-issue` or 'Implement issue #N'."
+
+## Invocation
+
+Natural language: "Preflight issue #N"

--- a/.cursor/commands/preflight-issue.md
+++ b/.cursor/commands/preflight-issue.md
@@ -1,0 +1,3 @@
+# Preflight Issue
+
+Follow [`.agents/workflows/preflight-issue.md`](.agents/workflows/preflight-issue.md).

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -88,3 +88,18 @@ body:
       default: 2
     validations:
       required: false
+
+  - type: textarea
+    id: implementation-references
+    attributes:
+      label: "Implementation References"
+      description: "Links for the Delivery Agent preflight phase."
+      value: |
+        - **Wireframe:** N/A
+        - **Parent issue:** N/A
+        - **Test issue:** N/A
+        - **Related decisions:** N/A
+        - **Feature plan doc:** plan/... or N/A
+        - **Failing code area:** src/... (path or feature area)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -92,3 +92,26 @@ body:
       description: "Any other context, screenshots, or links relevant to this feature request."
     validations:
       required: false
+
+  - type: textarea
+    id: implementation-references
+    attributes:
+      label: "Implementation References"
+      description: "Links for the Delivery Agent preflight phase. Use N/A where not applicable."
+      value: |
+        - **Wireframe:** plan/wireframes/... or N/A
+        - **Parent issue:** #N
+        - **Test issue:** #N or N/A
+        - **Related decisions:** DEC-NNN or N/A
+        - **Feature plan doc:** plan/... or N/A
+    validations:
+      required: false
+
+  - type: textarea
+    id: implementation-notes
+    attributes:
+      label: "Implementation Notes"
+      description: "For enabler issues: technical approach, layers affected, and dependencies."
+      placeholder: "Required for type/enabler issues. Leave blank for stories."
+    validations:
+      required: false

--- a/.github/prompts/preflight-issue.prompt.md
+++ b/.github/prompts/preflight-issue.prompt.md
@@ -1,0 +1,6 @@
+---
+name: Preflight Issue
+description: Run implementation preflight for a planned GitHub issue without writing code.
+---
+
+Follow [`.agents/workflows/preflight-issue.md`](../../.agents/workflows/preflight-issue.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,7 @@ When code changes are made, ensure the following are kept in sync:
 - For Blazor UI work, use MudBlazor components and the official MudBlazor layout patterns first; do not reintroduce bespoke layout structures when the library already provides an equivalent.
 - Prefer MudBlazor layout primitives and utility classes in `Class` attributes for spacing, alignment, sizing, and visibility before creating or extending `.razor.css` files.
 - Treat raw HTML and custom CSS as exceptional escape hatches only. If no MudBlazor component, parameter, or utility class can satisfy the requirement, keep the fallback minimal and explain the reason in the implementation summary or PR notes.
+- When implementing a planned issue, run implementation preflight before creating a feature branch; load linked wireframes and planning artefacts from the issue body.
 - When asked to "add a feature", apply the matching tier in **When Adding a New Feature** above.
 - When reviewing a PR diff, flag any non-UK English spelling in comments or strings.
 - For infrastructure changes, edit the AppHost in `src/SoloDevBoard.AppHost` or add configuration to `src/SoloDevBoard.App`; do not create hand-authored Bicep files (Aspire generates deployment Bicep at deploy time).
@@ -212,8 +213,9 @@ Canonical skills live in [`.agents/skills/`](.agents/skills/). See [`.agents/ski
 
 1. Do not start coding before planning and issue creation are complete.
 2. For page-producing UI work, do not start implementation before the planning wireframe exists in `plan/wireframes/` and is referenced by the relevant planning artefacts or issues.
-3. Do not close feature work before tests and documentation updates are complete.
-4. Scope-impacting changes must update `plan/SCOPE.md` and `plan/IMPLEMENTATION_PLAN.md` (via Tech Writer agent). New or changed work items must be created or updated as GitHub Issues and synced to Project #8.
+3. Do not start coding during `implement-issue` before implementation preflight completes (context loaded, touch map produced, proceed gate satisfied).
+4. Do not close feature work before tests and documentation updates are complete.
+5. Scope-impacting changes must update `plan/SCOPE.md` and `plan/IMPLEMENTATION_PLAN.md` (via Tech Writer agent). New or changed work items must be created or updated as GitHub Issues and synced to Project #8.
 
 ### PM operating system
 

--- a/plan/PM_RUNBOOK.md
+++ b/plan/PM_RUNBOOK.md
@@ -12,7 +12,8 @@ This runbook orchestrates [`.agents/contracts/`](../.agents/contracts/) and [`.a
 |------------------------------------------|------------------------------------------------------------|-----------------------------------------------|
 | Start your day                           | "Run the daily start workflow" or `/daily-start`           | Status summary + next action recommendation   |
 | Plan the next feature                    | "Plan the next item" or `/plan-next-issue`                 | GitHub issues with full metadata + tech spec  |
-| Implement planned work                   | "Implement issue #N" or `/implement-issue`                 | Code + tests + docs + ADR (if needed)         |
+| Implement planned work                   | "Implement issue #N" or `/implement-issue`                 | Preflight + code + tests + docs + decision log (if needed) |
+| Preflight before implementation          | "Preflight issue #N" or `/preflight-issue`                  | Context, touch map, approach sketch (no code)              |
 | Verify and create PR                     | "Verify issue #N", "Create PR for issue #N", or `/verify-and-create-pr` | PR + quality validation + issue closure       |
 | Address PR review comments               | "Address PR review comments on PR #N" or `/address-pr-review-comments` | PR fixes + thread replies + resolved comments |
 | Weekly health check                      | "Run the weekly PM review" or `/weekly-pm-review`            | Executive summary + priorities for next week  |
@@ -117,6 +118,16 @@ Plan the [feature name]
 #### Stage 2: Implementation (2-8 hours per feature, varies by size)
 **Trigger:** Planning complete, issues have `status/todo` label.
 
+**Run (preflight only — optional, recommended for `size/l+` or enablers):**
+```
+Preflight issue #[number]
+```
+
+**Run (Cursor preflight):**
+```
+/preflight-issue [number]
+```
+
 **Run (prompt or natural language):**
 ```
 Implement issue #[number]
@@ -129,10 +140,11 @@ Implement issue #[number]
 
 **What it does:**
 - Invokes the **Delivery** contract ([`.agents/contracts/delivery.md`](../.agents/contracts/delivery.md))
+- Runs **implementation preflight** before coding (load context, codebase discovery, touch map, proceed gate)
 - Writes code following layered architecture (Domain/Application/Infrastructure/App)
 - Creates xUnit v3 tests (NSubstitute, `Assert.*`, correct naming)
 - Updates user-facing docs in `docs/user-guide/` if needed
-- Creates ADR in `adr/` if architectural decision made
+- Records architectural decisions via `repo-decision-log` / `plan/DECISIONS.md` when needed (do not create new `adr/` files)
 - Ensures UK English throughout
 
 **Board expectation before coding starts:**
@@ -141,19 +153,21 @@ Implement issue #[number]
 - Starting work also stamps **Start Date** and the current size-based **Target Date** forecast on the roadmap item.
 - Untouched sibling items stay blank until they actually start.
 
-**Note:** The `/implement-issue` command focuses on code, tests, and docs. Update project board fields and issue labels in a separate planning or board-sync step when needed.
+**Note:** The `/implement-issue` command runs preflight, then code, tests, and docs. Update project board fields and issue labels in a separate planning or board-sync step when needed.
 
 **What you produce:**
+- Preflight summary (context loaded, touch map, approach) before coding begins
 - Source code in `src/` (compiles, follows conventions)
 - Test code in `tests/` (passes, full coverage)
-- Documentation updates (user guides, ADRs, XML comments)
+- Documentation updates (user guides, decision log entries, XML comments)
 
 **Gates before proceeding:**
+- ✅ Implementation preflight completed and proceed gate satisfied
 - ✅ All acceptance criteria met
 - ✅ Code compiles, zero errors/warnings
 - ✅ Tests pass locally (`dotnet test`)
 - ✅ Docs updated (if user-facing feature)
-- ✅ ADR created (if architectural decision)
+- ✅ Decision log updated (if architectural decision)
 - ✅ UK English verified
 
 **Next action:** Move to Stage 3 (Review).
@@ -329,7 +343,8 @@ START
   │   └─> Run daily start workflow → Follow recommendation
   │
   ├─ Have planned issue ready for coding?
-  │   └─> `/implement-issue` or "Implement issue #N"
+  │   ├─> Large or enabler? → `/preflight-issue` or "Preflight issue #N" (optional)
+  │   └─> `/implement-issue` or "Implement issue #N" (runs preflight, then codes)
   │
   ├─ Have implemented code ready for review?
   │   └─> `/verify-and-create-pr` or "Verify issue #N"
@@ -376,13 +391,14 @@ START
 ---
 
 ### Delivery ([`.agents/contracts/delivery.md`](../.agents/contracts/delivery.md))
-**Trigger:** "Implement issue #X", "Build feature X"
+**Trigger:** "Implement issue #X", "Preflight issue #X", "Build feature X"
 
 **Responsibilities:**
+- Runs implementation preflight (context, codebase discovery, touch map, proceed gate)
 - Implements code (Domain/Application/Infrastructure/App layers)
 - Creates xUnit v3 tests (NSubstitute, `Assert.*`)
 - Updates user-facing docs
-- Creates ADRs for architectural decisions
+- Records architectural decisions via `repo-decision-log` / `plan/DECISIONS.md`
 - Ensures UK English throughout
 - Hands off to Verify Agent when complete
 
@@ -418,6 +434,7 @@ Canonical workflow definitions live in [`.agents/workflows/`](../.agents/workflo
 |----------|----------------|----------------|
 | Daily start | [`daily-start.md`](../.agents/workflows/daily-start.md) | `/daily-start` |
 | Plan next issue | [`plan-next-issue.md`](../.agents/workflows/plan-next-issue.md) | `/plan-next-issue` |
+| Preflight issue | [`preflight-issue.md`](../.agents/workflows/preflight-issue.md) | `/preflight-issue` |
 | Implement issue | [`implement-issue.md`](../.agents/workflows/implement-issue.md) | `/implement-issue` |
 | Verify and create PR | [`verify-and-create-pr.md`](../.agents/workflows/verify-and-create-pr.md) | `/verify-and-create-pr` |
 | Address PR review comments | [`address-pr-review-comments.md`](../.agents/workflows/address-pr-review-comments.md) | `/address-pr-review-comments` |
@@ -439,12 +456,16 @@ These gates are defined in [`AGENTS.md`](../AGENTS.md) and enforced by role cont
 - ✅ GitHub issues created with labels/milestones
 - ✅ Test strategy defined
 
+### Before Coding (Delivery Agent enforces)
+- ✅ Implementation preflight completed (context loaded, touch map produced, proceed gate satisfied)
+- ✅ Linked wireframe read for page-producing UI work
+
 ### Before PR Creation (Delivery Agent enforces)
 - ✅ All acceptance criteria met
 - ✅ Code compiles, zero errors/warnings
 - ✅ Tests pass locally
 - ✅ Documentation updated (if user-facing)
-- ✅ ADR created (if architectural decision)
+- ✅ Decision log updated via `repo-decision-log` (if architectural decision)
 - ✅ UK English verified
 - ✅ Roadmap item moved to **In Progress** with Start Date and Target Date recorded
 
@@ -472,8 +493,8 @@ These gates are defined in [`AGENTS.md`](../AGENTS.md) and enforced by role cont
 | `tests/` (test code)                  | Delivery Agent           | Implementation                        |
 | `docs/user-guide/` (user docs)        | Delivery Agent           | User-facing features                  |
 | `docs/index.md` (quick links)         | Delivery Agent           | New doc pages added                   |
-| `adr/` (architectural decisions)      | Delivery Agent           | Architectural decisions               |
-| `plan/DECISIONS.md`                   | Delivery Agent           | New decision recorded                 |
+| `adr/` (archived decisions)           | —                        | Historical reference only             |
+| `plan/DECISIONS.md`                   | Delivery Agent           | New decision recorded via `repo-decision-log` |
 
 ---
 
@@ -493,7 +514,7 @@ These gates are defined in [`AGENTS.md`](../AGENTS.md) and enforced by role cont
 **Action:**
 1. Delivery Agent flags issue and pauses
 2. **If scope change:** Update `plan/SCOPE.md`, re-run PM Orchestrator
-3. **If architectural decision:** Document decision, create ADR, resume
+3. **If architectural decision:** Record via `repo-decision-log` in `plan/DECISIONS.md`, resume
 4. **If technical blocker:** Document in issue comments, add `status/blocked` label, escalate to you
 
 ---
@@ -616,11 +637,12 @@ Plan next item for Phase 1
 - [ ] I run `daily-start` every morning to get oriented
 - [ ] I use `plan-next-issue` to create technical specs before coding
 - [ ] I use `implement-issue` (workflow prompt or `/implement-issue`) only for planned issues with clear acceptance criteria
+- [ ] `implement-issue` runs preflight before coding; I use `/preflight-issue` first for large items or enablers when I want to review the approach
 - [ ] I use `verify-and-create-pr` to validate quality before PR merge
 - [ ] I run `weekly-pm-review` at least once per week
 - [ ] All my GitHub issues have labels per `plan/LABEL_STRATEGY.md`
 - [ ] All user-facing features have docs in `docs/user-guide/`
-- [ ] All architectural decisions have ADRs in `adr/`
+- [ ] All architectural decisions are recorded in `plan/DECISIONS.md` via `repo-decision-log`
 - [ ] I create or update GitHub Issues when new work is discovered
 - [ ] I update `plan/SCOPE.md` when scope changes
 - [ ] I approve and merge PRs manually (agents don't auto-merge)
@@ -643,6 +665,7 @@ Plan next item for [milestone]
 
 **Implementation:**
 ```
+Preflight issue #[number]
 Implement issue #[number]
 Build [feature name]
 ```


### PR DESCRIPTION
## Summary of Changes

Introduces a mandatory **implementation preflight** phase to the Delivery contract so agents load issue context, wireframes, and codebase touch maps before coding. Adds a standalone `/preflight-issue` workflow, strengthens PM planning handoff with `## Implementation References` in issue templates, and aligns the PM runbook and `AGENTS.md` execution gates.

## Related Issue(s)

Process improvement — no linked GitHub issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`) — not applicable; documentation and workflow changes only
- [x] I have added or updated tests to cover my changes — not applicable
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced — not applicable
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and `docs/index.md` has been updated — not applicable; agent workflow improvement

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- `/implement-issue` now runs preflight before the feature branch; `/preflight-issue` runs preflight only and always pauses for review.
- Tiered proceed gate: auto-continue for `size/xs`, `size/s`, and bugs; pause for `size/m+` and all enablers.
- Corrects PM runbook references from new `adr/` files to `repo-decision-log` / `plan/DECISIONS.md`.

## Test plan

- [x] Confirm `.agents/contracts/delivery.md` defines the five preflight steps and `Preflight Complete` output contract.
- [x] Confirm `/preflight-issue` thin mirrors point to `.agents/workflows/preflight-issue.md`.
- [x] Confirm issue templates include `Implementation References` and sync notes in `TEMPLATE_SYNC.md`.
- [x] Confirm `plan/PM_RUNBOOK.md` Stage 2 documents preflight and `/preflight-issue`.

Made with [Cursor](https://cursor.com)