### PR TITLE
Document PAT-only local trusted mode and self-hoster Azure deploy path (#247, #248).

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,14 +33,14 @@ We are committed to providing a welcoming and inclusive environment for all cont
 
 3. **Configure GitHub authentication (Aspire, recommended):**
 
-   For solo local development, use **PAT mode** (the default). Set your token via AppHost parameters:
+   For solo local development, use **PAT-only local trusted mode** (the default). Set your token via AppHost parameters:
 
    ```bash
    aspire secret set Parameters:gh-pat "<your-github-pat>"
    aspire start --apphost src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
-```
+   ```
 
-   Your GitHub login is resolved automatically from the PAT. See [`src/SoloDevBoard.AppHost/README.md`](src/SoloDevBoard.AppHost/README.md) for hosted sign-in parameters.
+   Your GitHub login is resolved automatically from the PAT. See [Getting Started — PAT-only local trusted mode](docs/getting-started.md#pat-only-local-trusted-mode) and [`src/SoloDevBoard.AppHost/README.md`](src/SoloDevBoard.AppHost/README.md) for the mode comparison and hosted sign-in parameters.
 4. **Open the app:**
    ```bash
    aspire describe

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Ensure you have the following installed:
 
 ### Run Locally
 
-SoloDevBoard uses **Aspire for local orchestration and production deployment** to Azure Container Apps. Two authentication modes are available: **PAT mode** (default, for solo local development) and **hosted sign-in** (GitHub App, for production). See [Getting Started](docs/getting-started.md#choose-your-authentication-mode) for the full mode guide.
+SoloDevBoard uses **Aspire for local orchestration and production deployment** to Azure Container Apps. Two authentication modes are available: **PAT-only local trusted mode** (default, for solo local development and trusted personal self-hosting) and **hosted sign-in** (GitHub App, for shared or public deployments). See [Getting Started — PAT-only local trusted mode](docs/getting-started.md#pat-only-local-trusted-mode) for the mode comparison.
 
 **Quick start with Aspire (recommended):**
 
@@ -54,7 +54,7 @@ cd solo-dev-board
 # Restore dependencies
 dotnet restore SoloDevBoard.slnx
 
-# Configure GitHub auth — one secret for PAT mode
+# Configure GitHub auth — one secret for PAT-only local trusted mode
 aspire secret set Parameters:gh-pat "<your-pat>"
 
 # Start with Aspire
@@ -74,7 +74,7 @@ dotnet run --project src/App/SoloDevBoard.App
 
 For **hosted sign-in mode** (GitHub App), see [docs/getting-started.md](docs/getting-started.md#hosted-sign-in-mode-setup) or [`src/SoloDevBoard.AppHost/README.md`](src/SoloDevBoard.AppHost/README.md).
 
-Aspire is used for both local orchestration and production deployment to Azure Container Apps. See [docs/deployment.md](docs/deployment.md) for Azure deployment instructions.
+Aspire is used for both local orchestration and production deployment to Azure Container Apps. See [docs/deployment.md](docs/deployment.md) for Azure deployment instructions, including the [self-hoster PAT path](docs/deployment.md#self-hoster-deployment-pat-mode) for a personal instance on your own subscription.
 
 ## Project Structure
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,6 +10,15 @@ SoloDevBoard deploys to **Azure Container Apps** via **Aspire** (`aspire deploy`
 
 Scale-to-zero is enabled (`MinReplicas = 0`) to minimise idle hosting costs. Expect cold starts and Blazor Server SignalR reconnects after idle periods.
 
+Choose an authentication mode **before** you deploy:
+
+| Path | Authentication | Best for |
+|---|---|---|
+| **[Self-hoster (PAT mode)](#self-hoster-deployment-pat-mode)** | One personal access token; no GitHub App | A personal instance on your own Azure subscription |
+| **[Hosted sign-in](#deploy-from-github-actions)** | GitHub App OAuth + allow-lists | Shared or public production deployments |
+
+Both paths use the same Aspire / Azure Container Apps stack. Only the AppHost parameters and GitHub Environment secrets differ.
+
 ---
 
 ## Prerequisites
@@ -18,12 +27,117 @@ Scale-to-zero is enabled (`MinReplicas = 0`) to minimise idle hosting costs. Exp
 |---|---|
 | Azure subscription | With permission to create resources in a resource group |
 | [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) | Logged in with `az login` |
-| GitHub repository admin access | To configure environments, secrets, and workflows |
-| GitHub App (hosted sign-in) | Recommended for production; see [Hosted Authentication](user-guide/hosted-authentication.md) |
+| GitHub repository admin access | To configure environments, secrets, and workflows (skip if you only deploy with local `aspire deploy`) |
+| GitHub Personal Access Token **or** GitHub App | PAT for [self-hoster mode](#self-hoster-deployment-pat-mode); GitHub App for [hosted sign-in](user-guide/hosted-authentication.md) |
+
+---
+
+## Self-hoster deployment (PAT mode)
+
+Use this path when you want a **personal** SoloDevBoard instance on your own Azure subscription without setting up a GitHub App. Authentication stays in **PAT-only local trusted mode**: the Container App uses one configured PAT for all GitHub API calls, and there is no `/auth/sign-in` flow.
+
+> **Trust boundary:** Anyone who can reach the Container App URL acts as the PAT owner. Prefer a private network, IP restrictions, or a URL you alone use. For shared or public endpoints, use [hosted sign-in](user-guide/hosted-authentication.md) instead. Local PAT setup is documented in [Getting Started — PAT-only local trusted mode](getting-started.md#pat-only-local-trusted-mode).
+
+### What you need
+
+1. An Azure subscription and a resource group (step 1 under [One-time Azure setup](#one-time-azure-setup)).
+2. A GitHub PAT with scopes `repo`, `read:org`, `workflow`, and `read:project` (same as local development).
+3. Either:
+   - **Local `aspire deploy`** (simplest for a personal instance — no GitHub Actions OIDC required), or
+   - **GitHub Actions CD** (same workflow as production; configure the environment for PAT mode).
+
+### Option A — Deploy locally with `aspire deploy` (recommended for first personal instance)
+
+1. Complete [Create a resource group](#1-create-a-resource-group) (OIDC identity is optional for this option).
+2. Log in and export Azure + PAT-mode parameters:
+
+```bash
+az login
+
+export Azure__SubscriptionId="$(az account show --query id -o tsv)"
+export Azure__Location="uksouth"
+export Azure__ResourceGroup="rg-solodevboard-prod"
+
+# PAT-only local trusted mode — no GitHub App
+export Parameters__hosted_sign_in_enabled="false"
+export Parameters__hosted_admission_enabled="true"   # ignored in PAT mode; any value is fine
+export Parameters__gh_pat="<your-github-pat>"
+export Parameters__gh_app_client_id="-"
+export Parameters__gh_app_client_secret="-"
+export Parameters__allowed_user_logins="-"
+export Parameters__allowed_org_logins="-"
+```
+
+On Windows PowerShell, use `$env:Azure__SubscriptionId = ...` (and the same pattern for the other variables) instead of `export`.
+
+3. Preview, then deploy:
+
+```bash
+dotnet build SoloDevBoard.slnx --configuration Release
+
+aspire deploy --list-steps \
+  --apphost src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj \
+  --environment Production \
+  --non-interactive
+
+aspire deploy \
+  --apphost src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj \
+  --environment Production \
+  --non-interactive
+```
+
+4. Open the Container App FQDN from the Aspire output or Azure portal. Expect the dashboard shell with a **Connected as @login** chip — not the `/welcome` hosted landing page.
+5. Optionally verify PAT connectivity: `curl -sf "https://<fqdn>/health/github"`.
+
+Secret parameters (`gh-pat`, and `gh-app-client-secret` when used) are written to the Aspire-provisioned `auth-secrets` Key Vault and referenced by the Container App. You do not create Key Vault secrets by hand.
+
+### Option B — Deploy via GitHub Actions in PAT mode
+
+Complete the full [One-time Azure setup](#one-time-azure-setup) (resource group + OIDC), then configure the GitHub environment for PAT mode:
+
+**Secrets**
+
+| Secret | Value |
+|---|---|
+| `AZURE_CLIENT_ID` | Managed identity `clientId` |
+| `AZURE_TENANT_ID` | `az account show --query tenantId -o tsv` |
+| `AZURE_SUBSCRIPTION_ID` | `az account show --query id -o tsv` |
+| `GH_PAT` | Your GitHub personal access token |
+| `GH_APP_CLIENT_SECRET` | `-` (not used in PAT mode; still required by the workflow mapping) |
+
+**Variables**
+
+| Variable | Value | Purpose |
+|---|---|---|
+| `AZURE_LOCATION` | e.g. `uksouth` | Azure region |
+| `AZURE_RESOURCE_GROUP` | e.g. `rg-solodevboard-prod` | Target resource group |
+| `HOSTED_SIGN_IN_ENABLED` | `false` | Keep PAT-only mode |
+| `HOSTED_ADMISSION_ENABLED` | `true` | Ignored in PAT mode |
+| `GH_APP_CLIENT_ID` | `-` | Inactive in PAT mode |
+| `ALLOWED_USER_LOGINS` | `-` | Inactive in PAT mode |
+| `ALLOWED_ORG_LOGINS` | `-` | Inactive in PAT mode |
+
+Then run **Actions → CD - Deploy to Azure → Run workflow**. No GitHub App callback URL is required for PAT mode.
+
+### PAT-mode parameter and environment variable cheat sheet
+
+| AppHost parameter | CD / local env var | Self-hoster (PAT) value |
+|---|---|---|
+| `hosted-sign-in-enabled` | `Parameters__hosted_sign_in_enabled` / `HOSTED_SIGN_IN_ENABLED` | `false` |
+| `gh-pat` | `Parameters__gh_pat` / `GH_PAT` | **your PAT** (secret) |
+| `gh-app-client-id` | `Parameters__gh_app_client_id` / `GH_APP_CLIENT_ID` | `-` |
+| `gh-app-client-secret` | `Parameters__gh_app_client_secret` / `GH_APP_CLIENT_SECRET` | `-` |
+| `hosted-admission-enabled` | `Parameters__hosted_admission_enabled` / `HOSTED_ADMISSION_ENABLED` | ignored |
+| `allowed-user-logins` | `Parameters__allowed_user_logins` / `ALLOWED_USER_LOGINS` | `-` |
+| `allowed-org-logins` | `Parameters__allowed_org_logins` / `ALLOWED_ORG_LOGINS` | `-` |
+
+See [`src/SoloDevBoard.AppHost/README.md`](../src/SoloDevBoard.AppHost/README.md) for the full parameter reference, [Azure Deployment Costs](user-guide/azure-costs.md) for cost guidance, and [PAT Connectivity](user-guide/pat-connectivity.md) for shell status and `/health/github`.
 
 ---
 
 ## One-time Azure setup
+
+The steps below are required for **GitHub Actions CD**. For a personal first deploy with local `aspire deploy` only, create the resource group (step 1) and skip OIDC (step 2) until you want CI/CD.
 
 ### 1. Create a resource group
 
@@ -89,31 +203,38 @@ az identity federated-credential create \
 
 ### 3. Configure the GitHub `production` environment
 
-In **Settings → Environments → production**, add:
+In **Settings → Environments → production**, add the secrets and variables for your chosen mode.
 
-**Secrets**
+**Shared Azure secrets (both modes)**
 
 | Secret | Value |
 |---|---|
 | `AZURE_CLIENT_ID` | Managed identity `clientId` from step 2 |
 | `AZURE_TENANT_ID` | `az account show --query tenantId -o tsv` |
 | `AZURE_SUBSCRIPTION_ID` | `az account show --query id -o tsv` |
-| `GH_PAT` | `-` for hosted sign-in, or a PAT for trusted self-hosted PAT mode |
-| `GH_APP_CLIENT_SECRET` | GitHub App client secret for hosted sign-in |
+
+**Hosted sign-in (recommended for shared / public production)**
+
+| Secret / variable | Value |
+|---|---|
+| Secret `GH_PAT` | `-` |
+| Secret `GH_APP_CLIENT_SECRET` | GitHub App client secret |
+| Variable `HOSTED_SIGN_IN_ENABLED` | `true` |
+| Variable `HOSTED_ADMISSION_ENABLED` | `true` |
+| Variable `GH_APP_CLIENT_ID` | your client ID |
+| Variable `ALLOWED_USER_LOGINS` | your login(s), or `-` |
+| Variable `ALLOWED_ORG_LOGINS` | org login(s), or `-` |
+
+**PAT self-hoster mode** — use the secret and variable tables under [Self-hoster deployment (PAT mode)](#self-hoster-deployment-pat-mode) instead (`HOSTED_SIGN_IN_ENABLED=false`, real `GH_PAT`, GitHub App values `-`).
 
 Secret parameters are written to the Aspire-provisioned `auth-secrets` Key Vault at deploy time and referenced by the Container App. You do not create or manage Key Vault secrets manually for the default deployment path.
 
-**Variables**
+**Shared Azure variables (both modes)**
 
 | Variable | Example | Purpose |
 |---|---|---|
 | `AZURE_LOCATION` | `uksouth` | Azure region for `aspire deploy` |
 | `AZURE_RESOURCE_GROUP` | `rg-solodevboard-prod` | Target resource group |
-| `HOSTED_SIGN_IN_ENABLED` | `true` | Enable hosted sign-in in production |
-| `HOSTED_ADMISSION_ENABLED` | `true` | Deny-by-default admission control |
-| `GH_APP_CLIENT_ID` | your client ID | GitHub App OAuth client ID |
-| `ALLOWED_USER_LOGINS` | `your-login` | Comma-separated user allow-list |
-| `ALLOWED_ORG_LOGINS` | `-` | Comma-separated org allow-list, or `-` |
 
 Enable required reviewers on the `production` environment before granting deploy access.
 
@@ -121,12 +242,12 @@ Enable required reviewers on the `production` environment before granting deploy
 
 ## Deploy from GitHub Actions
 
-The CD workflow (`.github/workflows/cd.yml`) runs `aspire deploy` with OIDC authentication.
+The CD workflow (`.github/workflows/cd.yml`) runs `aspire deploy` with OIDC authentication. Use this section for **hosted sign-in** production deploys (or PAT mode after configuring the environment as in [Option B](#option-b--deploy-via-github-actions-in-pat-mode)).
 
 1. Ensure steps above are complete.
 2. Open **Actions → CD - Deploy to Azure → Run workflow**.
 3. After a successful run, note the deployed Container App FQDN from the workflow output or Azure portal.
-4. Register the GitHub App callback URL: `https://<fqdn>/auth/callback`.
+4. **Hosted sign-in only:** register the GitHub App callback URL: `https://<fqdn>/auth/callback`.
 5. Open the provisioned Application Insights resource to confirm telemetry is flowing (see [Observability guide](user-guide/observability.md)).
 
 ### Enable automatic deploys
@@ -136,6 +257,8 @@ After the first successful manual deploy, uncomment the `push: branches: [main]`
 ---
 
 ## Deploy locally (operator testing)
+
+### Hosted sign-in
 
 ```bash
 az login
@@ -154,6 +277,10 @@ aspire deploy \
   --environment Production \
   --non-interactive
 ```
+
+### PAT self-hoster
+
+Use the environment exports and commands under [Option A — Deploy locally with aspire deploy](#option-a--deploy-locally-with-aspire-deploy-recommended-for-first-personal-instance).
 
 Preview deployment steps without applying:
 
@@ -262,7 +389,9 @@ az identity delete --name id-solodevboard-cd-prod --resource-group rg-solodevboa
 | Missing parameter prompt in CI | Secret not mapped | Add `Parameters__*` env vars to the deploy step |
 | Cold start / SignalR disconnect | Scale-to-zero idle | Expected; refresh the page or wait for the container to warm up |
 | 403 after sign-in | Allow-list | Update `ALLOWED_USER_LOGINS` or `ALLOWED_ORG_LOGINS` |
-| Callback URL mismatch | Stale GitHub App setting | Update callback to `https://<aca-fqdn>/auth/callback` |
+| Callback URL mismatch | Stale GitHub App setting | Update callback to `https://<aca-fqdn>/auth/callback` (hosted sign-in only) |
 | Secret not visible in Container App settings | Key Vault reference | Expected — inspect the `auth-secrets` vault for secret names; values are resolved at runtime |
+| PAT mode shows `/welcome` or requires sign-in | `hosted-sign-in-enabled` still `true` | Set `HOSTED_SIGN_IN_ENABLED` / `Parameters__hosted_sign_in_enabled` to `false` and redeploy |
+| PAT mode starts but GitHub calls fail | Missing or invalid `GH_PAT` | Set a real PAT with required scopes; confirm `/health/github` and the **Connected as @login** chip |
 
-For local development, see [Getting Started](getting-started.md). For hosted authentication details, see [Hosted Authentication](user-guide/hosted-authentication.md). For the Key Vault pattern, see [plan/HOSTED_AUTH_KEY_VAULT_PATTERN.md](../plan/HOSTED_AUTH_KEY_VAULT_PATTERN.md).
+For local development, see [Getting Started](getting-started.md) (including [PAT-only local trusted mode](getting-started.md#pat-only-local-trusted-mode)). For hosted authentication details, see [Hosted Authentication](user-guide/hosted-authentication.md). For the Key Vault pattern, see [plan/HOSTED_AUTH_KEY_VAULT_PATTERN.md](../plan/HOSTED_AUTH_KEY_VAULT_PATTERN.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,12 +26,27 @@ SoloDevBoard supports two **mutually exclusive** authentication modes. Choose on
 
 | Mode | When to use | What you configure |
 |---|---|---|
-| **PAT mode** (default) | Solo local development and trusted self-hosted use | `gh-pat` only (your GitHub login is resolved automatically) |
-| **Hosted sign-in** | Production deployments and local multi-tenant testing | `hosted-sign-in-enabled`, GitHub App OAuth credentials, and allow-lists |
+| **PAT-only local trusted mode** (default) | Solo local development and trusted personal self-hosting | `gh-pat` only (your GitHub login is resolved automatically) |
+| **Hosted sign-in** | Multi-user / public production deployments and local multi-tenant testing | `hosted-sign-in-enabled`, GitHub App OAuth credentials, and allow-lists |
 
-Parameters for the mode you are **not** using can be left unset.
+Parameters for the mode you are **not** using can be left unset (or set to `-` when Aspire requires a value).
 
-#### PAT mode
+#### How the modes differ
+
+| | PAT-only local trusted mode | Hosted sign-in |
+|---|---|---|
+| **Who authenticates** | Nobody signs in to SoloDevBoard — the app uses one configured token for all GitHub API calls | Each visitor signs in with GitHub at `/auth/sign-in` (landing at `/welcome`) |
+| **Identity** | Your login is resolved automatically from the PAT at startup | Per-user session claims (login, access token, installation, organisations) |
+| **Admission control** | Not applicable — anyone who can reach the app acts as the PAT owner | Operator allow-lists (`allowed-user-logins` / `allowed-org-logins`); deny-by-default |
+| **GitHub App required?** | No | Yes (OAuth App fallback exists but is disabled by default) |
+| **Trust boundary** | Suitable only where you trust every person who can reach the deployment (localhost, private network, or a personal Azure instance you alone use) | Suitable for shared or public endpoints |
+| **Connectivity UX** | App-bar **Connected as @login** chip; recovery at `/auth/connectivity-error` — see [PAT Connectivity](user-guide/pat-connectivity.md) | Session expiry and re-sign-in — see [Hosted Authentication](user-guide/hosted-authentication.md) |
+
+> **Security note:** PAT-only mode does **not** provide multi-user isolation. Do not expose a PAT-mode instance on a public URL that others can reach. For shared or public hosting, use hosted sign-in with admission control.
+
+#### PAT-only local trusted mode
+
+This is the **default** authentication path. Set `hosted-sign-in-enabled` to `false` (the shipped default) and supply a personal access token via the AppHost parameter `gh-pat`. No GitHub App, OAuth client, or allow-list is required.
 
 Create a PAT at [GitHub → Settings → Developer settings → Personal access tokens](https://github.com/settings/tokens) with these scopes:
 
@@ -40,13 +55,22 @@ Create a PAT at [GitHub → Settings → Developer settings → Personal access 
 - `workflow` (to manage GitHub Actions workflows)
 - `read:project` (read-only access to GitHub Projects; required for the Triage UI project board feature)
 
+**Quick local setup (Aspire):**
+
+```bash
+aspire secret set Parameters:gh-pat "<your-token>"
+aspire start --apphost src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
+```
+
+Your GitHub login is resolved automatically from the PAT. Full parameter tables and mode-switching steps are under [Configuration](#configuration) below. For runtime connectivity status and recovery, see [PAT Connectivity](user-guide/pat-connectivity.md). To run a **personal hosted instance** on your own Azure subscription with the same PAT mode, see [Self-hoster deployment (PAT mode)](deployment.md#self-hoster-deployment-pat-mode).
+
 #### Hosted sign-in mode
 
 Uses a GitHub App for OAuth sign-in at `/auth/sign-in`, with operator-managed allow-lists for users and organisations. Recommended for production and multi-tenant deployments. See [Hosted Authentication Guide](user-guide/hosted-authentication.md) for the full operator and local testing walkthrough.
 
 #### OAuth App fallback
 
-OAuth App fallback is supported but disabled by default. It is only used if enabled and the primary GitHub App authentication path is unavailable.
+OAuth App fallback is supported but disabled by default. It is only used if enabled and the primary GitHub App authentication path is unavailable. It does not replace PAT-only local trusted mode.
 
 ## Running Locally
 
@@ -111,7 +135,7 @@ When running via Aspire (`aspire start`), GitHub auth and admission settings are
 
 ### Choose your authentication mode
 
-**PAT mode (default local development)** — leave `hosted-sign-in-enabled` as `false`. Set `gh-pat` to your token. Set all hosted-sign-in parameters to `-`.
+**PAT-only local trusted mode (default)** — leave `hosted-sign-in-enabled` as `false`. Set `gh-pat` to your token. Set all hosted-sign-in parameters to `-`. This is the path for local development and trusted personal self-hosting; it does not depend on hosted sign-in infrastructure.
 
 **Hosted sign-in mode** — set `hosted-sign-in-enabled` to `true`, configure GitHub App OAuth credentials and allow-lists, and set `gh-pat` to `-`.
 
@@ -203,14 +227,14 @@ Your GitHub login is resolved automatically from the PAT when the app starts. Pa
 
 Non-secret defaults are in `src/SoloDevBoard.AppHost/appsettings.json`. Secret values are stored via `aspire secret set` or the AppHost user secrets store (`UserSecretsId` on `src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj`).
 
-#### PAT mode setup
+#### PAT-only local trusted mode setup
 
 ```bash
 aspire secret set Parameters:gh-pat "<your-token>"
 aspire start --apphost src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
 ```
 
-Your GitHub login is resolved automatically from the PAT at startup. You can also set the token via the Aspire dashboard **Parameters** tab on first run.
+Your GitHub login is resolved automatically from the PAT at startup. You can also set the token via the Aspire dashboard **Parameters** tab on first run. After the app starts, confirm the shell shows **Connected as @login** — see [PAT Connectivity](user-guide/pat-connectivity.md).
 
 #### Hosted sign-in mode setup
 
@@ -343,7 +367,7 @@ dotnet user-secrets set "GitHubAuth:PersonalAccessToken" "<your-token>" --projec
 - All denied admission attempts are logged for operator review.
 - The claim type for organisation logins can be set using `HostedOrganisationLoginsClaimType` to match your identity provider's claim mapping.
 - OAuth App fallback is only used if `HostedOAuthAppFallbackEnabled` is true and the primary GitHub App authentication path is unavailable. This fallback is disabled by default for security.
-- PAT-only local trusted mode is always available for local development and trusted self-hosted use, independent of hosted admission control or fallback settings.
+- PAT-only local trusted mode is always available for local development and trusted self-hosted use, independent of hosted admission control or fallback settings. See [PAT-only local trusted mode](#pat-only-local-trusted-mode) above and [Self-hoster deployment (PAT mode)](deployment.md#self-hoster-deployment-pat-mode) for Azure.
 
 ### Production secrets (GitHub Actions)
 
@@ -353,12 +377,12 @@ In production, secret AppHost parameters are supplied from the GitHub `productio
 
 ## Deploying to Azure
 
-SoloDevBoard deploys to Azure Container Apps via Aspire. See the [Deployment guide](deployment.md) for prerequisites, one-time OIDC bootstrap, GitHub Environment configuration, and first deploy steps. For logs, metrics, and traces after deployment, see the [Observability guide](user-guide/observability.md).
+SoloDevBoard deploys to Azure Container Apps via Aspire. See the [Deployment guide](deployment.md) for prerequisites, one-time OIDC bootstrap, GitHub Environment configuration, and first deploy steps. For a **personal instance with a PAT** (no GitHub App), start with [Self-hoster deployment (PAT mode)](deployment.md#self-hoster-deployment-pat-mode). For logs, metrics, and traces after deployment, see the [Observability guide](user-guide/observability.md).
 
 Summary:
 
 1. Install the [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) and log in (`az login`).
-2. Create a resource group and GitHub Actions OIDC identity (Azure CLI commands in [deployment.md](deployment.md)).
-3. Configure the GitHub `production` environment secrets and variables.
-4. Run the CD workflow manually via **Actions → CD - Deploy to Azure → Run workflow**.
-5. After the first successful deploy, update your GitHub App callback URL to the deployed Container App FQDN.
+2. Create a resource group (and GitHub Actions OIDC identity if you want CI/CD — Azure CLI commands in [deployment.md](deployment.md)).
+3. Configure authentication for your chosen mode: PAT self-hoster secrets/vars, or hosted sign-in GitHub App credentials.
+4. Deploy with local `aspire deploy` or run the CD workflow via **Actions → CD - Deploy to Azure → Run workflow**.
+5. After a successful hosted-sign-in deploy, update your GitHub App callback URL to the deployed Container App FQDN.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -147,7 +147,7 @@ Use `-` on inactive parameters. Shipped defaults are in `src/SoloDevBoard.AppHos
 
 Use the Aspire dashboard **Parameters** tab (or `aspire secret set` for secrets). Restart Aspire after changing mode.
 
-**Switch to PAT mode**
+**Switch to PAT-only local trusted mode**
 
 | Parameter | Action |
 |---|---|

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,8 +38,8 @@ It is built with the solo developer in mind: opinionated defaults, minimal confi
 
 ## Quick Links
 
-- 📖 [Getting Started](getting-started.md) — prerequisites, Aspire-first local setup, and configuration.
-- 🚀 [Deployment](deployment.md) — Azure Container Apps deployment via Aspire.
+- 📖 [Getting Started](getting-started.md) — prerequisites, Aspire-first local setup, PAT-only local trusted mode, and configuration.
+- 🚀 [Deployment](deployment.md) — Azure Container Apps via Aspire, including the [self-hoster PAT path](deployment.md#self-hoster-deployment-pat-mode).
 - 👤 [User Guide](user-guide/) — detailed guides for each feature area.
 - 👤 [Hosted Authentication Guide](user-guide/hosted-authentication.md) — hosted sign-in, operator allow-lists, and fallback modes for production deployments.
 - 🔑 [PAT Connectivity Guide](user-guide/pat-connectivity.md) — PAT validation, shell status, recovery UX, and `/health/github` for local trusted mode.

--- a/docs/user-guide/azure-costs.md
+++ b/docs/user-guide/azure-costs.md
@@ -4,7 +4,7 @@ Self-hosting SoloDevBoard on Azure incurs charges for the resources Aspire provi
 
 ## Resources Deployed
 
-Aspire deploys the following Azure resources (see [Deployment guide](../deployment.md) and [Observability guide](observability.md)):
+Aspire deploys the following Azure resources (see [Deployment guide](../deployment.md), including the [self-hoster PAT path](../deployment.md#self-hoster-deployment-pat-mode) for a personal instance, and [Observability guide](observability.md)):
 
 | Resource | Purpose | Pricing model |
 |---|---|---|
@@ -41,6 +41,12 @@ Aspire deploys the following Azure resources (see [Deployment guide](../deployme
 ## Azure Pricing Calculator
 
 For exact, up-to-date pricing, use the [Azure Pricing Calculator](https://azure.microsoft.com/en-gb/pricing/calculator/). Select UK South and add Container Apps, Container Registry (Basic), and Log Analytics.
+
+## Related documentation
+
+- [Self-hoster deployment (PAT mode)](../deployment.md#self-hoster-deployment-pat-mode) — personal Azure instance without a GitHub App.
+- [Getting Started — PAT-only local trusted mode](../getting-started.md#pat-only-local-trusted-mode) — local configuration and trust boundary.
+- [Observability](observability.md) — Application Insights and operational diagnostics after deploy.
 
 ## Disclaimer
 

--- a/docs/user-guide/hosted-authentication.md
+++ b/docs/user-guide/hosted-authentication.md
@@ -57,7 +57,8 @@ See [`src/SoloDevBoard.AppHost/README.md`](../../src/SoloDevBoard.AppHost/README
 
 ## Fallback and Local Trusted Modes
 
-- PAT-only local trusted mode remains available for development and self-hosted use. It does not require hosted sign-in infrastructure.
+- **PAT-only local trusted mode** remains available for development and trusted personal self-hosting. It does not require hosted sign-in infrastructure. See [Getting Started — PAT-only local trusted mode](../getting-started.md#pat-only-local-trusted-mode) and [PAT Connectivity](pat-connectivity.md).
+- To run a personal Azure instance with a PAT (no GitHub App), follow [Self-hoster deployment (PAT mode)](../deployment.md#self-hoster-deployment-pat-mode).
 - OAuth App fallback is supported but disabled by default. It is only used if enabled and the primary GitHub App authentication path is unavailable.
 
 ## Session and Token Flow
@@ -83,10 +84,10 @@ This is a known GitHub platform limitation for GitHub Apps, not a SoloDevBoard c
 
 ## Documentation References
 
-- See [Getting Started](../getting-started.md) for prerequisites and setup.
+- See [Getting Started](../getting-started.md) for prerequisites and setup, including the PAT versus hosted comparison.
 - See [DEC-011](../../plan/DECISIONS.md#dec-011-hosted-access-control-for-public-deployments) and [DEC-012](../../plan/DECISIONS.md#dec-012-github-app-first-hosted-authentication) for architectural rationale. Legacy ADR text: [ADR-0014](../../adr/archive/0014-hosted-access-control-for-public-deployments.md), [ADR-0015](../../adr/archive/0015-github-app-first-hosted-authentication.md).
 - See [plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md](../../plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md) for session and token flow details.
 
 ---
 
-> Hosted authentication is recommended for production deployments. PAT-only local trusted mode is preserved for development and trusted self-hosted use.
+> Hosted authentication is recommended for shared or public production deployments. PAT-only local trusted mode is preserved for development and trusted personal self-hosted use.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -24,6 +24,7 @@ The SoloDevBoard user guide provides detailed documentation for available featur
 - [About](about.md) — Application version, runtime environment, and repository link.
 - [Azure Deployment Costs](azure-costs.md) — Understand Azure resource charges, SKUs, and cost optimisation for SoloDevBoard deployments.
 - [Hosted Authentication](hosted-authentication.md) — Guide to hosted sign-in, operator allow-lists, and fallback modes for production deployments.
+- [PAT Connectivity](pat-connectivity.md) — PAT-only local trusted mode connectivity status, recovery UX, and `/health/github`.
 - [Observability](observability.md) — Structured logging, Application Insights telemetry, and operational diagnostics for hosted deployments.
 
 ## Coming Soon

--- a/docs/user-guide/pat-connectivity.md
+++ b/docs/user-guide/pat-connectivity.md
@@ -6,11 +6,13 @@ nav_order: 11
 
 # PAT Connectivity
 
-This guide explains how SoloDevBoard surfaces GitHub personal access token (PAT) connectivity in PAT-only local trusted mode. It complements [Hosted Authentication](hosted-authentication.md), which covers session-based sign-in for production deployments.
+This guide explains how SoloDevBoard surfaces GitHub personal access token (PAT) connectivity in **PAT-only local trusted mode**. It complements [Hosted Authentication](hosted-authentication.md), which covers session-based sign-in for multi-user and public deployments.
+
+For configuration, mode comparison, and when to choose PAT versus hosted sign-in, start with [Getting Started — PAT-only local trusted mode](../getting-started.md#pat-only-local-trusted-mode). For a personal Azure instance using the same mode, see [Self-hoster deployment (PAT mode)](../deployment.md#self-hoster-deployment-pat-mode).
 
 ## Overview
 
-When `GitHubAuth:HostedSignInEnabled` is `false`, SoloDevBoard authenticates to GitHub using a configured personal access token. The application now validates that token at startup and surfaces connectivity status in the shell before you reach feature workflows.
+When `GitHubAuth:HostedSignInEnabled` is `false`, SoloDevBoard authenticates to GitHub using a configured personal access token. The application validates that token at startup and surfaces connectivity status in the shell before you reach feature workflows.
 
 ## Startup validation
 
@@ -50,10 +52,11 @@ Use `/health/github` when you want Container Apps or external monitoring to veri
 
 ## Documentation references
 
-- See [Getting Started](../getting-started.md) for PAT configuration.
+- See [Getting Started — PAT-only local trusted mode](../getting-started.md#pat-only-local-trusted-mode) for configuration and mode comparison.
+- See [Self-hoster deployment (PAT mode)](../deployment.md#self-hoster-deployment-pat-mode) for deploying a personal Azure instance with a PAT.
 - See [Hosted Authentication](hosted-authentication.md) for the hosted sign-in model.
 - See [plan/wireframes/auth-entry-wireframe.md](../../plan/wireframes/auth-entry-wireframe.md) for layout reference.
 
 ---
 
-> PAT-only local trusted mode is intended for development and trusted self-hosted use. Production deployments should use hosted sign-in with admission control.
+> PAT-only local trusted mode is intended for development and trusted personal self-hosted use. Shared or public deployments should use hosted sign-in with admission control.

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -40,11 +40,11 @@ Phase 6 (v1.0.0) remaining work is tracked on the [v1.0.0 milestone](https://git
 
 ### V1 auth polish (Epic #101 follow-on)
 
-| Issue | Focus |
-|-------|-------|
-| [#247](https://github.com/markheydon/solo-dev-board/issues/247) | PAT-only local trusted mode documentation |
-| [#248](https://github.com/markheydon/solo-dev-board/issues/248) | Self-hoster deployment path (`aspire deploy` with PAT) |
-| [#249](https://github.com/markheydon/solo-dev-board/issues/249) | Hosted unauthenticated landing page |
-| [#314](https://github.com/markheydon/solo-dev-board/issues/314) | PAT/GitHub connectivity readiness (startup probe, shell status, recovery UX) |
+| Issue | Focus | Status |
+|-------|-------|--------|
+| [#247](https://github.com/markheydon/solo-dev-board/issues/247) | PAT-only local trusted mode documentation | Docs in [PR #324](https://github.com/markheydon/solo-dev-board/pull/324) |
+| [#248](https://github.com/markheydon/solo-dev-board/issues/248) | Self-hoster deployment path (`aspire deploy` with PAT) | Docs in [PR #324](https://github.com/markheydon/solo-dev-board/pull/324) |
+| [#249](https://github.com/markheydon/solo-dev-board/issues/249) | Hosted unauthenticated landing page | Done |
+| [#314](https://github.com/markheydon/solo-dev-board/issues/314) | PAT/GitHub connectivity readiness (startup probe, shell status, recovery UX) | Done |
 
 For phase sequencing and architecture milestones, see [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md). For product boundaries, see [SCOPE.md](SCOPE.md).

--- a/plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md
+++ b/plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md
@@ -79,16 +79,14 @@ See [DEC-012](DECISIONS.md#dec-012-github-app-first-hosted-authentication) and G
 
 ## Remaining V1 Auth Polish
 
-The hosted sign-in and admission-control boundaries above are delivered. The following open stories complete the V1 auth polish bundle without changing the operator secret model (Aspire parameters, user secrets, and Key Vault remain the configuration surface):
+The hosted sign-in and admission-control boundaries above are delivered. Operator secrets remain Aspire parameters, user secrets, and Key Vault — in-app secret editing is out of scope.
 
-| Issue | Scope |
-|-------|-------|
-| [#249](https://github.com/markheydon/solo-dev-board/issues/249) | Hosted unauthenticated landing page and sign-out return path |
-| [#314](https://github.com/markheydon/solo-dev-board/issues/314) | PAT-mode GitHub connectivity readiness (startup probe, shell status, recovery UX, optional `/health/github`) |
-| [#247](https://github.com/markheydon/solo-dev-board/issues/247) | PAT-only local trusted mode documentation |
-| [#248](https://github.com/markheydon/solo-dev-board/issues/248) | Self-hoster deployment documentation |
-
-In-app secret or environment-variable editing is explicitly out of scope for these stories.
+| Issue | Scope | Status |
+|-------|-------|--------|
+| [#249](https://github.com/markheydon/solo-dev-board/issues/249) | Hosted unauthenticated landing page and sign-out return path | Done |
+| [#314](https://github.com/markheydon/solo-dev-board/issues/314) | PAT-mode GitHub connectivity readiness (startup probe, shell status, recovery UX, optional `/health/github`) | Done |
+| [#247](https://github.com/markheydon/solo-dev-board/issues/247) | PAT-only local trusted mode documentation | Docs in [PR #324](https://github.com/markheydon/solo-dev-board/pull/324); see [getting-started.md](../docs/getting-started.md#pat-only-local-trusted-mode) |
+| [#248](https://github.com/markheydon/solo-dev-board/issues/248) | Self-hoster deployment documentation | Docs in [PR #324](https://github.com/markheydon/solo-dev-board/pull/324); see [deployment.md](../docs/deployment.md#self-hoster-deployment-pat-mode) |
 
 ## Rollout Notes
 

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -224,7 +224,7 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Configure structured logging and Application Insights telemetry. _(#107)_
 - [ ] Add operational hardening test coverage and validation expectations. _(#110; see plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md.)_
 - [x] Set up Dependabot for automated dependency updates. _(#109)_
-- [ ] Formalise and document PAT-only local trusted mode and self-hoster deployment path. _(#247, #248)_
+- [x] Formalise and document PAT-only local trusted mode and self-hoster deployment path. _(#247, #248; see docs/getting-started.md#pat-only-local-trusted-mode and docs/deployment.md#self-hoster-deployment-pat-mode.)_
 - [x] Dedicated unauthenticated landing page for hosted deployments. _(#249)_
 - [x] Surface GitHub auth connectivity problems before feature work fails (PAT-mode readiness). _(#314)_
 - [x] Implement hosted authentication session boundaries and per-request user context for GitHub App-first hosted mode. _(#103, #112; implemented on 2026-03-13, see plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md.)_

--- a/plan/SCOPE.md
+++ b/plan/SCOPE.md
@@ -23,7 +23,7 @@ Public-release hardening is in scope for v1.0.0, including:
 - Azure deployment via Aspire to Azure Container Apps with scale-to-zero ([DEC-015](DECISIONS.md#dec-015-aspire-azure-container-apps-deployment)).
 - OIDC authentication for GitHub Actions to Azure.
 - Operational hardening: response caching, health checks, structured logging, Application Insights telemetry, Dependabot configuration.
-- PAT-only local trusted mode for development and trusted self-hosted use.
+- PAT-only local trusted mode for development and trusted personal self-hosted use (see [docs/getting-started.md](../docs/getting-started.md#pat-only-local-trusted-mode) and [self-hoster PAT deploy](../docs/deployment.md#self-hoster-deployment-pat-mode)).
 - Separate OAuth App registration is not the intended default end state; it is only a fallback if GitHub App user authentication proves insufficient for hosted sign-in requirements.
 - Hosted authentication is secure-by-default, with deny-by-default admission control.
 
@@ -115,4 +115,5 @@ The following are explicitly **not** in scope for the current version of SoloDev
 | 2026-07-18 | Backlog-to-issues migration complete: GitHub Issues are the single source of truth for work items. `plan/BACKLOG.md` retired as a living queue (slim index only). Open work migrated to Issues #247–#259 (v1.0.0), #272–#288 (Phase 5), and #289–#293 (post-v1). | Solo developer |
 | 2026-07-18 | Planning sync: Phases 1–4 marked complete in BACKLOG.md and IMPLEMENTATION_PLAN.md. Deferred follow-on slices (label consistency warnings, project board migration, custom workflow template repos, Audit Dashboard enhancements) explicitly tracked. Phase 5 and Phase 6 remain the only active delivery phases. | Solo developer |
 | 2026-07-25 | V1 auth polish bundle clarified: hosted sign-in entry UX (#249) and PAT-mode GitHub connectivity readiness (#314) split from operator documentation (#247, #248). In-app secret editing remains out of scope; operator configuration stays via Aspire parameters, user secrets, and Key Vault. | Solo developer |
+| 2026-07-25 | PAT-only local trusted mode and self-hoster PAT Azure deploy path formalised in docs (#247, #248; PR #324). Scope bullet now links to getting-started and deployment guides. | Solo developer |
 

--- a/src/SoloDevBoard.AppHost/README.md
+++ b/src/SoloDevBoard.AppHost/README.md
@@ -8,7 +8,7 @@ Use `-` on inactive parameters. Shipped defaults are in `src/SoloDevBoard.AppHos
 
 ## Choose your authentication mode
 
-### PAT mode (default — solo local development)
+### PAT-only local trusted mode (default — solo local development and personal self-hosting)
 
 Set `gh-pat` to your token. Set all hosted-sign-in parameters to `-`:
 
@@ -20,6 +20,8 @@ Set `gh-pat` to your token. Set all hosted-sign-in parameters to `-`:
 | `gh-app-client-secret` | `-` |
 | `allowed-user-logins` | `-` |
 | `allowed-org-logins` | `-` |
+
+See [docs/getting-started.md — PAT-only local trusted mode](../docs/getting-started.md#pat-only-local-trusted-mode) for the mode comparison and local setup. For a personal Azure instance with the same mode, see [Self-hoster deployment (PAT mode)](../docs/deployment.md#self-hoster-deployment-pat-mode).
 
 ### Hosted sign-in mode (GitHub App)
 


### PR DESCRIPTION
## Summary of Changes

Formalise PAT-only local trusted mode documentation and add a self-hoster deployment path for running SoloDevBoard with a PAT on a personal Azure subscription.

- Clarify PAT versus hosted sign-in in `docs/getting-started.md` (comparison table, trust boundary, quick Aspire setup).
- Add self-hoster PAT deploy guidance in `docs/deployment.md` (`aspire deploy` Option A, GitHub Actions Option B, secrets/env cheat sheet).
- Cross-link indexes, PAT connectivity, hosted authentication, and AppHost README; mark #247/#248 done in the implementation plan.

## Related Issue(s)

Closes #247
Closes #248

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and `docs/index.md` has been updated

## Screenshots (if applicable)

N/A — documentation only.

## Additional Notes

Docs-only change; no application code modified. Build and unit tests were run as part of verify.