### PR TITLE
Fix E2E theme preference seeding before navigation (#325).

### DIFF
--- a/tests/E2E/fixtures/accessibility.ts
+++ b/tests/E2E/fixtures/accessibility.ts
@@ -107,12 +107,12 @@ export async function waitForAccessibilityScanReady(page: Page, path: string): P
   }
 }
 
-/** Seeds the browser theme preference before navigation. */
+/** Seeds the browser theme preference before the next navigation. */
 export async function seedThemePreference(
   page: Page,
   preference: 'system' | 'light' | 'dark',
 ): Promise<void> {
-  await page.evaluate(([key, value]) => {
+  await page.addInitScript(([key, value]) => {
     localStorage.setItem(key, value);
   }, [THEME_PREFERENCE_STORAGE_KEY, preference] as const);
 }


### PR DESCRIPTION
## Summary of Changes

Hotfix for a Playwright E2E failure on `main` after #326 merged. `seedThemePreference` in `tests/E2E/fixtures/accessibility.ts` now uses `page.addInitScript()` instead of `page.evaluate()`, avoiding a `SecurityError` when `localStorage` is accessed before the first navigation.

## Related Issue(s)

Relates to #325 (theme preference feature).

Fixes regression introduced by #326.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [ ] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and `docs/index.md` has been updated

## Screenshots (if applicable)

N/A — E2E fixture change only.

## Additional Notes

- Root cause: `page.evaluate()` ran before navigation, so `localStorage` was not available in the page context.
- `addInitScript()` registers the seeding logic to run on every navigation, including the first load.
- CI Playwright job (`accessibility.spec.ts` shell controls test) passes on this PR.
