### PR TITLE
[Chore] Formalise canonical pull request policy

### DIFF
--- a/.agents/contracts/code-review.md
+++ b/.agents/contracts/code-review.md
@@ -44,6 +44,9 @@ Invoke this agent when you need to review:
 - Check test naming follows `MethodUnderTest_Scenario_ExpectedOutcome`.
 - Ensure tests are placed in the matching `tests/*` project structure.
 
+### Pull request metadata
+- Confirm the title, template headings, labels, linking, and draft state match [`plan/PULL_REQUEST_POLICY.md`](../../plan/PULL_REQUEST_POLICY.md).
+
 ### Documentation and Planning
 - Confirm user-facing features include doc updates in `user-docs/content/docs/`.
 - Check `user-docs/content/_index.md` is updated if a new user guide page was added.

--- a/.agents/contracts/delivery.md
+++ b/.agents/contracts/delivery.md
@@ -123,11 +123,13 @@ Rules:
 
 Work on a dedicated feature branch.
 
-Naming convention:
+Naming convention (see also [`plan/PULL_REQUEST_POLICY.md`](../../plan/PULL_REQUEST_POLICY.md)):
 
 ```text
 feature/issue-N-description
 ```
+
+Platform-imposed names (`cursor/…`, `copilot/…`) are allowed; do not retitle the PR to match them.
 
 Examples:
 

--- a/.agents/contracts/verify.md
+++ b/.agents/contracts/verify.md
@@ -98,19 +98,16 @@ Do not open archived ADRs, release plans, scope documents, or implementation pla
 
 Create the PR after validation succeeds.
 
-Requirements:
+Follow [`plan/PULL_REQUEST_POLICY.md`](../../plan/PULL_REQUEST_POLICY.md) in full. In particular:
 
-- Link related issue
-- Copy issue labels
-- Add `status/in-review`
-- Assign `markheydon`
-- Apply issue milestone if present
-- Do NOT assign to Copilot either as a reviewer or assignee either manually or via a tool
-
-
-Use `.github/pull_request_template.md` which is available in the repo.
-- Ensure the PR body is generated from the repository template and not bypassed by supplying a custom `--body` value.
-- When using GitHub CLI, prefer `gh pr create --fill --base main --head <branch>` or the web flow so the repo template can be applied.
+- Title: `[<Type>] <Imperative summary> (#N)` — never Conventional Commits or `[type/…]`.
+- Body: keep every heading from `.github/pull_request_template.md`. Prefer `gh pr create --fill --base main --head <branch>` then `gh pr edit` to complete the template. If a platform API requires a custom body, copy those headings into it.
+- Link the issue with `Closes #N` (or `References #N` when auto-close is wrong).
+- Copy issue `type/`, `priority/`, `area/`, and `size/` labels onto the PR; set PR and issue `status/in-review`.
+- Assign `markheydon`; copy the issue milestone when present.
+- Open as ready for review unless the work is incomplete. Override vendor draft defaults.
+- Do NOT assign Copilot as reviewer or assignee.
+- Do NOT add the pull request to Project #8 as a standalone card.
 
 ---
 
@@ -140,7 +137,7 @@ Avoid generating lengthy reports unless a problem is found.
 
 Do NOT:
 
-- Confirm issue labels and milestone on the PR match planning expectations
+- Re-plan issue taxonomy or invent a different label set from [`LABEL_STRATEGY.md`](../../plan/LABEL_STRATEGY.md)
 - Update SCOPE.md
 - Update IMPLEMENTATION_PLAN.md
 - Update RELEASE_PLAN.md

--- a/.agents/skills/repo-github-gh-cli/SKILL.md
+++ b/.agents/skills/repo-github-gh-cli/SKILL.md
@@ -24,7 +24,7 @@ Use this skill when the user asks for command-line GitHub operations. Prioritise
 
 - Issue creation, updates, and triage
 - Label taxonomy operations aligned to `plan/LABEL_STRATEGY.md`
-- Pull request status and checks
+- Pull request status and checks (creation metadata: [`plan/PULL_REQUEST_POLICY.md`](../../plan/PULL_REQUEST_POLICY.md))
 - CI/CD workflow triggering and monitoring
 - Basic project board item operations
 

