### PR TITLE
Raise Application and Domain unit test coverage to meet the 80% target for #252.

### DIFF
--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationIdentityExceptionTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationIdentityExceptionTests.cs
@@ -1,0 +1,75 @@
+using SoloDevBoard.Application.Identity;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for Application identity exceptions.</summary>
+public sealed class ApplicationIdentityExceptionTests
+{
+    [Fact]
+    public void HostedAuthenticationRequiredException_DefaultConstructor_UsesExpectedMessage()
+    {
+        // Act
+        var exception = new HostedAuthenticationRequiredException();
+
+        // Assert
+        Assert.Equal("Hosted GitHub authentication is required. Sign in again to continue.", exception.Message);
+    }
+
+    [Fact]
+    public void HostedAuthenticationRequiredException_MessageConstructor_PreservesMessage()
+    {
+        // Act
+        var exception = new HostedAuthenticationRequiredException("Session expired.");
+
+        // Assert
+        Assert.Equal("Session expired.", exception.Message);
+    }
+
+    [Fact]
+    public void HostedAuthenticationRequiredException_InnerExceptionConstructor_PreservesInnerException()
+    {
+        // Arrange
+        var inner = new InvalidOperationException("Token rejected.");
+
+        // Act
+        var exception = new HostedAuthenticationRequiredException("Session expired.", inner);
+
+        // Assert
+        Assert.Equal("Session expired.", exception.Message);
+        Assert.Same(inner, exception.InnerException);
+    }
+
+    [Fact]
+    public void GitHubPatConnectivityRequiredException_DefaultConstructor_CreatesExceptionWithoutInnerException()
+    {
+        // Act
+        var exception = new GitHubPatConnectivityRequiredException();
+
+        // Assert
+        Assert.Null(exception.InnerException);
+    }
+
+    [Fact]
+    public void GitHubPatConnectivityRequiredException_MessageConstructor_PreservesMessage()
+    {
+        // Act
+        var exception = new GitHubPatConnectivityRequiredException("PAT rejected.");
+
+        // Assert
+        Assert.Equal("PAT rejected.", exception.Message);
+    }
+
+    [Fact]
+    public void GitHubPatConnectivityRequiredException_InnerExceptionConstructor_PreservesInnerException()
+    {
+        // Arrange
+        var inner = new InvalidOperationException("Unauthorized.");
+
+        // Act
+        var exception = new GitHubPatConnectivityRequiredException("PAT rejected.", inner);
+
+        // Assert
+        Assert.Equal("PAT rejected.", exception.Message);
+        Assert.Same(inner, exception.InnerException);
+    }
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.DependencyInjection;
+using SoloDevBoard.Application.Services.Audit;
+using SoloDevBoard.Application.Services.BoardRules;
+using SoloDevBoard.Application.Services.Common;
+using SoloDevBoard.Application.Services.Labels;
+using SoloDevBoard.Application.Services.Migration;
+using SoloDevBoard.Application.Services.Repositories;
+using SoloDevBoard.Application.Services.Triage;
+using SoloDevBoard.Application.Services.Workflows;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="ApplicationServiceCollectionExtensions"/>.</summary>
+public sealed class ApplicationServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddApplicationServices_NullServices_ThrowsArgumentNullException()
+    {
+        // Arrange
+        IServiceCollection? services = null;
+
+        // Act
+        var act = () => services!.AddApplicationServices();
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void AddApplicationServices_ValidServices_RegistersExpectedServices()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddApplicationServices();
+
+        // Assert
+        AssertServiceRegistration<IAppVersionService, AppVersionService>(services, ServiceLifetime.Singleton);
+        AssertServiceRegistration<IRepositoryService, RepositoryService>(services, ServiceLifetime.Scoped);
+        AssertServiceRegistration<ILabelManagerService, LabelService>(services, ServiceLifetime.Scoped);
+        AssertServiceRegistration<IMigrationService, MigrationService>(services, ServiceLifetime.Scoped);
+        AssertServiceRegistration<IAuditDashboardService, AuditDashboardService>(services, ServiceLifetime.Scoped);
+        AssertServiceRegistration<IAuditDashboardMarkdownExporter, AuditDashboardMarkdownExporter>(services, ServiceLifetime.Singleton);
+        AssertServiceRegistration<IBoardRulesService, BoardRulesService>(services, ServiceLifetime.Scoped);
+        AssertServiceRegistration<ITriageService, TriageService>(services, ServiceLifetime.Scoped);
+        AssertServiceRegistration<IWorkflowTemplateService, WorkflowTemplateService>(services, ServiceLifetime.Scoped);
+    }
+
+    private static void AssertServiceRegistration<TService, TImplementation>(
+        IServiceCollection services,
+        ServiceLifetime lifetime)
+    {
+        var descriptor = Assert.Single(services, d => d.ServiceType == typeof(TService));
+        Assert.Equal(lifetime, descriptor.Lifetime);
+        Assert.Equal(typeof(TImplementation), descriptor.ImplementationType);
+    }
+}

