### PR TITLE
Set status/in-progress when implementation starts

### DIFF
--- a/.agents/contracts/delivery.md
+++ b/.agents/contracts/delivery.md
@@ -83,8 +83,8 @@ Present the **Preflight Complete** output (see Output Contract) before continuin
 
 | Condition | Action |
 |-----------|--------|
-| `size/xs`, `size/s`, or `type/bug` | Auto-continue to feature branch |
-| `size/m`, `size/l`, `size/xl`, or `type/enabler` | Pause for user confirmation before coding |
+| `size/xs`, `size/s`, or `type/bug` | Auto-continue to mark work started, then feature branch |
+| `size/m`, `size/l`, `size/xl`, or `type/enabler` | Pause for user confirmation before marking work started and coding |
 | Missing acceptance criteria, missing wireframe on page-producing UI, or unresolved blocker | Escalate; do not code |
 
 **Standalone preflight:** When invoked via `preflight-issue` workflow only, always pause after **Preflight Complete** — do not create a branch or write code.
@@ -99,7 +99,27 @@ Do NOT during preflight:
 
 ---
 
-### 2. Feature Branch
+### 2. Mark Work Started
+
+After the proceed gate is satisfied, transition the implementing issue to `status/in-progress` **before** creating the feature branch. This signals that work has begun without using project board APIs directly — the [Roadmap Sync workflow](../../.github/workflows/roadmap-sync.yml) reacts to the label and updates Project #8 Status, Start Date, and Target Date.
+
+```bash
+gh issue edit <N> --repo markheydon/solo-dev-board --remove-label "status/todo" --add-label "status/in-progress"
+```
+
+Rules:
+
+- Apply only to the issue being implemented.
+- Skip if the issue already has `status/in-progress`.
+- Do not change label if the issue has `status/blocked` — escalate instead.
+- Do not edit parent issues, milestones, assignees, or the issue body.
+- Do not call `gh project` commands or set board fields directly.
+
+**Standalone preflight:** Do not apply this transition — work has not started yet.
+
+---
+
+### 3. Feature Branch
 
 Work on a dedicated feature branch.
 
@@ -120,7 +140,7 @@ Never implement directly on `main`.
 
 ---
 
-### 3. Implementation
+### 4. Implementation
 
 Implement the issue following repository standards.
 
@@ -138,7 +158,7 @@ Avoid scope creep.
 
 ---
 
-### 4. Tests
+### 5. Tests
 
 Add or update tests as appropriate.
 
@@ -159,7 +179,7 @@ Do not create tests solely to inflate coverage numbers.
 
 ---
 
-### 5. Documentation
+### 6. Documentation
 
 Update documentation when required.
 
@@ -181,7 +201,7 @@ Technical or internal changes:
 
 ---
 
-### 6. Decision log
+### 7. Decision log
 
 Record decisions via [`repo-decision-log`](../skills/repo-decision-log/SKILL.md) when:
 
@@ -193,7 +213,7 @@ Do not create files under `adr/`. Do not log routine implementation choices.
 
 ---
 
-### 7. Scope Changes
+### 8. Scope Changes
 
 If implementation reveals scope changes:
 
@@ -203,7 +223,7 @@ If implementation reveals scope changes:
 
 ---
 
-### 8. Self Review
+### 9. Self Review
 
 Before handoff:
 
@@ -273,10 +293,11 @@ Do NOT:
 - Create pull requests
 - Close issues
 - Manage milestones
-- Update project boards
+- Update project boards (use the `status/in-progress` label transition in §2 instead; Roadmap Sync updates the board)
 - Update release plans
 - Perform roadmap management
 - Implement unplanned scope
+- Edit GitHub issues except the narrow `status/in-progress` transition on the issue being implemented
 
 Do NOT commit directly to `main`.
 
@@ -303,6 +324,7 @@ Escalate to the user if:
 Implementation is complete when:
 
 - Implementation preflight completed and proceed gate satisfied
+- Issue transitioned to `status/in-progress` (or already in progress)
 - Acceptance criteria are implemented
 - Build succeeds
 - Tests pass

--- a/.agents/skills/repo-github-project/SKILL.md
+++ b/.agents/skills/repo-github-project/SKILL.md
@@ -219,61 +219,26 @@ gh issue edit "$issueNumber" --repo markheydon/solo-dev-board --add-assignee mar
 
 ### Event 2: Implementation Started (Delivery Agent responsibility)
 
