### PR TITLE
[Chore] Add PM progress review and archive stale Project #8 cards

### DIFF
--- a/.agents/skills/repo-github-project/SKILL.md
+++ b/.agents/skills/repo-github-project/SKILL.md
@@ -355,8 +355,9 @@ This repository also carries `.github/workflows/roadmap-sync.yml`, which exists 
 - missing roadmap items,
 - Status / Phase / Priority field drift,
 - Start Date / Target Date drift,
-- parent Feature / Epic roll-up dates, and
-- stray standalone pull request cards.
+- parent Feature / Epic roll-up dates,
+- stray standalone pull request cards, and
+- archiving closed non-duplicate issues 14 days after `closed_at` (and unarchiving if reopened).
 
 Prefer direct project updates when you have working credentials. Use the bridge as the reliability layer and fallback path.
 

--- a/.agents/workflows/pm-progress-review.md
+++ b/.agents/workflows/pm-progress-review.md
@@ -55,7 +55,7 @@ Cover each area:
 - **Overall status:** On track / at risk / blocked (one line).
 - **Top 3 priorities** for the next working session(s).
 - **Recommended actions** — grooming, scope updates, release plan changes, board metadata refresh.
-- **Project board status block** (optional markdown snippet for manual Project #8 readme update).
+- **Project board status block** — refresh [`plan/PROJECT_README.md`](../../plan/PROJECT_README.md) when the Project #8 info pane is stale, and include the paste-ready README in the review artefact.
 
 ### 5. Write the artefact
 

--- a/.github/scripts/roadmap-sync-archive.mjs
+++ b/.github/scripts/roadmap-sync-archive.mjs
@@ -1,0 +1,46 @@
+/**
+ * Archive eligibility for SoloDevBoard Roadmap (Project #8).
+ * Uses the issue close date, not the project-card updated timestamp.
+ */
+
+export const ARCHIVE_AFTER_CALENDAR_DAYS = 14;
+
+/**
+ * Returns true when a closed, non-duplicate issue has been closed long enough
+ * to hide from the live Roadmap and Story Board views.
+ * @param {{ state?: string | null, state_reason?: string | null, closed_at?: string | null, closedAt?: string | null }} issue
+ * @param {string} runDate ISO date `YYYY-MM-DD`.
+ * @returns {boolean}
+ */
+export function isIssueClosedLongEnoughToArchive(issue, runDate) {
+    const state = (issue?.state ?? '').toString().toLowerCase();
+
+    if (state !== 'closed') {
+        return false;
+    }
+
+    if ((issue?.state_reason ?? '').toString().toLowerCase() === 'duplicate') {
+        return false;
+    }
+
+    const closedAt = issue?.closed_at ?? issue?.closedAt ?? null;
+
+    if (!closedAt) {
+        return false;
+    }
+
+    const closedDate = closedAt.slice(0, 10);
+    const eligibleFrom = addUtcCalendarDays(closedDate, ARCHIVE_AFTER_CALENDAR_DAYS);
+    return eligibleFrom <= runDate;
+}
+
+/**
+ * @param {string} startDate
+ * @param {number} calendarDays
+ * @returns {string}
+ */
+export function addUtcCalendarDays(startDate, calendarDays) {
+    const date = new Date(`${startDate}T00:00:00.000Z`);
+    date.setUTCDate(date.getUTCDate() + calendarDays);
+    return date.toISOString().slice(0, 10);
+}

--- a/.github/scripts/roadmap-sync-archive.test.mjs
+++ b/.github/scripts/roadmap-sync-archive.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ARCHIVE_AFTER_CALENDAR_DAYS, isIssueClosedLongEnoughToArchive } from './roadmap-sync-archive.mjs';
+
+const runDate = '2026-08-18';
+
+test('isIssueClosedLongEnoughToArchive_OpenIssue_DoesNotArchive', () => {
+    const result = isIssueClosedLongEnoughToArchive({ state: 'open', closed_at: null }, runDate);
+
+    assert.equal(result, false);
+});
+
+test('isIssueClosedLongEnoughToArchive_DuplicateClosure_DoesNotArchive', () => {
+    const result = isIssueClosedLongEnoughToArchive(
+        { state: 'closed', state_reason: 'duplicate', closed_at: '2026-03-07T18:00:00Z' },
+        runDate);
+
+    assert.equal(result, false);
+});
+
+test('isIssueClosedLongEnoughToArchive_ClosedInsideWindow_DoesNotArchive', () => {
+    const result = isIssueClosedLongEnoughToArchive(
+        { state: 'closed', closed_at: '2026-08-17T23:23:03Z' },
+        runDate);
+
+    assert.equal(result, false);
+});
+
+test('isIssueClosedLongEnoughToArchive_ClosedExactlyFourteenDaysAgo_Archives', () => {
+    const result = isIssueClosedLongEnoughToArchive(
+        { state: 'CLOSED', closedAt: '2026-08-04T10:00:00Z' },
+        runDate);
+
+    assert.equal(result, true);
+    assert.equal(ARCHIVE_AFTER_CALENDAR_DAYS, 14);
+});
+
+test('isIssueClosedLongEnoughToArchive_FoundationIssueClosedInMarch_Archives', () => {
+    const result = isIssueClosedLongEnoughToArchive(
+        { state: 'closed', closed_at: '2026-03-07T18:53:28Z' },
+        runDate);
+
+    assert.equal(result, true);
+});

--- a/.github/scripts/roadmap-sync.mjs
+++ b/.github/scripts/roadmap-sync.mjs
@@ -1,8 +1,11 @@
+import { isIssueClosedLongEnoughToArchive } from './roadmap-sync-archive.mjs';
+
 const apiBaseUrl = 'https://api.github.com';
 const graphqlUrl = `${apiBaseUrl}/graphql`;
 const owner = 'markheydon';
 const repo = 'solo-dev-board';
 const projectId = 'PVT_kwHOAJefG84BQ6bh';
