### PR TITLE
[Chore] Align v1 paperwork and retarget post-v1 milestones (#364)

### DIFF
--- a/.agents/skills/repo-github-project/SKILL.md
+++ b/.agents/skills/repo-github-project/SKILL.md
@@ -30,7 +30,7 @@ Centralised reference and command patterns for maintaining the **SoloDevBoard Ro
 
 ### Phase Model Note
 
-As of 2026-03-17, the live GitHub Project board and the repository planning artefacts are aligned on a six-phase roadmap. `v0.5.0` maps to **Phase 5 — Cross-Repo PM Workflow** and `v1.0.0` maps to **Phase 6 — Polish and v1.0**.
+As of 2026-08-17, the live GitHub Project board and the repository planning artefacts stay on the six-phase model, with post-1.0 SemVer retargeting: `v1.1.0` is deferred follow-on polish (Phase 6 field), `v1.2.0` (formerly `v0.5.0`) maps to **Phase 5 — Cross-Repo PM Workflow**, and `v1.0.0` maps to **Phase 6 — Polish and v1.0**.
 
 ---
 
@@ -72,8 +72,8 @@ As of 2026-03-17, the live GitHub Project board and the repository planning arte
 | Phase 2 — Label Manager + Audit | `0f90ba94` | v0.2.0 |
 | Phase 3 — Migration + Triage | `f3de38ba` | v0.3.0 |
 | Phase 4 — Board Rules + Workflows | `f5bc6726` | v0.4.0 |
-| Phase 5 — Cross-Repo PM Workflow | `495afaf1` | v0.5.0 |
-| Phase 6 — Polish and v1.0 | `dfa36cee` | v1.0.0 |
+| Phase 5 — Cross-Repo PM Workflow | `495afaf1` | v1.2.0 (formerly v0.5.0) |
+| Phase 6 — Polish and v1.0 | `dfa36cee` | v1.0.0 and v1.1.0 |
 
 ### Priority Options
 
@@ -96,8 +96,10 @@ Determine the correct **Phase** option from the issue's milestone or area label:
 | `v0.2.0` | `area/labels`, `area/dashboard` | Phase 2 — Label Manager + Audit |
 | `v0.3.0` | `area/migration`, `area/triage` | Phase 3 — Migration + Triage |
 | `v0.4.0` | `area/board-rules`, `area/workflows` | Phase 4 — Board Rules + Workflows |
-| `v0.5.0` | `area/dashboard` | Phase 5 — Cross-Repo PM Workflow |
+| `v0.5.0` | `area/dashboard` | Phase 5 — Cross-Repo PM Workflow (legacy title; rename to v1.2.0) |
+| `v1.2.0` | `area/dashboard` | Phase 5 — Cross-Repo PM Workflow |
 | `v1.0.0` | any | Phase 6 — Polish and v1.0 |
+| `v1.1.0` | any | Phase 6 — Polish and v1.0 (deferred follow-ons) |
 
 **Precedence:** Milestone > area label. When a milestone is assigned, use the milestone to determine the phase.
 

--- a/.github/scripts/roadmap-sync.mjs
+++ b/.github/scripts/roadmap-sync.mjs
@@ -26,7 +26,9 @@ const phaseOptionsByMilestone = new Map([
     ['v0.3.0', 'f3de38ba'],
     ['v0.4.0', 'f5bc6726'],
     ['v0.5.0', '495afaf1'],
+    ['v1.2.0', '495afaf1'],
     ['v1.0.0', 'dfa36cee'],
+    ['v1.1.0', 'dfa36cee'],
 ]);
 
 const priorityOptionsByLabel = new Map([
@@ -348,8 +350,18 @@ function isClosedAsDuplicate(issue) {
 function determinePhaseOptionId(issue) {
     const milestoneTitle = issue.milestone?.title ?? null;
 
-    if (milestoneTitle && phaseOptionsByMilestone.has(milestoneTitle)) {
+    if (!milestoneTitle) {
+        return null;
+    }
+
+    if (phaseOptionsByMilestone.has(milestoneTitle)) {
         return phaseOptionsByMilestone.get(milestoneTitle);
+    }
+
+    for (const [prefix, optionId] of phaseOptionsByMilestone.entries()) {
+        if (milestoneTitle.startsWith(`${prefix} `) || milestoneTitle.startsWith(`${prefix}—`) || milestoneTitle.startsWith(`${prefix} —`)) {
+            return optionId;
+        }
     }
 
     return null;

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > **A single pane of glass for solo developers managing GitHub workloads across multiple repositories.**
 
-**IMPORTANT** SoloDevBoard is currently in **early development**. The project is under active development (or as active as my schedule will allow at least!). Please refer to the [project plan](plan/IMPLEMENTATION_PLAN.md) for the current roadmap and feature status.
+> **IMPORTANT** Public **v1.0.0** is ready to tag. The six core tools plus hosted and self-host hardening are in the v1 slice. Cross-Repo PM Workflow is later (**v1.2.0**). Please refer to the [project plan](plan/IMPLEMENTATION_PLAN.md) for the current roadmap and feature status.
 
 ## What Is SoloDevBoard?
 
@@ -13,13 +13,13 @@
 
 | Feature | Description | Status |
 |---------|-------------|--------|
-| **Audit Dashboard** | Consolidated view of issues, open PRs, label consistency, and workflow health across all repositories. | Available |
+| **Audit Dashboard** | Consolidated view of issues, open PRs, and workflow health across selected repositories. | Available |
 | **Label Manager** | Create, edit, synchronise, and enforce label taxonomies across multiple repositories from a single interface. | Available |
 | **Repositories** | View and manage repositories accessible to your GitHub account. | Available |
-| **One-Click Migration** | Migrate labels and milestones from one repository to another in a single action. Project board migration is planned. | Partially Available |
+| **One-Click Migration** | Migrate labels and milestones from one repository to another in a single action. Project board migration is planned for v1.1.0. | Partially Available |
 | **Board Rules Visualiser** | Visualise supported board states and transitions for GitHub Project v2 boards. | Partially Available |
 | **Triage UI** | Keyboard-friendly interface for triaging incoming issues quickly. | Available |
-| **Workflow Templates** | Browse, customise, and apply GitHub Actions workflow templates across repositories. | Coming Soon |
+| **Workflow Templates** | Browse, customise, and apply built-in GitHub Actions workflow templates across repositories. Custom template repositories are planned for v1.1.0. | Partially Available |
 
 
 ## Tech Stack

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -2,7 +2,7 @@
 
 **GitHub Issues are the single source of truth for open work.** This page is a roadmap index only — it does not hold a living work queue.
 
-For historical backlog content (pre-migration), see [archive/BACKLOG-2026-07-18.md](archive/BACKLOG-2026-07-18.md). Migration details: [BACKLOG_TO_ISSUES_MIGRATION.md](BACKLOG_TO_ISSUES_MIGRATION.md).
+For historical backlog content (pre-migration), see [archive/BACKLOG-2026-07-18.md](archive/BACKLOG-2026-07-18.md). Migration details: [BACKLOG_TO_ISSUES_MIGRATION.md](BACKLOG_TO_ISSUES_MIGRATION.md). Post-1.0 numbering is [DEC-024](DECISIONS.md#dec-024-post-10-milestone-numbering).
 
 ## Where to find work
 
@@ -12,7 +12,7 @@ For historical backlog content (pre-migration), see [archive/BACKLOG-2026-07-18.
 | [SoloDevBoard Roadmap (Project #8)](https://github.com/users/markheydon/projects/8) | Prioritisation, flow, Up Next queue |
 | [Milestones](https://github.com/markheydon/solo-dev-board/milestones) | Release targeting |
 
-## Roadmap Status (2026-07-25)
+## Roadmap Status (2026-08-17)
 
 | Phase | Milestone | Status |
 |-------|-----------|--------|
@@ -20,30 +20,33 @@ For historical backlog content (pre-migration), see [archive/BACKLOG-2026-07-18.
 | Phase 2 — Label Manager + Audit Dashboard | v0.2.0 | Complete |
 | Phase 3 — One-Click Migration + Triage UI | v0.3.0 | Complete |
 | Phase 4 — Board Rules Visualiser + Workflow Templates | v0.4.0 | Complete |
-| Phase 5 — Cross-Repo PM Workflow | v0.5.0 | Parked until after v1.0.0 — [#272](https://github.com/markheydon/solo-dev-board/issues/272) |
-| Phase 6 — Polish, Testing, and Azure Deployment | v1.0.0 | Active — release closure in progress |
+| Phase 6 — Polish, Testing, and Azure Deployment | v1.0.0 | Ready to tag — [#257](https://github.com/markheydon/solo-dev-board/issues/257) |
+| Deferred follow-ons | v1.1.0 | Not started — [#289](https://github.com/markheydon/solo-dev-board/issues/289) |
+| Phase 5 — Cross-Repo PM Workflow | v1.2.0 | Parked until after v1.0.0 — [#272](https://github.com/markheydon/solo-dev-board/issues/272) |
+
+The GitHub milestone for Phase 5 may still show the former title `v0.5.0 — Cross-Repo PM Workflow` until it is renamed. The v1.1.0 GitHub milestone does not exist yet.
 
 ## Key epics
 
 | Epic | Issue | Milestone |
 |------|-------|-----------|
-| Public Release Infrastructure and Authentication | [#101](https://github.com/markheydon/solo-dev-board/issues/101) | v1.0.0 |
-| Operational hardening for public release | [#102](https://github.com/markheydon/solo-dev-board/issues/102) | v1.0.0 |
-| Cross-Repo PM Workflow (Phase 5) | [#272](https://github.com/markheydon/solo-dev-board/issues/272) | v0.5.0 (parked) |
-| Post-v1 Improvements | [#289](https://github.com/markheydon/solo-dev-board/issues/289) | None |
+| Public Release Infrastructure and Authentication | [#101](https://github.com/markheydon/solo-dev-board/issues/101) | v1.0.0 (closed) |
+| Operational hardening for public release | [#102](https://github.com/markheydon/solo-dev-board/issues/102) | v1.0.0 (closed) |
+| v1.1 deferred follow-ons | [#289](https://github.com/markheydon/solo-dev-board/issues/289) | v1.1.0 (create GitHub milestone) |
+| Cross-Repo PM Workflow (Phase 5) | [#272](https://github.com/markheydon/solo-dev-board/issues/272) | v1.2.0 (rename GitHub milestone from v0.5.0) |
 
 ## Completed phases (summary)
 
-Phases 1–4 delivered foundation, Label Manager, Audit Dashboard, One-Click Migration (labels + milestones), Triage UI, Board Rules Visualiser, and built-in Workflow Templates. Deferred follow-on slices (label consistency warnings, project board migration, custom template repos, Audit Dashboard polish) are tracked under [#289](https://github.com/markheydon/solo-dev-board/issues/289) and child issues.
+Phases 1–4 delivered foundation, Label Manager, Audit Dashboard, One-Click Migration (labels + milestones), Triage UI, Board Rules Visualiser, and built-in Workflow Templates. Deferred follow-on slices (label consistency warnings, project board migration, custom template repos, hosted private Projects v2) are tracked under [#289](https://github.com/markheydon/solo-dev-board/issues/289) and child issues [#290](https://github.com/markheydon/solo-dev-board/issues/290)–[#293](https://github.com/markheydon/solo-dev-board/issues/293).
 
-Phase 6 (v1.0.0) remaining work is tracked on the [v1.0.0 milestone](https://github.com/markheydon/solo-dev-board/milestone/4), including issues [#110](https://github.com/markheydon/solo-dev-board/issues/110), [#247](https://github.com/markheydon/solo-dev-board/issues/247)–[#259](https://github.com/markheydon/solo-dev-board/issues/259). Operational hardening test coverage expectations are documented in [OPERATIONAL_HARDENING_TEST_COVERAGE.md](OPERATIONAL_HARDENING_TEST_COVERAGE.md).
+Phase 6 (v1.0.0) delivery is complete aside from tagging. Remaining work on the [v1.0.0 milestone](https://github.com/markheydon/solo-dev-board/milestone/4) is [#257](https://github.com/markheydon/solo-dev-board/issues/257) (tag and release notes) and [#364](https://github.com/markheydon/solo-dev-board/issues/364) (paperwork alignment). Duplicate Phase 5 issues #260–#271 were closed as duplicates of the #272-family stories. Operational hardening test coverage expectations are documented in [OPERATIONAL_HARDENING_TEST_COVERAGE.md](OPERATIONAL_HARDENING_TEST_COVERAGE.md).
 
 ### V1 auth polish (Epic #101 follow-on)
 
 | Issue | Focus | Status |
 |-------|-------|--------|
-| [#247](https://github.com/markheydon/solo-dev-board/issues/247) | PAT-only local trusted mode documentation | Docs in [PR #324](https://github.com/markheydon/solo-dev-board/pull/324) |
-| [#248](https://github.com/markheydon/solo-dev-board/issues/248) | Self-hoster deployment path (`aspire deploy` with PAT) | Docs in [PR #324](https://github.com/markheydon/solo-dev-board/pull/324) |
+| [#247](https://github.com/markheydon/solo-dev-board/issues/247) | PAT-only local trusted mode documentation | Done |
+| [#248](https://github.com/markheydon/solo-dev-board/issues/248) | Self-hoster deployment path (`aspire deploy` with PAT) | Done |
 | [#249](https://github.com/markheydon/solo-dev-board/issues/249) | Hosted unauthenticated landing page | Done |
 | [#314](https://github.com/markheydon/solo-dev-board/issues/314) | PAT/GitHub connectivity readiness (startup probe, shell status, recovery UX) | Done |
 

--- a/plan/BACKLOG_TO_ISSUES_MIGRATION.md
+++ b/plan/BACKLOG_TO_ISSUES_MIGRATION.md
@@ -2,7 +2,7 @@
 
 <!-- AI Collaborator Instructions: Migration complete 2026-07-18. This document is retained for history. -->
 
-**Status:** Complete — executed 2026-07-18.
+**Status:** Complete — executed 2026-07-18. Historical numbering in this file (`v0.5.0` for Phase 5, “post-v1” with no milestone) is superseded by [DEC-024](DECISIONS.md#dec-024-post-10-milestone-numbering): deferred slices are **v1.1.0**, Cross-Repo PM Workflow is **v1.2.0**.
 
 **Created:** 2026-07-18.
 

--- a/plan/DECISIONS.md
+++ b/plan/DECISIONS.md
@@ -229,6 +229,15 @@ Test coverage expectations for cache-hit, cache-miss, invalidation, TTL expiry, 
 
 ---
 
+### DEC-024: Post-1.0 milestone numbering
+
+**Status:** Active  
+**Date:** 2026-08-17  
+**Constitution:** [AGENTS.md — When Adding a New Feature](../AGENTS.md#when-adding-a-new-feature)  
+**Summary:** After the public `v1.0.0` tag, do not ship a `v0.x` release. Deferred slices from Phases 1–4 (label consistency warnings, project board migration, custom workflow template repositories, hosted private Projects v2) plus dogfood fixes use milestone **v1.1.0** under epic [#289](https://github.com/markheydon/solo-dev-board/issues/289). Cross-Repo PM Workflow (Phase 5, epic [#272](https://github.com/markheydon/solo-dev-board/issues/272)) uses milestone **v1.2.0** (the GitHub milestone formerly titled `v0.5.0`). Reject tagging `v0.5.0` after `v1.0.0` exists.
+
+---
+
 ## Superseded legacy (archive only)
 
 | Legacy ADR | Superseded by | Notes |

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -6,13 +6,13 @@
 This document describes the phased implementation of SoloDevBoard. Each phase has a clear goal, a set of key tasks, and defined dependencies.
 
 **Note on sequencing:**
-Phases remain the primary sequence for feature delivery. Unfinished work from earlier phases remains open until completed, regardless of progress in later phases. However, certain public-release prerequisites from Phase 6 (such as hosted authentication and admission control) may be pulled forward out of sequence when required to enable safe hosted validation. This does not imply that earlier phases are complete or that the product has reached v1.0.0 readiness.
+Phases remain the primary sequence for feature delivery. Unfinished work from earlier phases remains open until completed, regardless of progress in later phases. Public-release prerequisites from Phase 6 (hosted authentication and admission control) were pulled forward to enable safe hosted validation. After `v1.0.0`, deferred Phase 1–4 slices ship as **v1.1.0** and Cross-Repo PM Workflow (Phase 5) ships as **v1.2.0** ([DEC-024](DECISIONS.md#dec-024-post-10-milestone-numbering)).
 
-**Current roadmap status (2026-07-18):**
+**Current roadmap status (2026-08-17):**
 - Phases 1–4 are complete. All six core feature areas are delivered (Label Manager, Audit Dashboard, One-Click Migration, Triage UI, Board Rules Visualiser, Workflow Templates).
-- Phase 5 (Cross-Repo PM Workflow, v0.5.0) is parked until after v1.0.0 ships — tracked in [#272](https://github.com/markheydon/solo-dev-board/issues/272).
-- Phase 6 (Production Ready, v1.0.0) is the active release-closure phase.
-- Deferred follow-on slices from Phases 1–4 are tracked in [#289](https://github.com/markheydon/solo-dev-board/issues/289) and child issues.
+- Phase 6 (Production Ready, v1.0.0) is ready to tag. Remaining delivery work is [#257](https://github.com/markheydon/solo-dev-board/issues/257) (annotated tag, GitHub Release, production CD).
+- Deferred follow-on slices from Phases 1–4 are **v1.1.0**, tracked in [#289](https://github.com/markheydon/solo-dev-board/issues/289) and child issues [#290](https://github.com/markheydon/solo-dev-board/issues/290)–[#293](https://github.com/markheydon/solo-dev-board/issues/293).
+- Phase 5 (Cross-Repo PM Workflow) is parked as **v1.2.0** — tracked in [#272](https://github.com/markheydon/solo-dev-board/issues/272). The GitHub milestone may still show the former `v0.5.0` title until it is renamed.
 
 For the full feature scope, see [SCOPE.md](SCOPE.md). For open work, see [GitHub Issues](https://github.com/markheydon/solo-dev-board/issues) and [Project #8](https://github.com/users/markheydon/projects/8). The backlog index is at [BACKLOG.md](BACKLOG.md).
 
@@ -71,18 +71,18 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Implement `LabelService` in `Application` (CRUD, sync operations)
 - [x] Build MudBlazor UI components for the Label Manager
 - [x] Implement label synchronisation logic (compare source and target, produce diff, apply changes)
-- [x] Write unit tests for `LabelService` using Moq
+- [x] Write unit tests for `LabelService` using NSubstitute
 - [x] Write infrastructure tests for `GitHubLabelRepository` (mocked HTTP)
-- [x] Update `user-docs/content/docs/label-manager.md`
+- [x] Update `website/content/docs/label-manager.md`
 
 #### Audit Dashboard
 - [x] Design `AuditReport` domain record
 - [x] Implement `AuditDashboardService` in `Application` (aggregate data from multiple repositories)
 - [x] Build MudBlazor UI components for the Audit Dashboard
 - [x] Implement health indicators: unlabelled issues, stale PRs, failing workflows
-- [ ] Implement label consistency warnings _(deferred — originally scoped in SCOPE.md but not yet built)_
+- [ ] Implement label consistency warnings _(deferred to v1.1.0 — [#290](https://github.com/markheydon/solo-dev-board/issues/290))_
 - [x] Write unit tests for `AuditDashboardService`
-- [x] Update `user-docs/content/docs/audit-dashboard.md`
+- [x] Update `website/content/docs/audit-dashboard.md`
 
 ### Dependencies
 
@@ -105,9 +105,9 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Implement `MigrationService` in `Application` (diff, preview, apply).
 - [x] Build MudBlazor UI: source/target repository selection, diff preview, confirmation, summary.
 - [x] Support migration of labels and milestones for the current delivery slice.
-- [ ] Support migration of project board columns as a later slice of this feature.
+- [ ] Support migration of project board columns as a later slice of this feature. _(deferred to v1.1.0 — [#291](https://github.com/markheydon/solo-dev-board/issues/291))_
 - [x] Write unit tests for `MigrationService`.
-- [x] Update `user-docs/content/docs/one-click-migration.md`.
+- [x] Update `website/content/docs/one-click-migration.md`.
 
 #### Triage UI
 - [x] Design `TriageSession` and `TriageAction` domain records
@@ -115,14 +115,14 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Build focused MudBlazor triage view with keyboard shortcut support
 - [x] Implement quick actions: label, assign milestone, add to project, close as duplicate
 - [x] Write unit tests for `TriageService`
-- [x] Update `user-docs/content/docs/triage-ui.md`
+- [x] Update `website/content/docs/triage-ui.md`
 
 
 ### Dependencies
 
 - Phase 2 complete (Label Manager, GitHub label/milestone API integration)
 
-**Note:** v0.3.0 is complete. Project board column migration remains a deferred follow-on slice (ADR-0013).
+**Note:** v0.3.0 is complete. Project board column migration remains a deferred v1.1.0 slice (ADR-0013, [#291](https://github.com/markheydon/solo-dev-board/issues/291)).
 
 ---
 
@@ -143,7 +143,7 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Implement GraphQL client in `Infrastructure` (see ADR-0005)
 - [x] Build interactive MudBlazor-based diagram component (compare mode now available)
 - [x] Write unit tests for `BoardRuleService`, `BoardRulesComparer`, and compare mode functionality
-- [x] Update `user-docs/content/docs/board-rules-visualiser.md` _(compare mode documented as available)_
+- [x] Update `website/content/docs/board-rules-visualiser.md` _(compare mode documented as available)_
 
 #### Workflow Templates
 - [x] Design `WorkflowTemplate` domain record
@@ -151,8 +151,8 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Build MudBlazor UI: template browser, parameter editor, apply to repositories, staleness tracker
 - [x] Include built-in templates: CI (dotnet), CD (Aspire deploy to Azure Container Apps), Dependabot
 - [x] Write unit tests for `WorkflowTemplateService`
-- [x] Update `user-docs/content/docs/workflow-templates.md`
-- [ ] Support custom template repositories _(deferred follow-on slice — only built-in templates are available today)_
+- [x] Update `website/content/docs/workflow-templates.md`
+- [ ] Support custom template repositories _(deferred to v1.1.0 — [#292](https://github.com/markheydon/solo-dev-board/issues/292); only built-in templates are available today)_
 
 ### Dependencies
 
@@ -165,9 +165,9 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 
 **Goal:** Deliver Epic 7 — the UI-based implementation of the two-mode PM operating system from [markheydon/github-workflows](https://github.com/markheydon/github-workflows). This phase transforms SoloDevBoard from a collection of individual tools into a cohesive planning environment.
 
-**Milestone:** v0.5.0
+**Milestone:** v1.2.0
 
-**Status:** Not started. Phases 1–4 are complete; this is the next active phase.
+**Status:** Parked until after v1.0.0. Tracked in [#272](https://github.com/markheydon/solo-dev-board/issues/272). Do not tag this work as `v0.5.0` after 1.0 exists ([DEC-024](DECISIONS.md#dec-024-post-10-milestone-numbering)).
 
 ### Key Tasks
 
@@ -177,21 +177,21 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [ ] Build MudBlazor Daily Focus view: board state summary, stalled item alerts, top-3 recommended work items
 - [ ] Implement stalled item detection (Up Next for 3+ days; PRs In Review for 3+ days)
 - [ ] Write unit tests for `DailyFocusService`
-- [ ] Update `user-docs/content/docs/pm-workflow.md`
+- [ ] Update `website/content/docs/pm-workflow.md`
 
 #### Backlog Review
 - [ ] Implement `BacklogReviewService` in `Application` (cross-repo, priority-grouped, PR-aware)
 - [ ] Build MudBlazor Backlog Review view: groups for urgent, ready, blocked, deferred; neglected repo alerts
 - [ ] Implement neglected repo detection (no issue or PR activity in 14 days)
 - [ ] Write unit tests for `BacklogReviewService`
-- [ ] Update `user-docs/content/docs/pm-workflow.md`
+- [ ] Update `website/content/docs/pm-workflow.md`
 
 #### Iteration Planning
 - [ ] Design `IterationPlan` domain record
 - [ ] Implement `IterationPlanningService` in `Application` (capacity enforcement, stale resolution, milestone assignment)
 - [ ] Build MudBlazor Iteration Planning view: capacity indicator, stale item resolution, Up Next curation, optional milestone assignment
 - [ ] Write unit tests for `IterationPlanningService`
-- [ ] Update `user-docs/content/docs/pm-workflow.md`
+- [ ] Update `website/content/docs/pm-workflow.md`
 
 #### Repo Management
 - [ ] Implement excluded-repos configuration (persisted per user, applied to all cross-repo operations)
@@ -210,10 +210,10 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 
 **Milestone:** v1.0.0
 
-**Status:** Partially complete. Hosted authentication, Aspire ACA deployment, and Dependabot are delivered. Operational hardening, release closure, and remaining auth polish are open. Begins in earnest after Phase 5.
+**Status:** Delivery complete except the public tag. Hosted authentication, Aspire ACA deployment, operational hardening, 80% coverage, accessibility, E2E, and the public product site are done. Remaining: [#257](https://github.com/markheydon/solo-dev-board/issues/257) (tag and GitHub Release). Paperwork alignment is [#364](https://github.com/markheydon/solo-dev-board/issues/364).
 
 ### Key Tasks
-- [ ] Achieve ≥80% unit test coverage across `Application` and `Domain` projects. _(#252)_
+- [x] Achieve ≥80% unit test coverage across `Application` and `Domain` projects. _(#252)_
 - [x] Perform accessibility audit of primary journey shells (WCAG 2.1 AA). _(#253; see plan/ACCESSIBILITY_AUDIT.md and tests/E2E/tests/accessibility.spec.ts.)_
 - [x] Conduct performance review: identify and address slow GitHub API calls (caching, pagination). _(#254)_
 - [x] Complete Azure infrastructure baseline via Bicep (App Service, Key Vault, managed identity). _(#104 — superseded by ADR-0018 Aspire ACA migration.)_
@@ -222,7 +222,7 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Add health check endpoints for Azure Container Apps monitoring. _(#106 — readiness `/health`, liveness `/alive`, ACA probe via AppHost `WithHttpHealthCheck`)_
 - [x] Implement response caching for GitHub API calls to respect rate limits. _(#108)_
 - [x] Configure structured logging and Application Insights telemetry. _(#107)_
-- [ ] Add operational hardening test coverage and validation expectations. _(#110; see plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md.)_
+- [x] Add operational hardening test coverage and validation expectations. _(#110; see plan/OPERATIONAL_HARDENING_TEST_COVERAGE.md.)_
 - [x] Set up Dependabot for automated dependency updates. _(#109)_
 - [x] Formalise and document PAT-only local trusted mode and self-hoster deployment path. _(#247, #248; see docs/getting-started.md#pat-only-local-trusted-mode and docs/deployment.md#self-hoster-deployment-pat-mode.)_
 - [x] Dedicated unauthenticated landing page for hosted deployments. _(#249)_
@@ -235,19 +235,19 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Define and execute the migration and compatibility path away from the superseded hybrid hosted-authentication plan. _(#103, #118; strategy locked in plan/HOSTED_AUTH_MIGRATION_STRATEGY.md on 2026-03-13.)_
 - [x] Persist hosted authentication material securely using Azure Key Vault-backed patterns where required. _(#250; see plan/HOSTED_AUTH_KEY_VAULT_PATTERN.md.)_
 - [x] Replace the single-user `ICurrentUserContext` adapter with a per-request, per-user implementation backed by the hosted authentication session when hosted mode is enabled. _(Implemented on 2026-03-13; PAT-only local trusted mode preserved.)_
-- [ ] Enable CD pipeline with production environment gate (`.github/workflows/cd.yml` via `aspire deploy`). _(#251)_
+- [x] Enable CD pipeline with production environment gate (`.github/workflows/cd.yml` via `aspire deploy`). _(#251)_
 - [x] Write end-to-end tests for critical user journeys. _(#255; see tests/E2E/CRITICAL_JOURNEYS.md.)_
-- [x] Update hosted-authentication documentation for GitHub App-first hosted sign-in, admission-control allow-lists, PAT-only local trusted mode, and fallback boundaries. _(#119; completed on 2026-03-16; see docs/getting-started.md, infra/README.md, docs/hosted-authentication.md, and user-docs/content/_index.md.)_
-- [x] Write comprehensive end-user documentation for all shipped features under `user-docs/`. _(#256; Hugo site + screenshots; `pm-workflow.md` remains draft until Phase 5)_
-- [ ] Public product site: landing, User Guide IA, About narrative, `website/` rename, canonical `solodevboard.com`. _(#358; see plan/product-site-project-plan.md and DEC-023.)_
+- [x] Update hosted-authentication documentation for GitHub App-first hosted sign-in, admission-control allow-lists, PAT-only local trusted mode, and fallback boundaries. _(#119; completed on 2026-03-16; see docs/getting-started.md, docs/hosted-authentication.md, and website/content/_index.md.)_
+- [x] Write comprehensive end-user documentation for all shipped features under `website/`. _(#256; Hugo site + screenshots; `pm-workflow.md` remains draft until Phase 5 / v1.2.0)_
+- [x] Public product site: landing, User Guide IA, About narrative, `website/` rename, canonical `solodevboard.com`. _(#358; see plan/product-site-project-plan.md and DEC-023.)_
 - [ ] Tag v1.0.0 release on GitHub with release notes. _(#257)_
 
 
 ### Dependencies
 
-- Intended release sequence: complete Phase 5, then close out the remaining Phase 6 release work.
+- Intended release sequence: close v1.0.0, then v1.1.0 deferred slices, then Phase 5 as v1.2.0.
 
-**Note:** Hosted authentication and admission control were advanced out of sequence to enable safe hosted validation. Phases 1–4 are complete; v1.0.0 readiness depends on Phase 5 and the remaining Phase 6 tasks above.
+**Note:** Hosted authentication and admission control were advanced out of sequence to enable safe hosted validation. Phases 1–4 are complete. v1.0.0 readiness does not depend on Phase 5.
 
 
 ## AI Collaborator Instructions

--- a/plan/PROJECT_MANAGEMENT.md
+++ b/plan/PROJECT_MANAGEMENT.md
@@ -75,8 +75,9 @@ Milestones map to implementation phases and releases:
 | Phase 2 — Core Features | Phase 2 | v0.2.0 |
 | Phase 3 — Migration and Triage | Phase 3 | v0.3.0 |
 | Phase 4 — Visualisation and Templates | Phase 4 | v0.4.0 |
-| Phase 5 — Cross-Repo PM Workflow | Phase 5 | v0.5.0 |
+| Phase 5 — Cross-Repo PM Workflow | Phase 5 | v1.2.0 (GitHub milestone may still show the former `v0.5.0` title until renamed) |
 | Phase 6 — Polish and v1.0 | Phase 6 | v1.0.0 |
+| Deferred follow-ons | Phase 6 field | v1.1.0 |
 
 ### Milestone Workflow
 

--- a/plan/RELEASE_PLAN.md
+++ b/plan/RELEASE_PLAN.md
@@ -53,7 +53,7 @@ Application version numbers are calculated automatically at build time by [MinVe
 
 **Scope:**
 - Label Manager: view, create, edit, delete, and synchronise labels across repositories
-- Audit Dashboard: open issues, stale PRs, workflow statuses, label inconsistencies
+- Audit Dashboard: open issues, stale PRs, workflow statuses (label consistency warnings deferred to v1.1.0)
 
 **Target:** End of Phase 2
 
@@ -85,7 +85,44 @@ Application version numbers are calculated automatically at build time by [MinVe
 
 ---
 
-### v0.5.0 — Cross-Repo PM Workflow
+### v1.0.0 — Production Ready
+
+**Goal:** A stable, well-tested, and fully documented release of the six shipped tools, suitable for regular hosted and self-hosted use.
+
+**Scope:**
+- GitHub App authentication for hosted deployments (PAT remains for local trusted and self-hoster paths)
+- ≥80% unit test coverage on Application and Domain
+- Accessibility audit of primary journey shells (WCAG 2.1 AA)
+- Performance review and optimisation
+- Complete user-facing documentation for shipped features (Hugo site at `https://solodevboard.com/`; Cross-Repo PM Workflow guide remains draft until v1.2.0)
+- Full Azure deployment pipeline with staging and production environment gates
+
+**Status:** Ready to tag. Delivery issues on the v1.0.0 milestone are complete except [#257](https://github.com/markheydon/solo-dev-board/issues/257) (annotated tag, GitHub Release, production CD) and paperwork alignment [#364](https://github.com/markheydon/solo-dev-board/issues/364).
+
+**Sequencing note:** Selected hosted-authentication and Azure-delivery items were pulled forward to support safe hosted validation. Phases 1–4 are complete. Phase 5 is **not** a v1.0.0 blocker. After the tag, deferred slices are v1.1.0 and Cross-Repo PM Workflow is v1.2.0 ([DEC-024](DECISIONS.md#dec-024-post-10-milestone-numbering)).
+
+**Target:** End of Phase 6
+
+---
+
+### v1.1.0 — Deferred follow-ons
+
+**Goal:** Ship the Phase 1–4 slices that were parked to close v1.0.0, plus dogfood fixes found after the public tag.
+
+**Scope:**
+- Label consistency warnings on the Audit Dashboard ([#290](https://github.com/markheydon/solo-dev-board/issues/290))
+- Project board column migration ([#291](https://github.com/markheydon/solo-dev-board/issues/291))
+- Custom workflow template repositories ([#292](https://github.com/markheydon/solo-dev-board/issues/292))
+- Private user-owned Projects v2 via hosted sign-in ([#293](https://github.com/markheydon/solo-dev-board/issues/293))
+- Dogfood fixes raised after v1.0.0
+
+**Status:** Not started. Epic [#289](https://github.com/markheydon/solo-dev-board/issues/289). Create the GitHub milestone `v1.1.0 — Deferred follow-ons` and assign #289–#293 before work begins.
+
+**Target:** After v1.0.0
+
+---
+
+### v1.2.0 — Cross-Repo PM Workflow
 
 **Goal:** Deliver the Cross-Repo PM Workflow epic — Daily Focus, Backlog Review, Iteration Planning, and Repo Management.
 
@@ -95,29 +132,9 @@ Application version numbers are calculated automatically at build time by [MinVe
 - Iteration Planning: capacity management, Up Next curation, milestone assignment
 - Repo Management: excluded-repositories configuration
 
-**Status:** Not started. Next active phase.
+**Status:** Parked until after v1.0.0. Epic [#272](https://github.com/markheydon/solo-dev-board/issues/272). The GitHub milestone is still titled `v0.5.0 — Cross-Repo PM Workflow` until renamed to `v1.2.0`. Do not tag `v0.5.0` after 1.0 exists.
 
 **Target:** End of Phase 5 (see [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md))
-
----
-
-### v1.0.0 — Production Ready
-
-**Goal:** A stable, well-tested, and fully documented release suitable for regular use.
-
-**Scope:**
-- GitHub App authentication (replacing PAT for production)
-- ≥80% unit test coverage
-- Accessibility audit (WCAG 2.1 AA)
-- Performance review and optimisation
-- Complete user-facing documentation _(in progress via #256; Hugo site live, feature guides and screenshots included)_
-- Full Azure deployment pipeline with environment gates
-
-**Status:** Partially complete. Hosted authentication and Aspire ACA deployment are delivered; operational hardening and release closure remain open.
-
-**Sequencing note:** Selected hosted-authentication and Azure-delivery items were pulled forward to support safe hosted validation. Phases 1–4 are complete. The remaining delivery order is Phase 5, then Phase 6 closure.
-
-**Target:** End of Phase 6
 
 ---
 

--- a/plan/SCOPE.md
+++ b/plan/SCOPE.md
@@ -29,11 +29,11 @@ Public-release hardening is in scope for v1.0.0, including:
 
 ### 1. Audit Dashboard
 
-A consolidated view of repository health: open issues, stale PRs, label consistency warnings, and GitHub Actions workflow statuses across all configured repositories.
+A consolidated view of repository health: open issues, stale PRs, and GitHub Actions workflow statuses across selected repositories. Label consistency warnings are in scope for **v1.1.0** ([#290](https://github.com/markheydon/solo-dev-board/issues/290)), not v1.0.0.
 
 ### 2. One-Click Migration
 
-Copy labels, milestones, and project board configurations from a source repository to one or more target repositories in a single, preview-first action.
+Copy labels and milestones from a source repository to one or more target repositories in a single, preview-first action. Project board column migration is in scope for **v1.1.0** ([#291](https://github.com/markheydon/solo-dev-board/issues/291)), not v1.0.0.
 
 ### 3. Label Manager
 
@@ -49,11 +49,11 @@ A focused, keyboard-friendly interface for triaging incoming GitHub issues one a
 
 ### 6. Workflow Templates
 
-Browse, customise, and apply GitHub Actions workflow templates across repositories, with tracking of which repositories have which templates applied.
+Browse, customise, and apply built-in GitHub Actions workflow templates across repositories, with tracking of which repositories have which templates applied. Custom template repositories are in scope for **v1.1.0** ([#292](https://github.com/markheydon/solo-dev-board/issues/292)).
 
 ### 7. Cross-Repo PM Workflow
 
-A UI-based implementation of the two-mode PM operating system from [markheydon/github-workflows](https://github.com/markheydon/github-workflows): a Daily Focus view (board state, stalled items, top priorities), a cross-repository Backlog Review (prioritised work across all repos, neglected repo detection), and an Iteration Planning tool (capacity management, Up Next curation, milestone assignment). This epic represents the ultimate destination of SoloDevBoard.
+A UI-based implementation of the two-mode PM operating system from [markheydon/github-workflows](https://github.com/markheydon/github-workflows): a Daily Focus view (board state, stalled items, top priorities), a cross-repository Backlog Review (prioritised work across all repos, neglected repo detection), and an Iteration Planning tool (capacity management, Up Next curation, milestone assignment). This epic is **v1.2.0** (Phase 5) and is not part of the v1.0.0 tag ([DEC-024](DECISIONS.md#dec-024-post-10-milestone-numbering)).
 
 ### 8. Public product site (GitHub Pages)
 
@@ -121,4 +121,5 @@ The following are explicitly **not** in scope for the current version of SoloDev
 | 2026-07-25 | V1 auth polish bundle clarified: hosted sign-in entry UX (#249) and PAT-mode GitHub connectivity readiness (#314) split from operator documentation (#247, #248). In-app secret editing remains out of scope; operator configuration stays via Aspire parameters, user secrets, and Key Vault. | Solo developer |
 | 2026-07-25 | PAT-only local trusted mode and self-hoster PAT Azure deploy path formalised in docs (#247, #248; PR #324). Scope bullet now links to getting-started and deployment guides. | Solo developer |
 | 2026-08-16 | Public product site on GitHub Pages: landing, User Guide, About narrative, canonical `solodevboard.com`, source tree `website/` (DEC-023). | Solo developer |
+| 2026-08-17 | Post-1.0 numbering: deferred Phase 1–4 slices are v1.1.0 (#289–#293); Cross-Repo PM Workflow is v1.2.0 (#272). v1.0.0 is the six shipped tools plus hosted/self-host hardening, not Phase 5. Label consistency, project board migration, and custom template repos are explicitly not v1.0.0 (DEC-024). | Solo developer |
 

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -18,7 +18,7 @@ title: SoloDevBoard
 </div>
 
 <p class="hx:text-base hx:leading-7 hx:text-gray-700 hx:dark:text-gray-300 hx:mb-4">
-  If you keep several repositories, GitHub spreads the work across tabs: issues here, labels there, project boards somewhere else. SoloDevBoard is an open-source Blazor app you run locally or self-host — one place to audit those repositories, keep labels consistent, triage incoming work, and see how your boards behave.
+  If you keep several repositories, GitHub spreads the work across tabs: issues here, labels there, project boards somewhere else. SoloDevBoard is an open-source Blazor app you run locally or self-host — one place to audit those repositories, synchronise labels, triage incoming work, and see how your boards behave.
 </p>
 
 <p class="hx:text-base hx:leading-7 hx:text-gray-700 hx:dark:text-gray-300 hx:mb-4">

--- a/website/content/docs/audit-dashboard.md
+++ b/website/content/docs/audit-dashboard.md
@@ -3,11 +3,13 @@ weight: 30
 title: Audit Dashboard
 landing: true
 landingIcon: analytics
-landingSubtitle: "Consolidated view of issues, open PRs, label consistency, and workflow health across all repositories."
+landingSubtitle: "Consolidated view of issues, open PRs, and workflow health across selected repositories."
 guideStatus: Available
 ---
 
 The Audit Dashboard summarises open issues, open pull requests, and repository health across the repositories you select.
+
+> **Scope note** — Label consistency warnings are not part of v1.0.0. They are tracked for v1.1.0 as [#290](https://github.com/markheydon/solo-dev-board/issues/290).
 
 ![Audit Dashboard showing KPI summary and health indicators for markheydon/solo-dev-board](/images/audit-dashboard/overview.png)
 

--- a/website/content/docs/pm-workflow.md
+++ b/website/content/docs/pm-workflow.md
@@ -4,7 +4,7 @@ draft: true
 weight: 110
 ---
 
-> ⚠️ **Under Development** — This feature is planned for Phase 5 (v0.5.0). This page will be updated as the feature progresses.
+> ⚠️ **Under Development** — This feature is planned for Phase 5 (v1.2.0). This page will be updated as the feature progresses.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Align planning artefacts and public copy with the actual v1.0.0 go/no-go state, and retarget parked work onto a post-1.0 SemVer line.

- Record [DEC-024](plan/DECISIONS.md): deferred Phase 1–4 slices are **v1.1.0** (epic #289); Cross-Repo PM Workflow is **v1.2.0** (epic #272). Do not tag `v0.5.0` after 1.0 exists.
- Update implementation, release, backlog, scope, and project-management docs so Phase 6 is ready to tag except #257.
- Stop the Audit Dashboard landing tile and README from claiming label consistency (tracked as #290).
- Map `v1.1.0` / `v1.2.0` in roadmap-sync while keeping the current `v0.5.0` GitHub milestone title as a legacy key until it is renamed.

This PR does **not** tag `v1.0.0` or close #257.

## Related Issue(s)

Closes #364

References #257, #272, #289

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would change existing functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [ ] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Not applicable — paperwork and copy only.

## Additional Notes

GitHub milestone create/rename is not available to this agent (API 403). Operator steps before tagging remain: create `v1.1.0 — Deferred follow-ons`, rename milestone 6 to `v1.2.0 — Cross-Repo PM Workflow`, staging smoke, GitHub App callback URLs, production environment reviewers, then tag `v1.0.0`.

`node --check` passed on `.github/scripts/roadmap-sync.mjs`. No application code changes, so `dotnet test` was not run.

Merge this PR before tagging so the Audit Dashboard subtitle fix ships with the v1 Pages publish.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00f34-b19d-7d03-8766-8d982802962e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00f34-b19d-7d03-8766-8d982802962e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

