### PR TITLE
[Chore] Add OSS community files and complete funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
 github: [markheydon]
 ko_fi: markheydon
+custom: ["https://paypal.me/mheydon1973"]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/markheydon/solo-dev-board/security/advisories/new
+    about: Use private vulnerability reporting. Do not file a public issue for security problems.
+  - name: User Guide
+    url: https://solodevboard.com/docs/
+    about: End-user documentation for hosted and self-hosted SoloDevBoard.
+  - name: GitHub Discussions
+    url: https://github.com/markheydon/solo-dev-board/discussions
+    about: Questions and general conversation that are not bug reports or feature requests.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, colour, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behaviour that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologising to those affected by our mistakes,
+  and learning from the experience.
+- Focusing on what is best not just for us as individuals, but for the overall
+  community.
+
+Examples of unacceptable behaviour include:
+
+- The use of sexualised language or imagery, and sexual attention or advances of
+  any kind.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behaviour and will take appropriate and fair corrective action in
+response to any behaviour that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported to the community leaders responsible for enforcement via GitHub
+([@markheydon](https://github.com/markheydon)). Security-sensitive reports should
+use the [security policy](SECURITY.md) instead of a public issue.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct.
+
+### 1. Correction
+
+**Community impact:** Use of inappropriate language or other behaviour deemed
+unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behaviour was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community impact:** A violation through a single incident or series of
+actions.
+
+**Consequence:** A warning with consequences for continued behaviour. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary ban
+
+**Community impact:** A serious violation of community standards, including
+sustained inappropriate behaviour.
+
+**Consequence:** A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent ban
+
+**Community impact:** Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behaviour, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to SoloDevBoard! This document provi
 
 ## Code of Conduct
 
-We are committed to providing a welcoming and inclusive environment for all contributors. Please be respectful, constructive, and professional in all interactions. If you witness behaviour that violates these principles, please reach out to the project maintainers.
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). Please be respectful, constructive, and professional in all interactions. Report unacceptable behaviour to the maintainer as described in that document.
 
 ---
 
@@ -84,7 +84,7 @@ When suggesting a feature:
 
 ### Security Issues
 
-**Do not file public security issues.** If you discover a security vulnerability, please email the maintainers privately to allow for a fix before disclosure.
+**Do not file public security issues.** Follow [`SECURITY.md`](SECURITY.md) and use [GitHub private vulnerability reporting](https://github.com/markheydon/solo-dev-board/security/advisories/new).
 
 ---
 
@@ -160,7 +160,7 @@ When submitting a pull request that changes code, ensure related documentation i
 
 ## Licensing
 
-By contributing to SoloDevBoard, you agree that your contributions will be licensed under the [MIT License](LICENSE). This means your code can be used freely by others under the terms of that licence.
+By contributing to SoloDevBoard, you agree that your contributions will be licensed under the [MIT licence](LICENSE). This means your code can be used freely by others under the terms of that licence.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ solo-dev-board/
 
 ## Contributing
 
-SoloDevBoard welcomes contributions from all developers.
+SoloDevBoard welcomes contributions from all developers. Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 To contribute:
 
@@ -163,6 +163,10 @@ End-user documentation is published from `website/` to [GitHub Pages](https://so
 SoloDevBoard is developed with AI agents as active collaborators. [`AGENTS.md`](AGENTS.md) is the canonical source for architecture, conventions, UK English requirements, and workflow gates. Role contracts in [`.agents/contracts/`](.agents/contracts/), workflow entry points in [`.agents/workflows/`](.agents/workflows/), skills in [`.agents/skills/`](.agents/skills/), and the PM runbook in [`plan/PM_RUNBOOK.md`](plan/PM_RUNBOOK.md) provide structured workflows for planning, implementation, and review. For Cursor Cloud VM development, see [`plan/CURSOR_CLOUD.md`](plan/CURSOR_CLOUD.md).
 
 ---
+
+## Security
+
+Please report vulnerabilities privately as described in [`SECURITY.md`](SECURITY.md). Do not file public issues for security problems.
 
 ## Licence
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security policy
+
+## Supported versions
+
+Please report vulnerabilities against:
+
+- The current `main` branch.
+- Tagged `v1.x` releases, once they exist.
+
+Older pre-1.0 snapshots are not supported.
+
+## Reporting a vulnerability
+
+**Do not file a public GitHub issue for security problems.**
+
+Use [GitHub private vulnerability reporting](https://github.com/markheydon/solo-dev-board/security/advisories/new) so the maintainer can fix the issue before it is disclosed.
+
+If private reporting is unavailable, contact the maintainer through GitHub ([@markheydon](https://github.com/markheydon)) and say that the message is a security report. Do not include secrets, tokens, or exploit payloads in public channels.
+
+Please include:
+
+- A description of the issue and its impact.
+- Steps to reproduce, or a proof of concept that does not destroy data.
+- Affected versions, commit SHAs, or hosted URLs where you can share them privately.
+- Any suggested mitigation.
+
+You should receive an acknowledgement when the report is seen. A fix, advisory, or reasoned decline will follow once the issue has been assessed. Please do not disclose the vulnerability publicly until a fix is released, or the maintainer agrees that disclosure is appropriate.
+
+## Scope notes
+
+SoloDevBoard is a GitHub-authenticated Blazor Server app. Reports that matter most include:
+
+- Leakage of GitHub tokens, client secrets, or session cookies.
+- Authentication or admission-control bypass on hosted deployments.
+- Cross-user data exposure on a shared hosted instance.
+- Supply-chain issues in release artefacts or GitHub Actions workflows.
+
+Out of scope: denial-of-service against GitHub.com, issues that require a stolen PAT or physical access to a self-hosted machine, and theoretical findings with no practical impact.
+
+## Secrets in this repository
+
+This repository is public. Never commit personal access tokens, GitHub App client secrets, Azure credentials, or `.env` files. See [`AGENTS.md`](AGENTS.md#open-source--security) and [`CONTRIBUTING.md`](CONTRIBUTING.md#secrets--security).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Complete the open-source community files GitHub’s health check was missing, and add the PayPal funding link.

- Extend `.github/FUNDING.yml` with `custom: ["https://paypal.me/mheydon1973"]` (GitHub Sponsors and Ko-fi were already present).
- Add `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1, UK English).
- Add `SECURITY.md` pointing at private vulnerability reporting instead of an unspecified maintainer email.
- Add `.github/ISSUE_TEMPLATE/config.yml` with security, User Guide, and Discussions contact links.
- Point `README.md` and `CONTRIBUTING.md` at those files.

No tag and no production deploy in this PR.

## Related Issue(s)

Ad-hoc OSS hygiene before `v1.0.0` (no tracking issue).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [ ] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Not applicable.

## Additional Notes

GitHub community profile was at 71% (no code of conduct, no security policy, issue templates not detected). Private vulnerability reporting still has to be switched on in repository settings (this token cannot enable it).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00f34-b19d-7d03-8766-8d982802962e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00f34-b19d-7d03-8766-8d982802962e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