+const archivedStates = ['ARCHIVED', 'NOT_ARCHIVED'];
 
 const fieldIds = {
     status: 'PVTSSF_lAHOAJefG84BQ6bhzg-5WGY',
@@ -64,6 +67,10 @@ async function main() {
     console.log(`Roadmap sync complete for ${repositoryIssues.issues.length} issue(s).`);
 }
 
+function isProjectItemArchived(projectItem) {
+    return projectItem?.isArchived === true;
+}
+
 async function fetchProjectItemsAsync() {
     const issueItemsByContentId = new Map();
     const pullRequestItems = [];
@@ -73,16 +80,17 @@ async function fetchProjectItemsAsync() {
     while (hasNextPage) {
         const response = await graphqlAsync(
             `
-            query ProjectItems($projectId: ID!, $after: String) {
+            query ProjectItems($projectId: ID!, $after: String, $archivedStates: [ProjectV2ItemArchivedState!]) {
               node(id: $projectId) {
                 ... on ProjectV2 {
-                  items(first: 100, after: $after) {
+                  items(first: 100, after: $after, archivedStates: $archivedStates) {
                     pageInfo {
                       hasNextPage
                       endCursor
                     }
                     nodes {
                       id
+                      isArchived
                       content {
                         __typename
                         ... on Issue {
@@ -153,7 +161,7 @@ async function fetchProjectItemsAsync() {
                 }
               }
             }`,
-            { projectId, after });
+            { projectId, after, archivedStates });
 
         const itemsConnection = response.node?.items;
         const nodes = itemsConnection?.nodes ?? [];
@@ -215,10 +223,17 @@ async function syncIssueAsync(issue, issueItemsByContentId, timelineCache) {
         return;
     }
 
+    const shouldArchive = isIssueClosedLongEnoughToArchive(issue, getRunDate());
+
     if (!projectItem) {
+        if (shouldArchive) {
+            return;
+        }
+
         const projectItemId = await addIssueToProjectAsync(issue.node_id);
         projectItem = {
             id: projectItemId,
+            isArchived: false,
             content: {
                 __typename: 'Issue',
                 id: issue.node_id,
@@ -234,6 +249,15 @@ async function syncIssueAsync(issue, issueItemsByContentId, timelineCache) {
 
         issueItemsByContentId.set(issue.node_id, projectItem);
         console.log(`Added issue #${issue.number} to the roadmap project.`);
+    }
+
+    if (isProjectItemArchived(projectItem)) {
+        if (shouldArchive) {
+            return;
+        }
+
+        await unarchiveProjectItemAsync(projectItem.id, `issue #${issue.number}`);
+        projectItem.isArchived = false;
     }
 
     const currentStatusName = projectItem.status?.name ?? null;
@@ -263,6 +287,11 @@ async function syncIssueAsync(issue, issueItemsByContentId, timelineCache) {
     await syncDateFieldAsync(projectItem.id, fieldIds.startDate, projectItem.startDate?.date ?? null, startDate, `issue #${issue.number} start date`);
     await syncDateFieldAsync(projectItem.id, fieldIds.targetDate, projectItem.targetDate?.date ?? null, targetDate, `issue #${issue.number} target date`);
     await clearFieldAsync(projectItem.id, fieldIds.focusOrder, projectItem.focusOrder?.number ?? null, `issue #${issue.number} focus order`);
+
+    if (shouldArchive) {
+        await archiveProjectItemAsync(projectItem.id, `issue #${issue.number}`);
+        projectItem.isArchived = true;
+    }
 }
 
 async function syncParentIssuesAsync(issueItemsByContentId, issueByNumber, timelineCache) {
@@ -270,6 +299,10 @@ async function syncParentIssuesAsync(issueItemsByContentId, issueByNumber, timel
         const issue = projectItem.content;
 
         if (issue?.__typename !== 'Issue') {
+            continue;
+        }
+
+        if (isProjectItemArchived(projectItem)) {
             continue;
         }
 
@@ -480,6 +513,36 @@ async function addIssueToProjectAsync(contentId) {
         { projectId, contentId });
 
     return response.addProjectV2ItemById.item.id;
+}
+
+async function archiveProjectItemAsync(itemId, label) {
+    await graphqlAsync(
+        `
+        mutation ArchiveProjectItem($projectId: ID!, $itemId: ID!) {
+          archiveProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) {
+            item {
+              id
+            }
+          }
+        }`,
+        { projectId, itemId });
+
+    console.log(`Archived ${label} on the roadmap project.`);
+}
+
+async function unarchiveProjectItemAsync(itemId, label) {
+    await graphqlAsync(
+        `
+        mutation UnarchiveProjectItem($projectId: ID!, $itemId: ID!) {
+          unarchiveProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) {
+            item {
+              id
+            }
+          }
+        }`,
+        { projectId, itemId });
+
+    console.log(`Unarchived ${label} on the roadmap project.`);
 }
 
 async function deleteProjectItemAsync(itemId, label) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,23 @@ jobs:
       - name: Run tests
         run: dotnet test SoloDevBoard.slnx --no-build --verbosity normal
 
+  roadmap-sync-helpers:
+    name: Roadmap sync helpers
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      - name: Run archive-rule tests
+        run: node --test .github/scripts/roadmap-sync-archive.test.mjs
+
   e2e-pat:
     name: End-to-End (Playwright, PAT mode)
     runs-on: ubuntu-latest

--- a/.github/workflows/roadmap-sync.yml
+++ b/.github/workflows/roadmap-sync.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Run archive-rule tests
+        run: node --test .github/scripts/roadmap-sync-archive.test.mjs
+
       - name: Sync status labels
         env:
           ROADMAP_PROJECT_TOKEN: ${{ secrets.ROADMAP_PROJECT_TOKEN }}

--- a/plan/BACKLOG.md
+++ b/plan/BACKLOG.md
@@ -10,6 +10,7 @@ For historical backlog content (pre-migration), see [archive/BACKLOG-2026-07-18.
 |----------|---------|
 | [GitHub Issues (open)](https://github.com/markheydon/solo-dev-board/issues?q=is%3Aissue+is%3Aopen) | Canonical work items |
 | [SoloDevBoard Roadmap (Project #8)](https://github.com/users/markheydon/projects/8) | Prioritisation, flow, Up Next queue |
+| [Project info pane README](PROJECT_README.md) | Canonical copy of the Project #8 info pane text |
 | [Milestones](https://github.com/markheydon/solo-dev-board/milestones) | Release targeting |
 
 ## Roadmap Status (2026-08-18)

--- a/plan/DOCS_STRATEGY.md
+++ b/plan/DOCS_STRATEGY.md
@@ -52,6 +52,7 @@ plan/
 ├── PULL_REQUEST_POLICY.md      # Canonical PR title, body, labels, metadata
 ├── PROJECT_MANAGEMENT.md
 ├── PROJECT_BOARD_DESIGN.md
+├── PROJECT_README.md           # Canonical Project #8 info pane README
 ├── SPEC_KIT_MIGRATION.md       # Parked — future Spec Kit adoption
 └── DOCS_STRATEGY.md            # This file
 
@@ -171,5 +172,6 @@ When Copilot or another AI agent is asked to write or update documentation:
 > | New release | Update `plan/RELEASE_PLAN.md`; draft CHANGELOG entry |
 > | New label | Update `plan/LABEL_STRATEGY.md` |
 > | New board column or rule | Update `plan/PROJECT_BOARD_DESIGN.md` |
+> | Project #8 info pane / phase status | Update `plan/PROJECT_README.md` and paste into the project info pane |
 >
 > Documentation changes should be included in the **same PR** as the code change where possible. A PR that adds a feature without updating the relevant docs is considered incomplete.

--- a/plan/PROJECT_BOARD_DESIGN.md
+++ b/plan/PROJECT_BOARD_DESIGN.md
@@ -72,8 +72,11 @@ The following automation rules are configured on the board. These are documented
 
 ### Current Default Workflow Settings
 - **Enabled:** `Auto-add sub-issues to project`, `Auto-close issue`, `Item added to project`, and `Item closed`.
-- **Disabled:** `Auto-add to project`, `Pull request linked to issue`, `Pull request merged`, `Auto-archive items`, `Code changes requested`, `Code review approved`, and `Item reopened`.
-- **Reason:** SoloDevBoard uses an issue-driven roadmap. Agents manage issue creation and metadata deliberately, while GitHub workflow automation is kept to narrow issue-centric safety nets.
+- **Should be enabled:** `Auto-archive items` when Status is **Done** for 14 days (see below). This was left **off** on purpose during Phases 1–4 so the full history stayed on the board; it is not a broken workflow.
+- **Disabled:** `Auto-add to project`, `Pull request linked to issue`, `Pull request merged`, `Code changes requested`, `Code review approved`, and `Item reopened`.
+- **Reason:** SoloDevBoard uses an issue-driven roadmap. Agents manage issue creation and metadata deliberately. Built-in GitHub workflows stay as narrow safety nets, except auto-archive, which is now the way to keep Roadmap and Story Board on the live queue after v1.0.0.
+
+**How to turn auto-archive on (project owner, GitHub UI):** Project #8 → **Workflows** (the header currently shows 4 active, which matches the four enabled rules above) → **Auto-archive items** → enable → when items have been in **Done** for **2 weeks** (or 14 days). GitHub then hides those cards from board and Roadmap views; they remain in the project archive and the issues stay closed. Existing Phase 1–4 Done items should disappear from the Gantt on the next archive pass because they have been Done for months.
 
 ### Label: status/in-progress Applied
 - **Trigger:** The `status/in-progress` label is applied to an issue.
@@ -145,7 +148,7 @@ Do this in the GitHub UI (saved view settings); agents cannot edit Project views
 1. **Filter out Done** on the Roadmap view: `status:Todo,Up Next,In Progress` (or equivalent). The live queue is 22 items, not 152 closed cards.
 2. **Zoom to Quarter or Year** when you want historical bars; Month + Today will always look empty between active slices.
 3. **Treat Story Board as the default working view.** Bars reappear on Roadmap automatically when Roadmap Sync sets dates at Event 2 (work started) and Event 3 (done).
-4. Optional: enable **Auto-archive items** for Done cards after a cooling-off period so the Gantt is not dominated by Phases 1–4. Auto-archive is currently disabled by design; turning it on is a view-hygiene choice, not a date-policy change.
+4. **Enable Auto-archive items** for cards that have been in **Done** for 14 days. That is the fix for the Roadmap list being all of Phases 1–4: GitHub shows archived items only in the archive, so the Gantt starts at recent and in-flight work. This was disabled by design during build-out; turn it on in **Workflows**. Agents cannot toggle project workflows with the current GitHub MCP token.
 
 Do not put speculative dates on the parked Phase 5 queue (#272–#288) or unstarted v1.1.0 stories. The next visible Roadmap bar should be the first v1.1.0 item that actually starts.
 
@@ -163,7 +166,7 @@ The Project #8 info pane (https://github.com/users/markheydon/projects/8?pane=in
 
 Canonical copy: [`plan/PROJECT_README.md`](PROJECT_README.md). Refresh that file during each PM progress review, then paste the **Info pane README** block into the project (this repository cannot always write the user-owned Project README from an agent runtime).
 
-Leave the Project **short description** empty unless it is updated in the same pass as the README. It is a separate field and currently tends to lag.
+Leave the Project **short description** as a current one-liner (GitHub may refuse to save an empty value). Update it in the same pass as the README so it does not lag.
 
 Do not treat [`plan/BACKLOG.md`](BACKLOG.md) as the work queue in that README. Link GitHub Issues and this project instead.
 

--- a/plan/PROJECT_BOARD_DESIGN.md
+++ b/plan/PROJECT_BOARD_DESIGN.md
@@ -124,13 +124,36 @@ The rules defined here serve as both the operational configuration and the refer
 
 In addition to the default board view, the following saved views are useful:
 
-| View | Filter | Purpose |
+| View | Layout | Purpose |
 |------|--------|---------|
-| **Story Board** | `-label:type/epic -label:type/feature` | Day-to-day execution view; sort by **Focus Order** ascending when using **Up Next**. |
-| **Feature Board** | `label:type/feature` | Track feature-level progress without execution sequencing. |
-| **Epic Board** | `label:type/epic` | Track epic-level progress and phase coverage. |
-| **By Phase** | Filter by milestone | Focus on the current phase. |
-| **Untracked Issues** | No milestone assigned | Identify issues that need scheduling. |
+| **Story Board** | Board | Day-to-day execution; filter `-label:type/epic -label:type/feature`; sort by **Focus Order** ascending when using **Up Next**. This is the view that should stay useful after v1.0.0. |
+| **Feature Board** | Board | Track feature-level progress (`label:type/feature`). |
+| **Epic Board** | Board | Track epic-level progress (`label:type/epic`). |
+| **Roadmap** | Roadmap (Gantt) | Date-range visualisation of items that already have **Start Date** and **Target Date**. See [Keeping the Roadmap layout useful](#keeping-the-roadmap-layout-useful). Filter out Done for a live queue. |
+
+The GitHub **Roadmap** layout only draws bars for items with dates. SoloDevBoard date rules leave **Todo** items blank until work starts, then overwrite **Target Date** with the close date. After a release, a month-scale Roadmap zoomed to "today" therefore shows:
+
+- Closed items as left-pointing arrows (their date range is in the past).
+- Parked v1.1.0 / v1.2.0 items with **no bars** (no dates yet).
+
+That is expected. Do not invent Start/Target dates on untouched items just to fill the Gantt.
+
+### Keeping the Roadmap layout useful
+
+Do this in the GitHub UI (saved view settings); agents cannot edit Project views via the GitHub MCP server.
+
+1. **Filter out Done** on the Roadmap view: `status:Todo,Up Next,In Progress` (or equivalent). The live queue is 22 items, not 152 closed cards.
+2. **Zoom to Quarter or Year** when you want historical bars; Month + Today will always look empty between active slices.
+3. **Treat Story Board as the default working view.** Bars reappear on Roadmap automatically when Roadmap Sync sets dates at Event 2 (work started) and Event 3 (done).
+4. Optional: enable **Auto-archive items** for Done cards after a cooling-off period so the Gantt is not dominated by Phases 1–4. Auto-archive is currently disabled by design; turning it on is a view-hygiene choice, not a date-policy change.
+
+Do not put speculative dates on the parked Phase 5 queue (#272–#288) or unstarted v1.1.0 stories. The next visible Roadmap bar should be the first v1.1.0 item that actually starts.
+
+### Agent write access (Projects v2)
+
+GitHub MCP in Cursor can list issues and pull requests. It cannot mutate a **user-owned** Project. The Cloud Agent `gh` token is typically a GitHub App installation token, which can **read** Project #8 (`gh project item-list`) but often cannot **edit** README, short description, views, or item fields.
+
+Item-field writes already go through the Actions bridge and `ROADMAP_PROJECT_TOKEN` (ADR-0017). That is enough for Status/Phase/Priority/dates. A second PAT in Cursor Cloud (`SDB_ROADMAP_PROJECT_TOKEN`, classic, `project` plus `repo` scopes) is optional and only worth it if you want agents to update the info pane README, short description, or repair fields without waiting for the workflow. Reuse the same token family as `ROADMAP_PROJECT_TOKEN`; do not mint a broader token.
 
 ---
 
@@ -139,6 +162,8 @@ In addition to the default board view, the following saved views are useful:
 The Project #8 info pane (https://github.com/users/markheydon/projects/8?pane=info) is a short public description. Keep it aligned with live milestones, not with a stale phase name.
 
 Canonical copy: [`plan/PROJECT_README.md`](PROJECT_README.md). Refresh that file during each PM progress review, then paste the **Info pane README** block into the project (this repository cannot always write the user-owned Project README from an agent runtime).
+
+Leave the Project **short description** empty unless it is updated in the same pass as the README. It is a separate field and currently tends to lag.
 
 Do not treat [`plan/BACKLOG.md`](BACKLOG.md) as the work queue in that README. Link GitHub Issues and this project instead.
 

--- a/plan/PROJECT_BOARD_DESIGN.md
+++ b/plan/PROJECT_BOARD_DESIGN.md
@@ -72,11 +72,17 @@ The following automation rules are configured on the board. These are documented
 
 ### Current Default Workflow Settings
 - **Enabled:** `Auto-add sub-issues to project`, `Auto-close issue`, `Item added to project`, and `Item closed`.
-- **Should be enabled:** `Auto-archive items` when Status is **Done** for 14 days (see below). This was left **off** on purpose during Phases 1–4 so the full history stayed on the board; it is not a broken workflow.
+- **Should be enabled:** `Auto-archive items` with GitHub’s default `is:issue is:closed updated:<@today-2w`. This was left **off** on purpose during Phases 1–4 so the full history stayed on the board; it is not a broken workflow.
 - **Disabled:** `Auto-add to project`, `Pull request linked to issue`, `Pull request merged`, `Code changes requested`, `Code review approved`, and `Item reopened`.
 - **Reason:** SoloDevBoard uses an issue-driven roadmap. Agents manage issue creation and metadata deliberately. Built-in GitHub workflows stay as narrow safety nets, except auto-archive, which is now the way to keep Roadmap and Story Board on the live queue after v1.0.0.
 
-**How to turn auto-archive on (project owner, GitHub UI):** Project #8 → **Workflows** (the header currently shows 4 active, which matches the four enabled rules above) → **Auto-archive items** → enable → when items have been in **Done** for **2 weeks** (or 14 days). GitHub then hides those cards from board and Roadmap views; they remain in the project archive and the issues stay closed. Existing Phase 1–4 Done items should disappear from the Gantt on the next archive pass because they have been Done for months.
+**How to turn auto-archive on (project owner, GitHub UI):** Project #8 → **Workflows** (the header currently shows 4 active, which matches the four enabled rules above) → **Auto-archive items** → enable. Use GitHub’s default filter:
+
+```text
+is:issue is:closed updated:<@today-2w
+```
+
+That keeps open and in-flight work, ignores pull request cards, and archives closed issues that have had no activity for two weeks. Existing Phase 1–4 Done items should disappear from the Gantt on the next archive pass. A comment or label repair on a closed issue resets the two-week clock; nightly Roadmap Sync does not bump `updated` once `status/done` is already correct.
 
 ### Label: status/in-progress Applied
 - **Trigger:** The `status/in-progress` label is applied to an issue.

--- a/plan/PROJECT_BOARD_DESIGN.md
+++ b/plan/PROJECT_BOARD_DESIGN.md
@@ -82,7 +82,7 @@ The following automation rules are configured on the board. These are documented
 is:issue is:closed updated:<@today-2w
 ```
 
-That keeps open and in-flight work, ignores pull request cards, and archives closed issues that have had no activity for two weeks. Existing Phase 1–4 Done items should disappear from the Gantt on the next archive pass. A comment or label repair on a closed issue resets the two-week clock; nightly Roadmap Sync does not bump `updated` once `status/done` is already correct.
+That keeps open and in-flight work, ignores pull request cards, and archives closed issues that have had no **project-item** activity for two weeks. GitHub’s `updated:` here is the card’s last update on Project #8, not `issue.updated_at`. A bulk field write (for example the 17 August 2026 paperwork pass) resets that clock for every card, so the enable dialog may offer only a handful of matches even when the linked issues closed months ago. After such a pass, either wait two weeks or, for a one-off catch-up, temporarily use `is:issue is:closed` to archive every closed card, then restore the two-week filter. A comment or label repair on a closed issue also resets the clock; nightly Roadmap Sync does not, once fields already match.
 
 ### Label: status/in-progress Applied
 - **Trigger:** The `status/in-progress` label is applied to an issue.
@@ -154,7 +154,7 @@ Do this in the GitHub UI (saved view settings); agents cannot edit Project views
 1. **Filter out Done** on the Roadmap view: `status:Todo,Up Next,In Progress` (or equivalent). The live queue is 22 items, not 152 closed cards.
 2. **Zoom to Quarter or Year** when you want historical bars; Month + Today will always look empty between active slices.
 3. **Treat Story Board as the default working view.** Bars reappear on Roadmap automatically when Roadmap Sync sets dates at Event 2 (work started) and Event 3 (done).
-4. **Enable Auto-archive items** for cards that have been in **Done** for 14 days. That is the fix for the Roadmap list being all of Phases 1–4: GitHub shows archived items only in the archive, so the Gantt starts at recent and in-flight work. This was disabled by design during build-out; turn it on in **Workflows**. Agents cannot toggle project workflows with the current GitHub MCP token.
+4. **Enable Auto-archive items** with `is:issue is:closed updated:<@today-2w`. That is the fix for the Roadmap list being all of Phases 1–4: GitHub shows archived items only in the archive, so the Gantt starts at recent and in-flight work. This was disabled by design during build-out; turn it on in **Workflows**. Agents cannot toggle project workflows with the current GitHub MCP token.
 
 Do not put speculative dates on the parked Phase 5 queue (#272–#288) or unstarted v1.1.0 stories. The next visible Roadmap bar should be the first v1.1.0 item that actually starts.
 

--- a/plan/PROJECT_BOARD_DESIGN.md
+++ b/plan/PROJECT_BOARD_DESIGN.md
@@ -72,17 +72,10 @@ The following automation rules are configured on the board. These are documented
 
 ### Current Default Workflow Settings
 - **Enabled:** `Auto-add sub-issues to project`, `Auto-close issue`, `Item added to project`, and `Item closed`.
-- **Should be enabled:** `Auto-archive items` with GitHub’s default `is:issue is:closed updated:<@today-2w`. This was left **off** on purpose during Phases 1–4 so the full history stayed on the board; it is not a broken workflow.
-- **Disabled:** `Auto-add to project`, `Pull request linked to issue`, `Pull request merged`, `Code changes requested`, `Code review approved`, and `Item reopened`.
-- **Reason:** SoloDevBoard uses an issue-driven roadmap. Agents manage issue creation and metadata deliberately. Built-in GitHub workflows stay as narrow safety nets, except auto-archive, which is now the way to keep Roadmap and Story Board on the live queue after v1.0.0.
+- **Disabled:** `Auto-add to project`, `Pull request linked to issue`, `Pull request merged`, `Auto-archive items`, `Code changes requested`, `Code review approved`, and `Item reopened`.
+- **Reason:** SoloDevBoard uses an issue-driven roadmap. Agents manage issue creation and metadata deliberately. Built-in GitHub workflows stay as narrow safety nets. **Archiving closed cards is Roadmap Sync’s job**, not GitHub’s Auto-archive workflow, because GitHub’s `updated:` filter is the project-card clock and a bulk field write resets it.
 
-**How to turn auto-archive on (project owner, GitHub UI):** Project #8 → **Workflows** (the header currently shows 4 active, which matches the four enabled rules above) → **Auto-archive items** → enable. Use GitHub’s default filter:
-
-```text
-is:issue is:closed updated:<@today-2w
-```
-
-That keeps open and in-flight work, ignores pull request cards, and archives closed issues that have had no **project-item** activity for two weeks. GitHub’s `updated:` here is the card’s last update on Project #8, not `issue.updated_at`. A bulk field write (for example the 17 August 2026 paperwork pass) resets that clock for every card, so the enable dialog may offer only a handful of matches even when the linked issues closed months ago. After such a pass, either wait two weeks or, for a one-off catch-up, temporarily use `is:issue is:closed` to archive every closed card, then restore the two-week filter. A comment or label repair on a closed issue also resets the clock; nightly Roadmap Sync does not, once fields already match.
+**Archive rule (Roadmap Sync, nightly and on issue events):** closed, non-duplicate issues whose **`closed_at` is at least 14 calendar days ago** are archived on Project #8 via `archiveProjectV2Item`. Open items are never archived. Reopened issues are unarchived. Duplicate closures are still **removed**, not archived. Prefer this over GitHub **Auto-archive items**; if that workflow is on, turn it off so the two clocks do not fight.
 
 ### Label: status/in-progress Applied
 - **Trigger:** The `status/in-progress` label is applied to an issue.
@@ -154,7 +147,7 @@ Do this in the GitHub UI (saved view settings); agents cannot edit Project views
 1. **Filter out Done** on the Roadmap view: `status:Todo,Up Next,In Progress` (or equivalent). The live queue is 22 items, not 152 closed cards.
 2. **Zoom to Quarter or Year** when you want historical bars; Month + Today will always look empty between active slices.
 3. **Treat Story Board as the default working view.** Bars reappear on Roadmap automatically when Roadmap Sync sets dates at Event 2 (work started) and Event 3 (done).
-4. **Enable Auto-archive items** with `is:issue is:closed updated:<@today-2w`. That is the fix for the Roadmap list being all of Phases 1–4: GitHub shows archived items only in the archive, so the Gantt starts at recent and in-flight work. This was disabled by design during build-out; turn it on in **Workflows**. Agents cannot toggle project workflows with the current GitHub MCP token.
+4. **Leave GitHub Auto-archive off.** Roadmap Sync archives closed non-duplicate issues 14 days after `closed_at`. That is the catch-up for Phases 1–4 and the ongoing rule.
 
 Do not put speculative dates on the parked Phase 5 queue (#272–#288) or unstarted v1.1.0 stories. The next visible Roadmap bar should be the first v1.1.0 item that actually starts.
 

--- a/plan/PROJECT_BOARD_DESIGN.md
+++ b/plan/PROJECT_BOARD_DESIGN.md
@@ -134,6 +134,16 @@ In addition to the default board view, the following saved views are useful:
 
 ---
 
+## Info pane README
+
+The Project #8 info pane (https://github.com/users/markheydon/projects/8?pane=info) is a short public description. Keep it aligned with live milestones, not with a stale phase name.
+
+Canonical copy: [`plan/PROJECT_README.md`](PROJECT_README.md). Refresh that file during each PM progress review, then paste the **Info pane README** block into the project (this repository cannot always write the user-owned Project README from an agent runtime).
+
+Do not treat [`plan/BACKLOG.md`](BACKLOG.md) as the work queue in that README. Link GitHub Issues and this project instead.
+
+---
+
 ## AI Collaborator Instructions
 
 > When making changes to the project board structure:
@@ -145,3 +155,4 @@ In addition to the default board view, the following saved views are useful:
 > 5. Ensure label changes align with `LABEL_STRATEGY.md`.
 > 6. If a new automation rule requires a new label, add that label to `LABEL_STRATEGY.md` first.
 > 7. Keep project-only workflow states such as **Up Next** out of the issue label taxonomy unless there is a deliberate lifecycle change.
+> 8. When phase or milestone status changes, update [`plan/PROJECT_README.md`](PROJECT_README.md) so the info pane can be refreshed.

--- a/plan/PROJECT_README.md
+++ b/plan/PROJECT_README.md
@@ -4,7 +4,7 @@ Canonical copy of the GitHub Project **SoloDevBoard Roadmap** README (the text i
 
 This file is **not** applied automatically. After editing it, copy the fenced **Info pane README** block (the markdown inside the code fence) and paste it into Project #8 → Info.
 
-Leave the Project **short description** empty (or a one-liner that matches the current focus). It is a separate field from this README and goes stale faster.
+Keep the Project **short description** as a current one-liner (GitHub may refuse to save an empty value). Update it whenever the README focus changes.
 
 Refresh this file during each [PM progress review](../.agents/workflows/pm-progress-review.md) so the public board description does not lag the milestones.
 

--- a/plan/PROJECT_README.md
+++ b/plan/PROJECT_README.md
@@ -1,0 +1,65 @@
+# SoloDevBoard Roadmap (Project #8 info pane)
+
+Canonical copy of the GitHub Project **SoloDevBoard Roadmap** README (the text in the [info pane](https://github.com/users/markheydon/projects/8?pane=info)).
+
+This file is **not** applied automatically. After editing it, copy the fenced **Info pane README** block (the markdown inside the code fence) and paste it into Project #8 → Info.
+
+Refresh this file during each [PM progress review](../.agents/workflows/pm-progress-review.md) so the public board description does not lag the milestones.
+
+---
+
+## Info pane README
+
+```markdown
+## SoloDevBoard Roadmap
+
+SoloDevBoard provides a single pane of glass for solo developers managing GitHub workloads across multiple repositories.
+
+**Status:** On track. Public release [v1.0.0](https://github.com/markheydon/solo-dev-board/releases/tag/v1.0.0) tagged 17 August 2026.
+
+### Current focus
+
+v1.1.0 — deferred follow-ons ([#289](https://github.com/markheydon/solo-dev-board/issues/289)).
+
+Phases 1–4 and Phase 6 are complete. The six shipped tools plus hosted and self-host hardening are in production. Next work is the parked Phase 1–4 slices (label consistency warnings, project board column migration, custom workflow template repositories) and any dogfood fixes from the public tag. Private user-owned Projects v2 under hosted sign-in remains blocked ([#293](https://github.com/markheydon/solo-dev-board/issues/293)). Cross-Repo PM Workflow (Phase 5 / v1.2.0) stays parked until v1.1.0 is underway.
+
+### Roadmap
+
+| Phase | Milestone | Goal | Status |
+|---|---|---|---|
+| Phase 1 | v0.1.0 | Foundation — auth, repositories, dashboard shell. | Complete. |
+| Phase 2 | v0.2.0 | Label Manager + Audit Dashboard. | Complete. |
+| Phase 3 | v0.3.0 | One-Click Migration + Triage UI. | Complete. |
+| Phase 4 | v0.4.0 | Board Rules Visualiser + Workflow Templates. | Complete. |
+| Phase 6 | v1.0.0 | Production Ready — hosted validation and public release. | Complete. |
+| Phase 6 follow-ons | v1.1.0 | Deferred Phase 1–4 slices and dogfood fixes. | Not started. |
+| Phase 5 | v1.2.0 | Cross-Repo PM Workflow. | Parked. |
+
+Do not tag `v0.5.0` now that `v1.0.0` exists ([DEC-024](https://github.com/markheydon/solo-dev-board/blob/main/plan/DECISIONS.md#dec-024-post-10-milestone-numbering)).
+
+### Current snapshot
+
+Snapshot date: 18 August 2026.
+
+| Milestone | Closed | Open | Complete |
+|---|---:|---:|---|
+| v0.1.0 | 9 | 0 | 100% |
+| v0.2.0 | 73 | 0 | 100% |
+| v0.3.0 | 38 | 0 | 100% |
+| v0.4.0 | 25 | 0 | 100% |
+| v1.0.0 | 78 | 0 | 100% |
+| v1.1.0 | 0 | 5 | 0% |
+| v1.2.0 | 0 | 17 | Parked |
+
+v1.2.0 still has 12 closed duplicate issues (#260–#271) on the GitHub milestone. The live Phase 5 queue is #272–#288 (17 open). The table uses the live queue, not the duplicate closed count.
+
+### Key resources
+
+- [Repository](https://github.com/markheydon/solo-dev-board)
+- [Implementation plan](https://github.com/markheydon/solo-dev-board/blob/main/plan/IMPLEMENTATION_PLAN.md)
+- [GitHub Issues](https://github.com/markheydon/solo-dev-board/issues)
+- [Progress reviews](https://github.com/markheydon/solo-dev-board/tree/main/plan/weekly-updates)
+- [v1.0.0 release](https://github.com/markheydon/solo-dev-board/releases/tag/v1.0.0)
+- [Product site](https://solodevboard.com/)
+- [User Guide](https://solodevboard.com/docs/)
+```

--- a/plan/PROJECT_README.md
+++ b/plan/PROJECT_README.md
@@ -4,6 +4,8 @@ Canonical copy of the GitHub Project **SoloDevBoard Roadmap** README (the text i
 
 This file is **not** applied automatically. After editing it, copy the fenced **Info pane README** block (the markdown inside the code fence) and paste it into Project #8 → Info.
 
+Leave the Project **short description** empty (or a one-liner that matches the current focus). It is a separate field from this README and goes stale faster.
+
 Refresh this file during each [PM progress review](../.agents/workflows/pm-progress-review.md) so the public board description does not lag the milestones.
 
 ---

--- a/plan/weekly-updates/2026-08-18.md
+++ b/plan/weekly-updates/2026-08-18.md
@@ -13,31 +13,60 @@ v1.0.0 is tagged and published. Phases 1–4 and Phase 6 are complete, the six s
 - Start date: 2026-03-12.
 - Target date: clear the 22 August 2026 v1.0.0 tentative date; leave blank until v1.1.0 work actually starts.
 
+**Info pane README:** replace the Project #8 description (still frozen on Phase 3) with the canonical copy in [`plan/PROJECT_README.md`](../PROJECT_README.md). Paste the fenced **Info pane README** block into https://github.com/users/markheydon/projects/8?pane=info.
+
 ```markdown
-## Progress Status — 18 August 2026
+## SoloDevBoard Roadmap
 
-**v1.0.0 (Phase 6):** Complete — tagged and released 17 August 2026.
-**v1.1.0 (deferred follow-ons):** Active next queue — not started; epic #289.
-**v1.2.0 (Phase 5):** Parked — epic #272.
+SoloDevBoard provides a single pane of glass for solo developers managing GitHub workloads across multiple repositories.
 
-### Delivered since the last review
-- Closed the v1.0.0 milestone (78/78) and published [v1.0.0 — Production Ready](https://github.com/markheydon/solo-dev-board/releases/tag/v1.0.0).
-- Landed hosted hardening: telemetry (#107), Key Vault secrets (#250), health endpoints (#106), API caching (#108), hosted landing and PAT readiness (#249, #314), refresh tokens (#349).
-- Closed quality and docs gates: 80% coverage (#252), accessibility (#253), performance (#254), Playwright journeys (#255), Hugo user guide and public product site (#256, #358).
-- Shipped two-tier CD, MinVer versioning, optional shared ACR, and production tag CD (#251, #344, #372, #257).
+**Status:** On track. Public release [v1.0.0](https://github.com/markheydon/solo-dev-board/releases/tag/v1.0.0) tagged 17 August 2026.
 
-### Next session focus
-1. Dogfood production v1.0.0 and file any post-tag bugs against #289.
-2. Plan the first unblocked v1.1.0 story (#290) before coding (acceptance criteria and wireframe are missing).
-3. Populate Project #8 Up Next for that v1.1.0 slice; keep Phase 5 parked.
+### Current focus
 
-### Health indicators
-| Metric | Value |
-|---|---|
-| Tests | 555 passed, 0 failed, 0 skipped (CI Build and Test on `main`, 18 August 2026). Playwright PAT: 45 passed, 4 skipped. Hosted E2E: 4 passed. |
-| Compile errors | 0 |
-| Open PRs | 0 |
-| Active blockers | 1 (#293 — GitHub App cannot read private user-owned Projects v2) |
+v1.1.0 — deferred follow-ons ([#289](https://github.com/markheydon/solo-dev-board/issues/289)).
+
+Phases 1–4 and Phase 6 are complete. The six shipped tools plus hosted and self-host hardening are in production. Next work is the parked Phase 1–4 slices (label consistency warnings, project board column migration, custom workflow template repositories) and any dogfood fixes from the public tag. Private user-owned Projects v2 under hosted sign-in remains blocked ([#293](https://github.com/markheydon/solo-dev-board/issues/293)). Cross-Repo PM Workflow (Phase 5 / v1.2.0) stays parked until v1.1.0 is underway.
+
+### Roadmap
+
+| Phase | Milestone | Goal | Status |
+|---|---|---|---|
+| Phase 1 | v0.1.0 | Foundation — auth, repositories, dashboard shell. | Complete. |
+| Phase 2 | v0.2.0 | Label Manager + Audit Dashboard. | Complete. |
+| Phase 3 | v0.3.0 | One-Click Migration + Triage UI. | Complete. |
+| Phase 4 | v0.4.0 | Board Rules Visualiser + Workflow Templates. | Complete. |
+| Phase 6 | v1.0.0 | Production Ready — hosted validation and public release. | Complete. |
+| Phase 6 follow-ons | v1.1.0 | Deferred Phase 1–4 slices and dogfood fixes. | Not started. |
+| Phase 5 | v1.2.0 | Cross-Repo PM Workflow. | Parked. |
+
+Do not tag `v0.5.0` now that `v1.0.0` exists ([DEC-024](https://github.com/markheydon/solo-dev-board/blob/main/plan/DECISIONS.md#dec-024-post-10-milestone-numbering)).
+
+### Current snapshot
+
+Snapshot date: 18 August 2026.
+
+| Milestone | Closed | Open | Complete |
+|---|---:|---:|---|
+| v0.1.0 | 9 | 0 | 100% |
+| v0.2.0 | 73 | 0 | 100% |
+| v0.3.0 | 38 | 0 | 100% |
+| v0.4.0 | 25 | 0 | 100% |
+| v1.0.0 | 78 | 0 | 100% |
+| v1.1.0 | 0 | 5 | 0% |
+| v1.2.0 | 0 | 17 | Parked |
+
+v1.2.0 still has 12 closed duplicate issues (#260–#271) on the GitHub milestone. The live Phase 5 queue is #272–#288 (17 open). The table uses the live queue, not the duplicate closed count.
+
+### Key resources
+
+- [Repository](https://github.com/markheydon/solo-dev-board)
+- [Implementation plan](https://github.com/markheydon/solo-dev-board/blob/main/plan/IMPLEMENTATION_PLAN.md)
+- [GitHub Issues](https://github.com/markheydon/solo-dev-board/issues)
+- [Progress reviews](https://github.com/markheydon/solo-dev-board/tree/main/plan/weekly-updates)
+- [v1.0.0 release](https://github.com/markheydon/solo-dev-board/releases/tag/v1.0.0)
+- [Product site](https://solodevboard.com/)
+- [User Guide](https://solodevboard.com/docs/)
 ```
 
 ---
@@ -133,7 +162,8 @@ Dependabot and small chore PRs also merged throughout the window.
 
 ### Recommended Actions
 
-- Update the Project #8 status dialog using the snippet above (status On track; clear the 22 August 2026 target).
+- Paste the Project #8 info pane README from [`plan/PROJECT_README.md`](../PROJECT_README.md) (the live pane is still on Phase 3).
+- Update the Project #8 status dialog (status On track; clear the 22 August 2026 target).
 - Retitle the #289 board card to match the issue.
 - Do not start coding v1.1.0 until planning artefacts and a test issue exist.
 - Leave Phase 5 parked until v1.1.0 is underway or you explicitly reprioritise.

--- a/plan/weekly-updates/2026-08-18.md
+++ b/plan/weekly-updates/2026-08-18.md
@@ -1,0 +1,141 @@
+# PM Progress Review — 18 August 2026
+
+**Overall Status:** On track.
+
+v1.0.0 is tagged and published. Phases 1–4 and Phase 6 are complete, the six shipped tools plus hosted and self-host hardening are in the public release, and the next delivery queue is v1.1.0 deferred follow-ons under [#289](https://github.com/markheydon/solo-dev-board/issues/289). The review window is 21 July 2026 to 18 August 2026 (28 days of continuous delivery, not an idle gap).
+
+---
+
+## Project Board Status Update
+
+**Manual dialog values:**
+- Status: On track.
+- Start date: 2026-03-12.
+- Target date: clear the 22 August 2026 v1.0.0 tentative date; leave blank until v1.1.0 work actually starts.
+
+```markdown
+## Progress Status — 18 August 2026
+
+**v1.0.0 (Phase 6):** Complete — tagged and released 17 August 2026.
+**v1.1.0 (deferred follow-ons):** Active next queue — not started; epic #289.
+**v1.2.0 (Phase 5):** Parked — epic #272.
+
+### Delivered since the last review
+- Closed the v1.0.0 milestone (78/78) and published [v1.0.0 — Production Ready](https://github.com/markheydon/solo-dev-board/releases/tag/v1.0.0).
+- Landed hosted hardening: telemetry (#107), Key Vault secrets (#250), health endpoints (#106), API caching (#108), hosted landing and PAT readiness (#249, #314), refresh tokens (#349).
+- Closed quality and docs gates: 80% coverage (#252), accessibility (#253), performance (#254), Playwright journeys (#255), Hugo user guide and public product site (#256, #358).
+- Shipped two-tier CD, MinVer versioning, optional shared ACR, and production tag CD (#251, #344, #372, #257).
+
+### Next session focus
+1. Dogfood production v1.0.0 and file any post-tag bugs against #289.
+2. Plan the first unblocked v1.1.0 story (#290) before coding (acceptance criteria and wireframe are missing).
+3. Populate Project #8 Up Next for that v1.1.0 slice; keep Phase 5 parked.
+
+### Health indicators
+| Metric | Value |
+|---|---|
+| Tests | 555 passed, 0 failed, 0 skipped (CI Build and Test on `main`, 18 August 2026). Playwright PAT: 45 passed, 4 skipped. Hosted E2E: 4 passed. |
+| Compile errors | 0 |
+| Open PRs | 0 |
+| Active blockers | 1 (#293 — GitHub App cannot read private user-owned Projects v2) |
+```
+
+---
+
+## Project Board Metadata
+
+A metadata refresh is recommended because v1.0.0 has shipped and the live focus is now v1.1.0, still mapped to the Phase 6 board option.
+
+- **Phase:** 6 (Polish and v1.0 / v1.1.0 deferred follow-ons). Do not move #289–#293 off Phase 6; that mapping is intentional.
+- **Milestone:** `v1.1.0 — Deferred follow-ons` for the next session. Leave `v1.2.0` parked.
+- **Board:** SoloDevBoard Roadmap (GitHub Project #8).
+- **Up Next:** Empty. Populate only after a v1.1.0 story is planned.
+- **Card title drift:** The #289 board title still reads `[Epic] Post-v1 Improvements` while the issue is `[Epic] v1.1 deferred follow-ons`.
+- **Blocked item:** #293 is `status/blocked` but remains in Todo (acceptable; do not put it in Up Next).
+- **Historical hygiene:** Three Done items lack Phase (#129, #173, #229). Twelve closed duplicate Phase 5 issues (#260–#271) remain on the v1.2.0 milestone beside the live queue (#272–#288). No stray PR cards. No invalid date pairs.
+
+---
+
+## Executive Summary
+
+### Milestone Health
+
+| Milestone | Closed | Open | Complete | Status |
+|---|---:|---:|---:|---|
+| v0.1.0 — Foundation | 9 | 0 | 100% | Closed. |
+| v0.2.0 — Label Manager + Audit Dashboard | 73 | 0 | 100% | Closed. |
+| v0.3.0 — One-Click Migration + Triage UI | 38 | 0 | 100% | Closed. |
+| v0.4.0 — Board Rules Visualiser + Workflow Templates | 25 | 0 | 100% | Closed. |
+| v1.0.0 — Production Ready | 78 | 0 | 100% | Closed 17 August 2026. Tag [v1.0.0](https://github.com/markheydon/solo-dev-board/releases/tag/v1.0.0). |
+| v1.1.0 — Deferred follow-ons | 0 | 5 | 0% | Not started. Epic #289 plus #290–#293. |
+| v1.2.0 — Cross-Repo PM Workflow | 12 | 17 | n/a | Parked. Closed count is superseded duplicates #260–#271; live work is #272–#288. |
+
+### Scope / Governance Health
+
+- No scope drift against `plan/SCOPE.md`.
+- DEC-023 (public product site) and DEC-024 (post-1.0 numbering) landed in this window and match `SCOPE.md`, `IMPLEMENTATION_PLAN.md`, and `RELEASE_PLAN.md`.
+- Planning artefacts are current as of 18 August 2026: Phase 6 marked complete, v1.1.0 then v1.2.0 sequencing is explicit.
+- `plan/BACKLOG.md` remains an index only; GitHub Issues and Project #8 are the work queue.
+
+### Backlog Hygiene
+
+- All 22 open issues have `type/`, `priority/`, `area/`, `size/`, and a milestone.
+- v1.1.0 stories (#290–#292) are stubs without acceptance criteria, Implementation References, wireframes, or child test issues. Do not implement them until `plan-next-issue` completes.
+- Phase 5 stories (#273–#288) are similarly thin (parent pointer plus a one-line user story). That is acceptable while parked; they will need the same planning pass before delivery.
+- No open items are missing type or priority labels.
+
+### Release Confidence
+
+- **Shipped:** v1.0.0 (17 August 2026). Hosted app, product site, and User Guide are in the release notes.
+- **Next planned release:** v1.1.0 (deferred Phase 1–4 slices plus dogfood fixes).
+- **Confidence:** High for the shipped tag. Medium for v1.1.0 until the first story is planned and production dogfood is done.
+- Known release limitation: hosted GitHub App tokens often cannot read private user-owned Projects v2 (#293).
+
+### Quality Metrics
+
+- Latest `main` CI (18 August 2026, run after PR #375): Build and Test succeeded with 555 passed, 0 failed, 0 skipped (up from 382 at the last review).
+- Playwright PAT mode: 45 passed, 4 skipped. Hosted mode: 4 passed.
+- Open pull requests: 0.
+- Staging CD on the latest `main` push succeeded. Production CD is tag-gated from `v1.0.0`.
+- Scheduled Roadmap Sync failed on 18 August 2026 with a GitHub secondary rate limit (HTTP 403 on issue #305). This is operational noise, not a delivery blocker.
+
+### Delivery Activity Since The Last Review
+
+Priorities from 21 July 2026 are all done: Application Insights (#107), Key Vault hosted auth (#250), Audit Dashboard auto-refresh and Markdown export (#258, #259).
+
+Notable delivery in the window:
+
+- **v1.0.0 closure:** tag, GitHub Release, and milestone close (#257).
+- **Hosted and deploy:** health probes, caching, PAT/local trusted mode docs, two-tier CD, MinVer, refresh tokens, optional shared ACR, custom-domain certificate fix (#106, #108, #247, #248, #249, #251, #314, #344, #349, #372, #374).
+- **Quality gates:** coverage, accessibility, performance, Playwright, public-only docs capture (#252–#256, #332).
+- **Product surface:** Hugo/Hextra User Guide and `solodevboard.com` public site (#328, #333, #358).
+- **Governance:** canonical PR policy (DEC-022), post-1.0 numbering (DEC-024), OSS community files, GitHub App listing notes, cadence-neutral progress review rename (#352, #364, #369, #366, #375).
+
+Dependabot and small chore PRs also merged throughout the window.
+
+### Blocker Analysis
+
+- **#293** remains blocked on a GitHub platform limit (private user-owned Projects v2 under GitHub App user-to-server tokens). PAT mode with `read:project` is the documented workaround. Do not sequence this as the first v1.1.0 slice.
+- No other `status/blocked` issues.
+- Phase 5 is parked by decision, not blocked.
+
+### Velocity Trends
+
+- **56 issues closed** and **48 pull requests merged** since 21 July 2026.
+- This is a release-closure burst, not a stable weekly rate. Do not forecast v1.1.0 from this sample.
+- Use size-based estimates only after a v1.1.0 item actually starts (board date rules).
+
+### Top 3 Priorities For The Next Session
+
+1. Dogfood hosted production (`https://my.solodevboard.app/`) and the public site (`https://solodevboard.com/`); confirm About shows `1.0.0`, then file any defects as children of #289.
+2. Run `plan-next-issue` for [#290](https://github.com/markheydon/solo-dev-board/issues/290) (label consistency warnings) — first unblocked v1.1.0 story.
+3. Load that planned slice onto Project #8 Up Next; keep #272–#288 parked and #293 out of the queue.
+
+### Recommended Actions
+
+- Update the Project #8 status dialog using the snippet above (status On track; clear the 22 August 2026 target).
+- Retitle the #289 board card to match the issue.
+- Do not start coding v1.1.0 until planning artefacts and a test issue exist.
+- Leave Phase 5 parked until v1.1.0 is underway or you explicitly reprioritise.
+- Treat the scheduled Roadmap Sync rate-limit failure as a follow-up chore only if it repeats.
+- Optional: ignore or note the closed duplicate issues #260–#271 on the v1.2.0 milestone; they should not be reopened.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Add the 18 August 2026 PM progress review, a canonical Project #8 info pane README, and Roadmap Sync support for archiving closed non-duplicate issues 14 days after `closed_at` (with unarchive on reopen). GitHub’s built-in Auto-archive workflow should stay off; its `updated:` filter is the project-card clock and does not match issue close dates.

## Related Issue(s)

Ad-hoc planning artefact from `/pm-progress-review`, plus board-hygiene follow-up. No tracking issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Archive-rule tests: `node --test .github/scripts/roadmap-sync-archive.test.mjs` (5 passed). After merge, run **Roadmap Sync** via `workflow_dispatch` (or wait for 05:17 UTC) so Phases 1–4 drop off the Gantt immediately. Turn off GitHub **Auto-archive items** if it is still enabled.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf9d3b74-ae88-4108-8c6f-29ba8f628211?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf9d3b74-ae88-4108-8c6f-29ba8f628211&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