--- a/tests/Domain.Tests/SoloDevBoard.Domain.Tests/BoardRulesDefinitionTests.cs
+++ b/tests/Domain.Tests/SoloDevBoard.Domain.Tests/BoardRulesDefinitionTests.cs
@@ -1,0 +1,64 @@
+using SoloDevBoard.Domain.Entities.BoardRules;
+
+namespace SoloDevBoard.Domain.Tests;
+
+public sealed class BoardRulesDefinitionTests
+{
+    [Fact]
+    public void BoardRulesDefinition_WithUnsupportedDetails_ShouldReportPartialVisibility()
+    {
+        // Arrange & Act
+        var definition = new BoardRulesDefinition
+        {
+            ProjectId = "PVT_123",
+            ProjectTitle = "Roadmap",
+            OwnerLogin = "owner",
+            Columns =
+            [
+                new BoardColumn { Id = 1, Name = "Todo", Order = 0, LabelFilters = ["type/bug"] },
+            ],
+            Rules =
+            [
+                new BoardRule
+                {
+                    Id = 1,
+                    Name = "Auto-close",
+                    Trigger = "item.closed",
+                    Action = "move_to_done",
+                    IsEnabled = true,
+                },
+            ],
+            UnsupportedDetails = ["Automation rules are partially visible."],
+        };
+
+        // Assert
+        Assert.Equal("PVT_123", definition.ProjectId);
+        Assert.Equal("Roadmap", definition.ProjectTitle);
+        Assert.Equal("owner", definition.OwnerLogin);
+        Assert.Single(definition.Columns);
+        Assert.Equal("Todo", definition.Columns[0].Name);
+        Assert.Equal(0, definition.Columns[0].Order);
+        Assert.Equal(["type/bug"], definition.Columns[0].LabelFilters);
+        Assert.Single(definition.Rules);
+        Assert.Equal("Auto-close", definition.Rules[0].Name);
+        Assert.Equal("item.closed", definition.Rules[0].Trigger);
+        Assert.Equal("move_to_done", definition.Rules[0].Action);
+        Assert.True(definition.Rules[0].IsEnabled);
+        Assert.False(definition.HasFullVisibility);
+    }
+
+    [Fact]
+    public void BoardRulesDefinition_WithoutUnsupportedDetails_ShouldReportFullVisibility()
+    {
+        // Arrange & Act
+        var definition = new BoardRulesDefinition
+        {
+            ProjectId = "PVT_456",
+            ProjectTitle = "Delivery",
+            OwnerLogin = "owner",
+        };
+
+        // Assert
+        Assert.True(definition.HasFullVisibility);
+    }
+}

--- a/tests/Domain.Tests/SoloDevBoard.Domain.Tests/IssueTests.cs
+++ b/tests/Domain.Tests/SoloDevBoard.Domain.Tests/IssueTests.cs
@@ -1,4 +1,5 @@
 using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Domain.Entities.Milestones;
 using SoloDevBoard.Domain.Entities.Triage;
 
 namespace SoloDevBoard.Domain.Tests;
