### PR TITLE
Add Playwright coverage for critical user journeys (#255).

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,8 @@ When suggesting a feature:
    - Use the naming convention: `MethodUnderTest_Scenario_ExpectedOutcome`
    - All tests must pass: `dotnet test`
    - Aim for meaningful test coverage, not just coverage percentage
-   - Use Playwright for end-to-end user journeys where unit tests cannot validate the full workflow.
+   - Use Playwright for end-to-end user journeys where unit tests cannot validate the full workflow — see [`tests/E2E/README.md`](tests/E2E/README.md) and [`tests/E2E/CRITICAL_JOURNEYS.md`](tests/E2E/CRITICAL_JOURNEYS.md) for the CI journey inventory, local run steps, and selector conventions.
+   - Prefer `data-testid` attributes on loading, error, and empty UI states when adding journeys that will run in CI with placeholder auth.
    - Do not test .NET Aspire AppHost modelling or orchestration.
 
 4. **Architecture:**

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -236,7 +236,7 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Persist hosted authentication material securely using Azure Key Vault-backed patterns where required. _(#250; see plan/HOSTED_AUTH_KEY_VAULT_PATTERN.md.)_
 - [x] Replace the single-user `ICurrentUserContext` adapter with a per-request, per-user implementation backed by the hosted authentication session when hosted mode is enabled. _(Implemented on 2026-03-13; PAT-only local trusted mode preserved.)_
 - [ ] Enable CD pipeline with production environment gate (`.github/workflows/cd.yml` via `aspire deploy`). _(#251)_
-- [ ] Write end-to-end tests for critical user journeys. _(#255)_
+- [x] Write end-to-end tests for critical user journeys. _(#255; see tests/E2E/CRITICAL_JOURNEYS.md.)_
 - [x] Update hosted-authentication documentation for GitHub App-first hosted sign-in, admission-control allow-lists, PAT-only local trusted mode, and fallback boundaries. _(#119; completed on 2026-03-16; see docs/getting-started.md, infra/README.md, docs/user-guide/hosted-authentication.md, and docs/index.md.)_
 - [ ] Write comprehensive `docs/` content for all features. _(#256)_
 - [ ] Tag v1.0.0 release on GitHub with release notes. _(#257)_

--- a/plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md
+++ b/plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md
@@ -63,6 +63,7 @@ The following automated checks are proportionate to current repository tooling a
 | `dotnet format --verify-no-changes` | `ci.yml` | Prevents formatting drift in test and production code. |
 | E2E job waits for `GET /health` before Playwright suite | `ci.yml` (`e2e` job) | Confirms the app host starts and readiness endpoint responds in a realistic PAT-mode configuration. |
 | Playwright smoke test for `/health` | `tests/E2E/tests/smoke.spec.ts` | Lightweight post-startup health assertion in the browser test harness. |
+| Playwright critical user journey suite | `tests/E2E/CRITICAL_JOURNEYS.md`, `tests/E2E/tests/*.spec.ts` | Feature shell, navigation, and placeholder-auth error-state coverage for v1.0.0 release readiness (issue #255). |
 
 Not automated in CI (manual or deploy-time verification only):
 

--- a/src/App/SoloDevBoard.App/Components/Features/Repositories/Pages/Repositories.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Repositories/Pages/Repositories.razor
@@ -14,7 +14,8 @@
                        Color="Color.Primary"
                        StartIcon="@Icons.Material.Filled.Refresh"
                        OnClick="ReloadAsync"
-                       Disabled="isLoading">
+                       Disabled="isLoading"
+                       data-testid="repositories-refresh-button">
                 Refresh
             </MudButton>
 
@@ -75,7 +76,7 @@
 
     @if (isLoading)
     {
-        <MudPaper Class="pa-6" Elevation="1" aria-live="polite" role="status">
+        <MudPaper Class="pa-6" Elevation="1" aria-live="polite" role="status" data-testid="repositories-loading-state">
             <MudStack AlignItems="AlignItems.Center" Spacing="2">
                 <MudProgressCircular Indeterminate="true" Color="Color.Primary" Size="Size.Large" aria-label="Loading repositories" />
                 <MudText Typo="Typo.body1">Loading repositories...</MudText>
@@ -84,7 +85,7 @@
     }
     else if (!string.IsNullOrWhiteSpace(errorMessage))
     {
-        <MudPaper Class="pa-4" Elevation="1" aria-live="assertive" role="alert">
+        <MudPaper Class="pa-4" Elevation="1" aria-live="assertive" role="alert" data-testid="repositories-error-state">
             <MudAlert Severity="Severity.Error" Variant="Variant.Filled">
                 <MudStack Spacing="2">
                     <MudText Typo="Typo.h6">Unable to load repositories</MudText>
@@ -96,7 +97,7 @@
     }
     else if (repositories.Count == 0)
     {
-        <MudPaper Class="pa-4" Elevation="1" aria-live="polite">
+        <MudPaper Class="pa-4" Elevation="1" aria-live="polite" data-testid="repositories-empty-state">
             <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
                 <MudStack Spacing="1">
                     <MudText Typo="Typo.h6">No repositories found</MudText>
@@ -107,7 +108,7 @@
     }
     else
     {
-        <MudPaper Class="pa-2" Elevation="1">
+        <MudPaper Class="pa-2" Elevation="1" data-testid="repositories-grid">
             <MudDataGrid T="RepositoryDto"
                          Items="FilteredRepositories"
                          Hover="true"

--- a/tests/E2E/CRITICAL_JOURNEYS.md
+++ b/tests/E2E/CRITICAL_JOURNEYS.md
@@ -1,0 +1,55 @@
+# Critical user journeys
+
+This document defines the highest-priority SoloDevBoard user journeys covered by Playwright end-to-end tests in CI. It satisfies the journey-identification acceptance criterion for issue [#255](https://github.com/markheydon/solo-dev-board/issues/255) and complements [DEC-016](../../plan/DECISIONS.md#dec-016-formalised-testing-standard--xunit-v3-nsubstitute-playwright-e2e).
+
+## CI constraints
+
+The `e2e` job in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) starts the app with a placeholder personal access token (`GitHubAuth__PersonalAccessToken=ci-e2e-placeholder`) and hosted admission control disabled. Tests therefore assert **shell rendering, navigation, and empty or error states** rather than live GitHub catalogue data.
+
+For data-driven journeys against a real GitHub account, run the suite locally with a valid token — see [README.md](README.md).
+
+## Priority tiers
+
+### Tier 1 — Application shell and entry
+
+| Journey | Spec | What CI validates |
+|---------|------|-------------------|
+| Health endpoint responds before browser tests run | `smoke.spec.ts` | `GET /health` returns `Healthy`. |
+| Home dashboard renders and lists all feature entry points | `navigation.spec.ts`, `smoke.spec.ts` | Title, navigation shell, and all seven feature cards. |
+| Drawer navigation reaches every primary feature route | `navigation.spec.ts` | URL and page title for each route in `fixtures/navigation.ts`. |
+| About page shows deployment metadata | `about.spec.ts` | Version, auth mode, and repository link from the shell menu. |
+| PAT-mode welcome redirect and connectivity error page | `auth-entry.spec.ts` | `/welcome` redirects to home; connectivity error page renders guidance. |
+
+### Tier 2 — Feature shells without live GitHub data
+
+| Journey | Spec | What CI validates |
+|---------|------|-------------------|
+| Audit Dashboard repository selector failure | `audit-dashboard.spec.ts` | Feedback region and unable-to-load message; `/audit` alias. |
+| Repositories command strip and load failure | `repositories.spec.ts` | Refresh control, search field, and error state with retry. |
+| One-Click Migration setup shell | `migrate.spec.ts` | Workflow controls, disabled preview, and API failure feedback. |
+| Board Rules selector and compare mode | `board-rules.spec.ts` | Selector region, compare toggle, and repository load failure. |
+| Label Manager taxonomy tabs and empty repository state | `labels.spec.ts` | Tab strip, disabled actions, and no-repositories message. |
+| Workflow template browse, filter, and select | `workflows.spec.ts` | Built-in templates load; repository selector shows error. |
+| Triage not-started region without repositories | `triage.spec.ts` | Shell heading and no-repositories alert. |
+
+### Tier 3 — Out of CI scope (manual or future)
+
+| Journey | Rationale |
+|---------|-----------|
+| Hosted sign-in and admission-control denial | CI runs PAT mode with `HostedAdmissionControl__Enabled=false`. |
+| Live GitHub catalogue mutations (labels, migration apply, workflow deploy) | Requires a valid token and test repositories; covered by unit and component tests. |
+| Azure Container Apps probe behaviour | Validated at deploy time; see [OPERATIONAL_HARDENING_TEST_COVERAGE.md](../../plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md). |
+
+## Adding a new journey
+
+1. Confirm the journey belongs in Tier 1 or Tier 2 for CI, or document it in Tier 3 with rationale.
+2. Add or extend a spec under `tests/`.
+3. Prefer `data-testid` attributes on loading, error, and empty states — mirror existing feature pages.
+4. Update the coverage table in [README.md](README.md) and this document.
+5. Keep assertions resilient to placeholder auth unless the CI job is extended with secrets.
+
+## Related documentation
+
+- [tests/E2E/README.md](README.md) — local run and CI overview.
+- [plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md](../../plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md) — health and operational E2E expectations.
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — contributor testing guidance.

--- a/tests/E2E/README.md
+++ b/tests/E2E/README.md
@@ -2,6 +2,8 @@
 
 Playwright tests for key user journeys. These complement unit and bUnit component tests — they validate complete workflows in a real browser rather than replacing isolated unit coverage.
 
+Critical journeys, priority tiers, and CI constraints are documented in [CRITICAL_JOURNEYS.md](CRITICAL_JOURNEYS.md).
+
 ## Test coverage
 
 | Spec | What it validates |
@@ -9,6 +11,11 @@ Playwright tests for key user journeys. These complement unit and bUnit componen
 | `smoke.spec.ts` | Health endpoint and home page render |
 | `navigation.spec.ts` | Home feature cards and drawer navigation to all primary routes |
 | `about.spec.ts` | About page metadata via the shell menu |
+| `auth-entry.spec.ts` | PAT-mode welcome redirect and connectivity error page |
+| `audit-dashboard.spec.ts` | Audit Dashboard shell and repository load failure; `/audit` alias |
+| `repositories.spec.ts` | Repositories command strip and load failure handling |
+| `migrate.spec.ts` | One-Click Migration setup shell and API failure feedback |
+| `board-rules.spec.ts` | Board Rules selector region, compare mode, and load failure |
 | `labels.spec.ts` | Label Manager shell, tabs, and empty-repository state |
 | `workflows.spec.ts` | Built-in template browse/filter/select and repository error state |
 | `triage.spec.ts` | Triage shell and no-repositories alert without a live GitHub connection |

--- a/tests/E2E/tests/audit-dashboard.spec.ts
+++ b/tests/E2E/tests/audit-dashboard.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Audit Dashboard shell', () => {
+  test('page surfaces repository load failure without a live GitHub connection', async ({ page }) => {
+    await page.goto('/audit-dashboard');
+
+    await expect(page).toHaveTitle(/Audit Dashboard/);
+    await expect(page.getByRole('heading', { name: 'Audit Dashboard' })).toBeVisible();
+    await expect(page.getByTestId('audit-feedback-region')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('Unable to load repositories')).toBeVisible();
+  });
+
+  test('/audit route renders the same audit dashboard shell', async ({ page }) => {
+    await page.goto('/audit');
+
+    await expect(page).toHaveTitle(/Audit Dashboard/);
+    await expect(page.getByRole('heading', { name: 'Audit Dashboard' })).toBeVisible();
+    await expect(page.getByText('Unable to load repositories')).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/tests/E2E/tests/board-rules.spec.ts
+++ b/tests/E2E/tests/board-rules.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Board Rules Visualiser shell', () => {
+  test('selector region and compare mode toggle render before repository data is available', async ({ page }) => {
+    await page.goto('/board-rules');
+
+    await expect(page).toHaveTitle(/Board Rules Visualiser/);
+    await expect(page.getByRole('heading', { name: 'Board Rules Visualiser' })).toBeVisible();
+    await expect(page.getByTestId('board-rules-selector-region')).toBeVisible();
+    await expect(page.getByTestId('board-rules-compare-mode-toggle')).toBeVisible();
+    await expect(page.getByTestId('board-rules-visualisation-region')).toBeVisible();
+  });
+
+  test('repository load failure surfaces in the board rules feedback region', async ({ page }) => {
+    await page.goto('/board-rules');
+
+    await expect(page.getByTestId('board-rules-repositories-loading-state')).toBeHidden({ timeout: 15_000 });
+    await expect(page.getByTestId('board-rules-error-alert')).toBeVisible();
+    await expect(page.getByText(/GitHub API request failed/i)).toBeVisible();
+    await expect(page.getByTestId('board-rules-reload-repositories-button')).toBeVisible();
+  });
+});

--- a/tests/E2E/tests/migrate.spec.ts
+++ b/tests/E2E/tests/migrate.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('One-Click Migration shell', () => {
+  test('migration setup controls render and preview stays locked without repository data', async ({ page }) => {
+    await page.goto('/migrate');
+
+    await expect(page).toHaveTitle(/One-Click Migration/);
+    await expect(page.getByRole('heading', { name: 'One-Click Migration' })).toBeVisible();
+    await expect(page.getByTestId('migration-workflow-controls-card')).toBeVisible();
+    await expect(page.getByTestId('migration-workflow-controls-heading')).toHaveText('Migration setup');
+    await expect(page.getByTestId('migration-preview-button')).toBeDisabled();
+    await expect(page.getByTestId('migration-preview-empty-state')).toBeVisible();
+  });
+
+  test('repository load failure surfaces in the migration feedback region', async ({ page }) => {
+    await page.goto('/migrate');
+
+    await expect(page.getByTestId('migration-feedback-region')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('migration-operation-message')).toBeVisible();
+    await expect(page.getByText(/GitHub API request failed while loading repositories/i)).toBeVisible();
+  });
+});

--- a/tests/E2E/tests/navigation.spec.ts
+++ b/tests/E2E/tests/navigation.spec.ts
@@ -6,22 +6,32 @@ test.describe('Feature navigation', () => {
     await page.goto('/');
 
     await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Open Audit Dashboard' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Open Repositories' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Open One-Click Migration' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Open Label Manager' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Open Board Rules Visualiser' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Open Triage UI' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Open Workflow Templates' })).toBeVisible();
   });
 
   test('home feature cards navigate to the matching feature page', async ({ page }) => {
-    await page.goto('/');
+    const featureCards = [
+      { linkName: 'Open Audit Dashboard', path: '/audit-dashboard', title: /Audit Dashboard/ },
+      { linkName: 'Open Repositories', path: '/repositories', title: /Repositories/ },
+      { linkName: 'Open One-Click Migration', path: '/migrate', title: /One-Click Migration/ },
+      { linkName: 'Open Label Manager', path: '/labels', title: /Label Manager/ },
+      { linkName: 'Open Board Rules Visualiser', path: '/board-rules', title: /Board Rules Visualiser/ },
+      { linkName: 'Open Triage UI', path: '/triage', title: /Triage UI/ },
+      { linkName: 'Open Workflow Templates', path: '/workflows', title: /Workflow Templates/ },
+    ] as const;
 
-    await page.getByRole('link', { name: 'Open Label Manager' }).click();
-    await expect(page).toHaveURL(/\/labels$/);
-    await expect(page).toHaveTitle(/Label Manager/);
-
-    await page.goto('/');
-    await page.getByRole('link', { name: 'Open Workflow Templates' }).click();
-    await expect(page).toHaveURL(/\/workflows$/);
-    await expect(page).toHaveTitle(/Workflow Templates/);
+    for (const feature of featureCards) {
+      await page.goto('/');
+      await page.getByRole('link', { name: feature.linkName }).click();
+      await expect(page).toHaveURL(new RegExp(`${feature.path}$`));
+      await expect(page).toHaveTitle(feature.title);
+    }
   });
 
   test('drawer navigation reaches each primary feature route', async ({ page }) => {

--- a/tests/E2E/tests/repositories.spec.ts
+++ b/tests/E2E/tests/repositories.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Repositories shell', () => {
+  test('command strip and repository load failure are visible without a live GitHub connection', async ({ page }) => {
+    await page.goto('/repositories');
+
+    await expect(page).toHaveTitle(/Repositories/);
+    await expect(page.getByRole('heading', { name: 'Repositories' })).toBeVisible();
+    await expect(page.getByTestId('repositories-refresh-button')).toBeVisible();
+    await expect(page.getByLabel('Search repositories')).toBeVisible();
+    await expect(page.getByTestId('repositories-loading-state')).toBeHidden({ timeout: 15_000 });
+    await expect(page.getByTestId('repositories-error-state')).toBeVisible();
+    await expect(page.getByText('Unable to load repositories')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Try again' })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary of Changes

Adds Playwright end-to-end coverage for the highest-priority critical user journeys, documents the journey inventory in `tests/E2E/CRITICAL_JOURNEYS.md`, and extends existing navigation specs. Minor testability improvements on the Repositories page support stable selectors under placeholder auth in CI.

## Related Issue(s)

Closes #255

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] ✅ Test coverage (E2E Playwright specs and journey documentation)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and `docs/index.md` has been updated

## Screenshots (if applicable)

N/A — test and documentation changes only.

## Additional Notes

Journey inventory: `tests/E2E/CRITICAL_JOURNEYS.md`. New specs: `audit-dashboard`, `repositories`, `migrate`, `board-rules`. Expanded `navigation.spec.ts` home card assertions and click-through coverage.