--- a/.agents/workflows/verify-and-create-pr.md
+++ b/.agents/workflows/verify-and-create-pr.md
@@ -5,8 +5,9 @@
 
 ## Easy-to-miss specifics
 
-- Use `gh pr create --fill` so the repository PR template is applied; do not bypass with a custom `--body`.
-- Always use the repo's label strategy for the relevant labels. See the [label strategy](../../plan/label-strategy.md) for more details.
+- Follow [`plan/PULL_REQUEST_POLICY.md`](../../plan/PULL_REQUEST_POLICY.md) for title, body, labels, linking, draft state, assignee, and milestone.
+- Use `gh pr create --fill` so the repository PR template is applied; do not bypass with a custom `--body` unless the platform cannot apply the template — then copy the template headings into the body.
+- Always use the repo's label strategy for the relevant labels. See the [label strategy](../../plan/LABEL_STRATEGY.md).
 
 ## Invocation
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+      - type/chore
+      - priority/low
+      - status/in-review
+      - area/infrastructure
     assignees:
       - markheydon
     groups:
@@ -66,6 +70,10 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+      - type/chore
+      - priority/low
+      - status/in-review
+      - area/infrastructure
     assignees:
       - markheydon
 
@@ -79,6 +87,10 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+      - type/chore
+      - priority/low
+      - status/in-review
+      - area/infrastructure
     assignees:
       - markheydon
     groups:
@@ -99,6 +111,10 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+      - type/chore
+      - priority/low
+      - status/in-review
+      - area/infrastructure
     assignees:
       - markheydon
     groups:
@@ -119,6 +135,10 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+      - type/chore
+      - priority/low
+      - status/in-review
+      - area/infrastructure
     assignees:
       - markheydon
     groups:

--- a/.github/instructions/github-actions-ci-cd-best-practices.instructions.md
+++ b/.github/instructions/github-actions-ci-cd-best-practices.instructions.md
@@ -53,7 +53,7 @@ Use this instruction for authoring and reviewing workflows in this repository.
 ## Dependabot Pull Requests
 
 - Dependabot pull requests must use the normal pull request CI workflow and meet the same build and test requirements as any other pull request.
-- Apply labels that match the repository taxonomy: `type/chore`, `priority/low`, `status/in-review`, and `area/infrastructure` unless a specific update warrants different priority or area labels.
+- Apply labels that match the repository taxonomy via [`.github/dependabot.yml`](../dependabot.yml): `type/chore`, `priority/low`, `status/in-review`, and `area/infrastructure` unless a specific update warrants different priority or area labels. See [`plan/PULL_REQUEST_POLICY.md`](../../plan/PULL_REQUEST_POLICY.md).
 - Group related dependency updates so review stays focused and pull request volume remains manageable.
 - Review each Dependabot pull request for package relevance, release notes, and any breaking-change risk before merging.
 - Merge only after required checks pass; do not bypass branch protection or deployment gates for automated dependency updates.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Summary of Changes
 
