### PR TITLE
[Chore] Automated application version stamping with MinVer (#344)

### DIFF
--- a/.github/workflows/aspire-deploy.yml
+++ b/.github/workflows/aspire-deploy.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v6
@@ -53,6 +55,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v6
@@ -133,6 +137,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v6

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,10 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
+  <!-- Build -->
+  <ItemGroup>
+    <PackageVersion Include="MinVer" Version="7.0.0" />
+  </ItemGroup>
   <!-- UI -->
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="1.7.1" />

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -261,6 +261,8 @@ Leave `custom-domain` and `custom-domain-certificate-name` unset (or `-`) to use
 
 The CD workflow (`.github/workflows/cd.yml`) runs `aspire deploy` with OIDC authentication across two hosted tiers (see [CD pipeline tiers](#cd-pipeline-tiers-dec-021)).
 
+Deploy jobs check out the repository with `fetch-depth: 0` so [MinVer](https://github.com/adamralph/minver) can stamp version metadata from git tags and commit history into the built application. See [Release Plan — Build-time versioning](../plan/RELEASE_PLAN.md#build-time-versioning-minver) for expected version shapes on staging and production.
+
 | Tier | How to trigger |
 |---|---|
 | **Staging** | Merge to `main`, or **Actions → CD - Deploy to Azure → Run workflow** (manual) |
@@ -276,7 +278,8 @@ After a successful deploy:
    - Sign in with an allow-listed GitHub account completes and returns to the app.
    - One feature page (for example **Repositories**) loads GitHub data without errors.
    - Sign out returns to `/welcome`.
-5. **Container App environment verification:** confirm `GitHubAuth__HostedGitHubAppClientId` and `HostedAdmissionControl__AllowedUserLogins` on the active revision show real values (not `-` placeholders from `appsettings.Staging.json`).
+5. **Deployment version check:** open **More options → About**. Staging should show a version with a `staging` pre-release suffix (for example `1.0.1-staging.0.42`); production should show a clean SemVer matching the release tag (for example `1.0.0`). The **Build** line links to the deployed commit — compare it with the commit SHA from the GitHub Actions deploy run or the tip of the deployed branch/tag.
+6. **Container App environment verification:** confirm `GitHubAuth__HostedGitHubAppClientId` and `HostedAdmissionControl__AllowedUserLogins` on the active revision show real values (not `-` placeholders from `appsettings.Staging.json`).
 
 ## Deploy locally (operator testing)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -121,6 +121,8 @@ dotnet run --project src/App/SoloDevBoard.App
 
 > **Recommendation:** Aspire is the standardised path for local development. It ensures consistent behaviour across all environments and prepares you for production deployment to Azure Container Apps.
 
+When you run locally, open **More options → About** to see the MinVer-calculated application version and build commit SHA. Local builds use the same git-based versioning as CI; staging-style pre-release suffixes appear when your checkout is ahead of the latest `v*` tag.
+
 ---
 
 ## Configuration

--- a/plan/RELEASE_PLAN.md
+++ b/plan/RELEASE_PLAN.md
@@ -10,6 +10,24 @@ SoloDevBoard follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PA
 
 During the pre-1.0 development phase (`0.x.y`), minor version bumps may include breaking changes as the application stabilises.
 
+### Build-time versioning (MinVer)
+
+Application version numbers are calculated automatically at build time by [MinVer](https://github.com/adamralph/minver) from git tags on `SoloDevBoard.App`. The About page and GitHub API user-agent both read this stamped assembly metadata.
+
+| Deploy tier | Git state | Example About version | Example build metadata |
+|---|---|---|---|
+| **Production** | Build at tag `v1.0.0` | `1.0.0` | Short commit SHA (for example `abc1234`) |
+| **Staging** | `main` commits after the latest tag | `1.0.1-staging.0.42` | Short commit SHA |
+| **Local dev** | Untagged working tree | `1.0.x-staging.0.n` (from git history) | Short commit SHA when git metadata is available |
+
+**Production source of truth:** the `vX.Y.Z` git tag pushed for the release. Pushing that tag triggers production CD; MinVer stamps the tag version into the deployed assembly.
+
+**Staging identification:** staging builds use the `staging.0` pre-release identifier so the About version is clearly not a production release. Compare the About **Build** value with the commit SHA on `main` in GitHub to confirm which deployment you are viewing.
+
+**CI requirement:** CD and CI workflows check out the repository with `fetch-depth: 0` so MinVer can read tags and commit history.
+
+**Temporary v1 bootstrap:** until the first `v1.0.0` tag exists, `MinVerMinimumMajorMinor=1.0` in `SoloDevBoard.App.csproj` floors calculated versions at the 1.0 release line. Remove that property after `v1.0.0` is tagged.
+
 ---
 
 ## Release Roadmap
@@ -112,7 +130,7 @@ Feature branch → Pull Request → CI passes → Code review → Merge to main 
 ### Step-by-Step
 
 1. **Merge to `main`:** All features for the release are merged via PRs with the CI pipeline passing. CD deploys automatically to the **staging** Azure Container Apps environment.
-2. **Final smoke test:** Verify the deployment to the staging environment is healthy.
+2. **Final smoke test:** Verify the deployment to the staging environment is healthy. Open **More options → About** and confirm the version shows a `staging` pre-release suffix and that the **Build** commit SHA matches the latest commit on `main` for that deploy.
 3. **Update documentation:** Ensure all user-facing docs on `main` reflect the released features (validated by `hugo-ci` on PRs; not published until tagged).
 4. **Tag the release:**
    ```bash

--- a/src/App/SoloDevBoard.App/Components/Features/About/Pages/About.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/About/Pages/About.razor
@@ -15,6 +15,27 @@
                 <MudText Typo="Typo.body2" data-testid="about-version">@Version</MudText>
             </MudStack>
 
+            @if (!string.IsNullOrWhiteSpace(BuildMetadata))
+            {
+                <MudStack Row="true" Spacing="1">
+                    <MudText Typo="Typo.subtitle2">Build:</MudText>
+                    @if (BuildCommitUrl is not null)
+                    {
+                        <MudLink Href="@BuildCommitUrl"
+                                 Target="_blank"
+                                 rel="noopener noreferrer"
+                                 Typo="Typo.body2"
+                                 data-testid="about-build">
+                            @BuildMetadata
+                        </MudLink>
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.body2" data-testid="about-build">@BuildMetadata</MudText>
+                    }
+                </MudStack>
+            }
+
             <MudStack Row="true" Spacing="1">
                 <MudText Typo="Typo.subtitle2">.NET runtime:</MudText>
                 <MudText Typo="Typo.body2" data-testid="about-dotnet-version">@DotNetRuntimeVersion</MudText>

--- a/src/App/SoloDevBoard.App/Components/Features/About/Pages/About.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/About/Pages/About.razor.cs
@@ -24,6 +24,13 @@ public partial class About : ComponentBase
 
     private string Version => AppVersionService.Version;
 
+    private string BuildMetadata => AppVersionService.BuildMetadata;
+
+    private string? BuildCommitUrl =>
+        string.IsNullOrWhiteSpace(BuildMetadata)
+            ? null
+            : $"{RepositoryAddress}/commit/{BuildMetadata}";
+
     private string DotNetRuntimeVersion => Environment.Version.ToString();
 
     private string RepositoryUrl => RepositoryAddress;

--- a/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj
+++ b/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj
@@ -6,10 +6,18 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
 		<UserSecretsId>cbdadc72-0914-4dd0-928d-5f374af9c526</UserSecretsId>
+		<MinVerTagPrefix>v</MinVerTagPrefix>
+		<MinVerDefaultPreReleaseIdentifiers>staging.0</MinVerDefaultPreReleaseIdentifiers>
+		<!-- Remove after the v1.0.0 tag is created. -->
+		<MinVerMinimumMajorMinor>1.0</MinVerMinimumMajorMinor>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Markdig" />
+		<PackageReference Include="MinVer">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="MudBlazor" />
 	</ItemGroup>
 

--- a/src/Application/SoloDevBoard.Application/Properties/InternalsVisibleTo.cs
+++ b/src/Application/SoloDevBoard.Application/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SoloDevBoard.Application.Tests")]

--- a/src/Application/SoloDevBoard.Application/Services/Common/AppVersionMetadata.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/AppVersionMetadata.cs
@@ -1,0 +1,8 @@
+namespace SoloDevBoard.Application.Services.Common;
+
+/// <summary>Parsed application version metadata from assembly attributes.</summary>
+internal readonly record struct AppVersionMetadata(string Version, string BuildMetadata)
+{
+    /// <summary>Gets empty metadata when no version attributes are available.</summary>
+    public static AppVersionMetadata Empty { get; } = new("unknown", string.Empty);
+}

--- a/src/Application/SoloDevBoard.Application/Services/Common/AppVersionMetadataParser.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/AppVersionMetadataParser.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+
+namespace SoloDevBoard.Application.Services.Common;
+
+/// <summary>Parses version metadata from assembly attributes.</summary>
+internal static class AppVersionMetadataParser
+{
+    /// <summary>Parses version and build metadata from the supplied assembly.</summary>
+    /// <param name="assembly">The assembly to inspect.</param>
+    /// <returns>Parsed version metadata.</returns>
+    public static AppVersionMetadata Parse(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        var informationalVersion = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
+
+        if (!string.IsNullOrWhiteSpace(informationalVersion))
+        {
+            return ParseInformationalVersion(informationalVersion);
+        }
+
+        var assemblyVersion = assembly.GetName().Version?.ToString();
+        return string.IsNullOrWhiteSpace(assemblyVersion)
+            ? AppVersionMetadata.Empty
+            : new AppVersionMetadata(assemblyVersion, string.Empty);
+    }
+
+    private static AppVersionMetadata ParseInformationalVersion(string informationalVersion)
+    {
+        var metadataSeparatorIndex = informationalVersion.IndexOf('+', StringComparison.Ordinal);
+        if (metadataSeparatorIndex < 0)
+        {
+            return new AppVersionMetadata(informationalVersion, string.Empty);
+        }
+
+        var version = informationalVersion[..metadataSeparatorIndex];
+        var buildMetadata = informationalVersion[(metadataSeparatorIndex + 1)..];
+        return new AppVersionMetadata(version, buildMetadata);
+    }
+}

--- a/src/Application/SoloDevBoard.Application/Services/Common/AppVersionService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/AppVersionService.cs
@@ -6,35 +6,27 @@ namespace SoloDevBoard.Application.Services.Common;
 public sealed class AppVersionService : IAppVersionService
 {
     private const string ApplicationName = "SoloDevBoard";
-    private readonly string _version;
 
     /// <summary>Initialises a new instance of the <see cref="AppVersionService"/> class.</summary>
     public AppVersionService()
     {
-        _version = ResolveVersion();
+        var metadata = ResolveMetadata();
+        Version = metadata.Version;
+        BuildMetadata = metadata.BuildMetadata;
     }
 
     /// <inheritdoc/>
-    public string Version => _version;
+    public string Version { get; }
+
+    /// <inheritdoc/>
+    public string BuildMetadata { get; }
 
     /// <inheritdoc/>
     public string UserAgent => $"{ApplicationName}/{Version}";
 
-    private static string ResolveVersion()
+    private static AppVersionMetadata ResolveMetadata()
     {
         var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
-        var informationalVersion = assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
-            .InformationalVersion;
-
-        if (!string.IsNullOrWhiteSpace(informationalVersion))
-        {
-            var metadataSeparatorIndex = informationalVersion.IndexOf('+', StringComparison.Ordinal);
-            return metadataSeparatorIndex < 0
-                ? informationalVersion
-                : informationalVersion[..metadataSeparatorIndex];
-        }
-
-        return assembly.GetName().Version?.ToString() ?? "unknown";
+        return AppVersionMetadataParser.Parse(assembly);
     }
 }

--- a/src/Application/SoloDevBoard.Application/Services/Common/IAppVersionService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/IAppVersionService.cs
@@ -6,6 +6,9 @@ public interface IAppVersionService
     /// <summary>Gets the current application version.</summary>
     string Version { get; }
 
+    /// <summary>Gets build metadata from the assembly informational version, such as a commit SHA.</summary>
+    string BuildMetadata { get; }
+
     /// <summary>Gets the user-agent value for outbound HTTP requests.</summary>
     string UserAgent { get; }
 }

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
@@ -12,6 +12,7 @@ namespace SoloDevBoard.App.Tests;
 public sealed class AboutTests : BunitContext
 {
     private const string TestVersion = "1.2.3";
+    private const string TestBuildMetadata = "abc1234";
     private readonly IAppVersionService _appVersionService = Substitute.For<IAppVersionService>();
     private readonly IGitHubAuthenticationSummaryService _authenticationSummaryService = Substitute.For<IGitHubAuthenticationSummaryService>();
 
@@ -29,7 +30,7 @@ public sealed class AboutTests : BunitContext
     private void ConfigureVersionService()
     {
         _appVersionService.Version.Returns(TestVersion);
-
+        _appVersionService.BuildMetadata.Returns(TestBuildMetadata);
         _appVersionService.UserAgent.Returns($"SoloDevBoard/{TestVersion}");
     }
 
@@ -61,6 +62,33 @@ public sealed class AboutTests : BunitContext
 
         // Assert
         Assert.Contains(TestVersion, cut.Markup);
+    }
+
+    [Fact]
+    public void AboutPage_RenderedWithMockedVersionService_DisplaysBuildMetadataLink()
+    {
+        // Act
+        var cut = Render<About>();
+
+        // Assert
+        var buildLink = cut.Find("[data-testid='about-build']");
+        Assert.Equal(TestBuildMetadata, buildLink.TextContent.Trim());
+        Assert.Equal(
+            $"https://github.com/markheydon/solo-dev-board/commit/{TestBuildMetadata}",
+            buildLink.GetAttribute("href"));
+    }
+
+    [Fact]
+    public void AboutPage_RenderedWithoutBuildMetadata_HidesBuildRow()
+    {
+        // Arrange
+        _appVersionService.BuildMetadata.Returns(string.Empty);
+
+        // Act
+        var cut = Render<About>();
+
+        // Assert
+        Assert.Empty(cut.FindAll("[data-testid='about-build']"));
     }
 
     [Fact]

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/AppVersionMetadataParserTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/AppVersionMetadataParserTests.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SoloDevBoard.Application.Services.Common;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="AppVersionMetadataParser"/>.</summary>
+public sealed class AppVersionMetadataParserTests
+{
+    [Theory]
+    [InlineData("1.0.0+abc1234", "1.0.0", "abc1234")]
+    [InlineData("1.0.1-staging.0.5+def5678", "1.0.1-staging.0.5", "def5678")]
+    [InlineData("1.0.0", "1.0.0", "")]
+    public void Parse_InformationalVersionAttributePresent_ReturnsVersionAndBuildMetadata(
+        string informationalVersion,
+        string expectedVersion,
+        string expectedBuildMetadata)
+    {
+        // Arrange
+        var assembly = CreateAssemblyWithInformationalVersion(informationalVersion);
+
+        // Act
+        var metadata = AppVersionMetadataParser.Parse(assembly);
+
+        // Assert
+        Assert.Equal(expectedVersion, metadata.Version);
+        Assert.Equal(expectedBuildMetadata, metadata.BuildMetadata);
+    }
+
+    [Fact]
+    public void Parse_AssemblyVersionOnly_ReturnsNonEmptyVersion()
+    {
+        // Arrange
+        var assembly = typeof(AppVersionMetadataParserTests).Assembly;
+
+        // Act
+        var metadata = AppVersionMetadataParser.Parse(assembly);
+
+        // Assert
+        Assert.False(string.IsNullOrWhiteSpace(metadata.Version));
+    }
+
+    private static Assembly CreateAssemblyWithInformationalVersion(string informationalVersion)
+    {
+        var assemblyName = new AssemblyName(Guid.NewGuid().ToString("N"));
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+            assemblyName,
+            AssemblyBuilderAccess.Run);
+        assemblyBuilder.DefineDynamicModule("TestModule");
+        var attributeBuilder = new CustomAttributeBuilder(
+            typeof(AssemblyInformationalVersionAttribute).GetConstructor([typeof(string)])!,
+            [informationalVersion]);
+        assemblyBuilder.SetCustomAttribute(attributeBuilder);
+        return assemblyBuilder;
+    }
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/AppVersionServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/AppVersionServiceTests.cs
@@ -19,6 +19,19 @@ public sealed class AppVersionServiceTests
     }
 
     [Fact]
+    public void BuildMetadata_ValueRequested_ReturnsString()
+    {
+        // Arrange
+        var sut = new AppVersionService();
+
+        // Act
+        var buildMetadata = sut.BuildMetadata;
+
+        // Assert
+        Assert.NotNull(buildMetadata);
+    }
+
+    [Fact]
     public void UserAgent_ValueRequested_StartsWithAppNamePrefix()
     {
         // Arrange

--- a/tests/E2E/tests/about.spec.ts
+++ b/tests/E2E/tests/about.spec.ts
@@ -15,6 +15,7 @@ test('about page shows deployment metadata from the shell menu', async ({ page }
   await expect(page).toHaveTitle(/About/);
   await expect(page.getByTestId('about-application-name')).toContainText('SoloDevBoard');
   await expect(page.getByTestId('about-version')).not.toBeEmpty();
+  await expect(page.getByTestId('about-build')).not.toBeEmpty();
   await expect(page.getByTestId('about-dotnet-version')).toHaveText(/\d+\.\d+/);
   await expect(page.getByTestId('about-auth-mode')).toContainText('PAT-only local trusted mode');
   await expect(page.getByTestId('about-github-login')).toContainText('@');

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/InfrastructureServiceExtensionsTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/InfrastructureServiceExtensionsTests.cs
@@ -105,5 +105,7 @@ internal sealed class TestAppVersionService : IAppVersionService
 {
     public string Version => "1.0.0-test";
 
+    public string BuildMetadata => "test-build";
+
     public string UserAgent => "SoloDevBoard/1.0.0-test";
 }

--- a/user-docs/content/docs/about.md
+++ b/user-docs/content/docs/about.md
@@ -10,7 +10,8 @@ The About page provides essential information about the SoloDevBoard application
 ## Information shown
 
 - Application name and branding.
-- Application version.
+- Application version (SemVer from git tags via MinVer at build time).
+- Build commit SHA (when available), linked to the source repository for verification.
 - .NET runtime version currently in use.
 - GitHub authentication mode (hosted sign-in or PAT-only local trusted mode).
 - Current GitHub identity (`@login`) for the active authentication mode.


### PR DESCRIPTION
## Summary of Changes

Wire MinVer into `SoloDevBoard.App` so git tags and commit history stamp meaningful SemVer into deployed assemblies. Staging builds show a `staging` pre-release suffix; production builds at `v*` tags show clean release SemVer. The About page now displays build commit metadata linked to GitHub for deployment verification.

- Add MinVer 7.0.0 to `SoloDevBoard.App` (central package version in `Directory.Packages.props`).
- Extend `IAppVersionService` with `BuildMetadata`; show **Build** on About with commit link.
- Set `fetch-depth: 0` on CD/CI checkout so MinVer can read tags during deploy builds.
- Document staging vs production version verification in `plan/RELEASE_PLAN.md`, `docs/deployment.md`, `docs/getting-started.md`, and user About docs.

## Related Issue(s)

Closes #344

Complements #57 (application version centralisation).

## Type of Change

- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [x] 📝 Documentation (updates to docs, comments, or README)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `user-docs/` (or developer docs under `docs/`) have been updated

## Additional Notes

- Remove `MinVerMinimumMajorMinor=1.0` from `SoloDevBoard.App.csproj` after the first `v1.0.0` tag is created.
- After merge: confirm staging About shows a `staging` pre-release version and build SHA matching the deployed commit on `main`.
- CI on this PR: build/test, E2E (PAT + Hosted), Aspire deploy validate (Staging + Production), Hugo CI, and CodeQL — all green.