### PR TITLE
[Chore] Remove the unused OAuth App fallback authentication boundary

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ Parameters for the mode you are **not** using can be left unset (or set to `-` w
 | **Who authenticates** | Nobody signs in to SoloDevBoard — the app uses one configured token for all GitHub API calls | Each visitor signs in with GitHub at `/auth/sign-in` (landing at `/welcome`) |
 | **Identity** | Your login is resolved automatically from the PAT at startup | Per-user session claims (login, access token, installation, organisations) |
 | **Admission control** | Not applicable — anyone who can reach the app acts as the PAT owner | Operator allow-lists (`allowed-user-logins` / `allowed-org-logins`); deny-by-default |
-| **GitHub App required?** | No | Yes (OAuth App fallback exists but is disabled by default) |
+| **GitHub App required?** | No | Yes |
 | **Trust boundary** | Suitable only where you trust every person who can reach the deployment (localhost, private network, or a personal Azure instance you alone use) | Suitable for shared or public endpoints |
 | **Connectivity UX** | App-bar **Connected as @login** chip; recovery at `/auth/connectivity-error` — see [PAT Connectivity](pat-connectivity.md) | Session expiry and re-sign-in — see [Hosted Authentication](hosted-authentication.md) |
 
@@ -64,9 +64,6 @@ Your GitHub login is resolved automatically from the PAT. Full parameter tables 
 
 Uses a GitHub App for OAuth sign-in at `/auth/sign-in`, with operator-managed allow-lists for users and organisations. Recommended for production and multi-tenant deployments. See [Hosted Authentication Guide](hosted-authentication.md) for the full operator and local testing walkthrough.
 
-#### OAuth App fallback
-
-OAuth App fallback is supported but disabled by default. It is only used if enabled and the primary GitHub App authentication path is unavailable. It does not replace PAT-only local trusted mode.
 
 ## Running Locally
 
@@ -277,7 +274,6 @@ Located at `src/App/SoloDevBoard.App/appsettings.json`. The relevant sections ar
       "HostedAccessTokenClaimType": "solo-dev-board.github.access-token",
       "HostedInstallationIdClaimType": "solo-dev-board.github.installation-id",
       "HostedTokenExpiresAtClaimType": "solo-dev-board.github.token-expires-at",
-      "HostedOAuthAppFallbackEnabled": false,
       "HostedGitHubAppClientId": "",
       "HostedGitHubAppClientSecret": "",
       "HostedSignInCallbackPath": "/auth/callback",
@@ -307,7 +303,6 @@ Located at `src/App/SoloDevBoard.App/appsettings.json`. The relevant sections ar
 - `HostedAccessTokenClaimType`: Claim type used to map the hosted GitHub access token.
 - `HostedInstallationIdClaimType`: Claim type used to map the hosted GitHub installation identifier.
 - `HostedTokenExpiresAtClaimType`: Claim type used to map hosted token expiry (UTC) for fail-fast token validation.
-- `HostedOAuthAppFallbackEnabled`: Enables the OAuth App fallback compatibility boundary for hosted mode (disabled by default; only use if GitHub App auth is unavailable).
 - `HostedGitHubAppClientId`: GitHub App client identifier used for hosted sign-in.
 - `HostedGitHubAppClientSecret`: GitHub App client secret used for hosted sign-in.
 - `HostedSignInCallbackPath`: Callback route used by the hosted sign-in handshake.
@@ -353,7 +348,6 @@ Leave `PersonalAccessToken` empty in `appsettings.json` and supply it via an env
 | `GitHubAuth__HostedAccessTokenClaimType` | Claim type for hosted access token |
 | `GitHubAuth__HostedInstallationIdClaimType` | Claim type for hosted installation identifier |
 | `GitHubAuth__HostedTokenExpiresAtClaimType` | Claim type for hosted token expiry (UTC) |
-| `GitHubAuth__HostedOAuthAppFallbackEnabled` | Set to `true` to enable OAuth App fallback (disabled by default) |
 | `GitHubAuth__HostedGitHubAppClientId` | GitHub App client identifier for hosted sign-in |
 | `GitHubAuth__HostedGitHubAppClientSecret` | GitHub App client secret for hosted sign-in |
 | `GitHubAuth__HostedSignInCallbackPath` | Callback path for hosted sign-in |
@@ -395,14 +389,13 @@ When enabled:
 This is **screenshot hygiene, not a security boundary**. It does not block write operations and is intentionally unavailable as an Aspire AppHost deploy parameter. Leave it disabled for normal development and all hosted deployments. See [DEC-020](../plan/DECISIONS.md#dec-020-public-only-docs-capture-mode-for-documentation-screenshots).
 
 
-### Hosted Admission Control and Fallback Behaviour
+### Hosted Admission Control and Local Trusted Modes
 
 - Hosted sign-in mode requires `HostedGitHubAppClientId` and `HostedGitHubAppClientSecret` so the `/auth/sign-in` and `/auth/callback` handshake can establish a hosted session.
 - When `HostedAdmissionControl:Enabled` is true, hosted deployments deny all access by default unless the authenticated user's login or organisation is explicitly listed in the allow-lists.
 - All denied admission attempts are logged for operator review.
 - The claim type for organisation logins can be set using `HostedOrganisationLoginsClaimType` to match your identity provider's claim mapping.
-- OAuth App fallback is only used if `HostedOAuthAppFallbackEnabled` is true and the primary GitHub App authentication path is unavailable. This fallback is disabled by default for security.
-- PAT-only local trusted mode is always available for local development and trusted self-hosted use, independent of hosted admission control or fallback settings. See [PAT-only local trusted mode](#pat-only-local-trusted-mode) above and [Self-hoster deployment (PAT mode)](deployment.md#self-hoster-deployment-pat-mode) for Azure.
+- PAT-only local trusted mode is always available for local development and trusted self-hosted use, independent of hosted admission control. See [PAT-only local trusted mode](#pat-only-local-trusted-mode) above and [Self-hoster deployment (PAT mode)](deployment.md#self-hoster-deployment-pat-mode) for Azure.
 
 ### Production secrets (GitHub Actions)
 

--- a/docs/hosted-authentication.md
+++ b/docs/hosted-authentication.md
@@ -2,7 +2,7 @@
 
 # Hosted Authentication
 
-This guide explains the hosted sign-in model for SoloDevBoard, including user and operator expectations, prerequisites, and fallback paths.
+This guide explains the hosted sign-in model for SoloDevBoard, including user and operator expectations, prerequisites, and local trusted mode notes.
 
 ## Overview
 
@@ -61,11 +61,10 @@ CI runs a dedicated Playwright job (`e2e-hosted` in [`.github/workflows/ci.yml`]
 
 Full OAuth callback and post-login journeys remain manual or staging validation. See [tests/E2E/CRITICAL_JOURNEYS.md](../tests/E2E/CRITICAL_JOURNEYS.md).
 
-## Fallback and Local Trusted Modes
+## Local Trusted Modes
 
 - **PAT-only local trusted mode** remains available for development and trusted personal self-hosting. It does not require hosted sign-in infrastructure. See [Getting Started — PAT-only local trusted mode](getting-started.md#pat-only-local-trusted-mode) and [PAT Connectivity](pat-connectivity.md).
 - To run a personal Azure instance with a PAT (no GitHub App), follow [Self-hoster deployment (PAT mode)](deployment.md#self-hoster-deployment-pat-mode).
-- OAuth App fallback is supported but disabled by default. It is only used if enabled and the primary GitHub App authentication path is unavailable.
 
 ## Session and Token Flow
 

--- a/plan/DECISIONS.md
+++ b/plan/DECISIONS.md
@@ -120,7 +120,7 @@ A formal migration to GitHub Spec Kit is planned — see [`plan/SPEC_KIT_MIGRATI
 **Status:** Active  
 **Date:** 2026-03-13  
 **Legacy:** [ADR-0015](../adr/archive/0015-github-app-first-hosted-authentication.md)  
-**Summary:** Hosted sign-in prioritises GitHub App user authentication with admission control layered on top. OAuth App and hybrid flows are demoted to fallback only when App auth cannot satisfy requirements.
+**Summary:** Hosted sign-in uses GitHub App user authentication with admission control layered on top. The legacy OAuth App fallback boundary has been removed. PAT-only local trusted mode remains for development and trusted personal self-hosting.
 
 ---
 

--- a/plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md
+++ b/plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md
@@ -1,6 +1,6 @@
 # Hosted Authentication Session and Token Flow
 
-This document defines the hosted authentication and admission-control boundaries delivered for issues #111, #112, #113, #117, and #123.
+This document defines the hosted authentication and admission-control boundaries delivered for issues #111, #112, #117, and #123.
 
 ## Hosted Sign-In Application Boundary (#112)
 
@@ -58,12 +58,9 @@ This document defines the hosted authentication and admission-control boundaries
 - Operators are expected to review denied admission attempts regularly to detect unauthorised access attempts or misconfiguration.
 - Audit logs should be retained according to organisational policy and reviewed for suspicious activity.
 
-## OAuth App Fallback Boundary (#113)
+## Removed OAuth App Fallback Boundary (#113)
 
-- A separate OAuth App fallback path is now explicitly supported but remains disabled by default.
-- The fallback is controlled by the `GitHubAuth:HostedOAuthAppFallbackEnabled` configuration key.
-- OAuth App fallback is only used if enabled and the primary GitHub App authentication path is unavailable.
-- PAT-only local trusted mode is preserved and unaffected by hosted fallback settings.
+Hosted sign-in now uses GitHub App user authentication only. The separate OAuth App fallback path has been removed. PAT-only local trusted mode is preserved and unaffected by hosted sign-in settings.
 
 ## Test Coverage Expectations (Issue #114)
 
@@ -73,7 +70,7 @@ This section documents the test coverage requirements for GitHub App-first hoste
 - Installation discovery, token issuance, expiry, and failure handling are covered by unit tests and integration tests. Expiry and invalid token scenarios must be tested for explicit failure and no silent fallback.
 - Admission control and allow-list enforcement are covered by unit tests for edge cases (deny-by-default, allow-list misconfiguration, organisation claims mapping). Operator-managed allow-lists must be tested for both user and organisation paths.
 - Unit-test and mocked seams cover session creation, claim mapping, and admission control logic. Environment-dependent tests cover real GitHub App installation, token issuance, and expiry scenarios.
-- Documentation-sensitive regressions are covered by tests ensuring OAuth App fallback remains available but disabled by default, and PAT-only local trusted mode is preserved.
+- Documentation-sensitive regressions are covered by tests ensuring PAT-only local trusted mode is preserved.
 
 See [DEC-012](DECISIONS.md#dec-012-github-app-first-hosted-authentication) and GitHub Issues [#247](https://github.com/markheydon/solo-dev-board/issues/247)–[#250](https://github.com/markheydon/solo-dev-board/issues/250) for references to completed coverage and test boundaries.
 

--- a/src/App/SoloDevBoard.App/Authentication/HostedAuthErrorPresentation.cs
+++ b/src/App/SoloDevBoard.App/Authentication/HostedAuthErrorPresentation.cs
@@ -38,10 +38,6 @@ public static class HostedAuthErrorPresentationMapper
                 "GitHub unavailable",
                 "GitHub sign-in could not complete because GitHub returned an unexpected response. Try again later.",
                 StatusCodes.Status502BadGateway),
-            [HostedAuthErrorRoutes.SignInMisconfigured] = new(
-                "Sign-in unavailable",
-                "The requested sign-in method is not available on this deployment.",
-                StatusCodes.Status501NotImplemented),
             [HostedAuthErrorRoutes.SignInUnknown] = new(
                 "Sign-in failed",
                 "Hosted sign-in could not be completed. Try again, or contact the operator if the problem continues.",

--- a/src/App/SoloDevBoard.App/Program.cs
+++ b/src/App/SoloDevBoard.App/Program.cs
@@ -22,8 +22,6 @@ builder.AddServiceDefaults();
 
 var hostedSignInEnabled = builder.Configuration.GetValue<bool>(
     $"{GitHubAuthOptions.SectionName}:{nameof(GitHubAuthOptions.HostedSignInEnabled)}");
-var hostedOAuthFallbackEnabled = builder.Configuration.GetSection(GitHubAuthOptions.SectionName)
-    .GetValue<bool>(nameof(GitHubAuthOptions.HostedOAuthAppFallbackEnabled));
 var hostedCallbackBaseUri = builder.Configuration.GetSection(GitHubAuthOptions.SectionName)
     .GetValue<string>(nameof(GitHubAuthOptions.HostedSignInCallbackBaseUri));
 
@@ -221,13 +219,6 @@ if (hostedSignInEnabled)
 
         return Results.Redirect(returnUrl);
     }).AllowAnonymous();
-
-    if (hostedOAuthFallbackEnabled)
-    {
-        app.MapGet("/auth/sign-in/oauth-fallback", static () =>
-            Results.Redirect(HostedAuthErrorRoutes.BuildErrorUrl(HostedAuthErrorRoutes.SignInMisconfigured)))
-            .AllowAnonymous();
-    }
 
     app.MapGet("/auth/sign-out", (Delegate)SignOutHostedSession).AllowAnonymous();
     app.MapPost("/auth/sign-out", (Delegate)SignOutHostedSession).DisableAntiforgery().AllowAnonymous();

--- a/src/App/SoloDevBoard.App/appsettings.json
+++ b/src/App/SoloDevBoard.App/appsettings.json
@@ -9,7 +9,6 @@
     "HostedAccessTokenClaimType": "solo-dev-board.github.access-token",
     "HostedInstallationIdClaimType": "solo-dev-board.github.installation-id",
     "HostedTokenExpiresAtClaimType": "solo-dev-board.github.token-expires-at",
-    "HostedOAuthAppFallbackEnabled": false,
     "HostedGitHubAppClientId": "",
     "HostedGitHubAppClientSecret": "",
     "HostedSignInCallbackPath": "/auth/callback",

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubAuthOptions.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubAuthOptions.cs
@@ -53,15 +53,6 @@ public sealed class GitHubAuthOptions
     public string HostedTokenExpiresAtClaimType { get; set; } = HostedAuthClaimTypes.TokenExpiresAt;
 
     /// <summary>
-    /// Gets or sets a value indicating whether the legacy OAuth App hosted sign-in fallback boundary is enabled.
-    /// </summary>
-    /// <value>
-    /// <see langword="true" /> to expose the fallback-only compatibility boundary; otherwise, <see langword="false" />.
-    /// The default is <see langword="false" /> to keep GitHub App-first hosted sign-in as the standard path.
-    /// </value>
-    public bool HostedOAuthAppFallbackEnabled { get; set; }
-
-    /// <summary>
     /// Gets or sets the GitHub App client identifier used for hosted user sign-in.
     /// </summary>
     /// <value>The hosted GitHub App client identifier.</value>

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/Identity/HostedAuthErrorRoutes.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/Identity/HostedAuthErrorRoutes.cs
@@ -26,9 +26,6 @@ public static class HostedAuthErrorRoutes
     /// <summary>Gets the reason code when GitHub is unavailable during sign-in.</summary>
     public const string SignInUnavailable = "sign-in-unavailable";
 
-    /// <summary>Gets the reason code when a requested sign-in method is not configured.</summary>
-    public const string SignInMisconfigured = "sign-in-misconfigured";
-
     /// <summary>Gets the fallback reason code for unknown hosted authentication failures.</summary>
     public const string SignInUnknown = "sign-in-unknown";
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/HostedAuthErrorPresentationTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/HostedAuthErrorPresentationTests.cs
@@ -13,7 +13,6 @@ public sealed class HostedAuthErrorPresentationTests
     [InlineData(HostedAuthErrorRoutes.SignInIncomplete, "Sign-in incomplete")]
     [InlineData(HostedAuthErrorRoutes.SignInFailed, "Sign-in failed")]
     [InlineData(HostedAuthErrorRoutes.SignInUnavailable, "GitHub unavailable")]
-    [InlineData(HostedAuthErrorRoutes.SignInMisconfigured, "Sign-in unavailable")]
     [InlineData(HostedAuthErrorRoutes.SignInUnknown, "Sign-in failed")]
     [InlineData(HostedAuthErrorRoutes.SessionExpired, "Session expired")]
     public void Resolve_KnownReason_ReturnsExpectedTitle(string reason, string expectedTitle)


### PR DESCRIPTION
## Summary of Changes

Removes the unused OAuth App fallback authentication boundary. The `HostedOAuthAppFallbackEnabled` option and the `/auth/sign-in/oauth-fallback` route were disabled-by-default placeholders with no real sign-in flow. The real hosted sign-in handshake at `/auth/sign-in` and `/auth/callback` is unaffected, as is PAT-only local trusted mode.

- Removes `HostedOAuthAppFallbackEnabled` from `GitHubAuthOptions` and `appsettings.json`.
- Removes the conditional `oauth-fallback` route from `Program.cs`.
- Removes the now-dead `SignInMisconfigured` error code and its presentation mapping.
- Removes the matching `InlineData` from `HostedAuthErrorPresentationTests`.
- Updates `docs/getting-started.md`, `docs/hosted-authentication.md`, `plan/DECISIONS.md`, and `plan/HOSTED_AUTH_SESSION_AND_TOKEN_FLOW.md` to remove OAuth App fallback references and clarify GitHub App-only hosted sign-in.

## Related Issue(s)

Ad-hoc cleanup — the fallback boundary was originally introduced for issue #113 and is now being removed under DEC-012. No open issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [x] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `user-docs/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — no UI changes.

## Additional Notes

The `HostedGitHubAuthoriseEndpoint` and `HostedGitHubAccessTokenEndpoint` settings remain because they are the real GitHub App OAuth endpoints used by the hosted sign-in handshake.