### PR TITLE
Add operational hardening test coverage for #110.

### DIFF
--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -36,7 +36,7 @@ For historical backlog content (pre-migration), see [archive/BACKLOG-2026-07-18.
 
 Phases 1–4 delivered foundation, Label Manager, Audit Dashboard, One-Click Migration (labels + milestones), Triage UI, Board Rules Visualiser, and built-in Workflow Templates. Deferred follow-on slices (label consistency warnings, project board migration, custom template repos, Audit Dashboard polish) are tracked under [#289](https://github.com/markheydon/solo-dev-board/issues/289) and child issues.
 
-Phase 6 (v1.0.0) remaining work is tracked on the [v1.0.0 milestone](https://github.com/markheydon/solo-dev-board/milestone/4), including issues [#106](https://github.com/markheydon/solo-dev-board/issues/106)–[#108](https://github.com/markheydon/solo-dev-board/issues/108), [#110](https://github.com/markheydon/solo-dev-board/issues/110), and [#247](https://github.com/markheydon/solo-dev-board/issues/247)–[#259](https://github.com/markheydon/solo-dev-board/issues/259).
+Phase 6 (v1.0.0) remaining work is tracked on the [v1.0.0 milestone](https://github.com/markheydon/solo-dev-board/milestone/4), including issues [#110](https://github.com/markheydon/solo-dev-board/issues/110), [#247](https://github.com/markheydon/solo-dev-board/issues/247)–[#259](https://github.com/markheydon/solo-dev-board/issues/259). Operational hardening test coverage expectations are documented in [OPERATIONAL_HARDENING_TEST_COVERAGE.md](OPERATIONAL_HARDENING_TEST_COVERAGE.md).
 
 ### V1 auth polish (Epic #101 follow-on)
 

--- a/plan/DECISIONS.md
+++ b/plan/DECISIONS.md
@@ -178,6 +178,8 @@ A formal migration to GitHub Spec Kit is planned — see [`plan/SPEC_KIT_MIGRATI
 **Legacy:** [ADR-0005](../adr/archive/0005-github-api-strategy.md)  
 **Summary:** Cache read-heavy GitHub catalogue responses (repositories, labels, milestones) in Infrastructure using scoped `IMemoryCache` keys tied to the current user's owner login. Invalidate label and milestone catalogue entries on corresponding CRUD mutations. Reject Application-layer DTO caching, distributed cache for this tranche, and caching issues, pull requests, workflow runs, or GraphQL project board queries until a follow-up performance pass.
 
+Test coverage expectations for cache-hit, cache-miss, invalidation, TTL expiry, and configuration validation are documented in [OPERATIONAL_HARDENING_TEST_COVERAGE.md](OPERATIONAL_HARDENING_TEST_COVERAGE.md).
+
 ---
 
 ## Superseded legacy (archive only)

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -222,6 +222,7 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Add health check endpoints for Azure Container Apps monitoring. _(#106 — readiness `/health`, liveness `/alive`, ACA probe via AppHost `WithHttpHealthCheck`)_
 - [x] Implement response caching for GitHub API calls to respect rate limits. _(#108)_
 - [x] Configure structured logging and Application Insights telemetry. _(#107)_
+- [ ] Add operational hardening test coverage and validation expectations. _(#110; see plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md.)_
 - [x] Set up Dependabot for automated dependency updates. _(#109)_
 - [ ] Formalise and document PAT-only local trusted mode and self-hoster deployment path. _(#247, #248)_
 - [x] Dedicated unauthenticated landing page for hosted deployments. _(#249)_

--- a/plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md
+++ b/plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md
@@ -1,0 +1,79 @@
+# Operational Hardening Test Coverage
+
+This document defines the automated validation expectations for the production-readiness operational hardening tranche delivered in issues [#106](https://github.com/markheydon/solo-dev-board/issues/106)–[#108](https://github.com/markheydon/solo-dev-board/issues/108) and tracked by test issue [#110](https://github.com/markheydon/solo-dev-board/issues/110).
+
+The scope covers response caching, health endpoints and hosting probes, structured logging and telemetry redaction, and proportionate CI validation. It deliberately excludes the separate authentication tranche (see [HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md](HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md) for issue [#114](https://github.com/markheydon/solo-dev-board/issues/114)).
+
+---
+
+## Test Coverage Expectations (Issue #110)
+
+### GitHub API response caching ([#108](https://github.com/markheydon/solo-dev-board/issues/108), [DEC-018](DECISIONS.md#dec-018-github-api-response-caching-in-infrastructure))
+
+| Scenario | Test layer | Location |
+|---|---|---|
+| Cache hit on repeated read-heavy catalogue calls (repositories, labels, milestones) | Unit (mocked HTTP) | `tests/Infrastructure.Tests/.../GitHubApiCachingTests.cs` |
+| Cache key scoping by current user owner login | Unit | `GitHubApiCachingTests.cs`, `GitHubResponseCacheTests.cs` |
+| Case-insensitive owner/repo key normalisation | Unit | `GitHubApiCachingTests.cs` |
+| Defensive copy of cached catalogues returned to callers | Unit | `GitHubApiCachingTests.cs`, `GitHubResponseCacheTests.cs` |
+| Shared cache key between repository and service collaborators | Unit | `GitHubApiCachingTests.cs` |
+| Label and milestone catalogue invalidation after create, update, and delete mutations | Unit | `GitHubApiCachingTests.cs`, `GitHubResponseCacheTests.cs` |
+| TTL expiry and refetch after configured lifetime (labels and milestones) | Unit | `GitHubResponseCacheTests.cs` |
+| Invalid TTL configuration rejected at startup | Unit | `GitHubCacheOptionsValidatorTests.cs`, `InfrastructureServiceExtensionsTests.cs` |
+| `GitHubResponseCache` registered in DI composition root | Unit | `InfrastructureServiceExtensionsTests.cs` |
+
+Out of scope for this tranche: caching issues, pull requests, workflow runs, GraphQL project board queries, distributed cache, and Application-layer DTO caching (see DEC-018).
+
+### Health checks and hosting configuration ([#106](https://github.com/markheydon/solo-dev-board/issues/106))
+
+| Scenario | Test layer | Location |
+|---|---|---|
+| Readiness (`/health`) and liveness (`/alive`) endpoints return healthy in Development and Production | Unit (in-process host) | `tests/ServiceDefaults.Tests/.../HealthEndpointTests.cs` |
+| Liveness excludes non-`live` health checks while readiness includes all checks | Unit | `HealthEndpointTests.cs` |
+| GitHub PAT connectivity health check: valid PAT, invalid PAT, E2E placeholder skip | Unit | `tests/Infrastructure.Tests/.../GitHubPatConnectivityHealthCheckTests.cs` |
+| Hosted sign-in mode skips PAT connectivity probe | Unit | `GitHubPatConnectivityHealthCheckTests.cs` |
+| Health endpoints bypass hosted admission control middleware | Unit | `HostedAdmissionControlMiddlewareTests.cs` |
+| E2E smoke: `/health` returns `Healthy` before browser tests run | E2E | `tests/E2E/tests/smoke.spec.ts`, `.github/workflows/ci.yml` |
+
+Hosting probe wiring (`.WithHttpHealthCheck("/health")` on the AppHost `app` resource) is validated by manual deploy verification and operator documentation in [docs/deployment.md](../docs/deployment.md). AppHost orchestration modelling is not unit-tested per repository policy.
+
+`/health/github` is registered in `SoloDevBoard.App` for optional PAT connectivity monitoring. It is excluded from the default Azure Container Apps readiness probe so external GitHub outages do not trigger container restarts.
+
+### Structured logging and telemetry ([#107](https://github.com/markheydon/solo-dev-board/issues/107))
+
+| Scenario | Test layer | Location |
+|---|---|---|
+| OAuth callback URL query-string redaction | Unit | `tests/ServiceDefaults.Tests/.../TelemetryRedactionTests.cs` |
+| Sensitive HTTP header tag stripping on spans | Unit | `TelemetryRedactionTests.cs` |
+| Non-development environments configure JSON console logging | Unit | `StructuredLoggingConfigurationTests.cs` |
+
+Exporter selection (OTLP for local Aspire, Application Insights when `APPLICATIONINSIGHTS_CONNECTION_STRING` is present) is configuration-driven and verified operationally after deploy. See [docs/user-guide/observability.md](../docs/user-guide/observability.md).
+
+Health endpoint tracing exclusion is implemented in `SoloDevBoard.ServiceDefaults` and documented in the observability guide; it is not duplicated with brittle instrumentation assertions in unit tests.
+
+---
+
+## CI and Workflow Validation
+
+The following automated checks are proportionate to current repository tooling and delivery cost:
+
+| Check | Workflow / artefact | Purpose |
+|---|---|---|
+| `dotnet build` and `dotnet test` on every PR and push to `main` | `.github/workflows/ci.yml` (`build-and-test` job) | Regression gate for all unit and component tests, including operational hardening coverage above. |
+| `dotnet format --verify-no-changes` | `ci.yml` | Prevents formatting drift in test and production code. |
+| E2E job waits for `GET /health` before Playwright suite | `ci.yml` (`e2e` job) | Confirms the app host starts and readiness endpoint responds in a realistic PAT-mode configuration. |
+| Playwright smoke test for `/health` | `tests/E2E/tests/smoke.spec.ts` | Lightweight post-startup health assertion in the browser test harness. |
+
+Not automated in CI (manual or deploy-time verification only):
+
+- Azure Container Apps probe configuration in the live subscription.
+- Application Insights telemetry ingestion after `aspire deploy`.
+- GitHub API rate-limit behaviour under production load.
+
+---
+
+## Related Decisions and Documentation
+
+- [DEC-018: GitHub API response caching in Infrastructure](DECISIONS.md#dec-018-github-api-response-caching-in-infrastructure)
+- [Deployment — Health checks and Container Apps probes](../docs/deployment.md#health-checks-and-container-apps-probes)
+- [Observability and Telemetry](../docs/user-guide/observability.md)

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubApiCachingTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubApiCachingTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using NSubstitute;
 using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Domain.Entities.Milestones;
 using SoloDevBoard.Infrastructure.GitHub;
 using SoloDevBoard.Infrastructure.Labels;
 using SoloDevBoard.Infrastructure.Milestones;
@@ -328,6 +329,289 @@ public sealed class GitHubApiCachingTests
         Assert.Equal(3, handler.Requests.Count);
         Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
         Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
+        Assert.Equal(HttpMethod.Get, handler.Requests[2].Method);
+    }
+
+    [Fact]
+    public async Task UpdateLabelAsync_AfterCachedGetLabels_RefetchesLabelsOnNextRead()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "name": "enhancement",
+                    "color": "a2eeef",
+                    "description": null
+                  }
+                ]
+                """),
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                {
+                  "name": "enhancement",
+                  "color": "1d76db",
+                  "description": "Updated description"
+                }
+                """),
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "name": "enhancement",
+                    "color": "1d76db",
+                    "description": "Updated description"
+                  }
+                ]
+                """),
+        ]);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var currentUserContext = GitHubCachingTestSupport.CreateCurrentUserContext();
+        var responseCache = GitHubCachingTestSupport.CreateResponseCache(memoryCache, currentUserContext);
+        var sut = CreateLabelRepository(handler, responseCache, currentUserContext);
+
+        // Act
+        await sut.GetLabelsAsync("owner", "repo", cancellationToken);
+        await sut.UpdateLabelAsync(
+            "owner",
+            "repo",
+            "enhancement",
+            new Label { Name = "enhancement", Colour = "1d76db", Description = "Updated description" },
+            cancellationToken);
+        var refreshed = await sut.GetLabelsAsync("owner", "repo", cancellationToken);
+
+        // Assert
+        Assert.Single(refreshed);
+        Assert.Equal("Updated description", refreshed[0].Description);
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+        Assert.Equal(HttpMethod.Patch, handler.Requests[1].Method);
+        Assert.Equal(HttpMethod.Get, handler.Requests[2].Method);
+    }
+
+    [Fact]
+    public async Task DeleteLabelAsync_AfterCachedGetLabels_RefetchesLabelsOnNextRead()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "name": "enhancement",
+                    "color": "a2eeef",
+                    "description": null
+                  }
+                ]
+                """),
+            new HttpResponseMessage(HttpStatusCode.NoContent),
+            CreateJsonResponse(HttpStatusCode.OK, "[]"),
+        ]);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var currentUserContext = GitHubCachingTestSupport.CreateCurrentUserContext();
+        var responseCache = GitHubCachingTestSupport.CreateResponseCache(memoryCache, currentUserContext);
+        var sut = CreateLabelRepository(handler, responseCache, currentUserContext);
+
+        // Act
+        await sut.GetLabelsAsync("owner", "repo", cancellationToken);
+        await sut.DeleteLabelAsync("owner", "repo", "enhancement", cancellationToken);
+        var refreshed = await sut.GetLabelsAsync("owner", "repo", cancellationToken);
+
+        // Assert
+        Assert.Empty(refreshed);
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+        Assert.Equal(HttpMethod.Delete, handler.Requests[1].Method);
+        Assert.Equal(HttpMethod.Get, handler.Requests[2].Method);
+    }
+
+    [Fact]
+    public async Task CreateMilestoneAsync_AfterCachedGetMilestones_RefetchesMilestonesOnNextRead()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "id": 123,
+                    "number": 7,
+                    "title": "Sprint 7",
+                    "description": "Milestone description",
+                    "state": "open",
+                    "due_on": null,
+                    "open_issues": 2,
+                    "closed_issues": 5
+                  }
+                ]
+                """),
+            CreateJsonResponse(
+                HttpStatusCode.Created,
+                """
+                {
+                  "id": 124,
+                  "number": 8,
+                  "title": "Sprint 8",
+                  "description": "Next sprint",
+                  "state": "open",
+                  "due_on": null,
+                  "open_issues": 0,
+                  "closed_issues": 0
+                }
+                """),
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "id": 123,
+                    "number": 7,
+                    "title": "Sprint 7",
+                    "description": "Milestone description",
+                    "state": "open",
+                    "due_on": null,
+                    "open_issues": 2,
+                    "closed_issues": 5
+                  },
+                  {
+                    "id": 124,
+                    "number": 8,
+                    "title": "Sprint 8",
+                    "description": "Next sprint",
+                    "state": "open",
+                    "due_on": null,
+                    "open_issues": 0,
+                    "closed_issues": 0
+                  }
+                ]
+                """),
+        ]);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var currentUserContext = GitHubCachingTestSupport.CreateCurrentUserContext();
+        var responseCache = GitHubCachingTestSupport.CreateResponseCache(memoryCache, currentUserContext);
+        var sut = CreateMilestoneRepository(handler, responseCache, currentUserContext);
+
+        // Act
+        await sut.GetMilestonesAsync("owner", "repo", cancellationToken);
+        await sut.CreateMilestoneAsync(
+            "owner",
+            "repo",
+            new Milestone
+            {
+                Title = "Sprint 8",
+                Description = "Next sprint",
+                State = "open",
+            },
+            cancellationToken);
+        var refreshed = await sut.GetMilestonesAsync("owner", "repo", cancellationToken);
+
+        // Assert
+        Assert.Equal(2, refreshed.Count);
+        Assert.Equal("Sprint 8", refreshed[1].Title);
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+        Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
+        Assert.Equal(HttpMethod.Get, handler.Requests[2].Method);
+    }
+
+    [Fact]
+    public async Task UpdateMilestoneAsync_AfterCachedGetMilestones_RefetchesMilestonesOnNextRead()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "id": 123,
+                    "number": 7,
+                    "title": "Sprint 7",
+                    "description": "Milestone description",
+                    "state": "open",
+                    "due_on": null,
+                    "open_issues": 2,
+                    "closed_issues": 5
+                  }
+                ]
+                """),
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                {
+                  "id": 123,
+                  "number": 7,
+                  "title": "Sprint 7",
+                  "description": "Updated description",
+                  "state": "open",
+                  "due_on": null,
+                  "open_issues": 2,
+                  "closed_issues": 5
+                }
+                """),
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "id": 123,
+                    "number": 7,
+                    "title": "Sprint 7",
+                    "description": "Updated description",
+                    "state": "open",
+                    "due_on": null,
+                    "open_issues": 2,
+                    "closed_issues": 5
+                  }
+                ]
+                """),
+        ]);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var currentUserContext = GitHubCachingTestSupport.CreateCurrentUserContext();
+        var responseCache = GitHubCachingTestSupport.CreateResponseCache(memoryCache, currentUserContext);
+        var sut = CreateMilestoneRepository(handler, responseCache, currentUserContext);
+
+        // Act
+        await sut.GetMilestonesAsync("owner", "repo", cancellationToken);
+        await sut.UpdateMilestoneAsync(
+            "owner",
+            "repo",
+            7,
+            new Milestone
+            {
+                Id = 123,
+                Number = 7,
+                Title = "Sprint 7",
+                Description = "Updated description",
+                State = "open",
+            },
+            cancellationToken);
+        var refreshed = await sut.GetMilestonesAsync("owner", "repo", cancellationToken);
+
+        // Assert
+        Assert.Single(refreshed);
+        Assert.Equal("Updated description", refreshed[0].Description);
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+        Assert.Equal(HttpMethod.Patch, handler.Requests[1].Method);
         Assert.Equal(HttpMethod.Get, handler.Requests[2].Method);
     }
 

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubPatConnectivityHealthCheckTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubPatConnectivityHealthCheckTests.cs
@@ -59,6 +59,29 @@ public sealed class GitHubPatConnectivityHealthCheckTests
     }
 
     [Fact]
+    public async Task CheckHealthAsync_HostedSignInEnabled_ReturnsHealthyWithoutProbe()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        var handler = new StubHttpMessageHandler(static (_, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)));
+
+        var resolver = CreateResolver(handler);
+        var healthCheck = new GitHubPatConnectivityHealthCheck(
+            Options.Create(new GitHubAuthOptions
+            {
+                HostedSignInEnabled = true,
+                PersonalAccessToken = "ghp_test",
+            }),
+            resolver);
+
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext(), cancellationToken);
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+        Assert.Contains("Hosted sign-in", result.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task CheckHealthAsync_InvalidPat_ReturnsUnhealthy()
     {
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubResponseCacheTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubResponseCacheTests.cs
@@ -1,0 +1,205 @@
+using Microsoft.Extensions.Caching.Memory;
+using SoloDevBoard.Infrastructure.GitHub;
+
+namespace SoloDevBoard.Infrastructure.Tests;
+
+/// <summary>Unit tests for <see cref="GitHubResponseCache"/> cache key scoping, invalidation, and TTL behaviour.</summary>
+public sealed class GitHubResponseCacheTests
+{
+    [Fact]
+    public async Task GetOrCreateLabelsAsync_CalledTwice_ReturnsDefensiveCopies()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        var sut = GitHubCachingTestSupport.CreateResponseCache();
+        var factoryCalls = 0;
+
+        var first = await sut.GetOrCreateLabelsAsync(
+            "owner",
+            "repo",
+            _ =>
+            {
+                factoryCalls++;
+                return Task.FromResult<IReadOnlyList<string>>(["alpha"]);
+            },
+            cancellationToken);
+
+        var second = await sut.GetOrCreateLabelsAsync<string>(
+            "owner",
+            "repo",
+            static _ => throw new InvalidOperationException("Factory should not run on cache hit."),
+            cancellationToken);
+
+        Assert.NotSame(first, second);
+        Assert.Equal(["alpha"], first);
+        Assert.Equal(["alpha"], second);
+        Assert.Equal(1, factoryCalls);
+    }
+
+    [Fact]
+    public async Task GetOrCreateLabelsAsync_DifferentUsers_DoNotShareCache()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var userACache = GitHubCachingTestSupport.CreateResponseCache(
+            memoryCache,
+            GitHubCachingTestSupport.CreateCurrentUserContext("user-a"));
+        var userBCache = GitHubCachingTestSupport.CreateResponseCache(
+            memoryCache,
+            GitHubCachingTestSupport.CreateCurrentUserContext("user-b"));
+
+        var userAValues = await userACache.GetOrCreateLabelsAsync(
+            "owner",
+            "repo",
+            _ => Task.FromResult<IReadOnlyList<string>>(["user-a"]),
+            cancellationToken);
+
+        var userBValues = await userBCache.GetOrCreateLabelsAsync(
+            "owner",
+            "repo",
+            _ => Task.FromResult<IReadOnlyList<string>>(["user-b"]),
+            cancellationToken);
+
+        Assert.Equal(["user-a"], userAValues);
+        Assert.Equal(["user-b"], userBValues);
+    }
+
+    [Fact]
+    public async Task InvalidateLabels_RemovesCachedEntry_NextCallRefetches()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        var sut = GitHubCachingTestSupport.CreateResponseCache();
+        var factoryCalls = 0;
+
+        await sut.GetOrCreateLabelsAsync(
+            "owner",
+            "repo",
+            _ =>
+            {
+                factoryCalls++;
+                return Task.FromResult<IReadOnlyList<string>>(["before"]);
+            },
+            cancellationToken);
+
+        sut.InvalidateLabels("owner", "repo");
+
+        var refreshed = await sut.GetOrCreateLabelsAsync(
+            "owner",
+            "repo",
+            _ =>
+            {
+                factoryCalls++;
+                return Task.FromResult<IReadOnlyList<string>>(["after"]);
+            },
+            cancellationToken);
+
+        Assert.Equal(["after"], refreshed);
+        Assert.Equal(2, factoryCalls);
+    }
+
+    [Fact]
+    public async Task InvalidateMilestones_RemovesCachedEntry_NextCallRefetches()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        var sut = GitHubCachingTestSupport.CreateResponseCache();
+        var factoryCalls = 0;
+
+        await sut.GetOrCreateMilestonesAsync(
+            "owner",
+            "repo",
+            _ =>
+            {
+                factoryCalls++;
+                return Task.FromResult<IReadOnlyList<string>>(["before"]);
+            },
+            cancellationToken);
+
+        sut.InvalidateMilestones("owner", "repo");
+
+        var refreshed = await sut.GetOrCreateMilestonesAsync(
+            "owner",
+            "repo",
+            _ =>
+            {
+                factoryCalls++;
+                return Task.FromResult<IReadOnlyList<string>>(["after"]);
+            },
+            cancellationToken);
+
+        Assert.Equal(["after"], refreshed);
+        Assert.Equal(2, factoryCalls);
+    }
+
+    [Fact]
+    public async Task GetOrCreateLabelsAsync_AfterTtlExpires_RefetchesFromFactory()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        var sut = GitHubCachingTestSupport.CreateResponseCache(
+            options: new GitHubCacheOptions { LabelsTtlSeconds = 1 });
+        var factoryCalls = 0;
+
+        await sut.GetOrCreateLabelsAsync(
+            "owner",
+            "repo",
+            _ =>
+            {
+                factoryCalls++;
+                return Task.FromResult<IReadOnlyList<string>>(["first"]);
+            },
+            cancellationToken);
+
+        await Task.Delay(TimeSpan.FromMilliseconds(1_100), cancellationToken);
+
+        var refreshed = await sut.GetOrCreateLabelsAsync(
+            "owner",
+            "repo",
+            _ =>
+            {
+                factoryCalls++;
+                return Task.FromResult<IReadOnlyList<string>>(["second"]);
+            },
+            cancellationToken);
+
+        Assert.Equal(["second"], refreshed);
+        Assert.Equal(2, factoryCalls);
+    }
+
+    [Fact]
+    public async Task GetOrCreateMilestonesAsync_AfterTtlExpires_RefetchesFromFactory()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        var sut = GitHubCachingTestSupport.CreateResponseCache(
+            options: new GitHubCacheOptions { MilestonesTtlSeconds = 1 });
+        var factoryCalls = 0;
+
+        await sut.GetOrCreateMilestonesAsync(
+            "owner",
+            "repo",
+            _ =>
+            {
+                factoryCalls++;
+                return Task.FromResult<IReadOnlyList<string>>(["first"]);
+            },
+            cancellationToken);
+
+        await Task.Delay(TimeSpan.FromMilliseconds(1_100), cancellationToken);
+
+        var refreshed = await sut.GetOrCreateMilestonesAsync(
+            "owner",
+            "repo",
+            _ =>
+            {
+                factoryCalls++;
+                return Task.FromResult<IReadOnlyList<string>>(["second"]);
+            },
+            cancellationToken);
+
+        Assert.Equal(["second"], refreshed);
+        Assert.Equal(2, factoryCalls);
+    }
+}

--- a/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/HealthEndpointTests.cs
+++ b/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/HealthEndpointTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 
 namespace SoloDevBoard.ServiceDefaults.Tests;
@@ -38,6 +40,45 @@ public sealed class HealthEndpointTests
             var aliveBody = await aliveResponse.Content.ReadAsStringAsync(cancellationToken);
 
             Assert.Contains("Healthy", healthBody, StringComparison.Ordinal);
+            Assert.Contains("Healthy", aliveBody, StringComparison.Ordinal);
+        }
+        finally
+        {
+            await app.StopAsync(cancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task MapDefaultEndpoints_NonLiveCheckUnhealthy_LivenessRemainsHealthyWhileReadinessFails()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Production,
+        });
+        builder.Services.AddHealthChecks()
+            .AddCheck("self", static () => HealthCheckResult.Healthy(), ["live"])
+            .AddCheck("dependency", static () => HealthCheckResult.Unhealthy("Dependency unavailable."), ["ready"]);
+
+        var app = builder.Build();
+        app.MapDefaultEndpoints();
+
+        await app.StartAsync(cancellationToken);
+        try
+        {
+            var baseAddress = new Uri(app.Urls.First());
+            using var client = new HttpClient { BaseAddress = baseAddress };
+
+            var healthResponse = await client.GetAsync("/health", cancellationToken);
+            var aliveResponse = await client.GetAsync("/alive", cancellationToken);
+
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, healthResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, aliveResponse.StatusCode);
+
+            var healthBody = await healthResponse.Content.ReadAsStringAsync(cancellationToken);
+            var aliveBody = await aliveResponse.Content.ReadAsStringAsync(cancellationToken);
+            Assert.Equal("Unhealthy", healthBody);
             Assert.Contains("Healthy", aliveBody, StringComparison.Ordinal);
         }
         finally

--- a/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/StructuredLoggingConfigurationTests.cs
+++ b/tests/ServiceDefaults.Tests/SoloDevBoard.ServiceDefaults.Tests/StructuredLoggingConfigurationTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+
+namespace SoloDevBoard.ServiceDefaults.Tests;
+
+/// <summary>Tests for structured logging configuration in <see cref="Extensions"/>.</summary>
+public sealed class StructuredLoggingConfigurationTests
+{
+    [Fact]
+    public void ConfigureStructuredLogging_ProductionEnvironment_RegistersJsonConsoleProviderWithExpectedOptions()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Production,
+        });
+
+        builder.ConfigureStructuredLogging();
+
+        using var serviceProvider = builder.Services.BuildServiceProvider();
+        var providers = serviceProvider.GetServices<ILoggerProvider>().ToList();
+        var formatterOptions = serviceProvider.GetRequiredService<IOptions<JsonConsoleFormatterOptions>>().Value;
+
+        Assert.Single(providers);
+        Assert.IsType<ConsoleLoggerProvider>(providers[0]);
+        Assert.True(formatterOptions.IncludeScopes);
+        Assert.True(formatterOptions.UseUtcTimestamp);
+        Assert.Equal("yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'", formatterOptions.TimestampFormat);
+    }
+
+    [Fact]
+    public void ConfigureStructuredLogging_DevelopmentEnvironment_PreservesDefaultLoggingProviders()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+
+        builder.ConfigureStructuredLogging();
+
+        using var serviceProvider = builder.Services.BuildServiceProvider();
+        var providers = serviceProvider.GetServices<ILoggerProvider>().ToList();
+
+        Assert.True(providers.Count > 1);
+    }
+}


### PR DESCRIPTION
## Summary of Changes

Defines operational hardening test coverage expectations and adds automated tests for GitHub API response caching invalidation, health endpoint probe behaviour, hosted sign-in PAT probe skipping, and structured logging configuration.

## Related Issue(s)

Closes #110

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and `docs/index.md` has been updated

## Screenshots (if applicable)

N/A — test and planning documentation changes only.

## Additional Notes

Test coverage expectations are documented in `plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md`.