-When beginning work on an issue, set Status to "In Progress", set Start Date to today, and set Target Date using the size calibration table above. This transition can start from **Todo** or **Up Next**.
-
-```bash
-# Step 1: Find the project item ID for the issue.
-item_id=$(gh project item-list 8 --owner markheydon --format json --jq ".items[] | select(.content.number == $issueNumber) | .id" | head -n1)
-
-# Step 2: Update Status → In Progress.
-gh project item-edit \
-    --id "$item_id" \
-    --project-id "PVT_kwHOAJefG84BQ6bh" \
-    --field-id "PVTSSF_lAHOAJefG84BQ6bhzg-5WGY" \
-    --single-select-option-id "47fc9ee4"
-
-# Optional: Clear Focus Order once work starts so the queue only shows unstarted items.
-gh project item-edit --id "$item_id" --project-id "PVT_kwHOAJefG84BQ6bh" --field-id "PVTF_lAHOAJefG84BQ6bhzg_Lx34" --clear
-
-# Step 3: Set Start Date = today.
-today=$(date +%F)
-gh project item-edit \
-    --id "$item_id" \
-    --project-id "PVT_kwHOAJefG84BQ6bh" \
-    --field-id "PVTF_lAHOAJefG84BQ6bhzg-5WQE" \
-    --date "$today"
-
-# Step 4: Set Target Date = today + calendar days from size calibration table.
-#   xs → +1 day, s → +1 day, m → +3 days, l → +7 days, xl → +14 days.
-size_label=$(gh api "repos/markheydon/solo-dev-board/issues/$issueNumber" --jq '[.labels[].name | select(startswith("size/"))] | first')
-case "$size_label" in
-    "size/xs"|"size/s") calendar_days=1 ;;
-    "size/m") calendar_days=3 ;;
-    "size/l") calendar_days=7 ;;
-    "size/xl") calendar_days=14 ;;
-    *) calendar_days=3 ;;
-esac
-target_date=$(date -d "+$calendar_days day" +%F)
-gh project item-edit \
-    --id "$item_id" \
-    --project-id "PVT_kwHOAJefG84BQ6bh" \
-    --field-id "PVTF_lAHOAJefG84BQ6bhzg-5WQw" \
-    --date "$target_date"
-```
-
-Also update the issue label:
+When beginning work on an issue, apply `status/in-progress` to the issue. **Preferred path:** label only — the Roadmap Sync workflow moves the item to **In Progress** and sets Start Date and Target Date from the label event and `size/` label. Do not call `gh project` commands unless the user explicitly requests manual board repair.
 
 ```bash
 gh issue edit "$issueNumber" --repo markheydon/solo-dev-board --remove-label "status/todo" --add-label "status/in-progress"
 ```
 
-**If this is the first story started within its Feature**, also apply Event 2a to set the parent Feature and Epic Start Date = today and Target Date = the latest dated child Target Date currently known. Leave unstarted siblings blank until they actually begin work.
+Skip if the issue already has `status/in-progress`. Escalate if the issue has `status/blocked`.
+
+**Manual board path (fallback only):** If Roadmap Sync is unavailable and the user requests immediate board repair, use the `gh project item-edit` sequence from Event 2a patterns to set Status, Start Date, and Target Date on the implementing issue.
+
+**Parent roll-up:** Roadmap Sync updates parent Feature and Epic board Status and dates when a child receives `status/in-progress`. Do not edit parent issue labels during normal delivery.
+
+**Manual fallback (Event 2a):** If Roadmap Sync is unavailable and the user requests immediate parent repair, apply the sequence below for each parent Feature and Epic still in **Todo**.
 
 ---
 
-### Event 2a: Cascade "In Progress" to Parent Feature and Epic (Delivery Agent responsibility)
+### Event 2a: Cascade "In Progress" to Parent Feature and Epic (manual fallback)
 
-When starting work on a Story, Enabler, or Test, check whether the parent Feature and Epic are still "Todo" on the project board. If so:
+When starting work on a Story, Enabler, or Test, and Roadmap Sync cannot run, check whether the parent Feature and Epic are still "Todo" on the project board. If so:
+
 1. Move them to "In Progress" and set their Start Date = today.
 2. Set their Target Date = the latest Target Date among child issues that already have dates.
 