@@ -8,25 +9,37 @@ public sealed class IssueTests
     [Fact]
     public void Issue_WithInitialisedProperties_ShouldReturnCorrectValues()
     {
-        // Arrange & Act
+        // Arrange
+        var createdAt = new DateTimeOffset(2024, 3, 15, 10, 0, 0, TimeSpan.Zero);
+        var updatedAt = new DateTimeOffset(2024, 3, 16, 12, 0, 0, TimeSpan.Zero);
+        var milestone = new Milestone { Id = 4, Number = 1, Title = "Sprint 1" };
+
+        // Act
         var issue = new Issue
         {
             Id = 100,
             Number = 5,
             Title = "Fix the bug",
+            HtmlUrl = "https://github.com/owner/repo/issues/5",
             Body = "There is a bug that needs fixing.",
             State = "open",
             AuthorLogin = "developer1",
-            CreatedAt = new DateTimeOffset(2024, 3, 15, 10, 0, 0, TimeSpan.Zero),
-            UpdatedAt = new DateTimeOffset(2024, 3, 16, 12, 0, 0, TimeSpan.Zero),
+            Milestone = milestone,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
         };
 
         // Assert
         Assert.Equal(100, issue.Id);
         Assert.Equal(5, issue.Number);
         Assert.Equal("Fix the bug", issue.Title);
+        Assert.Equal("https://github.com/owner/repo/issues/5", issue.HtmlUrl);
+        Assert.Equal("There is a bug that needs fixing.", issue.Body);
         Assert.Equal("open", issue.State);
         Assert.Equal("developer1", issue.AuthorLogin);
+        Assert.Equal(milestone, issue.Milestone);
+        Assert.Equal(createdAt, issue.CreatedAt);
+        Assert.Equal(updatedAt, issue.UpdatedAt);
     }
 
     [Fact]

--- a/tests/Domain.Tests/SoloDevBoard.Domain.Tests/MilestoneTests.cs
+++ b/tests/Domain.Tests/SoloDevBoard.Domain.Tests/MilestoneTests.cs
@@ -1,0 +1,47 @@
+using SoloDevBoard.Domain.Entities.Milestones;
+
+namespace SoloDevBoard.Domain.Tests;
+
+public sealed class MilestoneTests
+{
+    [Fact]
+    public void Milestone_WithInitialisedProperties_ShouldReturnCorrectValues()
+    {
+        // Arrange
+        var dueOn = new DateTimeOffset(2026, 12, 31, 0, 0, 0, TimeSpan.Zero);
+
+        // Act
+        var milestone = new Milestone
+        {
+            Id = 10,
+            Number = 3,
+            Title = "v1.0.0",
+            Description = "First production release.",
+            State = "open",
+            DueOn = dueOn,
+            OpenIssues = 5,
+            ClosedIssues = 12,
+        };
+
+        // Assert
+        Assert.Equal(10, milestone.Id);
+        Assert.Equal(3, milestone.Number);
+        Assert.Equal("v1.0.0", milestone.Title);
+        Assert.Equal("First production release.", milestone.Description);
+        Assert.Equal("open", milestone.State);
+        Assert.Equal(dueOn, milestone.DueOn);
+        Assert.Equal(5, milestone.OpenIssues);
+        Assert.Equal(12, milestone.ClosedIssues);
+    }
+
+    [Fact]
+    public void Milestone_Records_WithSameValues_ShouldBeEqual()
+    {
+        // Arrange
+        var milestone1 = new Milestone { Id = 1, Number = 1, Title = "Sprint 1" };
+        var milestone2 = new Milestone { Id = 1, Number = 1, Title = "Sprint 1" };
+
+        // Assert
+        Assert.Equal(milestone1, milestone2);
+    }
+}

--- a/tests/Domain.Tests/SoloDevBoard.Domain.Tests/PullRequestTests.cs
+++ b/tests/Domain.Tests/SoloDevBoard.Domain.Tests/PullRequestTests.cs
@@ -1,0 +1,56 @@
+using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Domain.Entities.Milestones;
+using SoloDevBoard.Domain.Entities.Triage;
+
+namespace SoloDevBoard.Domain.Tests;
+
+public sealed class PullRequestTests
+{
+    [Fact]
+    public void PullRequest_WithInitialisedProperties_ShouldReturnCorrectValues()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 1, 10, 9, 0, 0, TimeSpan.Zero);
+        var updatedAt = new DateTimeOffset(2026, 1, 11, 14, 30, 0, TimeSpan.Zero);
+        var milestone = new Milestone { Id = 2, Number = 1, Title = "v1.0.0" };
+        var labels = new List<Label>
+        {
+            new() { Name = "enhancement", Colour = "a2eeef" },
+        };
+
+        // Act
+        var pullRequest = new PullRequest
+        {
+            Id = 500,
+            Number = 42,
+            Title = "Add triage support",
+            HtmlUrl = "https://github.com/owner/repo/pull/42",
+            Body = "Implements triage queue handling.",
+            State = "open",
+            AuthorLogin = "contributor",
+            HeadBranch = "feature/triage",
+            BaseBranch = "main",
+            IsDraft = true,
+            Labels = labels,
+            Milestone = milestone,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
+        };
+
+        // Assert
+        Assert.Equal(500, pullRequest.Id);
+        Assert.Equal(42, pullRequest.Number);
+        Assert.Equal("Add triage support", pullRequest.Title);
+        Assert.Equal("https://github.com/owner/repo/pull/42", pullRequest.HtmlUrl);
+        Assert.Equal("Implements triage queue handling.", pullRequest.Body);
+        Assert.Equal("open", pullRequest.State);
+        Assert.Equal("contributor", pullRequest.AuthorLogin);
+        Assert.Equal("feature/triage", pullRequest.HeadBranch);
+        Assert.Equal("main", pullRequest.BaseBranch);
+        Assert.True(pullRequest.IsDraft);
+        Assert.Single(pullRequest.Labels);
+        Assert.Equal(milestone, pullRequest.Milestone);
+        Assert.Equal(createdAt, pullRequest.CreatedAt);
+        Assert.Equal(updatedAt, pullRequest.UpdatedAt);
+    }
+}

