### PR TITLE
[Chore] Fail fast on Azure OIDC login in CD

### DIFF
--- a/.github/workflows/aspire-deploy.yml
+++ b/.github/workflows/aspire-deploy.yml
@@ -39,6 +39,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Fail fast on OIDC or environment-secret mistakes before restore, build, or Aspire install.
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v6
         with:
@@ -56,13 +64,6 @@ jobs:
 
       - name: List Aspire deployment steps
         run: aspire deploy --list-steps --apphost src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj --environment ${{ inputs.aspire_environment }} --non-interactive
-
-      - name: Azure login (OIDC)
-        uses: azure/login@v3
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy with Aspire
         run: aspire deploy --apphost src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj --environment ${{ inputs.aspire_environment }} --non-interactive

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -411,8 +411,8 @@ az identity delete --name id-solodevboard-cd-prod --resource-group rg-solodevboa
 
 | Symptom | Likely cause | Action |
 |---|---|---|
-| OIDC login fails in CD | Federated credential subject mismatch | Verify subject is `repo:<owner>/<repo>:environment:<staging|production>` |
-| Missing parameter prompt in CI | Secret not mapped | Add `Parameters__*` env vars to the deploy step |
+| OIDC login fails in CD | Stale `AZURE_CLIENT_ID` / tenant, or federated credential subject mismatch | CD logs in with OIDC immediately after checkout. Confirm secrets match the CD managed identity (`id-solodevboard-cd-prod`) and that a federated credential exists for `repo:<owner>/<repo>:environment:<staging\|production>`. `AADSTS700016` usually means the client ID is not in that tenant. |
+| Aspire deploy fails with `CertificateNotFound` | `CUSTOM_DOMAIN` set but `CUSTOM_DOMAIN_CERTIFICATE_NAME` does not exist in that Container Apps environment | List certificates on the **production** (or staging) ACA environment and set the variable to the certificate **name**, not the hostname. Leave the cert name unset until the managed certificate exists. |
 | Cold start / SignalR disconnect | Scale-to-zero idle | Expected; refresh the page or wait for the container to warm up |
 | 403 after sign-in | Allow-list | Update `ALLOWED_USER_LOGINS` or `ALLOWED_ORG_LOGINS` |
 | Callback URL mismatch | Stale GitHub App setting | Update callback to `https://<aca-fqdn>/auth/callback` (hosted sign-in only) |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Move Azure OIDC login to immediately after checkout in `aspire-deploy.yml` so a bad `AZURE_CLIENT_ID`, tenant, or federated credential fails before restore, build, and Aspire CLI install.

Also document `AADSTS700016` and `CertificateNotFound` in `docs/deployment.md`.

This does not change production certificate handling. Re-run the current `v1.0.0` deploy after the cert name is set.

## Related Issue(s)

Ad-hoc CD hygiene from the v1.0.0 production deploy (no tracking issue).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [ ] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Do not merge this in place of fixing `CUSTOM_DOMAIN_CERTIFICATE_NAME` for the in-flight `v1.0.0` production deploy. After merge, later CD runs fail fast on OIDC; this tag re-run still needs the real ACA certificate name.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00f34-b19d-7d03-8766-8d982802962e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00f34-b19d-7d03-8766-8d982802962e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

