### PR TITLE
Complete WCAG 2.1 AA accessibility audit for primary journeys (#253).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,6 +423,7 @@ FodyWeavers.xsd
 
 # Playwright files
 .playwright-mcp/
+tests/E2E/test-results/
 
 # Local developer settings
 **/appsettings.Development.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,7 @@ When suggesting a feature:
    - All tests must pass: `dotnet test`
    - Aim for meaningful test coverage, not just coverage percentage
    - Use Playwright for end-to-end user journeys where unit tests cannot validate the full workflow — see [`tests/E2E/README.md`](tests/E2E/README.md) and [`tests/E2E/CRITICAL_JOURNEYS.md`](tests/E2E/CRITICAL_JOURNEYS.md) for the CI journey inventory, local run steps, and selector conventions.
+   - Accessibility regression for primary journeys uses axe-core in Playwright (`accessibility.spec.ts`); findings are summarised in [`plan/ACCESSIBILITY_AUDIT.md`](plan/ACCESSIBILITY_AUDIT.md).
    - Prefer `data-testid` attributes on loading, error, and empty UI states when adding journeys that will run in CI with placeholder auth.
    - Do not test .NET Aspire AppHost modelling or orchestration.
 

--- a/plan/ACCESSIBILITY_AUDIT.md
+++ b/plan/ACCESSIBILITY_AUDIT.md
@@ -1,0 +1,80 @@
+# Accessibility audit — WCAG 2.1 AA
+
+This document records the WCAG 2.1 AA accessibility audit for SoloDevBoard primary journeys (issue [#253](https://github.com/markheydon/solo-dev-board/issues/253)).
+
+## Scope
+
+| Included | Excluded |
+|----------|----------|
+| Tier 1 and Tier 2 journeys from [CRITICAL_JOURNEYS.md](../tests/E2E/CRITICAL_JOURNEYS.md) | Hosted sign-in / admission-control denial (CI PAT mode) |
+| Application shell (app bar, drawer, skip link, theme) | Live GitHub catalogue mutations |
+| PAT connectivity error page | Azure Container Apps probe UI |
+| Light-mode default theme (axe in CI) | Manual screen-reader walkthrough of every dialog |
+
+Standard: **WCAG 2.1 Level A and AA**, automated with [axe-core](https://github.com/dequelabs/axe-core) via `@axe-core/playwright`.
+
+## Method
+
+1. Run axe against each audited route with tags `wcag2a`, `wcag2aa`, `wcag21a`, and `wcag21aa`.
+2. Treat **critical** and **serious** confirmed violations as blocking.
+3. Exclude transient `.mud-snackbar` overlays from page scans (snackbars animate and can produce false colour-contrast failures mid-transition).
+4. Keep regression coverage in `tests/E2E/tests/accessibility.spec.ts` (CI `e2e` job).
+
+## Routes audited
+
+| Route | Journey |
+|-------|---------|
+| `/` | Home dashboard |
+| `/about` | About |
+| `/auth/connectivity-error?reason=token-rejected` | PAT connectivity error |
+| `/audit-dashboard` | Audit Dashboard shell |
+| `/repositories` | Repositories shell |
+| `/migrate` | One-Click Migration shell |
+| `/labels` | Label Manager shell |
+| `/board-rules` | Board Rules shell |
+| `/triage` | Triage shell |
+| `/workflows` | Workflow Templates shell |
+
+## Findings and remediation
+
+### Critical / serious — fixed
+
+| Finding | Impact | Remediation |
+|---------|--------|-------------|
+| Shell icon buttons without accessible names (drawer toggle, dark mode) | Serious (button-name risk) | Added `aria-label` on `MudIconButton` controls in `MainLayout.razor`. |
+| No skip link to main content | Serious (keyboard / landmark) | Added “Skip to main content” link targeting `#main-content`, with minimal `.razor.css` (MudBlazor has no skip-link primitive). |
+| Insufficient colour contrast on Primary / Secondary / Success / Warning in light mode | Serious (`color-contrast`) | Retuned `SoloDevBoardTheme` light palette to WCAG AA ratios (for example Primary `#167c38`, Secondary `#0969da`, Warning `#9a6700`) and set explicit contrast text colours. |
+| Dark-mode filled controls risked light-on-light text | Serious | Bright dark palette accents use dark contrast text (`#0d1117`). |
+| Dark-mode error text on surface backgrounds below 4.5:1 | Serious (`color-contrast`) | Brightened dark `Error` to `#ff7b72` for WCAG AA on `#161b22` surfaces. |
+| Triage repository load failure duplicated inline alert with an error snackbar | Serious (snackbar contrast during animation) | Rely on the existing `MudAlert` / `operationMessage` region; removed redundant snackbars across all Triage error paths. |
+
+### Residual / incomplete (not blocking)
+
+Axe reported **incomplete** (needs review) items after remediation — no remaining confirmed critical/serious violations on the audited shells:
+
+| Rule | Notes |
+|------|-------|
+| `aria-prohibited-attr` (incomplete) | Typically MudBlazor structural nodes; revisit on MudBlazor upgrades. |
+| `color-contrast` (incomplete) | Axe could not resolve contrast on some dynamic/overlay nodes; light theme fixed for confirmed cases. |
+| `aria-valid-attr-value` (incomplete on `/migrate`) | Needs manual review against MudBlazor select/checkbox markup. |
+| MudBlazor snackbars | Page audits exclude `.mud-snackbar` to avoid animation false positives. Snackbars use the outlined variant with zero transition duration (`Program.cs`) and are regression-tested in isolation via `accessibility.spec.ts` (Repositories placeholder action). Prefer inline `MudAlert` for persistent page errors. |
+
+## Regression tests
+
+| Spec | Asserts |
+|------|---------|
+| `tests/E2E/tests/accessibility.spec.ts` | Each audited route has no critical/serious axe violations in **light and dark** mode; shell exposes skip link and labelled navigation controls; warning snackbar passes an isolated axe scan. |
+| `tests/E2E/fixtures/accessibility.ts` | Shared axe helpers, route list, shell-ready wait, and dark-mode toggle helper. |
+
+## Operator notes
+
+- Run accessibility E2E with the same host as other Playwright tests — see [tests/E2E/README.md](../tests/E2E/README.md).
+- Palette changes live in `src/App/SoloDevBoard.App/Themes/SoloDevBoardTheme.cs`. Re-run the accessibility suite after theme edits.
+- Dialog-heavy flows (label create/edit, board-rule detail) should be re-checked manually or with targeted axe scans when those UIs change substantially.
+
+## Acceptance criteria mapping
+
+| Criterion | Status |
+|-----------|--------|
+| Primary journeys audited | Done — Tier 1–2 routes above. |
+| Critical issues logged or fixed | Done — contrast and shell labelling fixed; residuals logged here. |

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -214,7 +214,7 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 
 ### Key Tasks
 - [ ] Achieve ≥80% unit test coverage across `Application` and `Domain` projects. _(#252)_
-- [ ] Perform accessibility audit of all Blazor components (WCAG 2.1 AA). _(#253)_
+- [x] Perform accessibility audit of primary journey shells (WCAG 2.1 AA). _(#253; see plan/ACCESSIBILITY_AUDIT.md and tests/E2E/tests/accessibility.spec.ts.)_
 - [ ] Conduct performance review: identify and address slow GitHub API calls (caching, pagination). _(#254)_
 - [x] Complete Azure infrastructure baseline via Bicep (App Service, Key Vault, managed identity). _(#104 — superseded by ADR-0018 Aspire ACA migration.)_
 - [x] Migrate production deployment to Aspire Azure Container Apps with scale-to-zero. _(ADR-0018.)_

--- a/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Triage/Pages/Triage.razor.cs
@@ -48,10 +48,6 @@ public partial class Triage : ComponentBase
     [Inject]
     public ILogger<Triage> Logger { get; set; } = default!;
 
-    /// <summary>Gets or sets the snackbar service used for non-blocking notifications.</summary>
-    [Inject]
-    public ISnackbar Snackbar { get; set; } = default!;
-
     /// <summary>Gets or sets the GitHub authentication recovery service.</summary>
     [Inject]
     public IGitHubAuthenticationRecoveryService GitHubAuthRecovery { get; set; } = default!;
@@ -73,6 +69,8 @@ public partial class Triage : ComponentBase
     private string selectedProjectBoardId = string.Empty;
     private string selectedProjectBoardStatusOptionId = string.Empty;
     private string? operationMessage;
+    // Persistent page feedback uses MudAlert via operationMessage; snackbars are not duplicated here
+    // because animated overlays can fail axe colour-contrast scans and duplicate inline alerts.
     private string? inaccessibleProjectBoardsWarning;
     private Severity operationSeverity = Severity.Info;
     private bool isLoadingPlanningOptions;
@@ -226,14 +224,12 @@ public partial class Triage : ComponentBase
             Logger.LogError(ex, "GitHub API request failed while loading triage repositories.");
             operationSeverity = Severity.Error;
             operationMessage = $"GitHub API request failed while loading repositories. {ex.Message}";
-            Snackbar.Add("Failed to load repositories for triage session scope.", Severity.Error);
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to load triage repositories.");
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while loading repositories.";
-            Snackbar.Add("An unexpected error occurred while loading triage repositories.", Severity.Error);
         }
         finally
         {
@@ -289,7 +285,6 @@ public partial class Triage : ComponentBase
         {
             operationSeverity = Severity.Warning;
             operationMessage = "Repository scope must be in owner/repository format.";
-            Snackbar.Add("Select a valid repository scope before starting triage.", Severity.Warning);
             return;
         }
 
@@ -320,14 +315,12 @@ public partial class Triage : ComponentBase
             Logger.LogError(ex, "GitHub API request failed while starting triage session for {RepositoryScope}.", selectedRepositoryFullName);
             operationSeverity = Severity.Error;
             operationMessage = $"GitHub API request failed while starting triage session. {ex.Message}";
-            Snackbar.Add("Failed to start triage session due to a GitHub API error.", Severity.Error);
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to start triage session for {RepositoryScope}.", selectedRepositoryFullName);
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while starting triage session.";
-            Snackbar.Add("An unexpected error occurred while starting triage session.", Severity.Error);
         }
         finally
         {
@@ -372,7 +365,6 @@ public partial class Triage : ComponentBase
             selectedQuickActionLabelName = string.Empty;
             operationSeverity = Severity.Error;
             operationMessage = $"GitHub API request failed while loading labels. {ex.Message}";
-            Snackbar.Add("Failed to load quick-action labels for triage.", Severity.Error);
         }
         catch (Exception ex)
         {
@@ -381,7 +373,6 @@ public partial class Triage : ComponentBase
             selectedQuickActionLabelName = string.Empty;
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while loading labels for quick actions.";
-            Snackbar.Add("An unexpected error occurred while loading quick-action labels.", Severity.Error);
         }
     }
 
@@ -473,14 +464,12 @@ public partial class Triage : ComponentBase
             Logger.LogError(ex, "GitHub API request failed while applying label to triage item.");
             operationSeverity = Severity.Error;
             operationMessage = $"GitHub API request failed while applying the label. {ex.Message}";
-            Snackbar.Add("Could not apply the selected label due to a GitHub API error.", Severity.Error);
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to apply label to the current triage item.");
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while applying the selected label.";
-            Snackbar.Add("Could not apply the selected label.", Severity.Error);
         }
         finally
         {
@@ -512,7 +501,6 @@ public partial class Triage : ComponentBase
             Logger.LogError(ex, "Failed to move to the next triage item without changes.");
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while moving to the next item without changes.";
-            Snackbar.Add("Could not move to the next item without changes.", Severity.Error);
         }
         finally
         {
@@ -575,14 +563,12 @@ public partial class Triage : ComponentBase
             Logger.LogError(ex, "GitHub API request failed while closing triage item as duplicate.");
             operationSeverity = Severity.Error;
             operationMessage = $"GitHub API request failed while closing as duplicate. {ex.Message}";
-            Snackbar.Add("Could not close the item as a duplicate due to a GitHub API error.", Severity.Error);
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to close the current triage item as duplicate.");
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while closing this item as a duplicate.";
-            Snackbar.Add("Could not close the item as a duplicate.", Severity.Error);
         }
         finally
         {
@@ -615,7 +601,6 @@ public partial class Triage : ComponentBase
             Logger.LogError(ex, "Failed to skip the current triage item.");
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while skipping this item.";
-            Snackbar.Add("Could not skip the current item.", Severity.Error);
         }
         finally
         {
@@ -692,14 +677,12 @@ public partial class Triage : ComponentBase
             Logger.LogError(ex, "GitHub API request failed while assigning milestone to triage item.");
             operationSeverity = Severity.Error;
             operationMessage = $"GitHub API request failed while assigning milestone. {ex.Message}";
-            Snackbar.Add("Could not assign the selected milestone due to a GitHub API error.", Severity.Error);
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to assign milestone to the current triage item.");
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while assigning the selected milestone.";
-            Snackbar.Add("Could not assign the selected milestone.", Severity.Error);
         }
         finally
         {
@@ -750,14 +733,12 @@ public partial class Triage : ComponentBase
             Logger.LogError(ex, "GitHub API request failed while adding triage item to project board.");
             operationSeverity = Severity.Error;
             operationMessage = $"GitHub API request failed while adding to project board. {ex.Message}";
-            Snackbar.Add("Could not add the item to the selected project board due to a GitHub API error.", Severity.Error);
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to add the current triage item to a project board.");
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while adding this item to a project board.";
-            Snackbar.Add("Could not add the item to the selected project board.", Severity.Error);
         }
         finally
         {
@@ -786,7 +767,6 @@ public partial class Triage : ComponentBase
             Logger.LogError(ex, "Failed to revisit skipped triage items.");
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while revisiting skipped items.";
-            Snackbar.Add("Could not revisit skipped triage items.", Severity.Error);
         }
         finally
         {
@@ -821,7 +801,6 @@ public partial class Triage : ComponentBase
             milestoneLoadFailed = true;
             operationSeverity = Severity.Error;
             operationMessage = $"GitHub API request failed while loading milestone options. {ex.Message}";
-            Snackbar.Add("Failed to load milestone options for triage.", Severity.Error);
         }
         catch (Exception ex)
         {
@@ -830,7 +809,6 @@ public partial class Triage : ComponentBase
             milestoneLoadFailed = true;
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while loading milestone options.";
-            Snackbar.Add("An unexpected error occurred while loading milestone options.", Severity.Error);
         }
 
         try
@@ -881,7 +859,6 @@ public partial class Triage : ComponentBase
             {
                 operationSeverity = Severity.Warning;
                 operationMessage = $"Milestones loaded, but project-board options could not be loaded. {ex.Message}";
-                Snackbar.Add("Failed to load project-board options for triage.", Severity.Warning);
             }
         }
         catch (Exception ex)
@@ -896,7 +873,6 @@ public partial class Triage : ComponentBase
             {
                 operationSeverity = Severity.Warning;
                 operationMessage = "Milestones loaded, but an unexpected error occurred while loading project-board options.";
-                Snackbar.Add("An unexpected error occurred while loading project-board options.", Severity.Warning);
             }
         }
         finally

--- a/src/App/SoloDevBoard.App/Components/Shell/Layout/MainLayout.razor
+++ b/src/App/SoloDevBoard.App/Components/Shell/Layout/MainLayout.razor
@@ -6,9 +6,15 @@
 <MudDialogProvider />
 <MudSnackbarProvider />
 
+<a href="#main-content" class="skip-to-content">Skip to main content</a>
+
 <MudLayout>
     <MudAppBar Elevation="1">
-        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
+        <MudIconButton Icon="@Icons.Material.Filled.Menu"
+                       Color="Color.Inherit"
+                       Edge="Edge.Start"
+                       aria-label="Toggle navigation drawer"
+                       OnClick="@((e) => DrawerToggle())" />
         <MudText Typo="Typo.h5" Class="ml-3">SoloDevBoard</MudText>
         <MudSpacer />
         @if (_showPatConnectionStatus && _patConnectionStatus is not null)
@@ -22,7 +28,10 @@
                 @_patConnectionStatus.StatusMessage
             </MudChip>
         }
-        <MudIconButton Icon="@(DarkLightModeButtonIcon)" Color="Color.Inherit" OnClick="@DarkModeToggle" />
+        <MudIconButton Icon="@(DarkLightModeButtonIcon)"
+                       Color="Color.Inherit"
+                       aria-label="@(_isDarkMode ? "Toggle light mode" : "Toggle dark mode")"
+                       OnClick="@DarkModeToggle" />
         <MudMenu Icon="@Icons.Material.Filled.MoreVert" Color="Color.Inherit" AriaLabel="More options">
             <MudMenuItem Href="/about" Icon="@Icons.Material.Filled.Info">About</MudMenuItem>
             @if (_showSignOut)
@@ -31,10 +40,14 @@
             }
         </MudMenu>
     </MudAppBar>
-    <MudDrawer id="nav-drawer" @bind-Open="_drawerOpen" ClipMode="DrawerClipMode.Always" Elevation="2">
+    <MudDrawer id="nav-drawer"
+               @bind-Open="_drawerOpen"
+               ClipMode="DrawerClipMode.Always"
+               Elevation="2"
+               aria-label="Primary navigation">
         <NavMenu />
     </MudDrawer>
-    <MudMainContent Class="pt-16 pa-4">
+    <MudMainContent id="main-content" Class="pt-16 pa-4" tabIndex="-1">
         @Body
     </MudMainContent>
 </MudLayout>

--- a/src/App/SoloDevBoard.App/Components/Shell/Layout/MainLayout.razor.css
+++ b/src/App/SoloDevBoard.App/Components/Shell/Layout/MainLayout.razor.css
@@ -1,0 +1,20 @@
+/* Skip link is an accessibility escape hatch — MudBlazor has no skip-link primitive. */
+.skip-to-content {
+    position: absolute;
+    left: -9999px;
+    top: 0;
+    z-index: 2000;
+    padding: 0.75rem 1rem;
+    background: var(--mud-palette-primary, #167c38);
+    color: var(--mud-palette-primary-text, #ffffff);
+    text-decoration: none;
+    border-radius: 0 0 6px 0;
+}
+
+.skip-to-content:focus {
+    left: 0;
+}
+
+#main-content:focus {
+    outline: none;
+}

--- a/src/App/SoloDevBoard.App/Program.cs
+++ b/src/App/SoloDevBoard.App/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
+using MudBlazor;
 using MudBlazor.Services;
 using SoloDevBoard.App.Authentication;
 using SoloDevBoard.App.Components.Shell;
@@ -34,7 +35,16 @@ if (TryGetConfiguredHttpsPort(hostedCallbackBaseUri, out var httpsPort))
 }
 
 // Add MudBlazor services.
-builder.Services.AddMudServices();
+builder.Services.AddMudServices(config =>
+{
+    config.SnackbarConfiguration.PositionClass = Defaults.Classes.Position.BottomRight;
+    config.SnackbarConfiguration.PreventDuplicates = true;
+    config.SnackbarConfiguration.ShowCloseIcon = true;
+    config.SnackbarConfiguration.VisibleStateDuration = 5000;
+    config.SnackbarConfiguration.ShowTransitionDuration = 0;
+    config.SnackbarConfiguration.HideTransitionDuration = 0;
+    config.SnackbarConfiguration.SnackbarVariant = Variant.Outlined;
+});
 
 // Add services to the container.
 builder.Services.AddRazorComponents()

--- a/src/App/SoloDevBoard.App/Themes/SoloDevBoardTheme.cs
+++ b/src/App/SoloDevBoard.App/Themes/SoloDevBoardTheme.cs
@@ -7,11 +7,13 @@ namespace SoloDevBoard.Themes;
 /// </summary>
 public static class SoloDevBoardTheme
 {
-    // Light palette inspired by GitHub.
+    // Light palette inspired by GitHub, tuned for WCAG 2.1 AA contrast (issue #253).
     private static PaletteLight PaletteLight => new()
     {
-        Primary = "#2da44e",
-        Secondary = "#2188ff",
+        Primary = "#167c38",
+        PrimaryContrastText = "#ffffff",
+        Secondary = "#0969da",
+        SecondaryContrastText = "#ffffff",
         Surface = "#f6f8fa",
         Background = "#ffffff",
         TextPrimary = "#24292e",
@@ -23,21 +25,27 @@ public static class SoloDevBoardTheme
         DrawerBackground = "#f6f8fa",
         AppbarBackground = "#ffffff",
         AppbarText = "#24292e",
-        Success = "#238636",
-        Warning = "#d29922",
+        Success = "#167c38",
+        SuccessContrastText = "#ffffff",
+        Warning = "#9a6700",
+        WarningContrastText = "#ffffff",
         Error = "#cf222e",
+        ErrorContrastText = "#ffffff",
         Info = "#0969da",
+        InfoContrastText = "#ffffff",
         LinesDefault = "#d0d7de",
         TableLines = "#d0d7de",
         Divider = "#d8dee4",
         OverlayLight = "#00000080",
     };
 
-    // Dark palette inspired by GitHub.
+    // Dark palette inspired by GitHub, tuned for WCAG 2.1 AA contrast (issue #253).
     private static PaletteDark PaletteDark => new()
     {
-        Primary = "#2ea043",
-        Secondary = "#2f81f7",
+        Primary = "#3fb950",
+        PrimaryContrastText = "#0d1117",
+        Secondary = "#58a6ff",
+        SecondaryContrastText = "#0d1117",
         Surface = "#161b22",
         Background = "#0d1117",
         TextPrimary = "#c9d1d9",
@@ -49,10 +57,14 @@ public static class SoloDevBoardTheme
         DrawerBackground = "#161b22",
         AppbarBackground = "#0d1117",
         AppbarText = "#c9d1d9",
-        Success = "#238636",
+        Success = "#3fb950",
+        SuccessContrastText = "#0d1117",
         Warning = "#d29922",
-        Error = "#cf222e",
-        Info = "#1f6feb",
+        WarningContrastText = "#0d1117",
+        Error = "#ff7b72",
+        ErrorContrastText = "#0d1117",
+        Info = "#58a6ff",
+        InfoContrastText = "#0d1117",
         LinesDefault = "#30363d",
         TableLines = "#30363d",
         Divider = "#30363d",

--- a/tests/E2E/CRITICAL_JOURNEYS.md
+++ b/tests/E2E/CRITICAL_JOURNEYS.md
@@ -19,6 +19,7 @@ For data-driven journeys against a real GitHub account, run the suite locally wi
 | Drawer navigation reaches every primary feature route | `navigation.spec.ts` | URL and page title for each route in `fixtures/navigation.ts`. |
 | About page shows deployment metadata | `about.spec.ts` | Version, auth mode, and repository link from the shell menu. |
 | PAT-mode welcome redirect and connectivity error page | `auth-entry.spec.ts` | `/welcome` redirects to home; connectivity error page renders guidance. |
+| WCAG 2.1 AA shell and route audit (no critical/serious axe violations) | `accessibility.spec.ts` | axe-core scan of Tier 1–2 routes in light and dark mode; skip link, labelled shell controls, and isolated snackbar scan. See [plan/ACCESSIBILITY_AUDIT.md](../../plan/ACCESSIBILITY_AUDIT.md). |
 
 ### Tier 2 — Feature shells without live GitHub data
 

--- a/tests/E2E/README.md
+++ b/tests/E2E/README.md
@@ -19,8 +19,11 @@ Critical journeys, priority tiers, and CI constraints are documented in [CRITICA
 | `labels.spec.ts` | Label Manager shell, tabs, and empty-repository state |
 | `workflows.spec.ts` | Built-in template browse/filter/select and repository error state |
 | `triage.spec.ts` | Triage shell and no-repositories alert without a live GitHub connection |
+| `accessibility.spec.ts` | WCAG 2.1 AA axe-core scan of Tier 1–2 journeys in light and dark mode; labelled shell controls; isolated snackbar contrast scan |
 
 Tests are designed to pass in CI with placeholder auth (`GitHubAuth__PersonalAccessToken=ci-e2e-placeholder`). Repository-dependent features assert empty or error states rather than live GitHub data.
+
+Accessibility findings and remediation notes for issue #253 live in [plan/ACCESSIBILITY_AUDIT.md](../../plan/ACCESSIBILITY_AUDIT.md).
 
 ## Prerequisites
 

--- a/tests/E2E/fixtures/accessibility.ts
+++ b/tests/E2E/fixtures/accessibility.ts
@@ -1,0 +1,91 @@
+import AxeBuilder from '@axe-core/playwright';
+import type { Result } from 'axe-core';
+import { expect, type Page } from '@playwright/test';
+
+/** Routes audited for WCAG 2.1 AA in the CI accessibility suite. */
+export const accessibilityRoutes = [
+  { path: '/', name: 'Home' },
+  { path: '/about', name: 'About' },
+  { path: '/auth/connectivity-error?reason=token-rejected', name: 'PAT connectivity error' },
+  { path: '/audit-dashboard', name: 'Audit Dashboard' },
+  { path: '/repositories', name: 'Repositories' },
+  { path: '/migrate', name: 'One-Click Migration' },
+  { path: '/labels', name: 'Label Manager' },
+  { path: '/board-rules', name: 'Board Rules' },
+  { path: '/triage', name: 'Triage' },
+  { path: '/workflows', name: 'Workflow Templates' },
+] as const;
+
+const wcagTags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] as const;
+
+function getBlockingViolations(violations: Result['violations']) {
+  return violations.filter(
+    (violation) => violation.impact === 'critical' || violation.impact === 'serious',
+  );
+}
+
+function formatViolationSummary(blocking: Result['violations']): string {
+  return blocking
+    .map((violation) => {
+      const nodes = violation.nodes
+        .slice(0, 5)
+        .map((node) => `    - ${node.target.join(' ')}: ${node.failureSummary}`)
+        .join('\n');
+      return `${violation.id} (${violation.impact}): ${violation.help}\n${nodes}`;
+    })
+    .join('\n\n');
+}
+
+function assertNoBlockingViolations(blocking: Result['violations'], context: string): void {
+  const summary = formatViolationSummary(blocking);
+  expect(blocking, `Critical/serious accessibility violations on ${context}:\n${summary}`).toEqual([]);
+}
+
+/**
+ * Runs axe-core against the current page for WCAG 2.1 A and AA rules.
+ * Asserts that no critical or serious violations are present.
+ */
+export async function expectNoCriticalOrSeriousViolations(page: Page, context: string): Promise<void> {
+  // Transient snackbars can animate mid-scan and report false colour-contrast failures.
+  // Page-level audits therefore exclude snackbar overlays; snackbar contrast is covered
+  // separately by expectNoCriticalOrSeriousViolationsOnSelector.
+  const results = await new AxeBuilder({ page })
+    .withTags([...wcagTags])
+    .exclude('.mud-snackbar')
+    .analyze();
+
+  assertNoBlockingViolations(getBlockingViolations(results.violations), context);
+}
+
+/**
+ * Runs axe-core against a specific selector on the current page.
+ * Use for isolated component scans such as MudBlazor snackbars.
+ */
+export async function expectNoCriticalOrSeriousViolationsOnSelector(
+  page: Page,
+  selector: string,
+  context: string,
+): Promise<void> {
+  const results = await new AxeBuilder({ page })
+    .include(selector)
+    .withTags([...wcagTags])
+    .analyze();
+
+  assertNoBlockingViolations(getBlockingViolations(results.violations), context);
+}
+
+/** Waits for the page to finish rendering before accessibility scans. */
+export async function waitForAccessibilityScanReady(page: Page, path: string): Promise<void> {
+  if (path.startsWith('/auth/connectivity-error')) {
+    await expect(page.getByRole('heading', { name: 'GitHub connection problem' })).toBeVisible();
+    return;
+  }
+
+  await expect(page.getByRole('navigation')).toBeVisible();
+}
+
+/** Enables dark mode via the shell theme toggle. */
+export async function enableDarkMode(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Toggle dark mode' }).click();
+  await expect(page.getByRole('button', { name: 'Toggle light mode' })).toBeVisible();
+}

--- a/tests/E2E/fixtures/accessibility.ts
+++ b/tests/E2E/fixtures/accessibility.ts
@@ -18,6 +18,16 @@ export const accessibilityRoutes = [
 
 const wcagTags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] as const;
 
+/** Route-specific loading indicators that must settle before page-level axe scans. */
+const routeLoadingTestIds: Readonly<Record<string, readonly string[]>> = {
+  '/repositories': ['repositories-loading-state'],
+  '/audit-dashboard': ['audit-loading-state'],
+  '/labels': ['labels-loading-state'],
+  '/board-rules': ['board-rules-repositories-loading-state'],
+  '/triage': ['triage-loading-repositories'],
+  '/workflows': ['workflow-repositories-loading-state', 'workflow-templates-loading-state'],
+};
+
 function getBlockingViolations(violations: Result['violations']) {
   return violations.filter(
     (violation) => violation.impact === 'critical' || violation.impact === 'serious',
@@ -82,6 +92,18 @@ export async function waitForAccessibilityScanReady(page: Page, path: string): P
   }
 
   await expect(page.getByRole('navigation')).toBeVisible();
+
+  const routePath = path.split('?')[0];
+  const loadingTestIds = routeLoadingTestIds[routePath] ?? [];
+
+  for (const testId of loadingTestIds) {
+    await expect(page.getByTestId(testId)).toBeHidden({ timeout: 15_000 });
+  }
+
+  // Filled primary controls are disabled during repository loads; wait for a stable enabled state.
+  if (routePath === '/repositories') {
+    await expect(page.getByTestId('repositories-refresh-button')).toBeEnabled({ timeout: 15_000 });
+  }
 }
 
 /** Enables dark mode via the shell theme toggle. */

--- a/tests/E2E/package-lock.json
+++ b/tests/E2E/package-lock.json
@@ -6,7 +6,21 @@
     "": {
       "name": "solodevboard-e2e",
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.52.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -23,6 +37,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/fsevents": {

--- a/tests/E2E/package.json
+++ b/tests/E2E/package.json
@@ -5,6 +5,7 @@
     "test": "playwright test"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.52.0"
   }
 }

--- a/tests/E2E/tests/accessibility.spec.ts
+++ b/tests/E2E/tests/accessibility.spec.ts
@@ -51,7 +51,7 @@ test.describe('WCAG 2.1 AA accessibility', () => {
 
   test('info snackbar meets WCAG 2.1 AA contrast requirements', async ({ page }) => {
     await page.goto('/repositories');
-    await expect(page.getByRole('heading', { name: 'Repositories' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Repositories', exact: true })).toBeVisible();
     await expect(page.getByTestId('repositories-loading-state')).toBeHidden({ timeout: 15_000 });
 
     await page.getByRole('button', { name: 'Add' }).click();

--- a/tests/E2E/tests/accessibility.spec.ts
+++ b/tests/E2E/tests/accessibility.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import {
+  accessibilityRoutes,
+  enableDarkMode,
+  expectNoCriticalOrSeriousViolations,
+  expectNoCriticalOrSeriousViolationsOnSelector,
+  waitForAccessibilityScanReady,
+} from '../fixtures/accessibility';
+
+test.describe('WCAG 2.1 AA accessibility', () => {
+  test.describe('light mode', () => {
+    for (const route of accessibilityRoutes) {
+      test(`${route.name} (${route.path}) has no critical or serious axe violations`, async ({ page }) => {
+        const response = await page.goto(route.path);
+        expect(response?.ok() || response?.status() === 401).toBeTruthy();
+
+        await waitForAccessibilityScanReady(page, route.path);
+        await expectNoCriticalOrSeriousViolations(page, `${route.name} (light)`);
+      });
+    }
+  });
+
+  test.describe('dark mode', () => {
+    for (const route of accessibilityRoutes) {
+      test(`${route.name} (${route.path}) has no critical or serious axe violations`, async ({ page }) => {
+        const response = await page.goto(route.path);
+        expect(response?.ok() || response?.status() === 401).toBeTruthy();
+
+        if (!route.path.startsWith('/auth/connectivity-error')) {
+          await waitForAccessibilityScanReady(page, route.path);
+          await enableDarkMode(page);
+        } else {
+          await waitForAccessibilityScanReady(page, route.path);
+        }
+
+        await expectNoCriticalOrSeriousViolations(page, `${route.name} (dark)`);
+      });
+    }
+  });
+
+  test('home shell exposes labelled navigation controls', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('link', { name: 'Skip to main content' })).toBeAttached();
+    await expect(page.getByRole('button', { name: 'Toggle navigation drawer' })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Toggle (dark|light) mode/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'More options' })).toBeVisible();
+    await expect(page.getByRole('navigation')).toBeVisible();
+    await expect(page.locator('#main-content')).toBeVisible();
+  });
+
+  test('info snackbar meets WCAG 2.1 AA contrast requirements', async ({ page }) => {
+    await page.goto('/repositories');
+    await expect(page.getByRole('heading', { name: 'Repositories' })).toBeVisible();
+    await expect(page.getByTestId('repositories-loading-state')).toBeHidden({ timeout: 15_000 });
+
+    await page.getByRole('button', { name: 'Add' }).click();
+    await expect(page.locator('.mud-snackbar').first()).toBeVisible();
+
+    await expectNoCriticalOrSeriousViolationsOnSelector(
+      page,
+      '.mud-snackbar',
+      'Repositories placeholder snackbar',
+    );
+  });
+});

--- a/tests/E2E/tests/repositories.spec.ts
+++ b/tests/E2E/tests/repositories.spec.ts
@@ -5,7 +5,7 @@ test.describe('Repositories shell', () => {
     await page.goto('/repositories');
 
     await expect(page).toHaveTitle(/Repositories/);
-    await expect(page.getByRole('heading', { name: 'Repositories' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Repositories', exact: true })).toBeVisible();
     await expect(page.getByTestId('repositories-refresh-button')).toBeVisible();
     await expect(page.getByLabel('Search repositories')).toBeVisible();
     await expect(page.getByTestId('repositories-loading-state')).toBeHidden({ timeout: 15_000 });


### PR DESCRIPTION
## Summary of Changes

Completes the WCAG 2.1 AA accessibility audit for Tier 1–2 primary journeys (#253).

- Adds axe-core Playwright regression coverage (`tests/E2E/tests/accessibility.spec.ts`) for all audited routes in light and dark mode.
- Fixes shell accessibility: `aria-label` on icon buttons, skip link to `#main-content`, and labelled navigation drawer.
- Retunes `SoloDevBoardTheme` light and dark palettes for WCAG AA colour contrast.
- Removes redundant Triage error snackbars in favour of existing inline `MudAlert` / `operationMessage` regions.
- Records scope, findings, and residuals in `plan/ACCESSIBILITY_AUDIT.md`.

## Related Issue(s)

Closes #253

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and `docs/index.md` has been updated

## Screenshots (if applicable)

N/A — accessibility and theme contrast changes; see `plan/ACCESSIBILITY_AUDIT.md` for remediation detail.

## Additional Notes

Global snackbar behaviour now uses the **outlined** variant, **bottom-right** position, **close icon**, **duplicate prevention**, and **5 s** duration — configured in `Program.cs` with zero show/hide transition duration to avoid false-positive axe colour-contrast failures during snackbar animation.