--- a/tests/Domain.Tests/SoloDevBoard.Domain.Tests/TriageEntityTests.cs
+++ b/tests/Domain.Tests/SoloDevBoard.Domain.Tests/TriageEntityTests.cs
@@ -1,0 +1,188 @@
+using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Domain.Entities.Milestones;
+using SoloDevBoard.Domain.Entities.Triage;
+
+namespace SoloDevBoard.Domain.Tests;
+
+public sealed class TriageEntityTests
+{
+    [Fact]
+    public void TriageSession_WithInitialisedProperties_ShouldReturnCorrectValues()
+    {
+        // Arrange
+        var startedAt = new DateTimeOffset(2026, 3, 1, 8, 0, 0, TimeSpan.Zero);
+        var queueItem = new TriageItem
+        {
+            ItemType = TriageItemType.Issue,
+            Id = 1,
+            Number = 10,
+            RepositoryFullName = "owner/repo",
+            Title = "Triage me",
+        };
+        var skippedItem = queueItem with { Number = 11, Title = "Skipped item" };
+        var action = new TriageAction
+        {
+            Id = 1,
+            ActionType = TriageActionType.Skipped,
+            ItemType = TriageItemType.Issue,
+            ItemNumber = 11,
+            RepositoryFullName = "owner/repo",
+            Detail = "Needs more context",
+            OccurredAt = startedAt,
+        };
+        var progress = new TriageSessionProgress
+        {
+            Id = 1,
+            TotalItems = 2,
+            ProcessedItems = 1,
+            RemainingItems = 1,
+            SkippedItems = 1,
+        };
+        var summary = new TriageSessionSummary
+        {
+            Id = 1,
+            TotalItems = 2,
+            ProcessedItems = 1,
+            RemainingItems = 1,
+            SkippedItems = 1,
+            LabelsAppliedCount = 1,
+            MilestonesAssignedCount = 0,
+            ProjectAssignmentsCount = 0,
+            DuplicateClosuresCount = 0,
+            LabelActionDetails = ["bug"],
+            MilestoneActionDetails = [],
+            ProjectActionDetails = [],
+            DuplicateActionDetails = [],
+            SkippedActionDetails = ["Needs more context"],
+            SkippedItemDetails = ["#11 Skipped item"],
+        };
+
+        // Act
+        var session = new TriageSession
+        {
+            Id = 1,
+            SessionId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+            OwnerLogin = "owner",
+            RepositoryName = "repo",
+            IncludePullRequests = true,
+            Queue = [queueItem],
+            CurrentIndex = 0,
+            SkippedItems = [skippedItem],
+            ActionHistory = [action],
+            Progress = progress,
+            Summary = summary,
+            StartedAt = startedAt,
+        };
+
+        // Assert
+        Assert.Equal(1, session.Id);
+        Assert.Equal(Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), session.SessionId);
+        Assert.Equal("owner", session.OwnerLogin);
+        Assert.Equal("repo", session.RepositoryName);
+        Assert.True(session.IncludePullRequests);
+        Assert.Single(session.Queue);
+        Assert.Equal(0, session.CurrentIndex);
+        Assert.Single(session.SkippedItems);
+        Assert.Single(session.ActionHistory);
+        Assert.Equal(progress, session.Progress);
+        Assert.Equal(summary, session.Summary);
+        Assert.Equal(startedAt, session.StartedAt);
+    }
+
+    [Fact]
+    public void TriageItem_WithMilestoneAndLabels_ShouldReturnCorrectValues()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 2, 1, 10, 0, 0, TimeSpan.Zero);
+        var updatedAt = new DateTimeOffset(2026, 2, 2, 11, 0, 0, TimeSpan.Zero);
+        var milestone = new Milestone { Id = 3, Number = 2, Title = "Backlog" };
+        var labels = new List<Label> { new() { Name = "triage", Colour = "ededed" } };
+
+        // Act
+        var item = new TriageItem
+        {
+            ItemType = TriageItemType.PullRequest,
+            Id = 99,
+            Number = 7,
+            RepositoryFullName = "owner/repo",
+            Title = "Review requested",
+            HtmlUrl = "https://github.com/owner/repo/pull/7",
+            Body = "Please review.",
+            State = "open",
+            AuthorLogin = "reviewer",
+            Labels = labels,
+            Milestone = milestone,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
+        };
+
+        // Assert
+        Assert.Equal(TriageItemType.PullRequest, item.ItemType);
+        Assert.Equal(99, item.Id);
+        Assert.Equal(7, item.Number);
+        Assert.Equal("owner/repo", item.RepositoryFullName);
+        Assert.Equal("Review requested", item.Title);
+        Assert.Equal("https://github.com/owner/repo/pull/7", item.HtmlUrl);
+        Assert.Equal("Please review.", item.Body);
+        Assert.Equal("open", item.State);
+        Assert.Equal("reviewer", item.AuthorLogin);
+        Assert.Single(item.Labels);
+        Assert.Equal(milestone, item.Milestone);
+        Assert.Equal(createdAt, item.CreatedAt);
+        Assert.Equal(updatedAt, item.UpdatedAt);
+    }
+
+    [Fact]
+    public void TriageProjectBoard_WithStatusOptions_ShouldReturnCorrectValues()
+    {
+        // Arrange & Act
+        var board = new TriageProjectBoard
+        {
+            Id = "PVT_789",
+            Title = "Inbox",
+            OwnerLogin = "owner",
+            StatusFieldId = "FIELD_1",
+            StatusOptions =
+            [
+                new TriageProjectBoardStatusOption { Id = "OPT_1", Name = "Todo" },
+                new TriageProjectBoardStatusOption { Id = "OPT_2", Name = "Done" },
+            ],
+        };
+
+        // Assert
+        Assert.Equal("PVT_789", board.Id);
+        Assert.Equal("Inbox", board.Title);
+        Assert.Equal("owner", board.OwnerLogin);
+        Assert.Equal("FIELD_1", board.StatusFieldId);
+        Assert.Equal(2, board.StatusOptions.Count);
+        Assert.Equal("Todo", board.StatusOptions[0].Name);
+        Assert.Equal("OPT_2", board.StatusOptions[1].Id);
+    }
+
+    [Fact]
+    public void TriageActionType_Values_ShouldContainExpectedMembers()
+    {
+        // Assert
+        Assert.Equal(
+            [
+                nameof(TriageActionType.LabelApplied),
+                nameof(TriageActionType.MilestoneAssigned),
+                nameof(TriageActionType.ProjectBoardAssigned),
+                nameof(TriageActionType.ClosedAsDuplicate),
+                nameof(TriageActionType.Skipped),
+            ],
+            Enum.GetNames<TriageActionType>());
+    }
+
+    [Fact]
+    public void TriageItemType_Values_ShouldContainExpectedMembers()
+    {
+        // Assert
+        Assert.Equal(
+            [
+                nameof(TriageItemType.Issue),
+                nameof(TriageItemType.PullRequest),
+            ],
+            Enum.GetNames<TriageItemType>());
+    }
+}

