### PR TITLE
Document user guide ↔ Playwright E2E alignment contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,18 @@ DTOs are `sealed record` types named `<Entity>Dto`, co-located in `SoloDevBoard.
 - Arrange / Act / Assert sections separated by blank lines (no comments required).
 - Use xUnit's built-in `Assert.*` methods for all assertions. **Do not add FluentAssertions, AwesomeAssertions, Shouldly, Moq, NUnit, or MSTest** (see [DEC-006](plan/DECISIONS.md#dec-006-no-fluentassertions--xunit-built-in-assertions-only) and [DEC-016](plan/DECISIONS.md#dec-016-formalised-testing-standard--xunit-v3-nsubstitute-playwright-e2e)).
 
+### End-user docs and Playwright E2E alignment
+
+The published user guide (`user-docs/`) and Playwright suite (`tests/E2E/`) must stay aligned **like-for-like**:
+
+1. **User guides describe actual application behaviour.** Do not document capabilities that are not shipped. Use scope notes for partial delivery.
+2. **Playwright E2E tests exercise what the guides claim.** Every published page in `user-docs/content/docs/` must map to at least one spec under `tests/E2E/tests/`. Assertions should target routes, controls, labels, and workflows described in the guide.
+3. **Loaded-state journeys use the docs-capture suite.** CI runs with placeholder auth and asserts shells, navigation, and empty or error states. Screenshots and populated UI states are captured manually via `tests/E2E/docs-capture/` with a real PAT — see [tests/E2E/USER_DOCS_ALIGNMENT.md](tests/E2E/USER_DOCS_ALIGNMENT.md).
+
+Canonical mapping and section-level inventory: [tests/E2E/USER_DOCS_ALIGNMENT.md](tests/E2E/USER_DOCS_ALIGNMENT.md). Update it alongside [tests/E2E/CRITICAL_JOURNEYS.md](tests/E2E/CRITICAL_JOURNEYS.md) when journeys change.
+
+**Screenshot hygiene (mandatory):** Never commit screenshots showing private repositories, private Projects v2 boards, tokens, or other confidential information. Capture with `DocsCapture:Enabled=true` (public catalogues only), light theme, 1400×900 viewport, and the `markheydon/solo-dev-board` example repository. See [plan/DOCS_STRATEGY.md](plan/DOCS_STRATEGY.md#screenshot-convention), [DEC-020](plan/DECISIONS.md#dec-020-public-only-docs-capture-mode-for-documentation-screenshots), and [docs/getting-started.md](docs/getting-started.md#docs-capture-mode).
+
 ---
 
 ## When Adding a New Feature
@@ -177,7 +189,8 @@ When code changes are made, ensure the following are kept in sync:
 
 | Change | Doc to update |
 |--------|--------------|
-| New end-user feature | `user-docs/content/docs/<feature>.md`, `user-docs/content/_index.md` (and docs landing), GitHub Issue + Project #8 sync |
+| New end-user feature | `user-docs/content/docs/<feature>.md`, `user-docs/content/_index.md` (and docs landing), matching Playwright spec in `tests/E2E/tests/`, `tests/E2E/USER_DOCS_ALIGNMENT.md`, `tests/E2E/CRITICAL_JOURNEYS.md`, GitHub Issue + Project #8 sync |
+| End-user behaviour change | `user-docs/content/docs/<feature>.md` and matching Playwright spec(s); refresh `tests/E2E/docs-capture/` screenshots when the UI changes materially |
 | New developer / operator guidance | `docs/<topic>.md` and `docs/README.md` as needed |
 | New decision | `plan/DECISIONS.md` (+ constitution if cross-cutting) |
 | Scope change | `plan/SCOPE.md`, `plan/IMPLEMENTATION_PLAN.md` |

--- a/plan/DOCS_STRATEGY.md
+++ b/plan/DOCS_STRATEGY.md
@@ -144,7 +144,7 @@ When Copilot or another AI agent is asked to write or update documentation:
 
 1. **UK English required.** All documentation must use UK English spelling. Run a spell check if possible.
 2. **Accuracy over completeness.** Do not document features that are not yet implemented. Use "Coming Soon" or "Under Development" notices for stubs.
-3. **Sync with code.** When updating docs, verify that the documented behaviour matches the current implementation.
+3. **Sync with code and E2E.** When updating docs, verify that the documented behaviour matches the current implementation and that Playwright specs in `tests/E2E/tests/` assert the same routes, controls, and workflows. Maintain the mapping in [tests/E2E/USER_DOCS_ALIGNMENT.md](../tests/E2E/USER_DOCS_ALIGNMENT.md).
 4. **Link generously.** Cross-reference related docs, decisions, and planning files. Use relative links within the same docs tree; use GitHub blob URLs when linking from the published site to repository-only files.
 5. **Heading hierarchy.** Use H1 for the page title, H2 for major sections, H3 for subsections. Do not skip levels.
 6. **Code blocks.** All code, commands, and configuration snippets must be in fenced code blocks with the appropriate language identifier.

--- a/tests/E2E/CRITICAL_JOURNEYS.md
+++ b/tests/E2E/CRITICAL_JOURNEYS.md
@@ -2,6 +2,8 @@
 
 This document defines the highest-priority SoloDevBoard user journeys covered by Playwright end-to-end tests in CI. It satisfies the journey-identification acceptance criterion for issue [#255](https://github.com/markheydon/solo-dev-board/issues/255) and complements [DEC-016](../../plan/DECISIONS.md#dec-016-formalised-testing-standard--xunit-v3-nsubstitute-playwright-e2e).
 
+Published user guides in `user-docs/content/docs/` must map to these journeys like-for-like. See [USER_DOCS_ALIGNMENT.md](USER_DOCS_ALIGNMENT.md) for the full guide-to-spec inventory and screenshot hygiene rules.
+
 ## CI constraints
 
 CI runs two Playwright jobs in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml):
@@ -24,6 +26,7 @@ For data-driven journeys against a real GitHub account, run the PAT suite locall
 | Health endpoint responds before browser tests run | `smoke.spec.ts` | `GET /health` returns `Healthy`. |
 | Home dashboard renders and lists all feature entry points | `navigation.spec.ts`, `smoke.spec.ts` | Title, navigation shell, and all seven feature cards. |
 | Drawer navigation reaches every primary feature route | `navigation.spec.ts` | URL and page title for each route in `fixtures/navigation.ts`. |
+| Appearance theme control cycles modes and persists preference | `appearance.spec.ts` | Automatic → Light → Dark cycle and browser storage persistence per [Appearance](../../user-docs/content/docs/appearance.md). |
 | About page shows deployment metadata | `about.spec.ts` | Version, auth mode, and repository link from the shell menu. |
 | PAT-mode welcome redirect and connectivity error page | `auth-entry.spec.ts` | `/welcome` redirects to home; connectivity error page renders guidance. |
 | Hosted sign-in login gate (unauthenticated redirect and welcome landing) | `auth-entry-hosted.spec.ts` | `/` and protected routes redirect to `/welcome`; sign-in CTA visible; Blazor negotiate succeeds. |
@@ -60,6 +63,7 @@ For data-driven journeys against a real GitHub account, run the PAT suite locall
 
 ## Related documentation
 
+- [tests/E2E/USER_DOCS_ALIGNMENT.md](USER_DOCS_ALIGNMENT.md) — user guide to Playwright spec mapping and screenshot hygiene.
 - [tests/E2E/README.md](README.md) — local run and CI overview.
 - [plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md](../../plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md) — health and operational E2E expectations.
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) — contributor testing guidance.

--- a/tests/E2E/README.md
+++ b/tests/E2E/README.md
@@ -4,12 +4,15 @@ Playwright tests for key user journeys. These complement unit and bUnit componen
 
 Critical journeys, priority tiers, and CI constraints are documented in [CRITICAL_JOURNEYS.md](CRITICAL_JOURNEYS.md).
 
+Published user guides must stay aligned with these tests like-for-like. See [USER_DOCS_ALIGNMENT.md](USER_DOCS_ALIGNMENT.md) for the guide-to-spec inventory and screenshot confidentiality rules.
+
 ## Test coverage
 
 | Spec | What it validates |
 |------|-------------------|
 | `smoke.spec.ts` | Health endpoint and home page render |
 | `navigation.spec.ts` | Home feature cards and drawer navigation to all primary routes |
+| `appearance.spec.ts` | Theme control cycles Automatic → Light → Dark and persists preference |
 | `about.spec.ts` | About page metadata via the shell menu |
 | `auth-entry.spec.ts` | PAT-mode welcome redirect and connectivity error page |
 | `auth-entry-hosted.spec.ts` | Hosted-mode login gate, welcome landing, and Blazor negotiate |

--- a/tests/E2E/USER_DOCS_ALIGNMENT.md
+++ b/tests/E2E/USER_DOCS_ALIGNMENT.md
@@ -1,0 +1,115 @@
+# User guide and Playwright E2E alignment
+
+This document maps published end-user guides in `user-docs/content/docs/` to Playwright coverage in `tests/E2E/`. It is the canonical inventory for keeping documentation, application behaviour, and automated journeys aligned like-for-like.
+
+## Alignment contract
+
+Three artefacts must stay in sync for every shipped end-user feature:
+
+1. **Application behaviour** — what SoloDevBoard actually does in the UI.
+2. **User guide** — what `user-docs/content/docs/<feature>.md` tells users they can do.
+3. **Playwright E2E** — what `tests/E2E/tests/*.spec.ts` asserts in CI (and, where applicable, what `tests/E2E/docs-capture/` records for screenshots).
+
+Rules:
+
+- **User guides describe real behaviour only.** Do not document planned or stubbed capabilities without a scope note. Remove or update docs when behaviour changes.
+- **E2E tests exercise what the guides claim.** Every published guide page must map to at least one Playwright spec. Assertions should target UI elements, routes, labels, and workflows described in the guide.
+- **CI uses placeholder auth.** Repository-dependent journeys assert shells, navigation, and empty or error states unless a job is extended with live secrets. Loaded-state behaviour is validated via the docs-capture suite (manual, real PAT) and unit/component tests.
+- **Screenshots follow public-only hygiene.** Never commit images showing private repositories, private Projects v2 boards, tokens, or other confidential information. Capture with `DocsCapture:Enabled=true` and the conventions in [plan/DOCS_STRATEGY.md](../../plan/DOCS_STRATEGY.md#screenshot-convention).
+
+When you add or change an end-user feature, update the user guide, the relevant Playwright spec(s), this mapping, and [CRITICAL_JOURNEYS.md](CRITICAL_JOURNEYS.md) in the same pull request.
+
+## Coverage matrix
+
+| User guide | App route(s) | Playwright spec (CI) | Docs-capture screenshot | CI tier | Notes |
+|------------|--------------|----------------------|-------------------------|---------|-------|
+| [Home dashboard](https://github.com/markheydon/solo-dev-board/blob/main/user-docs/content/_index.md) (site) / in-app `/` | `/` | `smoke.spec.ts`, `navigation.spec.ts`, `accessibility.spec.ts` | `dashboard/home.png` | Tier 1 | In-app home lists seven feature cards; About and Appearance are reached via the app bar. |
+| [Audit Dashboard](../../user-docs/content/docs/audit-dashboard.md) | `/audit-dashboard`, `/audit` | `audit-dashboard.spec.ts`, `accessibility.spec.ts` | `audit-dashboard/overview.png` | Tier 2 | Guide describes KPI cards, health sections, auto-refresh, and export; CI asserts shell, feedback region, and `/audit` alias with load failure. |
+| [Repositories](../../user-docs/content/docs/repositories.md) | `/repositories` | `repositories.spec.ts`, `accessibility.spec.ts` | `repositories/overview.png` | Tier 2 | Guide describes command strip, search, and grid; CI asserts refresh, search, and error state with retry. |
+| [One-Click Migration](../../user-docs/content/docs/one-click-migration.md) | `/migrate` | `migrate.spec.ts`, `accessibility.spec.ts` | `one-click-migration/overview.png` | Tier 2 | Guide describes preview/apply workflow and conflict strategies; CI asserts setup shell, disabled preview, and API failure feedback. |
+| [Label Manager](../../user-docs/content/docs/label-manager.md) | `/labels` | `labels.spec.ts`, `accessibility.spec.ts` | `label-manager/overview.png` | Tier 2 | Guide describes three tabs and taxonomy workflows; CI asserts tab strip, disabled actions, and no-repositories message. |
+| [Board Rules Visualiser](../../user-docs/content/docs/board-rules-visualiser.md) | `/board-rules` | `board-rules.spec.ts`, `accessibility.spec.ts` | `board-rules-visualiser/overview.png` | Tier 2 | Guide describes compare mode and board selection; CI asserts selector region, compare toggle, and load failure. |
+| [Triage UI](../../user-docs/content/docs/triage-ui.md) | `/triage` | `triage.spec.ts`, `accessibility.spec.ts` | `triage-ui/overview.png` | Tier 2 | Guide describes session queue, shortcuts, milestones, and project board actions; CI asserts not-started region and no-repositories alert. |
+| [Workflow Templates](../../user-docs/content/docs/workflow-templates.md) | `/workflows` | `workflows.spec.ts`, `accessibility.spec.ts` | `workflow-templates/overview.png` | Tier 2 | Guide describes browse, parameterise, apply, and drift; CI asserts built-in template browse/filter/select and repository error state. |
+| [Appearance](../../user-docs/content/docs/appearance.md) | App bar (all shell pages) | `appearance.spec.ts`, `accessibility.spec.ts` | `appearance/theme-toggle.png` | Tier 1 | Guide describes Automatic → Light → Dark cycling and persistence; not a drawer route. |
+| [About](../../user-docs/content/docs/about.md) | `/about` | `about.spec.ts`, `accessibility.spec.ts` | `about/overview.png` | Tier 1 | Guide describes More options menu access and metadata fields. |
+| Cross-Repo PM Workflow (`draft: true`) | — | — | — | — | Not published; excluded until Phase 5. |
+
+### Auth and entry journeys (operator docs, not user guide)
+
+These journeys are documented in `docs/hosted-authentication.md` and `docs/pat-connectivity.md` rather than the published user site:
+
+| Journey | Playwright spec | CI job |
+|---------|-----------------|--------|
+| PAT-mode welcome redirect and connectivity error page | `auth-entry.spec.ts` | `e2e-pat` |
+| Hosted sign-in login gate | `auth-entry-hosted.spec.ts` | `e2e-hosted` |
+
+## Guide section → assertion mapping
+
+Use this when extending specs so assertions track documented workflows.
+
+### Audit Dashboard
+
+| Guide section | CI assertion | Loaded-state validation |
+|---------------|--------------|-------------------------|
+| Accessing (`/audit-dashboard`, `/audit`) | `audit-dashboard.spec.ts` URL and title | `docs-capture` |
+| Repository selector and load failure | Feedback region, "Unable to load repositories" | `prepareAuditDashboardForCapture` |
+| KPI cards, health sections, auto-refresh, export | — | `docs-capture` + unit/component tests |
+
+### Label Manager
+
+| Guide section | CI assertion | Loaded-state validation |
+|---------------|--------------|-------------------------|
+| Three tabs (Labels, Recommended taxonomy, Synchronise) | Tab strip and headings | `docs-capture` |
+| No repositories message | Empty-state text | — |
+
+### Appearance
+
+| Guide section | CI assertion | Loaded-state validation |
+|---------------|--------------|-------------------------|
+| Theme button in app bar | `appearance.spec.ts`, `accessibility.spec.ts` labelled control | `docs-capture` |
+| Automatic → Light → Dark → Automatic cycle | `appearance.spec.ts` | — |
+| Browser persistence | `appearance.spec.ts` localStorage check | — |
+
+### About
+
+| Guide section | CI assertion |
+|---------------|--------------|
+| More options → About | `about.spec.ts` navigation |
+| Version, build, .NET, auth mode, login, repository link | `about.spec.ts` `data-testid` fields |
+
+## Screenshot and confidentiality
+
+Documentation screenshots are **not** part of the CI Playwright suite. They are captured manually via `tests/E2E/docs-capture/`:
+
+```bash
+# Prerequisites: real PAT, DocsCapture:Enabled=true, app running locally
+cd tests/E2E
+npm run capture:docs
+```
+
+Mandatory hygiene (see [DEC-020](../../plan/DECISIONS.md#dec-020-public-only-docs-capture-mode-for-documentation-screenshots) and [Docs capture mode](../../docs/getting-started.md#docs-capture-mode)):
+
+- Enable `DocsCapture:Enabled=true` so only **public** repositories and **public** Projects v2 boards appear.
+- Use **`markheydon/solo-dev-board`** as the canonical example repository.
+- Prefer **read-only** interactions (load, browse, inspect). Do not apply migrations, synchronise labels, close issues, or write workflow files for screenshots.
+- Use **light theme** at **1400×900** viewport with kebab-case PNG filenames under `user-docs/static/images/<feature-slug>/`.
+- **Do not commit** screenshots showing private repositories, private project boards, personal tokens, or other confidential information.
+
+Docs capture mode is screenshot hygiene, not a security boundary. Leave it disabled for normal development and all hosted deployments.
+
+## Adding or updating a feature
+
+1. Implement or change the feature in the application layer.
+2. Update `user-docs/content/docs/<feature>.md` and site indexes if the feature is user-facing.
+3. Add or extend `tests/E2E/tests/<feature>.spec.ts` to assert guide-described routes, controls, and CI-appropriate states.
+4. Extend `tests/E2E/docs-capture/` when the guide needs new or refreshed screenshots.
+5. Update this file, [CRITICAL_JOURNEYS.md](CRITICAL_JOURNEYS.md), and [README.md](README.md) coverage tables.
+6. Run the PAT E2E suite locally before merging.
+
+## Related documentation
+
+- [tests/E2E/CRITICAL_JOURNEYS.md](CRITICAL_JOURNEYS.md) — priority tiers and CI constraints.
+- [tests/E2E/README.md](README.md) — local run and screenshot capture.
+- [plan/DOCS_STRATEGY.md](../../plan/DOCS_STRATEGY.md) — documentation layers and screenshot convention.
+- [AGENTS.md](../../AGENTS.md) — constitution rules for docs ↔ E2E alignment.

--- a/tests/E2E/tests/appearance.spec.ts
+++ b/tests/E2E/tests/appearance.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { THEME_PREFERENCE_STORAGE_KEY } from '../fixtures/themePreference';
+
+test.describe('Appearance theme control', () => {
+  test('theme button cycles automatic, light, and dark modes', async ({ page }) => {
+    await page.goto('/');
+
+    const themeButton = page.getByRole('button', { name: /^Theme:/ });
+    await expect(themeButton).toBeVisible({ timeout: 15_000 });
+
+    // Default is automatic when no preference is stored.
+    await expect(themeButton).toHaveAccessibleName(/Theme: automatic \(follow system\)\. Activate light mode\./i);
+
+    await themeButton.click();
+    await expect(themeButton).toHaveAccessibleName(/Theme: light\. Activate dark mode\./i);
+
+    await themeButton.click();
+    await expect(themeButton).toHaveAccessibleName(/Theme: dark\. Activate automatic mode\./i);
+
+    await themeButton.click();
+    await expect(themeButton).toHaveAccessibleName(/Theme: automatic \(follow system\)\. Activate light mode\./i);
+  });
+
+  test('selected theme mode persists in browser storage', async ({ page }) => {
+    await page.goto('/');
+
+    const themeButton = page.getByRole('button', { name: /^Theme:/ });
+    await expect(themeButton).toBeVisible({ timeout: 15_000 });
+    await themeButton.click();
+
+    await expect
+      .poll(async () =>
+        page.evaluate((storageKey) => localStorage.getItem(storageKey), THEME_PREFERENCE_STORAGE_KEY),
+      )
+      .toBe('light');
+
+    await page.reload();
+    await expect(themeButton).toHaveAccessibleName(/Theme: light\. Activate dark mode\./i);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reviews alignment between published end-user guides (`user-docs/`) and Playwright E2E coverage, then codifies the like-for-like contract in repository documentation.

## Changes

- Add `tests/E2E/USER_DOCS_ALIGNMENT.md` — canonical mapping from each user guide page to Playwright specs, docs-capture screenshots, CI tier, and screenshot/confidentiality hygiene (DEC-020, DOCS_STRATEGY).
- Update `AGENTS.md` — new **End-user docs and Playwright E2E alignment** section and expanded Documentation Sync table.
- Add `tests/E2E/tests/appearance.spec.ts` — closes the only gap where a published guide (Appearance) had no dedicated journey spec (theme cycle and persistence).
- Cross-reference alignment doc from `CRITICAL_JOURNEYS.md`, `tests/E2E/README.md`, and `plan/DOCS_STRATEGY.md`.

## Review findings (no user-doc content changes required)

All nine published user guide pages now map to Playwright coverage:

| Area | Status |
|------|--------|
| Seven drawer/home features | Covered by feature specs + navigation |
| About (shell menu) | `about.spec.ts` |
| Appearance (app bar) | **New** `appearance.spec.ts` + accessibility theme checks |
| PM Workflow | Correctly excluded (`draft: true`) |
| Screenshots | All guides reference images captured via `docs-capture/` with public-only hygiene |

CI intentionally asserts shells and error/empty states with placeholder auth; loaded-state workflows documented in guides are validated via docs-capture (manual, real PAT) and unit/component tests — this split is now documented explicitly.

## Testing

- `PLAYWRIGHT_BASE_URL=http://localhost:5080 E2E_AUTH_MODE=pat npx playwright test appearance.spec.ts` — 2 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ced78bd-f47e-49be-84ad-88bded0f75a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ced78bd-f47e-49be-84ad-88bded0f75a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