-<!-- Provide a concise summary of what this PR does and why. Use UK English. -->
+<!-- Provide a concise summary of what this PR does and why. Use UK English. Title form: [<Type>] Imperative summary (#N) — see plan/PULL_REQUEST_POLICY.md. -->
 
 ## Related Issue(s)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,7 @@ This repository is **open source and public**. The following guidelines ensure s
 - Ensure no secrets appear in your commits before submitting a PR.
 - Use `.gitignore` to exclude local secrets (`.env`, `secrets.json`, etc.).
 - Review [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
+- **Pull request metadata** (title, template body, labels, linking, draft state, assignee, milestone) follows [`plan/PULL_REQUEST_POLICY.md`](plan/PULL_REQUEST_POLICY.md) ([DEC-022](plan/DECISIONS.md#dec-022-canonical-pull-request-policy)). That file overrides vendor agent defaults when they conflict.
 
 ### .gitignore Protections
 
@@ -192,6 +193,7 @@ When code changes are made, ensure the following are kept in sync:
 | New end-user feature | `user-docs/content/docs/<feature>.md`, `user-docs/content/_index.md` (and docs landing), matching Playwright spec in `tests/E2E/tests/`, `tests/E2E/USER_DOCS_ALIGNMENT.md`, `tests/E2E/CRITICAL_JOURNEYS.md`, GitHub Issue + Project #8 sync |
 | End-user behaviour change | `user-docs/content/docs/<feature>.md` and matching Playwright spec(s); refresh `tests/E2E/docs-capture/` screenshots when the UI changes materially |
 | New developer / operator guidance | `docs/<topic>.md` and `docs/README.md` as needed |
+| Pull request process | [`plan/PULL_REQUEST_POLICY.md`](plan/PULL_REQUEST_POLICY.md), [`CONTRIBUTING.md`](CONTRIBUTING.md) |
 | New decision | `plan/DECISIONS.md` (+ constitution if cross-cutting) |
 | Scope change | `plan/SCOPE.md`, `plan/IMPLEMENTATION_PLAN.md` |
 | New env variable | `docs/getting-started.md`, `docs/deployment.md`, `src/SoloDevBoard.AppHost/README.md` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,10 +124,12 @@ When suggesting a feature:
    - Reference issue numbers when relevant (e.g., `Fixes #42`)
 
 6. **Pull request submission:**
-   - Create a descriptive PR title and body
-   - Reference any related issues
-   - Ensure all CI checks pass (build, tests, linting)
-   - Request a code review from the maintainers
+   - Follow [`plan/PULL_REQUEST_POLICY.md`](plan/PULL_REQUEST_POLICY.md) for title, template body, labels, linking, draft state, assignee, and milestone.
+   - Title form: `[<Type>] <Imperative summary> (#N)` (for example `[Story] Select a repository and project board to visualise (#183)`).
+   - Complete `.github/pull_request_template.md`; do not replace it with a vendor walkthrough.
+   - Apply at least `type/` and `priority/` labels, plus `status/in-review` while the PR is open.
+   - Ensure all CI checks pass (build, tests, linting).
+   - Request a code review from the maintainers.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To contribute:
 5. Use the issue templates in `.github/ISSUE_TEMPLATE/` to report bugs or request features.
 6. When implementing a feature or fix, reference the relevant issue in your commit message.
 7. Add or update tests in the appropriate test project under `tests/`.
-8. Submit your changes via a pull request using the provided template.
+8. Submit your changes via a pull request that follows [`plan/PULL_REQUEST_POLICY.md`](plan/PULL_REQUEST_POLICY.md) and `.github/pull_request_template.md`.
 9. The CI workflow will build and test your changes automatically.
 10. The project maintainer will review your PR and provide feedback or merge when ready.
 

--- a/plan/CURSOR_CLOUD.md
+++ b/plan/CURSOR_CLOUD.md
@@ -4,6 +4,12 @@ Maintainer notes for running SoloDevBoard in the Cursor Cloud VM. Standard local
 
 ---
 
+## Pull requests
+
+Cursor Cloud agents often default to **draft** PRs, `cursor/…` branch names, and a custom body. Those platform defaults **do not** replace repository policy. Follow [`PULL_REQUEST_POLICY.md`](PULL_REQUEST_POLICY.md): `[<Type>]` titles, the GitHub PR template headings in the body, taxonomy labels on the PR, ready-for-review when Verify gates pass, and no standalone Project #8 PR cards.
+
+---
+
 ## Toolchain
 
 - The .NET SDK pinned by `global.json` (`10.0.300`) is installed at `~/.dotnet`; the Aspire CLI (`13.4.6`, matching `Aspire.AppHost.Sdk`) is installed as a global tool at `~/.dotnet/tools`. Both are on `PATH` via `~/.bashrc`. Non-login shells (for example `bash -c`) do not source `~/.bashrc`, so invoke the SDK with the absolute path `~/.dotnet/dotnet` when `dotnet`/`aspire` are not already on `PATH`.

--- a/plan/DECISIONS.md
+++ b/plan/DECISIONS.md
@@ -211,6 +211,15 @@ Test coverage expectations for cache-hit, cache-miss, invalidation, TTL expiry, 
 
 ---
 
+### DEC-022: Canonical pull request policy
+
+**Status:** Active  
+**Date:** 2026-08-16  
+**Constitution:** [AGENTS.md — Contributing & Pull Requests](../AGENTS.md#contributing--pull-requests)  
+**Summary:** Pull request title, body, labels, linking, draft state, assignee, milestone, and branch conventions are defined in [`plan/PULL_REQUEST_POLICY.md`](PULL_REQUEST_POLICY.md). That file is the single source of truth for humans and AI agents. Titles use `[<Type>] <Imperative summary> (#N)` (not Conventional Commits). Bodies must keep the GitHub PR template headings. PRs require `type/` and `priority/` labels (plus `status/in-review` while open) and must not be added as standalone Project #8 cards. Ready-for-review is the default when Verify gates pass; vendor draft defaults must be overridden. Reject ad-hoc agent title styles, template-free bodies, and unlabelled agent PRs.
+
+---
+
 ## Superseded legacy (archive only)
 
 | Legacy ADR | Superseded by | Notes |

--- a/plan/DOCS_STRATEGY.md
+++ b/plan/DOCS_STRATEGY.md
@@ -48,6 +48,7 @@ plan/
 ├── BACKLOG.md
 ├── RELEASE_PLAN.md
 ├── LABEL_STRATEGY.md
+├── PULL_REQUEST_POLICY.md      # Canonical PR title, body, labels, metadata
 ├── PROJECT_MANAGEMENT.md
 ├── PROJECT_BOARD_DESIGN.md
 ├── SPEC_KIT_MIGRATION.md       # Parked — future Spec Kit adoption

--- a/plan/LABEL_STRATEGY.md
+++ b/plan/LABEL_STRATEGY.md
@@ -4,7 +4,7 @@
 
 This document defines the canonical label taxonomy for all SoloDevBoard GitHub repositories. All labels should be created using the definitions below to ensure consistency.
 
-For instructions on how to create these labels in bulk, see [PROJECT_MANAGEMENT.md](PROJECT_MANAGEMENT.md).
+For instructions on how to create these labels in bulk, see [PROJECT_MANAGEMENT.md](PROJECT_MANAGEMENT.md). For pull request titles, template usage, and PR metadata, see [PULL_REQUEST_POLICY.md](PULL_REQUEST_POLICY.md).
 
 ---
 
@@ -112,7 +112,7 @@ A script to create all labels at once will be provided in `infra/scripts/create-
 - Apply `type/chore` to maintenance tasks, refactoring, or dependency updates with no user-facing change.
 - Apply `type/documentation` to issues or PRs that only touch documentation.
 
-#### `priority/` — Always required on issues
+#### `priority/` — Always required on issues and PRs
 - Apply `priority/critical` only when the issue is blocking all progress or affects production.
 - Apply `priority/high` when the issue should be resolved in the current release.
 - Apply `priority/medium` as the default for new feature requests.

--- a/plan/PM_RUNBOOK.md
+++ b/plan/PM_RUNBOOK.md
@@ -185,7 +185,7 @@ Verify issue #[number]
 **What it does:**
 - Invokes **Verify Agent**
 - Validates all quality gates (code, tests, docs)
-- Creates pull request with proper metadata
+- Creates pull request with metadata from [`PULL_REQUEST_POLICY.md`](PULL_REQUEST_POLICY.md)
 - Updates issue labels to `status/in-review`
 - Provides verify summary
 
@@ -415,7 +415,7 @@ START
 
 **Responsibilities:**
 - Validates quality gates (code, tests, docs, backlog sync)
-- Creates pull request with metadata
+- Creates pull request with metadata from [`PULL_REQUEST_POLICY.md`](PULL_REQUEST_POLICY.md)
 - Updates issue labels (`status/in-review` → `status/done`)
 - Closes issues post-merge
 - Suggests next backlog item

--- a/plan/PROJECT_MANAGEMENT.md
+++ b/plan/PROJECT_MANAGEMENT.md
@@ -52,11 +52,11 @@ Roadmap date handling follows the same lifecycle:
 
 ### Linking Issues to PRs
 
-Reference the issue in your PR description using `Closes #<issue-number>` so GitHub automatically closes the issue when the PR is merged.
+Follow [`PULL_REQUEST_POLICY.md`](PULL_REQUEST_POLICY.md). Reference the issue in the PR description using `Closes #<issue-number>` so GitHub automatically closes the issue when the PR is merged.
 
 ### Automated Dependency PRs
 
-- Dependabot pull requests are treated as maintenance work and should use the `type/chore` label.
+- Dependabot pull requests are treated as maintenance work. [`.github/dependabot.yml`](../.github/dependabot.yml) applies `type/chore`, `priority/low`, `status/in-review`, `area/infrastructure`, and `dependencies`.
 - Dependabot pull requests should normally use `priority/low`, `status/in-review`, and `area/infrastructure` unless the update affects a different area or becomes urgent.
 - Dependabot pull requests do not need a separate tracking issue unless the update uncovers breaking changes, follow-up work, or a broader remediation task.
 - Dependabot updates should be grouped by related package area where practical so each pull request stays reviewable.

--- a/plan/PULL_REQUEST_POLICY.md
+++ b/plan/PULL_REQUEST_POLICY.md
@@ -1,0 +1,188 @@
+# SoloDevBoard — Pull request policy
+
+<!-- AI Collaborator Instructions: This is the canonical PR creation policy. Follow it whenever you open or update a pull request. Do not invent a different title style, body layout, or label set. -->
+
+This document is the **single source of truth** for how pull requests are titled, labelled, linked, and described. Human contributors, GitHub Copilot, Cursor Cloud agents, Devin, and other automations all follow it.
+
+Related artefacts:
+
+- Template: [`.github/pull_request_template.md`](../.github/pull_request_template.md).
+- Labels: [`LABEL_STRATEGY.md`](LABEL_STRATEGY.md).
+- Verify workflow: [`.agents/workflows/verify-and-create-pr.md`](../.agents/workflows/verify-and-create-pr.md) and [`.agents/contracts/verify.md`](../.agents/contracts/verify.md).
+- Branch naming for planned work: [`.agents/contracts/delivery.md`](../.agents/contracts/delivery.md) (Feature Branch).
+- Roadmap board: [`PROJECT_BOARD_DESIGN.md`](PROJECT_BOARD_DESIGN.md) — do not add PR cards to Project #8.
+- Decision: [DEC-022](DECISIONS.md#dec-022-canonical-pull-request-policy).
+
+---
+
+## Why this exists
+
+PR metadata was previously split across the GitHub template, `CONTRIBUTING.md`, the Verify contract, the label strategy, Dependabot config, and vendor agent defaults. Those sources disagreed (title format, draft vs ready, template vs custom body). The result was inconsistent PRs, especially from AI agents. This file wins when other instructions conflict, including vendor defaults such as Cursor Cloud draft PRs or Conventional Commits titles.
+
+---
+
+## Title
+
+Use this shape:
+
+```text
+[<Type>] <Imperative summary> (#<issue>)
+```
+
+Rules:
+
+- `<Type>` is exactly one of: `Story`, `Feature`, `Enabler`, `Bug`, `Chore`, `Test`, `Documentation`.
+- Match the linked issue `type/` label (`type/story` → `Story`, `type/documentation` → `Documentation`).
+- Use sentence case after the type token, UK English, and an imperative verb (`Add`, `Fix`, `Document`, not `Added` or `Adding`).
+- Append `(#N)` when the PR implements one issue. For several issues use `(#249, #314)`.
+- Omit the issue suffix only for genuine ad-hoc work with no tracking issue.
+
+Examples:
+
+```text
+[Story] Select a repository and project board to visualise (#183)
+[Enabler] Persist hosted auth secrets via Key Vault at deploy time (#250)
+[Bug] Fix Application Insights blocking local Aspire runs (#107)
+[Chore] Automated application version stamping with MinVer (#344)
+[Test] Add Playwright coverage for critical user journeys (#255)
+[Documentation] Complete comprehensive user docs with safe public screenshots (#256)
+```
+
+Do **not** use:
+
+- Conventional Commits prefixes (`feat:`, `fix:`, `chore(deps):`, `feat(#349):`).
+- Label names in the title (`[type/story]`, `[type/chore]`).
+- Unstable casing (`[story]`, `[WIP]` on a PR that is ready for review).
+- The raw branch name as the title.
+- Vague titles (`Update files`, `Implement issue #184` with no summary).
+
+Dependabot may keep its generated `Bump …` titles. Prefer a `[dependabot]:` prefix when a workflow already applies one; do not rewrite Dependabot titles by hand unless they are misleading.
+
+---
+
+## Body
+
+Always populate [`.github/pull_request_template.md`](../.github/pull_request_template.md). Required headings:
+
+1. `## Summary of Changes`
+2. `## Related Issue(s)`
+3. `## Type of Change`
+4. `## Checklist`
+5. `## Screenshots (if applicable)`
+6. `## Additional Notes`
+
+Rules:
+
+- UK English in all prose.
+- Tick every applicable checklist item; leave non-applicable items unticked rather than deleting them.
+- Put walkthroughs, test evidence, and agent-specific notes under **Additional Notes**, not as a replacement for the template.
+- Do not submit an empty body, a commit-list-only body, or a vendor “Walkthrough” body that omits the template headings.
+
+### How to create the body (tooling)
+
+| Tool | What to do |
+|------|------------|
+| GitHub CLI | `gh pr create --fill --base main --head <branch>` so GitHub applies the template, then `gh pr edit` to fill headings, labels, assignee, and milestone. Do not pass a custom `--body` that drops the template. |
+| GitHub web UI | Leave the pre-filled template in place and complete it. |
+| Cursor Cloud `ManagePullRequest` / similar APIs that require a custom body | Copy the template headings verbatim into `body`. After create, set `draft` to `false` when the work is ready for review. |
+| Copilot / other agents | Same content rules. Prefer the Verify workflow over ad-hoc PR creation. |
+
+---
+
+## Issue linking
+
+- Planned work **must** link the tracking issue in **Related Issue(s)**.
+- Use `Closes #N` (or `Closes #N, #M`) when merging the PR should close those issues.
+- Use `References #N` when the PR is related but must not auto-close the issue (docs-only follow-up, partial delivery, investigation).
+- Do not invent a tracking issue number. If none exists for planned feature work, stop and follow the planning workflow rather than opening an unlinked feature PR.
+
+---
+
+## Labels
+
+Apply taxonomy labels from [`LABEL_STRATEGY.md`](LABEL_STRATEGY.md) on the **pull request** at creation time (not only on the issue).
+
+| Group | On PRs | Rule |
+|-------|--------|------|
+| `type/` | Required | Copy from the linked issue, or choose the best match for ad-hoc work. |
+| `priority/` | Required | Copy from the linked issue. Default `priority/medium` if the issue has none. Dependabot: `priority/low`. |
+| `status/` | Required | `status/in-review` while the PR is open. Do not set `status/done` on an open PR. |
+| `area/` | Required when the area is known | Copy from the issue. Use `area/docs` for documentation-only PRs and `area/infrastructure` for CI, Aspire, and deploy work. |
+| `size/` | Optional | Copy from the issue when present. Do not invent a size on the PR alone. |
+
+Also allowed: GitHub’s `dependencies` label on Dependabot PRs, in addition to the taxonomy labels.
+
+Do **not**:
+
+- Leave a human or agent PR with only `status/done` or with no `type/` / `priority/`.
+- Put the pull request on Project #8 as a standalone card. Link it through `Closes #N` so it appears on the issue’s **Linked pull requests** field.
+
+When the PR is opened, set the **issue** to `status/in-review` (remove `status/in-progress` / `status/todo`) as described in the Verify contract.
+
+---
+
+## Other metadata
+
+| Field | Policy |
+|-------|--------|
+| Base branch | `main` unless the maintainer asked for another base. |
+| Draft | **Ready for review** (`draft: false`) when Verify gates pass. Use draft only when the branch is known to be incomplete or blocked. Vendor defaults that create drafts must be overridden once the work is ready. |
+| Assignee | `markheydon`. |
+| Reviewers | Do **not** assign Copilot (or equivalent bot) as reviewer or assignee. |
+| Milestone | Copy from the linked issue when present. |
+| Projects | Do not add the PR to the SoloDevBoard Roadmap (Project #8). |
+
+---
+
+## Branches
+
+Preferred for planned issues:
+
+```text
+feature/issue-N-short-kebab-description
+```
+
+Also accepted when a platform imposes the name:
+
+- Cursor Cloud: `cursor/<descriptive-name>-<id>` (do not fight the platform suffix).
+- GitHub Copilot coding agent: `copilot/…`.
+- Dependabot: `dependabot/…`.
+
+Never implement on `main`. Do not retitle the PR to match a vendor branch name.
+
+---
+
+## Dependabot
+
+Dependabot PRs follow [`PROJECT_MANAGEMENT.md`](PROJECT_MANAGEMENT.md) and this label set:
+
+- `type/chore`
+- `priority/low`
+- `status/in-review` (while open)
+- `area/infrastructure`
+- `dependencies` (config-generated)
+
+They do not need a tracking issue or the `[Chore]` title form. Merge only after CI passes and a relevance review.
+
+Configure those taxonomy labels in [`.github/dependabot.yml`](../.github/dependabot.yml) so new bot PRs are not created with `dependencies` alone.
+
+---
+
+## Agent checklist (copy this)
+
+Before opening a PR:
+
+1. Confirm the branch is not `main`.
+2. Title matches `[<Type>] <Imperative summary> (#N)`.
+3. Body includes every template heading, completed in UK English.
+4. `Closes #N` or `References #N` is present when an issue exists.
+5. Labels include `type/*`, `priority/*`, `status/in-review`, and `area/*` when known.
+6. Assignee is `markheydon`; milestone is copied; Copilot is not assigned.
+7. The PR is not draft unless the work is incomplete.
+8. The PR is not added as a Project #8 card.
+
+---
+
+## Reviewers
+
+When reviewing a PR for conventions, flag deviations from this file as process issues (title, template, labels, draft, missing `Closes #`). Coding review remains [`.agents/contracts/code-review.md`](../.agents/contracts/code-review.md).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Pull request metadata was split across the GitHub template, contributing docs, the Verify contract, the label strategy, Dependabot config, and vendor agent defaults. Those sources disagreed, so Copilot, Cursor, Devin, and humans produced different titles, bodies, and labels.

This change adds a single source of truth at `plan/PULL_REQUEST_POLICY.md` (DEC-022) and points the other artefacts at it. Titles are `[<Type>] <Imperative summary> (#N)`. Bodies must keep the repository template headings. PRs require `type/` and `priority/` (plus `status/in-review` while open). Ready-for-review is the default when work is complete. Dependabot config now applies the taxonomy labels described in `plan/PROJECT_MANAGEMENT.md`.

## Related Issue(s)

Ad-hoc documentation and process fix. No tracking issue.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [x] Chore / maintenance (dependency update, refactoring, tooling)
- [ ] Refactoring (no functional change, improves code quality)
- [x] Documentation (updates to docs, comments, or README)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [ ] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [ ] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `user-docs/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Not applicable (process and documentation only).

## Additional Notes

Audit of 94 PRs created since 16 May 2026 is in the PR discussion context: mixed `[Story]` / `[type/story]` / Conventional Commits / plain titles; Cursor `cursor/` branches vs `feature/issue-N`; template bodies vs agent walkthroughs; many Dependabot PRs labelled only `dependencies`; several Cursor PRs with only `status/done`.

This PR itself follows the new policy (title form, template headings, ready for review). Apply `type/chore`, `priority/medium`, `status/in-review`, `area/docs`, and `area/infrastructure` after merge tooling if they are not set automatically.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00b6d-62d5-7da1-a396-11ef3cf1938d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00b6d-62d5-7da1-a396-11ef3cf1938d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

