### PR TITLE
feat(apphost): optional shared Azure Container Registry for deploys

### DIFF
--- a/.github/workflows/aspire-deploy.yml
+++ b/.github/workflows/aspire-deploy.yml
@@ -75,3 +75,5 @@ jobs:
           Parameters__allowed_org_logins: ${{ vars.ALLOWED_ORG_LOGINS }}
           Parameters__gh_pat: ${{ secrets.GH_PAT }}
           Parameters__gh_app_client_secret: ${{ secrets.GH_APP_CLIENT_SECRET }}
+          Parameters__shared_acr_name: ${{ vars.SHARED_ACR_NAME }}
+          Parameters__shared_acr_resource_group: ${{ vars.SHARED_ACR_RESOURCE_GROUP }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="1.6.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ContainerRegistry" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="13.4.6" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />

--- a/docs/azure-costs.md
+++ b/docs/azure-costs.md
@@ -40,6 +40,14 @@ Aspire deploys the following Azure resources (see [Deployment guide](deployment.
 - Review Log Analytics ingestion if log volume grows.
 - Use dev/test pricing offers if eligible.
 
+## Shared Container Registry
+
+Aspire provisions a Basic ACR (~£4–5/month per registry in UK South) for each Aspire deploy environment by default. If you run several Aspire apps or CD tiers, those fixed charges can exceed compute costs.
+
+Set `SHARED_ACR_NAME` and `SHARED_ACR_RESOURCE_GROUP` on your GitHub Environments (or the matching `Parameters__shared_acr_*` values for local deploys) to push images to one central registry in a platform resource group instead. See [Optional shared Container Registry](deployment.md#optional-shared-container-registry) in the deployment guide and [DEC-022](../plan/DECISIONS.md#dec-022-optional-shared-azure-container-registry).
+
+After migrating, delete orphaned per-deployment registries in the app resource group to remove duplicate fixed charges.
+
 ## Azure Pricing Calculator
 
 For exact, up-to-date pricing, use the [Azure Pricing Calculator](https://azure.microsoft.com/en-gb/pricing/calculator/). Select UK South and add Container Apps, Container Registry (Basic), and Log Analytics.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -246,8 +246,33 @@ Secret parameters are written to the Aspire-provisioned `auth-secrets` Key Vault
 |---|---|---|
 | `AZURE_LOCATION` | `uksouth` | Azure region for `aspire deploy` |
 | `AZURE_RESOURCE_GROUP` | `rg-solodevboard-prod` | Target resource group (shared across tiers) |
+| `SHARED_ACR_NAME` | *(unset)* or `acrmyorgprod` | Optional shared Container Registry name; leave unset for Aspire-provisioned per-deployment registry |
+| `SHARED_ACR_RESOURCE_GROUP` | *(unset)* or `rg-platform-shared` | Resource group containing the shared registry; required when `SHARED_ACR_NAME` is set |
 
 Enable required reviewers on the `production` environment before granting production deploy access. Staging deploys automatically on merge to `main`; production deploys on `v*` release tags.
+
+### Optional shared Container Registry
+
+By default, Aspire provisions a Basic Azure Container Registry in the app resource group for each Aspire deploy environment (Development, Staging, Production). That is convenient for contributors but can multiply fixed ACR costs across tiers and projects.
+
+To use one central registry in a dedicated platform resource group instead, set `SHARED_ACR_NAME` and `SHARED_ACR_RESOURCE_GROUP` on the GitHub Environment (or export the matching `Parameters__*` values for local deploys). When both are set, the AppHost references the existing registry via `PublishAsExisting` and attaches it to the Container Apps environment. When unset, behaviour is unchanged.
+
+**One-time platform setup**
+
+1. Create the shared ACR once in your platform resource group (for example `rg-platform-shared`). Basic tier is sufficient unless you need geo-replication or advanced features.
+2. Grant the CD deploy managed identity (`AZURE_CLIENT_ID`) **AcrPush** on the shared ACR. Contributor on the app resource group remains unchanged.
+3. After the first shared deploy, verify Aspire assigned **AcrPull** to the Container Apps environment managed identity on the shared registry (Azure portal → Access control (IAM)).
+
+**Migration from per-deployment registries**
+
+After a successful deploy using the shared registry, manually delete orphaned `Microsoft.ContainerRegistry/registries` resources in the app resource group. Aspire does not remove them automatically.
+
+| AppHost parameter | CD / local env var | Shared ACR value |
+|---|---|---|
+| `shared-acr-name` | `Parameters__shared_acr_name` / `SHARED_ACR_NAME` | registry name (for example `acrmyorgprod`) |
+| `shared-acr-resource-group` | `Parameters__shared_acr_resource_group` / `SHARED_ACR_RESOURCE_GROUP` | platform resource group (for example `rg-platform-shared`) |
+
+Leave both unset (or set to `-` locally) to keep the default Aspire-provisioned registry. See [DEC-022](../plan/DECISIONS.md#dec-022-optional-shared-azure-container-registry) and [Azure Deployment Costs](azure-costs.md#shared-container-registry).
 
 ---
 
@@ -312,7 +337,7 @@ Aspire generates and applies Bicep at deploy time. A typical deployment includes
 |---|---|
 | Azure Container Apps environment | Hosts the containerised app (Consumption profile) |
 | Container App (`app`) | Runs SoloDevBoard (scale-to-zero enabled) |
-| Azure Container Registry | Stores built container images |
+| Azure Container Registry | Stores built container images (Aspire-provisioned per deployment, or optional shared registry — see [Optional shared Container Registry](#optional-shared-container-registry)) |
 | Azure Key Vault (`auth-secrets`) | Stores hosted auth secret parameters as Key Vault secrets |
 | Application Insights | Application logs, metrics, and distributed traces |
 | Log Analytics workspace | Container platform logs and Application Insights backing store |
@@ -405,5 +430,7 @@ az identity delete --name id-solodevboard-cd-prod --resource-group rg-solodevboa
 | Secret not visible in Container App settings | Key Vault reference | Expected — inspect the `auth-secrets` vault for secret names; values are resolved at runtime |
 | PAT mode shows `/welcome` or requires sign-in | `hosted-sign-in-enabled` still `true` | Set `HOSTED_SIGN_IN_ENABLED` / `Parameters__hosted_sign_in_enabled` to `false` and redeploy |
 | PAT mode starts but GitHub calls fail | Missing or invalid `GH_PAT` | Set a real PAT with required scopes; confirm `/health/github` and the **Connected as @login** chip |
+| Image pull fails after enabling shared ACR | Missing AcrPush or AcrPull on shared registry | Grant AcrPush to the CD identity and verify AcrPull on the Container Apps managed identity |
+| Deploy fails with shared ACR parameter error | `SHARED_ACR_NAME` set without resource group | Set both `SHARED_ACR_NAME` and `SHARED_ACR_RESOURCE_GROUP` |
 
 For local development, see [Getting Started](getting-started.md) (including [PAT-only local trusted mode](getting-started.md#pat-only-local-trusted-mode)). For hosted authentication details, see [Hosted Authentication](hosted-authentication.md). For the Key Vault pattern, see [plan/HOSTED_AUTH_KEY_VAULT_PATTERN.md](../plan/HOSTED_AUTH_KEY_VAULT_PATTERN.md).

--- a/plan/DECISIONS.md
+++ b/plan/DECISIONS.md
@@ -209,6 +209,15 @@ Test coverage expectations for cache-hit, cache-miss, invalidation, TTL expiry, 
 
 ---
 
+### DEC-022: Optional shared Azure Container Registry
+
+**Status:** Active  
+**Date:** 2026-07-30  
+**Constitution:** [AGENTS.md — Infrastructure](../AGENTS.md#infrastructure)  
+**Summary:** Deployments may optionally reference an existing Azure Container Registry in a dedicated platform resource group via AppHost parameters `shared-acr-name` and `shared-acr-resource-group`. When unset (default `-`), Aspire continues to auto-provision a per-deployment Basic ACR in the app resource group. Shared registry wiring is deploy-only (`IsPublishMode`); local `aspire start` is unchanged. Operators grant the CD managed identity AcrPush on the shared registry; Aspire assigns AcrPull to the Container Apps environment managed identity via `WithAzureContainerRegistry`. Reject mandatory shared ACR for local development, hand-authored Bicep for registry attachment, or automatic deletion of legacy per-deployment registries.
+
+---
+
 ## Superseded legacy (archive only)
 
 | Legacy ADR | Superseded by | Notes |

--- a/src/SoloDevBoard.AppHost/AppHost.cs
+++ b/src/SoloDevBoard.AppHost/AppHost.cs
@@ -2,7 +2,7 @@ using Azure.Provisioning.KeyVault;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureContainerAppEnvironment("aca");
+var aca = builder.AddAzureContainerAppEnvironment("aca");
 
 var hostedSignInEnabled = builder.AddParameter("hosted-sign-in-enabled")
     .WithDescription("Enable GitHub App hosted sign-in at /auth/sign-in. When false, PAT mode is used (default).");
@@ -41,6 +41,35 @@ var app = builder.AddProject<Projects.SoloDevBoard_App>("app")
 
 if (builder.ExecutionContext.IsPublishMode)
 {
+    builder.AddParameter("shared-acr-name")
+        .WithDescription("Optional shared Azure Container Registry name. Use '-' to let Aspire provision a per-deployment registry.");
+
+    builder.AddParameter("shared-acr-resource-group")
+        .WithDescription("Resource group containing the shared registry. Required when shared-acr-name is set.");
+
+    var acrNameValue = Environment.GetEnvironmentVariable("Parameters__shared_acr_name")
+        ?? builder.Configuration["Parameters:shared-acr-name"]
+        ?? builder.Configuration["Parameters:shared_acr_name"]
+        ?? "-";
+    var acrRgValue = Environment.GetEnvironmentVariable("Parameters__shared_acr_resource_group")
+        ?? builder.Configuration["Parameters:shared-acr-resource-group"]
+        ?? builder.Configuration["Parameters:shared_acr_resource_group"]
+        ?? "-";
+
+    if (acrNameValue is not ("-" or ""))
+    {
+        if (acrRgValue is "-" or "")
+        {
+            throw new InvalidOperationException(
+                "shared-acr-resource-group must be set when shared-acr-name is configured.");
+        }
+
+        var acr = builder.AddAzureContainerRegistry("shared-acr")
+            .PublishAsExisting(acrNameValue, acrRgValue);
+
+        aca = aca.WithAzureContainerRegistry(acr);
+    }
+
     var authSecretsVault = builder.AddAzureKeyVault("auth-secrets");
 
     authSecretsVault.AddSecret("auth-gh-pat", "gh-pat", githubPat);

--- a/src/SoloDevBoard.AppHost/README.md
+++ b/src/SoloDevBoard.AppHost/README.md
@@ -96,6 +96,10 @@ Local `aspire start` continues to bind these parameters directly from user secre
 
 See [plan/HOSTED_AUTH_KEY_VAULT_PATTERN.md](../../plan/HOSTED_AUTH_KEY_VAULT_PATTERN.md) for the full pattern.
 
+### Optional shared Container Registry
+
+Deploy-only parameters `shared-acr-name` and `shared-acr-resource-group` default to `-`. When both are set at deploy time, the AppHost references an existing Azure Container Registry in a platform resource group instead of letting Aspire provision a per-deployment registry. Leave unset for the default stress-free path. See [docs/deployment.md — Optional shared Container Registry](../../docs/deployment.md#optional-shared-container-registry) and [DEC-022](../../plan/DECISIONS.md#dec-022-optional-shared-azure-container-registry).
+
 Preview deployment steps:
 
 ```bash
@@ -118,6 +122,8 @@ AppHost parameters map to workflow environment variables with underscores instea
 | `hosted-admission-enabled` | `Parameters__hosted_admission_enabled` |
 | `allowed-user-logins` | `Parameters__allowed_user_logins` |
 | `allowed-org-logins` | `Parameters__allowed_org_logins` |
+| `shared-acr-name` | `Parameters__shared_acr_name` / `SHARED_ACR_NAME` |
+| `shared-acr-resource-group` | `Parameters__shared_acr_resource_group` / `SHARED_ACR_RESOURCE_GROUP` |
 
 Azure deployment settings:
 

--- a/src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
+++ b/src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Azure.AppContainers" />
+    <PackageReference Include="Aspire.Hosting.Azure.ContainerRegistry" />
     <PackageReference Include="Aspire.Hosting.Azure.ApplicationInsights" />
     <PackageReference Include="Aspire.Hosting.Azure.KeyVault" />
     <PackageReference Include="MessagePack" />

--- a/src/SoloDevBoard.AppHost/appsettings.json
+++ b/src/SoloDevBoard.AppHost/appsettings.json
@@ -11,6 +11,8 @@
     "hosted-admission-enabled": "true",
     "gh-app-client-id": "-",
     "allowed-user-logins": "-",
-    "allowed-org-logins": "-"
+    "allowed-org-logins": "-",
+    "shared-acr-name": "-",
+    "shared-acr-resource-group": "-"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds optional shared Azure Container Registry support for Aspire deploys, building on PR #336 (three-tier CD pipeline).

When `SHARED_ACR_NAME` and `SHARED_ACR_RESOURCE_GROUP` are set on a GitHub Environment (or the matching `Parameters__shared_acr_*` values for local deploys), the AppHost references an existing ACR in a platform resource group via `PublishAsExisting` and `WithAzureContainerRegistry`. When unset, behaviour is unchanged — Aspire auto-provisions a per-deployment Basic ACR.

### AppHost

- Add `Aspire.Hosting.Azure.ContainerRegistry` 13.4.6.
- Deploy-only parameters `shared-acr-name` and `shared-acr-resource-group` (default `-`).
- Conditional wiring in `IsPublishMode` only; `aspire start` unchanged.

### CD

- Map `SHARED_ACR_NAME` and `SHARED_ACR_RESOURCE_GROUP` in reusable `aspire-deploy.yml`.

### Documentation

- Operator setup, permissions, and migration notes in `docs/deployment.md`.
- Cost guidance in `docs/azure-costs.md`.
- [DEC-022](plan/DECISIONS.md#dec-022-optional-shared-azure-container-registry).

## Verification

- `dotnet build SoloDevBoard.slnx --configuration Release` — success.
- `aspire deploy --list-steps` (default) — `provision-aca-acr` path.
- `aspire deploy --list-steps` with shared parameters — `provision-shared-acr` / `login-to-acr-shared-acr`; generated Bicep references existing registry in platform RG.

## Operator follow-up

Before enabling shared ACR on staging/production environments:

1. Create the shared ACR in your platform resource group (e.g. `rg-platform-shared`).
2. Grant the CD managed identity `AcrPush` on that registry.
3. Set `SHARED_ACR_NAME` and `SHARED_ACR_RESOURCE_GROUP` on the GitHub Environment.
4. After first successful deploy, delete orphaned per-deployment registries in the app resource group if migrating.

## Related

- Builds on #336 / DEC-021
- DEC-022
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c4dc875-4d28-4453-931b-839fc0e566cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c4dc875-4d28-4453-931b-839fc0e566cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

