### PR TITLE
[Chore] Stop Roadmap Sync tripping GitHub secondary rate limits

### DIFF
--- a/.github/eslint.config.mjs
+++ b/.github/eslint.config.mjs
@@ -8,6 +8,7 @@ export default [
                 console: 'readonly',
                 fetch: 'readonly',
                 process: 'readonly',
+                Response: 'readonly',
                 setTimeout: 'readonly',
             },
         },

--- a/.github/eslint.config.mjs
+++ b/.github/eslint.config.mjs
@@ -8,6 +8,7 @@ export default [
                 console: 'readonly',
                 fetch: 'readonly',
                 process: 'readonly',
+                setTimeout: 'readonly',
             },
         },
         rules: {

--- a/.github/scripts/github-http.mjs
+++ b/.github/scripts/github-http.mjs
@@ -5,6 +5,24 @@
 export const githubMaxAttempts = 6;
 
 /**
+ * @param {string} bodyText
+ * @returns {string}
+ */
+export function extractGitHubErrorMessage(bodyText) {
+    try {
+        const payload = JSON.parse(bodyText);
+
+        if (typeof payload.message === 'string') {
+            return payload.message;
+        }
+    } catch {
+        // Response body is not JSON.
+    }
+
+    return bodyText;
+}
+
+/**
  * @param {number} status
  * @param {string} bodyText
  * @returns {boolean}
@@ -18,7 +36,17 @@ export function isTransientGitHubLimit(status, bodyText) {
         return false;
     }
 
-    return /secondary rate limit|rate limit/i.test(bodyText);
+    const message = extractGitHubErrorMessage(bodyText);
+
+    return /secondary rate limit/i.test(message) || /rate limit exceeded/i.test(message);
+}
+
+/**
+ * @param {string} errorText
+ * @returns {boolean}
+ */
+export function isTransientGitHubGraphQlError(errorText) {
+    return /RATE_LIMITED|rate limit/i.test(errorText);
 }
 
 /**
@@ -47,13 +75,58 @@ export function sleep(milliseconds) {
 }
 
 /**
+ * @param {{ status: number, errorText: string, retryAfter: string | null, graphqlRateLimited?: boolean }} outcome
+ * @param {number} attempt
+ * @returns {boolean}
+ */
+export function shouldRetryGitHubRequest(outcome, attempt) {
+    if (attempt >= githubMaxAttempts) {
+        return false;
+    }
+
+    if (outcome.graphqlRateLimited) {
+        return true;
+    }
+
+    return isTransientGitHubLimit(outcome.status, outcome.errorText);
+}
+
+/**
+ * @param {(attempt: number) => Promise<{ success: true, value: unknown } | { success: false, status: number, errorText: string, retryAfter: string | null, graphqlRateLimited?: boolean, error: Error }>} executeOnce
+ * @param {string} label
+ * @returns {Promise<unknown>}
+ */
+export async function withGitHubRetry(executeOnce, label) {
+    for (let attempt = 1; attempt <= githubMaxAttempts; attempt += 1) {
+        const outcome = await executeOnce(attempt);
+
+        if (outcome.success) {
+            return outcome.value;
+        }
+
+        if (shouldRetryGitHubRequest(outcome, attempt)) {
+            const delayMs = delayMsForAttempt(attempt, outcome.retryAfter);
+            console.warn(
+                `GitHub rate limit on ${label}; waiting ${delayMs}ms (attempt ${attempt}/${githubMaxAttempts}).`,
+            );
+            await sleep(delayMs);
+            continue;
+        }
+
+        throw outcome.error;
+    }
+
+    throw new Error(`GitHub request failed for ${label} after ${githubMaxAttempts} attempts.`);
+}
+
+/**
  * @param {{ url: string, token: string, userAgent: string, method?: string, body?: string, apiVersion?: string }} options
  * @returns {Promise<unknown>}
  */
 export async function githubJsonRequest(options) {
     const method = options.method ?? 'GET';
 
-    for (let attempt = 1; attempt <= githubMaxAttempts; attempt += 1) {
+    return withGitHubRetry(async () => {
         const response = await fetch(options.url, {
             method,
             headers: {
@@ -67,26 +140,21 @@ export async function githubJsonRequest(options) {
         });
 
         if (response.status === 204) {
-            return null;
+            return { success: true, value: null };
         }
 
         const text = await response.text();
 
         if (response.ok) {
-            return text ? JSON.parse(text) : null;
+            return { success: true, value: text ? JSON.parse(text) : null };
         }
 
-        if (isTransientGitHubLimit(response.status, text) && attempt < githubMaxAttempts) {
-            const delayMs = delayMsForAttempt(attempt, response.headers.get('retry-after'));
-            console.warn(
-                `GitHub rate limit on ${method} ${options.url} (HTTP ${response.status}); waiting ${delayMs}ms (attempt ${attempt}/${githubMaxAttempts}).`,
-            );
-            await sleep(delayMs);
-            continue;
-        }
-
-        throw new Error(`REST request failed (${response.status}) for ${options.url}: ${text}`);
-    }
-
-    throw new Error(`REST request failed for ${options.url} after ${githubMaxAttempts} attempts.`);
+        return {
+            success: false,
+            status: response.status,
+            errorText: text,
+            retryAfter: response.headers.get('retry-after'),
+            error: new Error(`REST request failed (${response.status}) for ${options.url}: ${text}`),
+        };
+    }, `${method} ${options.url}`);
 }

--- a/.github/scripts/github-http.mjs
+++ b/.github/scripts/github-http.mjs
@@ -1,0 +1,92 @@
+/**
+ * Shared GitHub HTTP helpers with retry on secondary rate limits.
+ */
+
+export const githubMaxAttempts = 6;
+
+/**
+ * @param {number} status
+ * @param {string} bodyText
+ * @returns {boolean}
+ */
+export function isTransientGitHubLimit(status, bodyText) {
+    if (status === 429) {
+        return true;
+    }
+
+    if (status !== 403) {
+        return false;
+    }
+
+    return /secondary rate limit|rate limit/i.test(bodyText);
+}
+
+/**
+ * @param {number} attempt 1-based attempt that just failed
+ * @param {string | null} retryAfterHeader
+ * @returns {number}
+ */
+export function delayMsForAttempt(attempt, retryAfterHeader) {
+    const retryAfterSeconds = Number(retryAfterHeader);
+
+    if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+        return retryAfterSeconds * 1000;
+    }
+
+    return Math.min(32_000, 1000 * (2 ** attempt));
+}
+
+/**
+ * @param {number} milliseconds
+ * @returns {Promise<void>}
+ */
+export function sleep(milliseconds) {
+    return new Promise(resolve => {
+        setTimeout(resolve, milliseconds);
+    });
+}
+
+/**
+ * @param {{ url: string, token: string, userAgent: string, method?: string, body?: string, apiVersion?: string }} options
+ * @returns {Promise<unknown>}
+ */
+export async function githubJsonRequest(options) {
+    const method = options.method ?? 'GET';
+
+    for (let attempt = 1; attempt <= githubMaxAttempts; attempt += 1) {
+        const response = await fetch(options.url, {
+            method,
+            headers: {
+                Authorization: `Bearer ${options.token}`,
+                Accept: 'application/vnd.github+json',
+                'User-Agent': options.userAgent,
+                ...(options.apiVersion ? { 'X-GitHub-Api-Version': options.apiVersion } : {}),
+                ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+            },
+            body: options.body,
+        });
+
+        if (response.status === 204) {
+            return null;
+        }
+
+        const text = await response.text();
+
+        if (response.ok) {
+            return text ? JSON.parse(text) : null;
+        }
+
+        if (isTransientGitHubLimit(response.status, text) && attempt < githubMaxAttempts) {
+            const delayMs = delayMsForAttempt(attempt, response.headers.get('retry-after'));
+            console.warn(
+                `GitHub rate limit on ${method} ${options.url} (HTTP ${response.status}); waiting ${delayMs}ms (attempt ${attempt}/${githubMaxAttempts}).`,
+            );
+            await sleep(delayMs);
+            continue;
+        }
+
+        throw new Error(`REST request failed (${response.status}) for ${options.url}: ${text}`);
+    }
+
+    throw new Error(`REST request failed for ${options.url} after ${githubMaxAttempts} attempts.`);
+}

--- a/.github/scripts/github-http.test.mjs
+++ b/.github/scripts/github-http.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { delayMsForAttempt, isTransientGitHubLimit } from './github-http.mjs';
+
+test('isTransientGitHubLimit_SecondaryRateLimit403_IsTransient', () => {
+    const result = isTransientGitHubLimit(403, '{"message":"You have exceeded a secondary rate limit."}');
+
+    assert.equal(result, true);
+});
+
+test('isTransientGitHubLimit_TooManyRequests_IsTransient', () => {
+    const result = isTransientGitHubLimit(429, '{"message":"API rate limit exceeded"}');
+
+    assert.equal(result, true);
+});
+
+test('isTransientGitHubLimit_ForbiddenWithoutRateLimit_IsNotTransient', () => {
+    const result = isTransientGitHubLimit(403, '{"message":"Resource not accessible by integration"}');
+
+    assert.equal(result, false);
+});
+
+test('delayMsForAttempt_RetryAfterHeader_UsesSeconds', () => {
+    const result = delayMsForAttempt(1, '7');
+
+    assert.equal(result, 7000);
+});
+
+test('delayMsForAttempt_MissingHeader_UsesExponentialBackoff', () => {
+    const result = delayMsForAttempt(3, null);
+
+    assert.equal(result, 8000);
+});

--- a/.github/scripts/github-http.test.mjs
+++ b/.github/scripts/github-http.test.mjs
@@ -1,6 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { delayMsForAttempt, isTransientGitHubLimit } from './github-http.mjs';
+import {
+    delayMsForAttempt,
+    extractGitHubErrorMessage,
+    githubJsonRequest,
+    isTransientGitHubLimit,
+} from './github-http.mjs';
 
 test('isTransientGitHubLimit_SecondaryRateLimit403_IsTransient', () => {
     const result = isTransientGitHubLimit(403, '{"message":"You have exceeded a secondary rate limit."}');
@@ -15,9 +20,19 @@ test('isTransientGitHubLimit_TooManyRequests_IsTransient', () => {
 });
 
 test('isTransientGitHubLimit_ForbiddenWithoutRateLimit_IsNotTransient', () => {
-    const result = isTransientGitHubLimit(403, '{"message":"Resource not accessible by integration"}');
+    const body = JSON.stringify({
+        message: 'Resource not accessible by integration',
+        documentation_url: 'https://docs.github.com/rest/overview/rate-limits-for-the-rest-api',
+    });
+    const result = isTransientGitHubLimit(403, body);
 
     assert.equal(result, false);
+});
+
+test('extractGitHubErrorMessage_InvalidJson_ReturnsBodyText', () => {
+    const result = extractGitHubErrorMessage('plain text error');
+
+    assert.equal(result, 'plain text error');
 });
 
 test('delayMsForAttempt_RetryAfterHeader_UsesSeconds', () => {
@@ -30,4 +45,35 @@ test('delayMsForAttempt_MissingHeader_UsesExponentialBackoff', () => {
     const result = delayMsForAttempt(3, null);
 
     assert.equal(result, 8000);
+});
+
+test('githubJsonRequest_SecondaryRateLimitThenSuccess_Retries', async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+
+    globalThis.fetch = async () => {
+        calls += 1;
+
+        if (calls === 1) {
+            return new Response(JSON.stringify({ message: 'You have exceeded a secondary rate limit.' }), {
+                status: 403,
+                headers: { 'retry-after': '0' },
+            });
+        }
+
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    try {
+        const result = await githubJsonRequest({
+            url: 'https://api.github.com/test',
+            token: 'test-token',
+            userAgent: 'solo-dev-board-test',
+        });
+
+        assert.deepEqual(result, { ok: true });
+        assert.equal(calls, 2);
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
 });

--- a/.github/scripts/roadmap-sync.mjs
+++ b/.github/scripts/roadmap-sync.mjs
@@ -1,5 +1,5 @@
 import { isIssueClosedLongEnoughToArchive } from './roadmap-sync-archive.mjs';
-import { githubJsonRequest, isTransientGitHubLimit, delayMsForAttempt, sleep, githubMaxAttempts } from './github-http.mjs';
+import { githubJsonRequest, isTransientGitHubGraphQlError, withGitHubRetry } from './github-http.mjs';
 
 const apiBaseUrl = 'https://api.github.com';
 const graphqlUrl = `${apiBaseUrl}/graphql`;
@@ -261,6 +261,12 @@ async function syncIssueAsync(issue, issueItemsByContentId, timelineCache) {
         projectItem.isArchived = false;
     }
 
+    if (shouldArchive) {
+        await archiveProjectItemAsync(projectItem.id, `issue #${issue.number}`);
+        projectItem.isArchived = true;
+        return;
+    }
+
     const currentStatusName = projectItem.status?.name ?? null;
     const desiredStatusName = determineRoadmapStatus(issue, currentStatusName);
     const desiredPhaseOptionId = determinePhaseOptionId(issue);
@@ -288,11 +294,6 @@ async function syncIssueAsync(issue, issueItemsByContentId, timelineCache) {
     await syncDateFieldAsync(projectItem.id, fieldIds.startDate, projectItem.startDate?.date ?? null, startDate, `issue #${issue.number} start date`);
     await syncDateFieldAsync(projectItem.id, fieldIds.targetDate, projectItem.targetDate?.date ?? null, targetDate, `issue #${issue.number} target date`);
     await clearFieldAsync(projectItem.id, fieldIds.focusOrder, projectItem.focusOrder?.number ?? null, `issue #${issue.number} focus order`);
-
-    if (shouldArchive) {
-        await archiveProjectItemAsync(projectItem.id, `issue #${issue.number}`);
-        projectItem.isArchived = true;
-    }
 }
 
 async function syncParentIssuesAsync(issueItemsByContentId, issueByNumber, timelineCache) {
@@ -694,7 +695,7 @@ async function fetchIssueTimelineAsync(issueNumber) {
 }
 
 async function graphqlAsync(query, variables) {
-    for (let attempt = 1; attempt <= githubMaxAttempts; attempt += 1) {
+    return withGitHubRetry(async () => {
         const response = await fetch(graphqlUrl, {
             method: 'POST',
             headers: {
@@ -715,28 +716,23 @@ async function graphqlAsync(query, variables) {
             payload = { message: text };
         }
 
-        const payloadText = text;
         const hasErrors = Boolean(payload.errors && payload.errors.length > 0);
-        const errorText = hasErrors ? JSON.stringify(payload.errors) : payloadText;
-        const graphqlRateLimited = hasErrors && /RATE_LIMITED|rate limit/i.test(errorText);
+        const errorText = hasErrors ? JSON.stringify(payload.errors) : text;
+        const graphqlRateLimited = hasErrors && isTransientGitHubGraphQlError(errorText);
 
         if (response.ok && !hasErrors) {
-            return payload.data;
+            return { success: true, value: payload.data };
         }
 
-        if ((isTransientGitHubLimit(response.status, errorText) || graphqlRateLimited) && attempt < githubMaxAttempts) {
-            const delayMs = delayMsForAttempt(attempt, response.headers.get('retry-after'));
-            console.warn(
-                `GitHub rate limit on GraphQL (HTTP ${response.status}); waiting ${delayMs}ms (attempt ${attempt}/${githubMaxAttempts}).`,
-            );
-            await sleep(delayMs);
-            continue;
-        }
-
-        throw new Error(`GraphQL request failed: ${JSON.stringify(payload.errors ?? payload, null, 2)}`);
-    }
-
-    throw new Error('GraphQL request failed after retries.');
+        return {
+            success: false,
+            status: response.status,
+            errorText,
+            retryAfter: response.headers.get('retry-after'),
+            graphqlRateLimited,
+            error: new Error(`GraphQL request failed: ${JSON.stringify(payload.errors ?? payload, null, 2)}`),
+        };
+    }, 'GraphQL');
 }
 
 async function restAsync(path) {

--- a/.github/scripts/roadmap-sync.mjs
+++ b/.github/scripts/roadmap-sync.mjs
@@ -1,4 +1,5 @@
 import { isIssueClosedLongEnoughToArchive } from './roadmap-sync-archive.mjs';
+import { githubJsonRequest, isTransientGitHubLimit, delayMsForAttempt, sleep, githubMaxAttempts } from './github-http.mjs';
 
 const apiBaseUrl = 'https://api.github.com';
 const graphqlUrl = `${apiBaseUrl}/graphql`;
@@ -693,41 +694,58 @@ async function fetchIssueTimelineAsync(issueNumber) {
 }
 
 async function graphqlAsync(query, variables) {
-    const response = await fetch(graphqlUrl, {
-        method: 'POST',
-        headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'application/json',
-            Accept: 'application/vnd.github+json',
-            'User-Agent': 'solo-dev-board-roadmap-sync',
-        },
-        body: JSON.stringify({ query, variables }),
-    });
+    for (let attempt = 1; attempt <= githubMaxAttempts; attempt += 1) {
+        const response = await fetch(graphqlUrl, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'Content-Type': 'application/json',
+                Accept: 'application/vnd.github+json',
+                'User-Agent': 'solo-dev-board-roadmap-sync',
+            },
+            body: JSON.stringify({ query, variables }),
+        });
 
-    const payload = await response.json();
+        const text = await response.text();
+        let payload = {};
 
-    if (!response.ok || (payload.errors && payload.errors.length > 0)) {
+        try {
+            payload = text ? JSON.parse(text) : {};
+        } catch {
+            payload = { message: text };
+        }
+
+        const payloadText = text;
+        const hasErrors = Boolean(payload.errors && payload.errors.length > 0);
+        const errorText = hasErrors ? JSON.stringify(payload.errors) : payloadText;
+        const graphqlRateLimited = hasErrors && /RATE_LIMITED|rate limit/i.test(errorText);
+
+        if (response.ok && !hasErrors) {
+            return payload.data;
+        }
+
+        if ((isTransientGitHubLimit(response.status, errorText) || graphqlRateLimited) && attempt < githubMaxAttempts) {
+            const delayMs = delayMsForAttempt(attempt, response.headers.get('retry-after'));
+            console.warn(
+                `GitHub rate limit on GraphQL (HTTP ${response.status}); waiting ${delayMs}ms (attempt ${attempt}/${githubMaxAttempts}).`,
+            );
+            await sleep(delayMs);
+            continue;
+        }
+
         throw new Error(`GraphQL request failed: ${JSON.stringify(payload.errors ?? payload, null, 2)}`);
     }
 
-    return payload.data;
+    throw new Error('GraphQL request failed after retries.');
 }
 
 async function restAsync(path) {
-    const response = await fetch(`${apiBaseUrl}${path}`, {
-        headers: {
-            Authorization: `Bearer ${token}`,
-            Accept: 'application/vnd.github+json',
-            'User-Agent': 'solo-dev-board-roadmap-sync',
-            'X-GitHub-Api-Version': '2022-11-28',
-        },
+    return githubJsonRequest({
+        url: `${apiBaseUrl}${path}`,
+        token,
+        userAgent: 'solo-dev-board-roadmap-sync',
+        apiVersion: '2022-11-28',
     });
-
-    if (!response.ok) {
-        throw new Error(`REST request failed (${response.status}) for ${path}: ${await response.text()}`);
-    }
-
-    return response.json();
 }
 
 function getLabelNames(issue) {

--- a/.github/scripts/sync-status-labels.mjs
+++ b/.github/scripts/sync-status-labels.mjs
@@ -1,3 +1,5 @@
+import { githubJsonRequest } from './github-http.mjs';
+
 const apiBaseUrl = 'https://api.github.com';
 const owner = 'markheydon';
 const repo = 'solo-dev-board';
@@ -33,11 +35,8 @@ if (!token) {
 await main();
 
 async function main() {
-    const [issues, pullRequests, openLinkedIssueNumbers] = await Promise.all([
-        fetchIssuesAsync(),
-        fetchPullRequestsAsync(),
-        fetchOpenLinkedIssueNumbersAsync(),
-    ]);
+    const { issues, pullRequests } = await fetchIssuesAndPullRequestsAsync();
+    const openLinkedIssueNumbers = await fetchOpenLinkedIssueNumbersAsync();
 
     const items = [
         ...issues.map(issue => ({ kind: 'issue', item: issue })),
@@ -79,11 +78,8 @@ async function main() {
 
     console.log(`Applied status label repairs to ${repairs.filter(repair => !repair.plan.reportOnly).length} item(s).`);
 
-    const [refreshedIssues, refreshedPullRequests, refreshedOpenLinkedIssueNumbers] = await Promise.all([
-        fetchIssuesAsync(),
-        fetchPullRequestsAsync(),
-        fetchOpenLinkedIssueNumbersAsync(),
-    ]);
+    const { issues: refreshedIssues, pullRequests: refreshedPullRequests } = await fetchIssuesAndPullRequestsAsync();
+    const refreshedOpenLinkedIssueNumbers = await fetchOpenLinkedIssueNumbersAsync();
 
     const refreshedItems = [
         ...refreshedIssues.map(issue => ({ kind: 'issue', item: issue })),
@@ -228,54 +224,36 @@ async function applyRepairAsync({ kind, item, plan }) {
     console.log(`Updated ${kind} #${item.number}: ${plan.action}`);
 }
 
-async function fetchIssuesAsync() {
+async function fetchIssuesAndPullRequestsAsync() {
     const issues = [];
-    let page = 1;
-
-    while (true) {
-        const pageIssues = await restAsync(`/repos/${owner}/${repo}/issues?state=all&per_page=100&page=${page}`);
-        const issuesOnly = pageIssues.filter(issue => !issue.pull_request);
-
-        issues.push(...issuesOnly);
-
-        if (pageIssues.length < 100) {
-            break;
-        }
-
-        page += 1;
-    }
-
-    return issues;
-}
-
-async function fetchPullRequestsAsync() {
     const pullRequests = [];
     let page = 1;
 
     while (true) {
-        const pagePullRequests = await restAsync(`/repos/${owner}/${repo}/pulls?state=all&per_page=100&page=${page}`);
-        const issueBackedPullRequests = await Promise.all(
-            pagePullRequests.map(async pullRequest => {
-                const issue = await restAsync(`/repos/${owner}/${repo}/issues/${pullRequest.number}`);
-                return {
-                    number: pullRequest.number,
-                    state: pullRequest.state,
+        const pageItems = await restAsync(`/repos/${owner}/${repo}/issues?state=all&per_page=100&page=${page}`);
+
+        for (const item of pageItems) {
+            if (item.pull_request) {
+                pullRequests.push({
+                    number: item.number,
+                    state: item.state,
                     state_reason: null,
-                    labels: issue.labels ?? [],
-                };
-            }),
-        );
+                    labels: item.labels ?? [],
+                });
+                continue;
+            }
 
-        pullRequests.push(...issueBackedPullRequests);
+            issues.push(item);
+        }
 
-        if (pagePullRequests.length < 100) {
+        if (pageItems.length < 100) {
             break;
         }
 
         page += 1;
     }
 
-    return pullRequests;
+    return { issues, pullRequests };
 }
 
 async function fetchOpenLinkedIssueNumbersAsync() {
@@ -314,25 +292,12 @@ async function fetchOpenLinkedIssueNumbersAsync() {
 }
 
 async function restAsync(path, options = {}) {
-    const response = await fetch(`${apiBaseUrl}${path}`, {
+    return githubJsonRequest({
+        url: `${apiBaseUrl}${path}`,
+        token,
+        userAgent: 'solo-dev-board-sync-status-labels',
+        apiVersion: '2022-11-28',
         method: options.method ?? 'GET',
-        headers: {
-            Authorization: `Bearer ${token}`,
-            Accept: 'application/vnd.github+json',
-            'User-Agent': 'solo-dev-board-sync-status-labels',
-            'X-GitHub-Api-Version': '2022-11-28',
-            ...(options.body ? { 'Content-Type': 'application/json' } : {}),
-        },
         body: options.body,
     });
-
-    if (response.status === 204) {
-        return null;
-    }
-
-    if (!response.ok) {
-        throw new Error(`REST request failed (${response.status}) for ${path}: ${await response.text()}`);
-    }
-
-    return response.json();
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           node-version: "24"
 
       - name: Run archive-rule tests
-        run: node --test .github/scripts/roadmap-sync-archive.test.mjs
+        run: node --test .github/scripts/*.test.mjs
 
   e2e-pat:
     name: End-to-End (Playwright, PAT mode)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           node-version: "24"
 
-      - name: Run archive-rule tests
+      - name: Run GitHub automation script tests
         run: node --test .github/scripts/*.test.mjs
 
   e2e-pat:

--- a/.github/workflows/roadmap-sync.yml
+++ b/.github/workflows/roadmap-sync.yml
@@ -52,7 +52,7 @@ jobs:
           node-version: "24"
 
       - name: Run archive-rule tests
-        run: node --test .github/scripts/roadmap-sync-archive.test.mjs
+        run: node --test .github/scripts/*.test.mjs
 
       - name: Sync status labels
         env:

--- a/.github/workflows/roadmap-sync.yml
+++ b/.github/workflows/roadmap-sync.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           node-version: "24"
 
-      - name: Run archive-rule tests
+      - name: Run GitHub automation script tests
         run: node --test .github/scripts/*.test.mjs
 
       - name: Sync status labels

--- a/plan/DECISIONS.md
+++ b/plan/DECISIONS.md
@@ -249,6 +249,15 @@ Test coverage expectations for cache-hit, cache-miss, invalidation, TTL expiry, 
 
 ---
 
+### DEC-026: Project #8 archive rule via Roadmap Sync
+
+**Status:** Active  
+**Date:** 2026-08-18  
+**Related:** [DEC-014](#dec-014-github-actions-bridge-for-roadmap-project-sync), [`plan/PROJECT_BOARD_DESIGN.md`](PROJECT_BOARD_DESIGN.md)  
+**Summary:** Closed, non-duplicate issues on Project #8 are archived by the Roadmap Sync bridge **14 calendar days after `closed_at`**, using `archiveProjectV2Item`. GitHub **Auto-archive items** stays off because its `updated:` filter tracks project-card activity, not issue closure, and bulk field writes reset that clock. Reopened issues are unarchived; duplicates are removed from the project, not archived. Eligible cards are archived without a preceding field-sync pass to limit API churn on catch-up runs. Reject enabling GitHub Auto-archive alongside Roadmap Sync or archiving by card `updated` timestamp.
+
+---
+
 ## Superseded legacy (archive only)
 
 | Legacy ADR | Superseded by | Notes |

--- a/plan/PROJECT_BOARD_DESIGN.md
+++ b/plan/PROJECT_BOARD_DESIGN.md
@@ -75,7 +75,7 @@ The following automation rules are configured on the board. These are documented
 - **Disabled:** `Auto-add to project`, `Pull request linked to issue`, `Pull request merged`, `Auto-archive items`, `Code changes requested`, `Code review approved`, and `Item reopened`.
 - **Reason:** SoloDevBoard uses an issue-driven roadmap. Agents manage issue creation and metadata deliberately. Built-in GitHub workflows stay as narrow safety nets. **Archiving closed cards is Roadmap Sync’s job**, not GitHub’s Auto-archive workflow, because GitHub’s `updated:` filter is the project-card clock and a bulk field write resets it.
 
-**Archive rule (Roadmap Sync, nightly and on issue events):** closed, non-duplicate issues whose **`closed_at` is at least 14 calendar days ago** are archived on Project #8 via `archiveProjectV2Item`. Open items are never archived. Reopened issues are unarchived. Duplicate closures are still **removed**, not archived. Prefer this over GitHub **Auto-archive items**; if that workflow is on, turn it off so the two clocks do not fight.
+**Archive rule (Roadmap Sync, nightly and on issue events):** closed, non-duplicate issues whose **`closed_at` is at least 14 calendar days ago** are archived on Project #8 via `archiveProjectV2Item` without a preceding field-sync pass ([DEC-026](DECISIONS.md#dec-026-project-8-archive-rule-via-roadmap-sync)). Open items are never archived. Reopened issues are unarchived. Duplicate closures are still **removed**, not archived. Prefer this over GitHub **Auto-archive items**; if that workflow is on, turn it off so the two clocks do not fight.
 
 ### Label: status/in-progress Applied
 - **Trigger:** The `status/in-progress` label is applied to an issue.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Roadmap Sync failed on `workflow_dispatch` with HTTP 403 secondary rate limits while `sync-status-labels.mjs` fetched every pull request in parallel (`Promise.all` of one `/issues/{n}` call per PR).

This change:

- Loads issues and pull requests (with labels) from the paginated `/issues?state=all` list, so that N+1 burst goes away.
- Retries transient 403/429 responses with backoff in both status-label and roadmap-sync HTTP helpers.

After merge, run **Roadmap Sync** again so the 14-day `closed_at` archive pass can run.

## Related Issue(s)

Ad-hoc follow-up to the failed Roadmap Sync after PR #376. No tracking issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Not applicable.

## Additional Notes

`node --test .github/scripts/*.test.mjs` passes (10 tests). ESLint for `.github/scripts` is clean. This PR does not archive cards by itself; merge it, then re-run Roadmap Sync.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf9d3b74-ae88-4108-8c6f-29ba8f628211?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf9d3b74-ae88-4108-8c6f-29ba8f628211&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

