### PR TITLE
[Documentation] Correct GitHub App Profile and token-expiry settings

### DIFF
--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -32,7 +32,7 @@ Hosted sign-in is an OAuth **authorization code** flow against this GitHub App. 
 | Setting | Value |
 |---------|--------|
 | **Callback URL** | One entry per public origin, each ending `/auth/callback`. Register **all** of them (GitHub allows up to ten). Do **not** enable wildcard matching. |
-| **Expire user authorization tokens** | **On** (required). SoloDevBoard already refreshes user access tokens. |
+| **Expire user authorization tokens** | **On** (required). SoloDevBoard already refreshes user access tokens. On current GitHub App settings this is **Optional features → User-to-server token expiration** (leave it enabled; do not click **Opt-out**). |
 | **Request user authorization (OAuth) during installation** | **On**. The hosted app needs a user-to-server token (`ghu_…`), not only an installation token. |
 | **Enable Device Flow** | **Off**. Device flow is for CLIs and headless clients and increases phishing risk. |
 | **Setup URL** | Leave blank if OAuth-during-install is on (GitHub sends users through the callback instead). Otherwise use `https://solodevboard.com/`. |
@@ -80,7 +80,7 @@ Private user-owned Projects v2 still often fail under GitHub App tokens even wit
 
 | Permission | Access | Why |
 |------------|--------|-----|
-| Profile | Read-only | `GET /user` for the signed-in login. |
+| Profile | Read and write | `GET /user` for the signed-in login. GitHub App **Account** permissions offer only **No access** or **Read and write** for Profile; there is no read-only option. |
 | Email addresses | No access | SoloDevBoard does not use email. |
 
 Hosted OAuth scopes requested by the app are `read:user read:org` ([`GitHubAuth:HostedSignInScopes`](getting-started.md)). Repository work uses the GitHub App's repository permissions on the user-to-server token, not extra OAuth scopes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Correct the GitHub App listing guide so it matches the live GitHub UI:

- Account **Profile** is **Read and write** (GitHub does not offer read-only for that permission).
- User-to-server token expiry is **Optional features → User-to-server token expiration** (do not opt out).

## Related Issue(s)

Ad-hoc operator-docs correction (no tracking issue).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [ ] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Not applicable (operator markdown only).

## Additional Notes

Confirmed against the live SoloDevBoard GitHub App settings while preparing v1.0.0 hosted sign-in.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00f34-b19d-7d03-8766-8d982802962e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00f34-b19d-7d03-8766-8d982802962e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

