### PR TITLE
Add public-only docs capture mode for safe screenshots

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,6 +127,8 @@ Then run **Actions → CD - Deploy to Azure → Run workflow**. No GitHub App ca
 | `allowed-user-logins` | `Parameters__allowed_user_logins` / `ALLOWED_USER_LOGINS` | `-` |
 | `allowed-org-logins` | `Parameters__allowed_org_logins` / `ALLOWED_ORG_LOGINS` | `-` |
 
+`DocsCapture__Enabled` is a **local-only** application setting for documentation screenshots. It is intentionally **not** an AppHost parameter and must not be enabled on hosted deployments. See [Docs capture mode](getting-started.md#docs-capture-mode) and [DEC-020](../plan/DECISIONS.md#dec-020-public-only-docs-capture-mode-for-documentation-screenshots).
+
 See [`src/SoloDevBoard.AppHost/README.md`](../src/SoloDevBoard.AppHost/README.md) for the full parameter reference, [Azure Deployment Costs](azure-costs.md) for cost guidance, and [PAT Connectivity](pat-connectivity.md) for shell status and `/health/github`.
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -348,12 +348,32 @@ Leave `PersonalAccessToken` empty in `appsettings.json` and supply it via an env
 | `GitHub__Cache__RepositoriesTtlSeconds` | Cache lifetime in seconds for repository catalogue responses |
 | `GitHub__Cache__LabelsTtlSeconds` | Cache lifetime in seconds for label catalogue responses |
 | `GitHub__Cache__MilestonesTtlSeconds` | Cache lifetime in seconds for milestone catalogue responses |
+| `DocsCapture__Enabled` | Set to `true` locally to restrict catalogues to public GitHub content for documentation screenshots (default `false`) |
 
 To set PAT-only values for the **legacy `dotnet run` path** (without Aspire), use .NET User Secrets on the app project. Only the PAT is required; owner login is resolved automatically:
 
 ```bash
 dotnet user-secrets set "GitHubAuth:PersonalAccessToken" "<your-token>" --project src/App/SoloDevBoard.App
 ```
+
+### Docs capture mode
+
+Use docs capture mode when taking screenshots for the published user guide so private repositories and private Projects v2 boards cannot appear in the UI.
+
+Enable it locally with user secrets or an environment variable:
+
+```bash
+dotnet user-secrets set "DocsCapture:Enabled" "true" --project src/App/SoloDevBoard.App
+```
+
+When enabled:
+
+- Repository catalogues return only public repositories (`type=public`, with a defensive `!IsPrivate` filter).
+- Project board discovery returns only public Projects v2 boards.
+- Board rules requests for a private project return the unavailable fallback.
+- A startup warning is logged to confirm the mode is active.
+
+This is **screenshot hygiene, not a security boundary**. It does not block write operations and is intentionally unavailable as an Aspire AppHost deploy parameter. Leave it disabled for normal development and all hosted deployments. See [DEC-020](../plan/DECISIONS.md#dec-020-public-only-docs-capture-mode-for-documentation-screenshots).
 
 
 ### Hosted Admission Control and Fallback Behaviour

--- a/plan/DECISIONS.md
+++ b/plan/DECISIONS.md
@@ -191,6 +191,15 @@ Test coverage expectations for cache-hit, cache-miss, invalidation, TTL expiry, 
 
 ---
 
+### DEC-020: Public-only docs capture mode for documentation screenshots
+
+**Status:** Active  
+**Date:** 2026-07-26  
+**Constitution:** [AGENTS.md — Documentation Sync](../AGENTS.md#documentation-sync), [AGENTS.md — Open Source & Security](../AGENTS.md#open-source--security)  
+**Summary:** Local documentation screenshot capture uses a `DocsCapture:Enabled` flag that restricts repository and Projects v2 catalogues to public GitHub content only. Filtering is applied at the Infrastructure catalogue chokepoints (`GitHubService` repository lists and project board discovery/definition). The mode defaults to disabled, is enabled only via local user secrets or `DocsCapture__Enabled`, and is intentionally not an Aspire AppHost deploy parameter. This is screenshot hygiene for published user-guide images, not a security boundary, and does not block write operations. Reject treating the flag as access control or exposing it as a hosted deployment switch.
+
+---
+
 ## Superseded legacy (archive only)
 
 | Legacy ADR | Superseded by | Notes |

--- a/src/App/SoloDevBoard.App/Components/Shared/Components/RepositorySelector.razor
+++ b/src/App/SoloDevBoard.App/Components/Shared/Components/RepositorySelector.razor
@@ -21,6 +21,8 @@
                          MinCharacters="0"
                          Clearable="true"
                          Immediate="true"
+                         CoerceValue="false"
+                         CoerceText="false"
                          Disabled="@(Disabled || (SingleSelectionOnly && SelectedRepositories.Count > 0))"
                          Adornment="Adornment.Start"
                          AdornmentIcon="@Icons.Material.Filled.Search"

--- a/src/App/SoloDevBoard.App/appsettings.json
+++ b/src/App/SoloDevBoard.App/appsettings.json
@@ -24,6 +24,9 @@
     "AllowedOrganisationLogins": "",
     "HostedOrganisationLoginsClaimType": "solo-dev-board.github.organisation-logins"
   },
+  "DocsCapture": {
+    "Enabled": false
+  },
   "GitHub": {
     "Cache": {
       "RepositoriesTtlSeconds": 60,

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/Common/InfrastructureServiceExtensions.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/Common/InfrastructureServiceExtensions.cs
@@ -31,6 +31,7 @@ public static class InfrastructureServiceExtensions
         ArgumentNullException.ThrowIfNull(configuration);
 
         services.Configure<GitHubAuthOptions>(configuration.GetSection(GitHubAuthOptions.SectionName));
+        services.Configure<DocsCaptureOptions>(configuration.GetSection(DocsCaptureOptions.SectionName));
         services.AddOptions<GitHubCacheOptions>()
             .Bind(configuration.GetSection(GitHubCacheOptions.SectionName))
             .PostConfigure(static options =>
@@ -58,6 +59,7 @@ public static class InfrastructureServiceExtensions
         services.AddSingleton<GitHubPatOwnerLoginResolver>();
         services.AddHostedService<GitHubAuthConfigurationValidator>();
         services.AddHostedService<GitHubPatStartupInitializer>();
+        services.AddHostedService<DocsCaptureStartupLogger>();
         services.AddHttpClient(GitHubPatOwnerLoginResolver.HttpClientName, static (serviceProvider, client) =>
         {
             var appVersionService = serviceProvider.GetRequiredService<IAppVersionService>();

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/DocsCaptureOptions.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/DocsCaptureOptions.cs
@@ -1,0 +1,19 @@
+namespace SoloDevBoard.Infrastructure.GitHub;
+
+/// <summary>
+/// Configuration for local-only docs capture mode.
+/// When enabled, repository and project board catalogues are restricted to public GitHub content
+/// so documentation screenshots cannot leak private data. This is screenshot hygiene, not a security boundary.
+/// </summary>
+public sealed class DocsCaptureOptions
+{
+    /// <summary>Configuration section name for docs capture settings.</summary>
+    public const string SectionName = "DocsCapture";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether docs capture mode is enabled.
+    /// Defaults to <see langword="false"/>. Enable only for local screenshot capture via user secrets
+    /// or the <c>DocsCapture__Enabled</c> environment variable.
+    /// </summary>
+    public bool Enabled { get; set; }
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/DocsCaptureStartupLogger.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/DocsCaptureStartupLogger.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace SoloDevBoard.Infrastructure.GitHub;
+
+/// <summary>Logs a startup warning when docs capture mode is active.</summary>
+public sealed class DocsCaptureStartupLogger(
+    IOptions<DocsCaptureOptions> docsCaptureOptions,
+    ILogger<DocsCaptureStartupLogger> logger) : IHostedService
+{
+    private readonly DocsCaptureOptions _docsCaptureOptions =
+        docsCaptureOptions?.Value ?? throw new ArgumentNullException(nameof(docsCaptureOptions));
+    private readonly ILogger<DocsCaptureStartupLogger> _logger =
+        logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <inheritdoc/>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_docsCaptureOptions.Enabled)
+        {
+            _logger.LogWarning(
+                "Docs capture mode is enabled. Repository and project board catalogues are restricted to public GitHub content only. This is for local documentation screenshots and is not a security boundary.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.Options;
 using SoloDevBoard.Application.Services.BoardRules;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Domain.Entities.Labels;
@@ -19,14 +20,22 @@ public sealed class GitHubService : IGitHubService
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly GitHubResponseCache _responseCache;
+    private readonly DocsCaptureOptions _docsCaptureOptions;
 
     /// <summary>Initialises a new instance of the <see cref="GitHubService"/> class.</summary>
     /// <param name="httpClientFactory">The factory used to create named <see cref="HttpClient"/> instances.</param>
     /// <param name="responseCache">The cache used for read-heavy GitHub API catalogue responses.</param>
-    public GitHubService(IHttpClientFactory httpClientFactory, GitHubResponseCache responseCache)
+    /// <param name="docsCaptureOptions">Docs capture mode options that restrict catalogues to public content when enabled.</param>
+    public GitHubService(
+        IHttpClientFactory httpClientFactory,
+        GitHubResponseCache responseCache,
+        IOptions<DocsCaptureOptions> docsCaptureOptions)
     {
+        ArgumentNullException.ThrowIfNull(docsCaptureOptions);
+
         _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
         _responseCache = responseCache ?? throw new ArgumentNullException(nameof(responseCache));
+        _docsCaptureOptions = docsCaptureOptions.Value;
     }
 
     /// <inheritdoc/>
@@ -36,14 +45,18 @@ public sealed class GitHubService : IGitHubService
             async ct =>
             {
                 var client = CreateAuthenticatedClient();
-                const string endpoint = "/user/repos?sort=updated&per_page=100";
-                return await GetPagedAsync<RepositoryResponseDto, Repository>(
+                var endpoint = _docsCaptureOptions.Enabled
+                    ? "/user/repos?sort=updated&per_page=100&type=public"
+                    : "/user/repos?sort=updated&per_page=100";
+                var repositories = await GetPagedAsync<RepositoryResponseDto, Repository>(
                         client,
                         endpoint,
                         static dto => dto.ToDomain(),
                         JsonOptions,
                         ct)
                     .ConfigureAwait(false);
+
+                return ApplyDocsCaptureRepositoryFilter(repositories);
             },
             cancellationToken).ConfigureAwait(false);
     }
@@ -68,13 +81,15 @@ public sealed class GitHubService : IGitHubService
             {
                 var client = CreateAuthenticatedClient();
                 var endpoint = $"/users/{Uri.EscapeDataString(owner)}/repos?per_page=100";
-                return await GetPagedAsync<RepositoryResponseDto, Repository>(
+                var repositories = await GetPagedAsync<RepositoryResponseDto, Repository>(
                         client,
                         endpoint,
                         static dto => dto.ToDomain(),
                         JsonOptions,
                         ct)
                     .ConfigureAwait(false);
+
+                return ApplyDocsCaptureRepositoryFilter(repositories);
             },
             cancellationToken).ConfigureAwait(false);
     }
@@ -88,6 +103,17 @@ public sealed class GitHubService : IGitHubService
             .ToArray();
     }
 
+    private IReadOnlyList<Repository> ApplyDocsCaptureRepositoryFilter(IReadOnlyList<Repository> repositories)
+    {
+        if (!_docsCaptureOptions.Enabled)
+        {
+            return repositories;
+        }
+
+        return repositories
+            .Where(static repository => !repository.IsPrivate)
+            .ToArray();
+    }
     /// <inheritdoc/>
     /// <remarks>
     /// The GitHub <c>/issues</c> endpoint returns both issues and pull requests. Items with a
@@ -384,7 +410,7 @@ public sealed class GitHubService : IGitHubService
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
 
-        const string query = "query TriageProjectBoards($owner: String!, $repo: String!) { repository(owner: $owner, name: $repo) { projectsV2(first: 50) { nodes { id title owner { ... on User { login } ... on Organization { login } } fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } } }";
+        const string query = "query TriageProjectBoards($owner: String!, $repo: String!) { repository(owner: $owner, name: $repo) { projectsV2(first: 50) { nodes { id title public owner { ... on User { login } ... on Organization { login } } fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } } }";
 
         var client = CreateAuthenticatedClient();
         var requestBody = new GraphQlRequestDto(
@@ -406,7 +432,20 @@ public sealed class GitHubService : IGitHubService
             .Where(static node => node is not null)
             .Select(static node => node!)
             .ToArray();
-        var inaccessibleLinkedProjectCount = rawNodes.Count - accessibleNodes.Length;
+
+        if (_docsCaptureOptions.Enabled)
+        {
+            accessibleNodes = accessibleNodes
+                .Where(static node => node.IsPublic)
+                .ToArray();
+        }
+
+        var totalLinkedProjectCount = _docsCaptureOptions.Enabled
+            ? accessibleNodes.Length
+            : rawNodes.Count;
+        var inaccessibleLinkedProjectCount = _docsCaptureOptions.Enabled
+            ? 0
+            : rawNodes.Count - accessibleNodes.Length;
 
         if (payload.Errors.Count > 0 && accessibleNodes.Length == 0)
         {
@@ -423,7 +462,7 @@ public sealed class GitHubService : IGitHubService
 
         return new RepositoryProjectBoardDiscoveryResult(
             supportedProjectBoards,
-            rawNodes.Count,
+            totalLinkedProjectCount,
             inaccessibleLinkedProjectCount);
     }
 
@@ -434,7 +473,7 @@ public sealed class GitHubService : IGitHubService
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
         ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
 
-        const string query = "query GetBoardRulesDefinition($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { id title owner { ... on User { login } ... on Organization { login } } fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }";
+        const string query = "query GetBoardRulesDefinition($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { id title public owner { ... on User { login } ... on Organization { login } } fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }";
 
         var client = CreateAuthenticatedClient();
         var requestBody = new GraphQlRequestDto(
@@ -456,14 +495,23 @@ public sealed class GitHubService : IGitHubService
             throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
         }
 
-        return ToBoardRulesDefinitionDto(payload.Data?.Node) ?? new BoardRulesDefinitionDto(
+        var node = payload.Data?.Node;
+        if (_docsCaptureOptions.Enabled && node is not null && !node.IsPublic)
+        {
+            return CreateUnavailableBoardRulesDefinition(projectId);
+        }
+
+        return ToBoardRulesDefinitionDto(node) ?? CreateUnavailableBoardRulesDefinition(projectId);
+    }
+
+    private static BoardRulesDefinitionDto CreateUnavailableBoardRulesDefinition(string projectId)
+        => new(
             projectId,
             string.Empty,
             string.Empty,
             Array.Empty<BoardColumnDto>(),
             Array.Empty<BoardRuleDto>(),
             new[] { "The requested project board was not found or is unavailable." });
-    }
 
     private static BoardRulesDefinitionDto? ToBoardRulesDefinitionDto(ProjectBoardNodeDto? node)
     {
@@ -1282,6 +1330,9 @@ public sealed class GitHubService : IGitHubService
 
         [JsonPropertyName("title")]
         public string Title { get; init; } = string.Empty;
+
+        [JsonPropertyName("public")]
+        public bool IsPublic { get; init; }
 
         [JsonPropertyName("owner")]
         public GraphQlOwnerDto? Owner { get; init; }

--- a/src/SoloDevBoard.AppHost/README.md
+++ b/src/SoloDevBoard.AppHost/README.md
@@ -116,3 +116,9 @@ Azure deployment settings:
 | Subscription | `Azure__SubscriptionId` |
 | Region | `Azure__Location` |
 | Resource group | `Azure__ResourceGroup` |
+
+### Local-only application settings (not AppHost parameters)
+
+| Setting | Environment variable | Notes |
+|---|---|---|
+| Docs capture mode | `DocsCapture__Enabled` | Local screenshot hygiene only. Defaults to `false`. Restricts repository and project board catalogues to public GitHub content. **Not** wired as an AppHost parameter and must stay disabled on hosted deployments. See [Docs capture mode](../../docs/getting-started.md#docs-capture-mode) and [DEC-020](../../plan/DECISIONS.md#dec-020-public-only-docs-capture-mode-for-documentation-screenshots). |

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/DocsCaptureModeTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/DocsCaptureModeTests.cs
@@ -1,0 +1,386 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Infrastructure.GitHub;
+
+namespace SoloDevBoard.Infrastructure.Tests;
+
+/// <summary>Tests for public-only docs capture mode filtering in <see cref="GitHubService"/>.</summary>
+public sealed class DocsCaptureModeTests
+{
+    [Fact]
+    public void DocsCaptureOptions_Default_IsDisabled()
+    {
+        var options = new DocsCaptureOptions();
+
+        Assert.False(options.Enabled);
+    }
+
+    [Fact]
+    public async Task GetRepositoriesAsync_DocsCaptureEnabled_UsesPublicTypeQueryAndExcludesPrivateRepos()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "id": 1,
+                    "name": "public-repo",
+                    "full_name": "mark/public-repo",
+                    "description": "Public",
+                    "html_url": "https://github.com/mark/public-repo",
+                    "private": false,
+                    "archived": false,
+                    "created_at": "2026-03-01T10:00:00Z",
+                    "updated_at": "2026-03-02T11:00:00Z"
+                  },
+                  {
+                    "id": 2,
+                    "name": "private-repo",
+                    "full_name": "mark/private-repo",
+                    "description": "Private",
+                    "html_url": "https://github.com/mark/private-repo",
+                    "private": true,
+                    "archived": false,
+                    "created_at": "2026-03-01T10:00:00Z",
+                    "updated_at": "2026-03-02T11:00:00Z"
+                  }
+                ]
+                """),
+        ]);
+
+        var sut = CreateSubject(handler, docsCaptureEnabled: true);
+
+        var result = await sut.GetRepositoriesAsync(cancellationToken);
+
+        var repository = Assert.Single(result);
+        Assert.Equal("public-repo", repository.Name);
+        Assert.False(repository.IsPrivate);
+        Assert.Single(handler.Requests);
+        Assert.Equal(
+            "https://api.github.com/user/repos?sort=updated&per_page=100&type=public",
+            handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task GetRepositoriesAsync_DocsCaptureDisabled_IncludesPrivateReposAndOmitsTypePublic()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "id": 1,
+                    "name": "public-repo",
+                    "full_name": "mark/public-repo",
+                    "description": "Public",
+                    "html_url": "https://github.com/mark/public-repo",
+                    "private": false,
+                    "archived": false,
+                    "created_at": "2026-03-01T10:00:00Z",
+                    "updated_at": "2026-03-02T11:00:00Z"
+                  },
+                  {
+                    "id": 2,
+                    "name": "private-repo",
+                    "full_name": "mark/private-repo",
+                    "description": "Private",
+                    "html_url": "https://github.com/mark/private-repo",
+                    "private": true,
+                    "archived": false,
+                    "created_at": "2026-03-01T10:00:00Z",
+                    "updated_at": "2026-03-02T11:00:00Z"
+                  }
+                ]
+                """),
+        ]);
+
+        var sut = CreateSubject(handler, docsCaptureEnabled: false);
+
+        var result = await sut.GetRepositoriesAsync(cancellationToken);
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, repository => repository.IsPrivate);
+        Assert.Equal(
+            "https://api.github.com/user/repos?sort=updated&per_page=100",
+            handler.Requests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task GetRepositoriesAsync_OwnerScoped_DocsCaptureEnabled_ExcludesPrivateRepos()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(
+                HttpStatusCode.OK,
+                """
+                [
+                  {
+                    "id": 1,
+                    "name": "public-repo",
+                    "full_name": "owner/public-repo",
+                    "description": "Public",
+                    "html_url": "https://github.com/owner/public-repo",
+                    "private": false,
+                    "archived": false,
+                    "created_at": "2026-03-01T10:00:00Z",
+                    "updated_at": "2026-03-02T11:00:00Z"
+                  },
+                  {
+                    "id": 2,
+                    "name": "private-repo",
+                    "full_name": "owner/private-repo",
+                    "description": "Private",
+                    "html_url": "https://github.com/owner/private-repo",
+                    "private": true,
+                    "archived": false,
+                    "created_at": "2026-03-01T10:00:00Z",
+                    "updated_at": "2026-03-02T11:00:00Z"
+                  }
+                ]
+                """),
+        ]);
+
+        var sut = CreateSubject(handler, docsCaptureEnabled: true);
+
+        var result = await sut.GetRepositoriesAsync("owner", cancellationToken);
+
+        var repository = Assert.Single(result);
+        Assert.Equal("public-repo", repository.Name);
+        Assert.False(repository.IsPrivate);
+    }
+
+    [Fact]
+    public async Task GetProjectBoardsForRepositoryAsync_DocsCaptureEnabled_ExcludesPrivateProjectsFromTotals()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "projectsV2": {
+                            "nodes": [
+                                {
+                                    "id": "PVT_public",
+                                    "title": "Public Roadmap",
+                                    "public": true,
+                                    "owner": { "login": "owner" },
+                                    "fields": {
+                                        "nodes": [
+                                            {
+                                                "id": "PVTF_status",
+                                                "name": "Status",
+                                                "options": [
+                                                    { "id": "option-one", "name": "In Progress" }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "PVT_private",
+                                    "title": "Private Board",
+                                    "public": false,
+                                    "owner": { "login": "owner" },
+                                    "fields": {
+                                        "nodes": [
+                                            {
+                                                "id": "PVTF_status_private",
+                                                "name": "Status",
+                                                "options": [
+                                                    { "id": "option-two", "name": "Todo" }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler, docsCaptureEnabled: true);
+
+        var result = await sut.GetProjectBoardsForRepositoryAsync("owner", "repo", cancellationToken);
+
+        var board = Assert.Single(result.SupportedProjectBoards);
+        Assert.Equal("Public Roadmap", board.Title);
+        Assert.Equal(1, result.TotalLinkedProjectCount);
+        Assert.Equal(0, result.InaccessibleLinkedProjectCount);
+
+        var warning = LinkedProjectBoardVisibility.BuildInaccessibleProjectsWarning(
+            result.TotalLinkedProjectCount,
+            result.InaccessibleLinkedProjectCount);
+        Assert.Null(warning);
+    }
+
+    [Fact]
+    public async Task GetBoardRulesDefinitionAsync_DocsCaptureEnabled_PrivateProject_ReturnsUnavailableFallback()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "node": {
+                        "id": "PVT_private",
+                        "title": "Private Board",
+                        "public": false,
+                        "owner": { "login": "owner" },
+                        "fields": {
+                            "nodes": [
+                                {
+                                    "id": "PVTF_status",
+                                    "name": "Status",
+                                    "options": [
+                                        { "id": "option-one", "name": "In Progress" }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler, docsCaptureEnabled: true);
+
+        var result = await sut.GetBoardRulesDefinitionAsync("owner", "repo", "PVT_private", cancellationToken);
+
+        Assert.Equal("PVT_private", result.ProjectId);
+        Assert.Empty(result.ProjectTitle);
+        Assert.Contains(
+            result.UnsupportedDetails,
+            detail => detail.Contains("not found or is unavailable", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DocsCaptureStartupLogger_Enabled_LogsWarning()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var logger = new CapturingLogger<DocsCaptureStartupLogger>();
+        var sut = new DocsCaptureStartupLogger(
+            Options.Create(new DocsCaptureOptions { Enabled = true }),
+            logger);
+
+        await sut.StartAsync(cancellationToken);
+
+        Assert.Contains(
+            logger.Messages,
+            message => message.Contains("Docs capture mode is enabled", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DocsCaptureStartupLogger_Disabled_DoesNotLogWarning()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var logger = new CapturingLogger<DocsCaptureStartupLogger>();
+        var sut = new DocsCaptureStartupLogger(
+            Options.Create(new DocsCaptureOptions { Enabled = false }),
+            logger);
+
+        await sut.StartAsync(cancellationToken);
+
+        Assert.Empty(logger.Messages);
+    }
+
+    private static GitHubService CreateSubject(HttpMessageHandler handler, bool docsCaptureEnabled)
+    {
+        var client = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.github.com"),
+        };
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory
+            .CreateClient(GitHubService.GitHubApiClientName)
+            .Returns(client);
+
+        var responseCache = GitHubCachingTestSupport.CreateResponseCache();
+        return new GitHubService(
+            httpClientFactory,
+            responseCache,
+            Options.Create(new DocsCaptureOptions { Enabled = docsCaptureEnabled }));
+    }
+
+    private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json)
+    {
+        return new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+    }
+
+    private sealed class QueueMessageHandler(IEnumerable<HttpResponseMessage> responses) : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new(responses);
+
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(await CloneRequestAsync(request, cancellationToken).ConfigureAwait(false));
+
+            if (_responses.Count == 0)
+            {
+                throw new InvalidOperationException("No mocked responses are left in the queue.");
+            }
+
+            return _responses.Dequeue();
+        }
+
+        private static async Task<HttpRequestMessage> CloneRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri);
+
+            if (request.Content is not null)
+            {
+                var content = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                var mediaType = request.Content.Headers.ContentType?.MediaType ?? "application/json";
+                clone.Content = new StringContent(content, Encoding.UTF8, mediaType);
+            }
+
+            return clone;
+        }
+    }
+
+    private sealed class CapturingLogger<T> : Microsoft.Extensions.Logging.ILogger<T>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => NullLogger<T>.Instance.BeginScope(state);
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel,
+            Microsoft.Extensions.Logging.EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
+    }
+}

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubApiCachingTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubApiCachingTests.cs
@@ -672,7 +672,7 @@ public sealed class GitHubApiCachingTests
             .Returns(new HttpClient(handler) { BaseAddress = new Uri("https://api.github.com") });
 
         var responseCache = GitHubCachingTestSupport.CreateResponseCache(memoryCache, context);
-        return new GitHubService(httpClientFactory, responseCache);
+        return new GitHubService(httpClientFactory, responseCache, Options.Create(new DocsCaptureOptions()));
     }
 
     private static GitHubLabelRepository CreateLabelRepository(

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Domain.Entities.Labels;
@@ -1439,7 +1440,7 @@ public sealed class GitHubServiceTests
             .Returns(client);
 
         var responseCache = GitHubCachingTestSupport.CreateResponseCache();
-        return new GitHubService(httpClientFactory, responseCache);
+        return new GitHubService(httpClientFactory, responseCache, Options.Create(new DocsCaptureOptions()));
     }
 
     private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json, string? linkHeader = null)


### PR DESCRIPTION
## Summary of Changes

Adds a local-only public content filter for documentation screenshot capture.

- Introduces `DocsCapture:Enabled` (default `false`) that restricts repository catalogues to public repos (`type=public` plus a defensive `!IsPrivate` filter) and Projects v2 discovery/definition to public boards only.
- Logs a startup warning when the mode is active; no UI chrome so screenshots stay clean.
- Records DEC-020 and documents the flag in operator docs. Intentionally not exposed as an Aspire AppHost deploy parameter — screenshot hygiene, not a security boundary.

## Related Issue(s)

Closes #331

Unblocks #256

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `user-docs/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — no UI chrome for the mode. Confirmation is the Repositories page showing only Public chips when enabled, plus the startup warning in logs.

## Additional Notes

- Filtering is catalogue-level in `GitHubService` only; per-repo calls remain gated by the filtered repository selector.
- Enable locally with `dotnet user-secrets set "DocsCapture:Enabled" "true" --project src/App/SoloDevBoard.App` or `DocsCapture__Enabled=true`.
- Unit coverage: `DocsCaptureModeTests`.