--- a/tests/Domain.Tests/SoloDevBoard.Domain.Tests/WorkflowEntityTests.cs
+++ b/tests/Domain.Tests/SoloDevBoard.Domain.Tests/WorkflowEntityTests.cs
@@ -1,0 +1,109 @@
+using SoloDevBoard.Domain.Entities.Workflows;
+
+namespace SoloDevBoard.Domain.Tests;
+
+public sealed class WorkflowEntityTests
+{
+    [Fact]
+    public void WorkflowTemplate_WithInitialisedProperties_ShouldReturnCorrectValues()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+
+        // Act
+        var template = new WorkflowTemplate
+        {
+            Id = 5,
+            Name = "CI",
+            Description = "Continuous integration workflow.",
+            Category = "Automation",
+            Tags = ["ci", "dotnet"],
+            WorkflowFilePath = ".github/workflows/ci.yml",
+            TriggerDescription = "On push and pull request",
+            YamlContent = "name: CI",
+            CreatedAt = createdAt,
+        };
+
+        // Assert
+        Assert.Equal(5, template.Id);
+        Assert.Equal("CI", template.Name);
+        Assert.Equal("Continuous integration workflow.", template.Description);
+        Assert.Equal("Automation", template.Category);
+        Assert.Equal(["ci", "dotnet"], template.Tags);
+        Assert.Equal(".github/workflows/ci.yml", template.WorkflowFilePath);
+        Assert.Equal("On push and pull request", template.TriggerDescription);
+        Assert.Equal("name: CI", template.YamlContent);
+        Assert.Equal(createdAt, template.CreatedAt);
+    }
+
+    [Fact]
+    public void WorkflowFile_WithInitialisedProperties_ShouldReturnCorrectValues()
+    {
+        // Arrange & Act
+        var workflowFile = new WorkflowFile
+        {
+            Path = ".github/workflows/deploy.yml",
+            Content = "name: Deploy",
+            Sha = "abc123",
+        };
+
+        // Assert
+        Assert.Equal(".github/workflows/deploy.yml", workflowFile.Path);
+        Assert.Equal("name: Deploy", workflowFile.Content);
+        Assert.Equal("abc123", workflowFile.Sha);
+    }
+
+    [Fact]
+    public void WorkflowRun_WithInitialisedProperties_ShouldReturnCorrectValues()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 5, 1, 9, 15, 0, TimeSpan.Zero);
+        var updatedAt = new DateTimeOffset(2026, 5, 1, 9, 20, 0, TimeSpan.Zero);
+
+        // Act
+        var workflowRun = new WorkflowRun
+        {
+            Id = 9001,
+            WorkflowName = "CI",
+            Status = "completed",
+            Conclusion = "success",
+            HeadBranch = "main",
+            HeadSha = "deadbeef",
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
+            HtmlUrl = "https://github.com/owner/repo/actions/runs/9001",
+        };
+
+        // Assert
+        Assert.Equal(9001, workflowRun.Id);
+        Assert.Equal("CI", workflowRun.WorkflowName);
+        Assert.Equal("completed", workflowRun.Status);
+        Assert.Equal("success", workflowRun.Conclusion);
+        Assert.Equal("main", workflowRun.HeadBranch);
+        Assert.Equal("deadbeef", workflowRun.HeadSha);
+        Assert.Equal(createdAt, workflowRun.CreatedAt);
+        Assert.Equal(updatedAt, workflowRun.UpdatedAt);
+        Assert.Equal("https://github.com/owner/repo/actions/runs/9001", workflowRun.HtmlUrl);
+    }
+
+    [Fact]
+    public void WorkflowTemplateParameter_WithInitialisedProperties_ShouldReturnCorrectValues()
+    {
+        // Arrange & Act
+        var parameter = new WorkflowTemplateParameter
+        {
+            Name = "dotnetVersion",
+            Label = ".NET version",
+            Description = "SDK version used by the workflow.",
+            DefaultValue = "10.0.x",
+            IsRequired = true,
+        };
+
+        // Assert
+        Assert.Equal("dotnetVersion", parameter.Name);
+        Assert.Equal(".NET version", parameter.Label);
+        Assert.Equal("SDK version used by the workflow.", parameter.Description);
+        Assert.Equal("10.0.x", parameter.DefaultValue);
+        Assert.True(parameter.IsRequired);
+    }
+}


### PR DESCRIPTION
﻿## Summary of Changes

Adds unit tests across Application and Domain to meet the 80% line coverage target for issue #252. New tests cover domain entity records and enums, Application service registration, and identity exception handling.

## Related Issue(s)

Closes #252

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and `docs/index.md` has been updated

## Screenshots (if applicable)

N/A — test-only change.

## Additional Notes

No user-facing behaviour changed; documentation updates are not required.