--- a/.agents/workflows/implement-issue.md
+++ b/.agents/workflows/implement-issue.md
@@ -12,6 +12,8 @@
 - For UI work, read the linked wireframe from [`plan/wireframes/`](../../plan/wireframes/).
 - Invoke `dotnet-best-practices` during preflight for all issues; invoke `mudblazor` for UI issues.
 - Apply the tiered proceed gate: auto-continue for `size/xs`, `size/s`, and `type/bug`; pause for `size/m+` and all `type/enabler` issues.
+- After the proceed gate, set `status/in-progress` on the issue (see Mark Work Started in the Delivery contract) before creating the feature branch.
+- Do not set `status/in-progress` during standalone `/preflight-issue`.
 - Consult other skills when relevant — do not require reading every skill up front.
 
 ### Area label → codebase hints

--- a/.agents/workflows/preflight-issue.md
+++ b/.agents/workflows/preflight-issue.md
@@ -6,7 +6,7 @@
 
 ## Easy-to-miss specifics
 
-- Run preflight only — do not create a feature branch or write code.
+- Run preflight only — do not create a feature branch, write code, or change issue labels.
 - Follow Implementation Preflight in the Delivery contract (load context, validate readiness, codebase discovery, sketch).
 - Area label → codebase hints: see [implement-issue workflow](implement-issue.md).
 - Always pause after the **Preflight Complete** output, even for `size/xs` and `size/s` issues.

--- a/plan/PM_RUNBOOK.md
+++ b/plan/PM_RUNBOOK.md
@@ -153,7 +153,7 @@ Implement issue #[number]
 - Starting work also stamps **Start Date** and the current size-based **Target Date** forecast on the roadmap item.
 - Untouched sibling items stay blank until they actually start.
 
-**Note:** The `/implement-issue` command runs preflight, then code, tests, and docs. Update project board fields and issue labels in a separate planning or board-sync step when needed.
+**Note:** The `/implement-issue` command runs preflight, sets `status/in-progress` on the issue, then code, tests, and docs. Roadmap Sync updates Project #8 board fields from the label. Do not call `gh project` commands during implementation.
 
 **What you produce:**
 - Preflight summary (context loaded, touch map, approach) before coding begins
@@ -395,6 +395,7 @@ START
 
 **Responsibilities:**
 - Runs implementation preflight (context, codebase discovery, touch map, proceed gate)
+- Sets `status/in-progress` on the implementing issue (Roadmap Sync updates Project #8)
 - Implements code (Domain/Application/Infrastructure/App layers)
 - Creates xUnit v3 tests (NSubstitute, `Assert.*`)
 - Updates user-facing docs
@@ -458,6 +459,7 @@ These gates are defined in [`AGENTS.md`](../AGENTS.md) and enforced by role cont
 
 ### Before Coding (Delivery Agent enforces)
 - ✅ Implementation preflight completed (context loaded, touch map produced, proceed gate satisfied)
+- ✅ Issue label set to `status/in-progress` (Roadmap Sync updates the board)
 - ✅ Linked wireframe read for page-producing UI work
 
 ### Before PR Creation (Delivery Agent enforces)


### PR DESCRIPTION
## Summary of Changes

Extends the delivery workflow so `/implement-issue` sets `status/in-progress` on the implementing issue after preflight passes and before the feature branch is created. Roadmap Sync reacts to the label and updates Project #8 Status, Start Date, and Target Date without Delivery calling `gh project` commands.

## Related Issue(s)

Follow-up to #317 (implementation preflight). No linked GitHub issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`) — not applicable; workflow documentation only
- [x] I have added or updated tests to cover my changes — not applicable
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced — not applicable
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and `docs/index.md` has been updated — not applicable

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- `/preflight-issue` explicitly does not change issue labels.
- `repo-github-project` Event 2 now prefers label-only delivery; manual `gh project` paths are documented as fallback only.

## Test plan

- [x] Confirm `delivery.md` defines Mark Work Started with `gh issue edit` rules and boundaries carve-out.
- [x] Confirm `implement-issue.md` documents the label step after the proceed gate.
- [x] Confirm `preflight-issue.md` forbids label changes.
- [x] Confirm `PM_RUNBOOK.md` Stage 2 references label-driven Roadmap Sync.

Made with [Cursor](https://cursor.com)