### PR TITLE
[Documentation] Plan Cross-Repo PM Workflow and agent issue linking (#272)

### DIFF
--- a/.agents/contracts/pm-orchestrator.md
+++ b/.agents/contracts/pm-orchestrator.md
@@ -69,7 +69,7 @@ Invoke this when you need to:
 - For `type/enabler` issues, include an `## Implementation Notes` section (technical approach, layers affected, dependencies)
 - Assign to current milestone if applicable
 - **Assign to `markheydon`** — all issues must be assigned at creation (see repo-github-project skill Event 1)
-- Note parent/child sub-issue hierarchy (Epic→Feature→Story/Enabler/Test) and any blocking relationships — GitHub CLI cannot set either; produce a **Manual Linking Required** table in the handoff for the user to set via the GitHub UI
+- Set parent/child sub-issue hierarchy (Epic→Feature→Story/Enabler/Test) and blocking relationships after creating issues. Use GitHub MCP `sub_issue_write` for parents and `gh api` REST issue-dependencies for blocking — see `repo-github-gh-cli` and `repo-github-issues`. Do **not** ask the user to click Relationships in the GitHub UI unless those APIs fail. Dedicated `gh issue` subcommands still do not exist ([cli/cli#10298](https://github.com/cli/cli/issues/10298), [cli/cli#11757](https://github.com/cli/cli/issues/11757)); the REST and MCP paths are the supported workaround.
 
 ### 5. Project Board Sync
 - Use `repo-github-project` skill to add each created issue to the **SoloDevBoard Roadmap** project (#8)
@@ -143,15 +143,15 @@ Deliver to user:
 2. **Issue links**: Direct links to created issues
 3. **Next action**: "Ready for Delivery Agent — run 'implement issue #X'" or, for a tightly related batch, "implement issues #X, #Y, and #Z"
 4. **Blockers**: Any dependencies or scope questions that need resolution
-5. **Manual Linking Required** — table of parent/child and blocking relationships to set via the GitHub UI (since `gh` CLI supports neither; see [cli/cli#11757](https://github.com/cli/cli/issues/11757) and [cli/cli#10298](https://github.com/cli/cli/issues/10298)):
+5. **Relationships applied** — table of parent/child and blocking links the agent set. Only include a **Manual fallback** subsection if MCP or REST failed (permissions, circular dependency, API error):
 
-   **Sub-issues** (open parent issue → Sub-issues → Add):
+   **Sub-issues** (set via MCP `sub_issue_write`):
    | Parent Issue | Child Issue(s) | Relationship |
    |---|---|---|
    | #X Epic title | #Y Feature title | Epic → Feature |
    | #Y Feature title | #Z Enabler, #A Story, #B Test | Feature → deliverables |
 
-   **Blocking** (open issue → Relationships → Mark as blocking):
+   **Blocking** (set via REST `dependencies/blocked_by`):
    | Blocking Issue | Blocked Issue | Type |
    |---|---|---|
    | #Z Enabler title | #A Story, #B Story | blocks |
@@ -167,6 +167,7 @@ Planning is complete when:
 - ✅ GitHub issues created with correct labels/milestones and Implementation References sections
 - ✅ Test strategy defined via `breakdown-test`
 - ✅ Dependencies and acceptance criteria documented
+- ✅ Sub-issue parents and blocking relationships set via MCP/REST (manual UI only if APIs fail)
 - ✅ All created issues added to project board with Phase/Priority/Status/dates set
 - ✅ No scope ambiguity or blockers
 - ✅ Handoff package delivered

--- a/.agents/skills/repo-github-gh-cli/SKILL.md
+++ b/.agents/skills/repo-github-gh-cli/SKILL.md
@@ -110,7 +110,40 @@ gh project item-edit \
 # NOTE: Prefer `gh project item-edit` for project field updates.
 # Use raw GraphQL only when `gh project` does not expose the required operation.
 # See `.agents/skills/repo-github-project/SKILL.md` for the SoloDevBoard-specific field IDs and queue workflow.
+
+# Capture the project item id from item-add (item-list defaults to 30 items).
+item_id=$(gh project item-add 8 --owner markheydon \
+	--url https://github.com/markheydon/solo-dev-board/issues/123 \
+	--format json --jq .id)
+
+# Look up an existing item without listing the whole board.
+gh project item-list 8 --owner markheydon --query 123 --format json --jq '.items[0].id'
 ```
+
+### Issue hierarchy and blocking
+
+`gh issue` has **no** first-class sub-issue or block commands yet ([cli/cli#11757](https://github.com/cli/cli/issues/11757), [cli/cli#10298](https://github.com/cli/cli/issues/10298)). Agents must still set both via API and must **not** leave them as a GitHub UI chore for the user.
+
+**Sub-issues:** GitHub MCP `sub_issue_write` (`method: add`). `sub_issue_id` is the issue **database id** (`gh api repos/OWNER/REPO/issues/N --jq .id`), not the `#` number.
+
+**Blocking:** REST [issue dependencies](https://docs.github.com/en/rest/issues/issue-dependencies). POST against the **blocked** issue; `issue_id` is the **blocking** issue's database id as a JSON integer (a quoted string returns 422).
+
+```bash
+# Resolve database ids (not issue numbers).
+blocker_id=$(gh api repos/markheydon/solo-dev-board/issues/382 --jq .id)
+
+# Mark #273 as blocked by #382.
+gh api -X POST repos/markheydon/solo-dev-board/issues/273/dependencies/blocked_by \
+	--input - <<EOF
+{"issue_id": ${blocker_id}}
+EOF
+
+# HTTP 422 "already been taken" means the link already exists — treat as success.
+# List current blockers:
+gh api repos/markheydon/solo-dev-board/issues/273/dependencies/blocked_by --jq '.[].number'
+```
+
+The inverse endpoint is `.../issues/{number}/dependencies/blocking` (this issue blocks others). Prefer `blocked_by` so the dependent issue is the path parameter.
 
 ### Safety Rules
 

--- a/.agents/skills/repo-github-issues/SKILL.md
+++ b/.agents/skills/repo-github-issues/SKILL.md
@@ -17,6 +17,7 @@ Manage GitHub issues using the `@modelcontextprotocol/server-github` MCP server.
 | `mcp__github__search_issues` | Search issues |
 | `mcp__github__add_issue_comment` | Add comments |
 | `mcp__github__list_issues` | List repository issues |
+| `mcp__github__sub_issue_write` | Add, remove, or reprioritise a sub-issue (`sub_issue_id` is the numeric GitHub issue **id**, not the `#` number) |
 
 ## Workflow
 
@@ -127,6 +128,16 @@ Always apply at least one `type/` and one `priority/` label.
 | `status/` | `status/todo`, `status/in-progress`, `status/blocked`, `status/ice-box`, `status/in-review`, `status/done` |
 | `area/` | `area/dashboard`, `area/migration`, `area/labels`, `area/board-rules`, `area/triage`, `area/workflows`, `area/infrastructure`, `area/docs` |
 | `size/` | `size/xs`, `size/s`, `size/m`, `size/l`, `size/xl` |
+
+## Issue relationships (agents must set these)
+
+After creating a planned hierarchy, **do not** ask the user to click Sub-issues or Relationships in the GitHub UI.
+
+1. **Parent / child:** GitHub MCP `sub_issue_write` with `method: add`, parent `issue_number`, and child `sub_issue_id` (database id from create/get). To move a child, use `replace_parent: true`.
+2. **Blocking:** REST via `gh api` as documented in `repo-github-gh-cli` (`POST .../issues/{blocked_number}/dependencies/blocked_by` with JSON integer `issue_id` of the **blocking** issue). `gh issue` has no first-class block command yet ([cli/cli#10298](https://github.com/cli/cli/issues/10298)).
+3. Mention `#N` in the issue body as well so the graph is readable without opening the Relationships widget.
+
+If either API returns an error other than “already taken”, put a **Manual fallback** table in the planning handoff with the exact `gh api` commands.
 
 ## Tips
 

--- a/.agents/skills/repo-github-project/SKILL.md
+++ b/.agents/skills/repo-github-project/SKILL.md
@@ -161,7 +161,7 @@ After the daily-start workflow recommends a short execution batch and the user e
 
 ```bash
 # Step 1: Find the project item ID for the issue.
-item_id=$(gh project item-list 8 --owner markheydon --format json --jq ".items[] | select(.content.number == $issueNumber) | .id" | head -n1)
+item_id=$(gh project item-list 8 --owner markheydon --query "$issueNumber" --format json --jq ".items[0].id")
 
 # Step 2: Set Status → Up Next.
 gh project item-edit \
@@ -183,12 +183,10 @@ gh project item-edit \
 After creating a new issue, add it to the project and set Status, Phase, and Priority. **Do not set Start Date or Target Date** — dates are calculated and set only when work actually begins (Event 2).
 
 ```bash
-# Step 1: Add the issue to the project.
+# Step 1: Add the issue to the project and capture the item id.
+# Do not rely on `item-list` without `--query`: it defaults to 30 items.
 issue_url="https://github.com/markheydon/solo-dev-board/issues/$issueNumber"
-gh project item-add 8 --owner markheydon --url "$issue_url" >/dev/null
-
-# Step 2: Find the new project item ID.
-item_id=$(gh project item-list 8 --owner markheydon --format json --jq ".items[] | select(.content.number == $issueNumber) | .id" | head -n1)
+item_id=$(gh project item-add 8 --owner markheydon --url "$issue_url" --format json --jq .id)
 
 # Step 3: Set Status → Todo.
 gh project item-edit \
@@ -252,7 +250,7 @@ This is a **one-time transition** — once a parent is "In Progress" it remains 
 # For each parent issue number ($parent_issue_number = Feature or Epic issue number):
 
 # Step 1: Find the parent project item ID if the parent is still in Todo.
-parent_item_id=$(gh project item-list 8 --owner markheydon --format json --jq ".items[] | select(.content.number == $parent_issue_number and .status == \"Todo\") | .id" | head -n1)
+parent_item_id=$(gh project item-list 8 --owner markheydon --query "$parent_issue_number" --format json --jq 'select(.items[0].status == "Todo") | .items[0].id')
 
 # Step 2: If the parent is still Todo, update Status → In Progress and Start Date → today.
 if [ -n "$parent_item_id" ]; then
@@ -273,7 +271,7 @@ When a PR is merged and the issue is closed, update Status to "Done" and **overw
 
 ```bash
 # Step 1: Find the project item ID for the issue.
-item_id=$(gh project item-list 8 --owner markheydon --format json --jq ".items[] | select(.content.number == $issueNumber) | .id" | head -n1)
+item_id=$(gh project item-list 8 --owner markheydon --query "$issueNumber" --format json --jq ".items[0].id")
 
 # Step 2: Update Status → Done.
 gh project item-edit \
@@ -301,7 +299,7 @@ After closing a Story, Enabler, or Test via Event 3, check whether **all sibling
 
 ```bash
 # For the parent Feature ($feature_issue_number) — run after each child closure.
-feature_item_id=$(gh project item-list 8 --owner markheydon --format json --jq ".items[] | select(.content.number == $feature_issue_number) | .id" | head -n1)
+feature_item_id=$(gh project item-list 8 --owner markheydon --query "$feature_issue_number" --format json --jq ".items[0].id")
 
 # Close the Feature issue only if all children are closed.
 gh issue edit "$feature_issue_number" --repo markheydon/solo-dev-board --remove-label "status/in-progress" --add-label "status/done"
@@ -339,10 +337,11 @@ Historical backfills should prefer accurate actuals, but a conservative same-day
 
 ## Checking Project State
 
-List all items and their current state:
+List items (raise `--limit` or use `--query`; the default list is 30 items):
 
 ```bash
-gh project item-list 8 --owner markheydon --format json --jq '.items[] | {id, title: .title, number: .content.number, status}'
+gh project item-list 8 --owner markheydon --limit 100 --format json --jq '.items[] | {id, title: .title, number: .content.number, status}'
+gh project item-list 8 --owner markheydon --query 382 --format json --jq '.items[0] | {id, title, status}'
 ```
 
 View the roadmap in the browser:

--- a/.agents/workflows/plan-next-issue.md
+++ b/.agents/workflows/plan-next-issue.md
@@ -7,7 +7,7 @@
 ## Easy-to-miss specifics
 
 - A wireframe in `plan/wireframes/` is required before page-producing UI planning is considered complete.
-- Produce a **Manual Linking Required** table for parent/child sub-issues and blocking relationships — the GitHub CLI cannot set these.
+- Set parent/child sub-issues (MCP `sub_issue_write`) and blocking relationships (`gh api` REST issue-dependencies) as part of planning. Do not leave them for the user. Report a **Manual fallback** table only if those APIs fail.
 - Sync each created issue to Project #8 per the `repo-github-project` skill.
 
 ## Invocation

--- a/plan/DECISIONS.md
+++ b/plan/DECISIONS.md
@@ -277,6 +277,15 @@ Test coverage expectations for cache-hit, cache-miss, invalidation, TTL expiry, 
 
 ---
 
+### DEC-029: Cross-Repo PM Workflow board selection and local settings
+
+**Status:** Active  
+**Date:** 2026-08-18  
+**Related:** [DEC-018](#dec-018-github-api-response-caching-in-infrastructure), [DEC-027](#dec-027-post-10-milestone-and-work-item-hierarchy), [`plan/GITHUB_PROJECTS_V2_ACCESS.md`](GITHUB_PROJECTS_V2_ACCESS.md)  
+**Summary:** Cross-Repo PM Workflow ([#272](https://github.com/markheydon/solo-dev-board/issues/272)) uses a **user-selected Projects v2 board** as the planning board (discovered the same way as Triage/Board Rules). Do not hard-code SoloDevBoard Roadmap (Project #8) field ids in application code. PM settings (selected board node id, excluded `owner/name` repositories, capacity limit, stall and neglect day thresholds) persist in **browser localStorage**, following the theme-preference pattern, because the solution has no application database. Board-state counts include all cards on the selected board; Daily Focus recommendations, Backlog Review, Planning candidates, and per-repo summaries honour exclusions. Hosted GitHub App sign-in still cannot read some private user-owned boards ([#293](https://github.com/markheydon/solo-dev-board/issues/293)); reuse the existing inaccessible-board warning. Reject storing PATs in localStorage, treating Project #8 as the only supported board, or adding EF Core solely for these preferences.
+
+---
+
 ## Superseded legacy (archive only)
 
 | Legacy ADR | Superseded by | Notes |

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -167,7 +167,7 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 
 **Milestone:** v1.1.0 (sole open milestone; formerly planned as v1.2.0 — see [DEC-027](DECISIONS.md#dec-027-post-10-milestone-and-work-item-hierarchy))
 
-**Status:** Not started. Feature [#272](https://github.com/markheydon/solo-dev-board/issues/272) (no parent epic). Stories #273–#288.
+**Status:** Planned (2026-08-18). Feature [#272](https://github.com/markheydon/solo-dev-board/issues/272) (no parent epic). Stories #273–#288 plus enablers and tests. Wireframe: `plan/wireframes/pm-workflow-wireframe.md`. Plan: `plan/cross-repo-pm-workflow-project-plan.md`. Decision: [DEC-029](DECISIONS.md#dec-029-cross-repo-pm-workflow-board-selection-and-local-settings).
 
 ### Key Tasks
 

--- a/plan/PROJECT_MANAGEMENT.md
+++ b/plan/PROJECT_MANAGEMENT.md
@@ -51,6 +51,17 @@ Implementation **phases** in `IMPLEMENTATION_PLAN.md` are historical sequencing 
 - Assign the issue to the current milestone if it is planned for the current phase.
 - Link epics by mentioning the parent issue (e.g. "Part of #12") in the issue body.
 
+### Issue relationships (sub-issues and blocking)
+
+GitHub sub-issues and issue dependencies are the hierarchy source of truth. Agents set them after issue creation:
+
+| Relationship | How agents set it |
+|--------------|-------------------|
+| Parent / child (Epic → Feature → Story/Enabler/Test) | GitHub MCP `sub_issue_write` |
+| Blocking / blocked-by | REST `POST /repos/{owner}/{repo}/issues/{blocked}/dependencies/blocked_by` via `gh api` |
+
+`gh issue` still has no dedicated subcommands for either ([cli/cli#11757](https://github.com/cli/cli/issues/11757), [cli/cli#10298](https://github.com/cli/cli/issues/10298)). That does **not** mean the user must click Relationships in the UI — use the REST and MCP paths in [`.agents/skills/repo-github-gh-cli/SKILL.md`](../.agents/skills/repo-github-gh-cli/SKILL.md). Mention `#N` in the issue body as well so the graph is readable in comments and search.
+
 ### Issue Lifecycle
 
 ```
@@ -165,3 +176,4 @@ When using Copilot Chat to manage issues:
 > 3. Assign the issue to the appropriate milestone.
 > 4. Use the user story format in the issue body when creating from planning input.
 > 5. Sync the issue to Project #8 per the `repo-github-project` skill.
+> 6. Set sub-issue parents and blocking relationships via MCP/`gh api` (see `repo-github-gh-cli`). Do not ask the user to click Relationships in the GitHub UI unless those APIs fail.

--- a/plan/cross-repo-pm-workflow-issues-checklist.md
+++ b/plan/cross-repo-pm-workflow-issues-checklist.md
@@ -1,0 +1,70 @@
+# Cross-Repo PM Workflow — issues checklist
+
+Parent: [#272](https://github.com/markheydon/solo-dev-board/issues/272). Milestone: **v1.1.0** (number 7). Assignee: `markheydon`. Status on new/updated children: `status/todo` (do not add an Up Next **label**).
+
+Wireframe: `plan/wireframes/pm-workflow-wireframe.md`. Plan: `plan/cross-repo-pm-workflow-project-plan.md`. Decisions: DEC-027, DEC-028, DEC-029.
+
+## New issues (created during planning)
+
+| Kind | Issue | Size | Priority | Area | Blocks |
+|------|-------|------|----------|------|--------|
+| Enabler | [#382](https://github.com/markheydon/solo-dev-board/issues/382) Projects v2 item catalogue | `size/l` | high | `area/infrastructure` | #273, #275, #283–#285 |
+| Enabler | [#383](https://github.com/markheydon/solo-dev-board/issues/383) PM settings persistence | `size/s` | high | `area/infrastructure` | #273, #274, #277, #284, #287 |
+| Enabler | [#384](https://github.com/markheydon/solo-dev-board/issues/384) Cross-repo work-item catalogue | `size/l` | high | `area/infrastructure` | #274, #276, #277, #279, #281, #288 |
+| Test | [#385](https://github.com/markheydon/solo-dev-board/issues/385) Daily Focus | `size/m` | medium | `area/dashboard` | Feature close-out |
+| Test | [#386](https://github.com/markheydon/solo-dev-board/issues/386) Backlog Review | `size/m` | medium | `area/dashboard` | Feature close-out |
+| Test | [#387](https://github.com/markheydon/solo-dev-board/issues/387) Iteration Planning | `size/m` | medium | `area/dashboard` | Feature close-out |
+| Test | [#388](https://github.com/markheydon/solo-dev-board/issues/388) Repo Management | `size/s` | medium | `area/dashboard` | Feature close-out |
+
+## Existing stories (spec upgrade)
+
+| # | Page | Size after spec | Depends on |
+|---|------|-----------------|------------|
+| 273 | Daily Focus — board state | `size/m` | Item catalogue, settings |
+| 274 | Daily Focus — top 3 | `size/m` | Work-item catalogue, settings |
+| 275 | Daily Focus — Up Next stall | `size/s` | Item catalogue, 273 |
+| 276 | Daily Focus — PR review stall | `size/s` | Work-item catalogue, 273 |
+| 277 | Backlog — grouped view | `size/l` | Work-item catalogue, settings |
+| 278 | Backlog — missing core labels | `size/s` | 277 |
+| 279 | Backlog — epics near complete | `size/m` | Work-item catalogue, 277 |
+| 280 | Backlog — issue vs PR chips | `size/xs` | 277 |
+| 281 | Backlog — neglected repos | `size/s` | Work-item catalogue, 277 |
+| 282 | Backlog — priority/high surface | `size/s` | 277 |
+| 283 | Planning — add to Up Next | `size/l` | Item catalogue, 274 or 277 for candidates |
+| 284 | Planning — capacity | `size/m` | Settings, 283 |
+| 285 | Planning — resolve stalled first | `size/m` | 275, 283 |
+| 286 | Planning — bulk milestone | `size/s` | 283 |
+| 287 | Repos — exclusions | `size/m` | Settings enabler |
+| 288 | Repos — counts summary | `size/s` | Work-item catalogue, 287 |
+
+## Blocking relationships (set in GitHub)
+
+Sub-issues: all rows below are children of **#272**.
+
+| Blocking | Blocked | Type |
+|----------|---------|------|
+| #382 item catalogue | #273, #275, #283, #284, #285 | blocks |
+| #383 settings | #273, #274, #277, #284, #287 | blocks |
+| #384 work-item catalogue | #274, #276, #277, #279, #281, #288 | blocks |
+| #287 | #274, #277, #283, #288 (query scope; board occupancy on #273 does not wait) | blocks |
+| #273 | #275, #276 | blocks |
+| #277 | #278, #279, #280, #281, #282 | blocks |
+| #283 | #284, #285, #286 | blocks |
+| #275 | #285 | blocks |
+| Each area test | corresponding stories (tests blocked by stories) | blocks |
+
+Suggested delivery order (Up Next later, not this session):
+
+1. Three enablers (item catalogue and work-item catalogue can proceed in parallel after settings is started).
+2. #287 then #288.
+3. #273 then #274, #275, #276.
+4. #277 then #278–#282.
+5. #283 then #284–#286.
+6. Four test issues in parallel with the last story in each area.
+
+## Do not
+
+- Set Project **Phase** (v1.1.0 leaves Phase blank).
+- Set Start/Target dates at planning time.
+- Put Features in Up Next.
+- Merge #280/#282 into #277 on the board; keep slices, same route.

--- a/plan/cross-repo-pm-workflow-project-plan.md
+++ b/plan/cross-repo-pm-workflow-project-plan.md
@@ -1,0 +1,115 @@
+# Cross-Repo PM Workflow — project plan
+
+## Project overview
+
+### Feature summary
+
+Ship a visual two-mode PM operating system inside SoloDevBoard (feature [#272](https://github.com/markheydon/solo-dev-board/issues/272), milestone **v1.1.0**). PM Mode (weekly/fortnightly) reviews the backlog and curates **Up Next**. Work Mode (daily) uses Daily Focus as a morning nudge while the selected Projects v2 board remains the execution pane of glass.
+
+The sixteen child stories (#273–#288) were created as one-line stubs. This plan specifies them as slices of **four pages**, plus three **enablers** (API and settings) and four **test** issues. [#272](https://github.com/markheydon/solo-dev-board/issues/272) stays a Feature with no parent Epic (DEC-027 catch-up exception).
+
+### Success criteria
+
+- A signed-in user can select a planning board and see Status occupancy plus active load.
+- Daily Focus lists stalled Up Next items, stalled review PRs, and three recommended unblocked items.
+- Backlog Review groups cross-repo issues and PRs by urgency, flags missing `type/` or `priority/` labels, near-complete epics, and neglected repositories.
+- Iteration Planning moves selected items to Up Next with Focus Order, enforces a soft capacity limit, and requires stalled Up Next resolution first.
+- Excluded repositories persist in the browser and are omitted from PM queries (except raw board occupancy).
+- User guide `website/content/docs/pm-workflow.md` can drop `draft: true` only when the four pages match the guide; Playwright maps the published page.
+
+### Key milestones (no calendar dates)
+
+1. Enablers: project item GraphQL, work-item catalogue, localStorage settings.
+2. Repo Management UI (board, exclusions, thresholds, per-repo counts).
+3. Daily Focus read-only view.
+4. Backlog Review read-only view.
+5. Iteration Planning writes (Up Next, stall resolution, optional milestone).
+6. Tests, user guide, E2E alignment, docs-capture screenshots.
+
+### Risk assessment
+
+| Risk | Mitigation |
+|------|------------|
+| No project-item **read** API today | Enabler ships GraphQL item catalogue before UI stories. |
+| Hosted App cannot see private user-owned boards | Reuse inaccessible-board warning; PAT mode remains the path for private boards (#293). |
+| Rate limits from fan-out across many repos | Bound parallelism; reuse Audit-style per-repo fetch; do not cache issue lists unless a follow-up to DEC-018 is recorded. |
+| Stall clock without Status-changed-at | Prefer field-updated timestamp; document fallback to item `updatedAt`. |
+| Overlapping stories (#280, #282 vs #277) | Same page, incremental acceptance criteria; do not add extra routes. |
+
+## Work item hierarchy
+
+```mermaid
+graph TD
+    F["Feature #272 Cross-Repo PM Workflow"] --> E1["Enabler: Projects v2 item catalogue"]
+    F --> E2["Enabler: PM settings persistence"]
+    F --> E3["Enabler: Cross-repo work-item catalogue"]
+    F --> R["Stories #287–#288 Repo Management"]
+    F --> D["Stories #273–#276 Daily Focus"]
+    F --> B["Stories #277–#282 Backlog Review"]
+    F --> P["Stories #283–#286 Iteration Planning"]
+    F --> T["Tests: four area issues"]
+    E1 --> D
+    E1 --> P
+    E2 --> R
+    E2 --> D
+    E2 --> B
+    E2 --> P
+    E3 --> D
+    E3 --> B
+    E3 --> R
+    R --> D
+    D --> P
+    B --> P
+```
+
+## GitHub issues breakdown
+
+See [cross-repo-pm-workflow-issues-checklist.md](cross-repo-pm-workflow-issues-checklist.md) for labels, sizes, and blocking edges.
+
+### Pages and MudBlazor
+
+| Page | MudBlazor first | Avoid |
+|------|-----------------|-------|
+| Shell | `MudTabs` / `MudSelect` / `MudAlert` / `MudButton` | Custom tab CSS |
+| Daily Focus | `MudPaper` KPI chips, `MudSimpleTable` or `MudList` | Hard-coded Project #8 option ids |
+| Backlog | `MudExpansionPanels`, `MudChip`, `MudTextField` search | Duplicate Audit Dashboard layout |
+| Planning | `MudProgressLinear` capacity, `MudDialog` confirm, `MudCheckBox` picker | Unconditional writes |
+| Repos | `MudNumericField`, `MudSwitch`/`MudChip` exclude list, `MudTable` | Server database |
+
+### Technical approach (enablers)
+
+1. **Projects v2 item catalogue** — extend `IGitHubService` with GraphQL `node(id: project) { ... on ProjectV2 { items { ... Status, Focus Order, content, updatedAt } } } }` plus writes already used by Triage (`updateProjectV2ItemFieldValue` for Status and number Focus Order). Discover field ids from the board, same as Status options today.
+2. **PM settings** — `IPmSettingsService` + JS localStorage (mirror theme preference). Defaults: capacity 8, stall days 3, neglect days 14, empty exclusion list.
+3. **Work-item catalogue** — fan-out `GetIssuesAsync` / `GetPullRequestsAsync` across included repos; map to `PmWorkItemDto` with labels, milestone, URL, updated-at. Label helpers for `type/`, `priority/`, `status/`. Epic-near-complete uses GraphQL sub-issue summary on open `type/epic` (and `type/feature` if useful) issues.
+
+### Definition of done (feature)
+
+- [ ] All child stories, enablers, and tests closed or explicitly deferred.
+- [ ] Wireframe behaviour present on the four routes.
+- [ ] Unit tests for services; bUnit for page shells; Playwright spec for `/pm-workflow` empty/error/nav.
+- [ ] `website/content/docs/pm-workflow.md` published (not draft) and `tests/E2E/USER_DOCS_ALIGNMENT.md` updated.
+- [ ] No secrets in localStorage.
+
+## Priority and value
+
+| Slice | Priority | Notes |
+|-------|----------|--------|
+| Enablers | `priority/high` | Critical path |
+| Repo Management | `priority/high` | Unlocks correct query scope |
+| Daily Focus | `priority/high` | First user-visible value |
+| Backlog Review | `priority/medium` | PM Mode |
+| Iteration Planning | `priority/medium` | Writes; after read views |
+| Tests | `priority/medium` | Pair with each slice |
+
+## Dependency management
+
+**Blocking (must set in GitHub UI or via GraphQL):** listed in the issues checklist.
+
+**Related, not blocking:** #293 (hosted private boards), Audit Dashboard reuse, Triage board discovery, DEC-014 Roadmap Sync (reference for Status semantics, not a runtime dependency).
+
+## Implementation references
+
+- Wireframe: `plan/wireframes/pm-workflow-wireframe.md`
+- Decisions: DEC-008, DEC-018, DEC-027, DEC-028, DEC-029
+- User guide stub: `website/content/docs/pm-workflow.md`
+- Access limitation: `plan/GITHUB_PROJECTS_V2_ACCESS.md`

--- a/plan/cross-repo-pm-workflow-test-strategy.md
+++ b/plan/cross-repo-pm-workflow-test-strategy.md
@@ -1,0 +1,82 @@
+# Cross-Repo PM Workflow — test strategy
+
+## Scope
+
+Validate feature [#272](https://github.com/markheydon/solo-dev-board/issues/272) against `plan/wireframes/pm-workflow-wireframe.md` and `website/content/docs/pm-workflow.md`.
+
+Layers:
+
+| Layer | Where | What |
+|-------|--------|------|
+| Unit | `tests/Application` (and Domain if records need tests) | Ranking, stall detection, grouping, capacity, exclusion filter, label helpers |
+| Component | `tests/App` bUnit | Tab shell, empty/error/loading, disabled Planning add when stalled |
+| E2E | `tests/E2E/tests/pm-workflow.spec.ts` | Nav, four routes, no-board and load-failure shells (CI placeholder auth) |
+| Docs-capture | `tests/E2E/docs-capture/` | Public-only screenshots after UI exists (DEC-020) |
+
+Do not test AppHost orchestration.
+
+## Quality objectives
+
+- Stall and capacity rules are deterministic and unit-tested (3-day and 14-day boundaries inclusive).
+- UI never hard-codes Project #8 field ids.
+- Playwright CI does not require a live PAT; it asserts shell copy aligned with the user guide.
+- UK English in assertions (`colour` not required here; “organisation” not used).
+
+## Risks
+
+| Risk | Test |
+|------|------|
+| Wrong stall timestamp | Unit tests with injected clock and Status-changed-at vs `updatedAt` fallback |
+| Excluded repo still in recommendations | Unit: catalogue filter; bUnit: summary table |
+| Planning write without resolving stall | bUnit: add button disabled |
+| Hosted inaccessible board | bUnit/E2E: warning text already used by Triage |
+| Guide published while draft behaviour remains | Keep `draft: true` until E2E mapping lands in the same PR as publish |
+
+## Coverage by area
+
+### Enablers
+
+- GraphQL mapping: items, Status name, Focus Order, content number/repo.
+- Settings round-trip fake storage.
+- Work items: label parse, priority rank, blocked/ice-box exclusion, issue vs PR.
+
+### Daily Focus (#273–#276)
+
+- Column counts from fixture boards with extra Status names.
+- Active load = Up Next + In Progress.
+- Top 3 ranking table.
+- Stall inclusive of day 3.
+
+### Backlog (#277–#282)
+
+- Group membership decision table (urgent, ready, triage, parked, neglected).
+- Epic complete: `subIssues.total > 0` and `completed == total`.
+- Chip for Issue vs PR.
+
+### Planning (#283–#286)
+
+- Focus Order assignment skips Feature/Epic.
+- Capacity dialog when exceeding limit.
+- Milestone skip list for repos without that milestone.
+
+### Repo Management (#287–#288)
+
+- Exclude/include persistence.
+- Counts ignore excluded repos.
+
+## E2E alignment
+
+When the guide is published, add a row to `tests/E2E/USER_DOCS_ALIGNMENT.md`:
+
+| Guide | Routes | Spec | CI |
+|-------|--------|------|-----|
+| `pm-workflow.md` | `/pm-workflow`, `/pm-workflow/daily-focus`, `/pm-workflow/backlog`, `/pm-workflow/planning`, `/pm-workflow/repos` | `pm-workflow.spec.ts` | Tier 2 shell |
+
+Update `tests/E2E/CRITICAL_JOURNEYS.md` with the morning-focus and planning-session journeys.
+
+## Definition of done (tests)
+
+- [ ] Four `type/test` issues closed with the paired stories.
+- [ ] xUnit naming `MethodUnderTest_Scenario_ExpectedOutcome`.
+- [ ] NSubstitute + `Assert.*` only.
+- [ ] Alignment docs updated in the PR that publishes the user guide.

--- a/plan/product-site-project-plan.md
+++ b/plan/product-site-project-plan.md
@@ -46,7 +46,7 @@ Turn the Hugo/Hextra site into the **public product site** for SoloDevBoard: mar
 | Domain/rename enabler | #361 | #358 | sub-issue (blocks deploy) |
 | Hugo test issue | #362 | #358 | sub-issue |
 
-GitHub CLI cannot set sub-issue relationships; link manually in the GitHub UI after creation.
+Sub-issues and blocking are set by agents via MCP `sub_issue_write` and REST issue-dependencies (`gh api`), not by clicking the GitHub UI. See `.agents/skills/repo-github-gh-cli/SKILL.md`.
 
 ## Implementation references
 

--- a/plan/wireframes/README.md
+++ b/plan/wireframes/README.md
@@ -16,6 +16,7 @@ This directory contains planning-only wireframe references for key SoloDevBoard 
 - [board-rules-visualiser-wireframe.md](board-rules-visualiser-wireframe.md): Board Rules Visualiser wireframe, repository/project selection, interactive diagram, rule detail and conflict panels, compare mode, and responsive layout.
 - [workflow-templates-wireframe.md](workflow-templates-wireframe.md): Workflow Templates page wireframe, template browser, parameter editor, apply-to-repository flow, status/feedback region, and responsive layout.
 - [auth-entry-wireframe.md](auth-entry-wireframe.md): Hosted sign-in landing page, PAT connectivity shell indicator, recovery pages, and manual test scenarios for issues #249 and #314.
+- [pm-workflow-wireframe.md](pm-workflow-wireframe.md): Cross-Repo PM Workflow hub, Daily Focus, Backlog Review, Iteration Planning, and Repo Management for feature #272.
 - [product-site-landing-wireframe.md](product-site-landing-wireframe.md): Public product site landing (`/`), navigation, feature grid, and release version badge.
 - [product-site-about-wireframe.md](product-site-about-wireframe.md): Product About/history section (`/about/`), origin and AI-collaborator narrative pages.
 

--- a/plan/wireframes/pm-workflow-wireframe.md
+++ b/plan/wireframes/pm-workflow-wireframe.md
@@ -1,0 +1,185 @@
+# Cross-Repo PM Workflow Wireframe
+
+## Purpose
+
+The Cross-Repo PM Workflow is a four-page planning area inside SoloDevBoard. It replaces the prompt-and-script operating system from [markheydon/github-workflows](https://github.com/markheydon/github-workflows) with a MudBlazor UI: a morning **Daily Focus**, a cross-repository **Backlog Review**, a guided **Iteration Planning** session that curates **Up Next**, and **Repo Management** for which repositories and which Projects v2 board participate.
+
+This wireframe is the planning baseline for feature [#272](https://github.com/markheydon/solo-dev-board/issues/272) (stories #273–#288 plus enablers and tests).
+
+## User Goals
+
+- See board occupancy and what to work on today without opening GitHub.
+- Review open work across repositories grouped by urgency.
+- Curate a realistic **Up Next** batch without over-committing.
+- Exclude personal or irrelevant repositories from PM operations.
+- Operate entirely with keyboard and MudBlazor primitives.
+
+## Information architecture
+
+Drawer entry: **PM Workflow** (`Icons.Material.Filled.ViewWeek`) linking to `/pm-workflow`.
+
+The hub is a `MudTabs` shell (or equivalent `MudNavLink` sub-nav) with four routes:
+
+| Tab | Route | Primary stories |
+|-----|-------|-----------------|
+| Daily Focus | `/pm-workflow/daily-focus` | #273–#276 |
+| Backlog | `/pm-workflow/backlog` | #277–#282 |
+| Planning | `/pm-workflow/planning` | #283–#286 |
+| Repos | `/pm-workflow/repos` | #287–#288 |
+
+Shared chrome on every tab:
+
+- Planning board selector (`MudSelect`) — required before data loads.
+- Short status line: selected board title, repository count after exclusions, last refreshed time, refresh button.
+- Inaccessible private Projects v2 warning (reuse Triage/Board Rules copy; see `plan/GITHUB_PROJECTS_V2_ACCESS.md` and #293).
+
+## Shared chrome
+
+```
++------------------------------------------------------------------+
+| PM Workflow                                                      |
++------------------------------------------------------------------+
+| Board: [ SoloDevBoard Roadmap v ]   Repos: 12 included   [Refresh]
+| [Daily Focus] [Backlog] [Planning] [Repos]                       |
+|------------------------------------------------------------------|
+| (tab content)                                                    |
++------------------------------------------------------------------+
+```
+
+## Daily Focus (`/pm-workflow/daily-focus`)
+
+```
++------------------------------------------------------------------+
+| Board state                                                      |
+| [Todo 14] [Up Next 4] [In Progress 2] [Blocked 1] [Ice Box 6]    |
+| [Done 3]   Active load: 6 / 8 (Up Next + In Progress)            |
+|------------------------------------------------------------------|
+| Stalled                                                          |
+| Up Next 3+ days:  #275 title  (4d)  [Open]                       |
+| PRs awaiting review 3+ days:  owner/repo#12  (5d)  [Open]        |
+|------------------------------------------------------------------|
+| Recommended today (top 3 unblocked)                              |
+| 1. [priority/high] owner/repo#40  Title…                         |
+| 2. [priority/medium] owner/repo#41 Title…                        |
+| 3. [priority/medium] owner/repo#42 Title…                        |
++------------------------------------------------------------------+
+```
+
+### Interaction notes
+
+- Column chips are read-only counts for Status options discovered on the selected board (do not hard-code Project #8 option ids).
+- **Active load** is Up Next + In Progress item count; the denominator is the configurable capacity from Repo Management (default 8).
+- Stalled **Up Next** uses time in that Status (prefer Status-changed-at; fall back to item updated-at with a footnote).
+- Stalled PRs: if the board has an **In Review** (or equivalent) Status, use time in that column. Otherwise use open, non-draft PRs with pending review (`reviewDecision` pending or requested reviewers) aged three or more days.
+- Top three: unblocked (`status/blocked` absent, board Status not Blocked/Ice Box), ranked `priority/critical` > `high` > `medium` > `low` > unlabelled, then recency. Exclude items already In Progress.
+- Empty, loading, and GitHub error states use `MudAlert` plus retry, matching Audit Dashboard.
+
+## Backlog Review (`/pm-workflow/backlog`)
+
+```
++------------------------------------------------------------------+
+| Filter: [All types v] [All repos v]   Search [            ]      |
+|------------------------------------------------------------------|
+| Urgent (priority/high and critical)                              |
+|  [Issue] owner/repo#10 Title  labels…                            |
+|  [PR]    owner/repo#11 Title                                     |
+|------------------------------------------------------------------|
+| Ready to start                                                   |
+|  unblocked stories/bugs not on Up Next / In Progress             |
+|------------------------------------------------------------------|
+| Awaiting triage (missing type/ or priority/)                     |
+|------------------------------------------------------------------|
+| Blocked / deferred (status/blocked, status/ice-box, board park)  |
+|------------------------------------------------------------------|
+| Epics near completion (open parent, all children closed)         |
+|------------------------------------------------------------------|
+| Neglected repositories (no issue/PR activity in 14 days)         |
++------------------------------------------------------------------+
+```
+
+### Interaction notes
+
+- Groups are `MudExpansionPanel` sections with counts in the header.
+- Issue versus pull request is a `MudChip` on every row (#280). Do not split into separate pages.
+- **Urgent** is the `priority/high` and `priority/critical` surface (#282). It is the first panel, not a separate route.
+- **Core labels** for #278 are `type/` and `priority/` (the same pair AGENTS.md requires on new issues). Items missing either are awaiting triage.
+- Rows are read-only with an external GitHub link. Adding to Up Next happens on the Planning tab.
+- Neglected repos list repository full name, last issue/PR activity date (or never), and open counts.
+
+## Iteration Planning (`/pm-workflow/planning`)
+
+```
++------------------------------------------------------------------+
+| Capacity  [========    ]  6 / 8   Warns in amber when at limit   |
+|------------------------------------------------------------------|
+| Resolve stalled Up Next before adding                            |
+|  #275  4d  [Re-commit] [Mark Blocked] [Ice Box] [Remove]         |
+|------------------------------------------------------------------|
+| Candidate picker                                                 |
+|  Search across included repos   [ ] issues  [ ] PRs              |
+|  [ ] owner/repo#50  Title   [Add to Up Next]                     |
+|------------------------------------------------------------------|
+| This batch (Up Next)                                             |
+|  1. #40  [Focus Order]   2. #41                                  |
+|  [Assign milestone to selected: v1.1.0 v] [Apply]                |
++------------------------------------------------------------------+
+```
+
+### Interaction notes
+
+- Adding new items is disabled (with explanation) while any stalled Up Next item remains unresolved (#285). **Re-commit** clears stall by recording a fresh Status touch (move away and back, or update Focus Order) so the three-day clock restarts; document the exact GraphQL approach in the enabler notes.
+- **Mark Blocked** / **Ice Box** set board Status and apply `status/blocked` or `status/ice-box` on the issue (DEC-028). **Remove** returns the item to Todo and clears Focus Order.
+- New Up Next items receive sequential Focus Order (stories, enablers, and tests only; skip Feature/Epic parents).
+- Capacity warning is not a hard stop: the user can exceed the limit after confirming a `MudDialog`.
+- Bulk milestone (#286) is optional and applies only to selected batch items that belong to repositories where that milestone exists; skip others with a snackbar summary.
+
+## Repo Management (`/pm-workflow/repos`)
+
+```
++------------------------------------------------------------------+
+| Planning board  [ SoloDevBoard Roadmap v ]                       |
+| Capacity limit  [ 8 ]     Stall days  [ 3 ]   Neglect days [ 14 ]|
+|------------------------------------------------------------------|
+| Excluded repositories                                            |
+|  Search catalogue  [ ] owner/personal-site  [Exclude]            |
+|  Currently excluded: owner/dotfiles  [Include]                   |
+|------------------------------------------------------------------|
+| Per-repository summary                                           |
+|  Repo              Issues  PRs  Last activity  Included?         |
+|  owner/solo-dev-board  12    2   2 days ago     Yes              |
++------------------------------------------------------------------+
+```
+
+### Interaction notes
+
+- Settings persist in browser `localStorage` (DEC-029), same pattern as theme preference.
+- Exclusion applies to Daily Focus recommendations, Backlog, Planning candidates, and the summary table. The planning **board** itself is independent of repo exclusion (a user-owned board can span excluded repos; those cards still appear on board-state counts).
+- Archived GitHub repositories are omitted from the include list by default (reuse `GetActiveRepositoriesAsync`).
+- Persist: selected board node id, capacity, stall days, neglect days, excluded `owner/name` list.
+
+## State variants
+
+- **No board selected:** tabs show an instructional alert; data tables hidden.
+- **Loading:** `MudProgressLinear` indeterminate at top of tab.
+- **Partial failure:** some repos failed; show count and retry those.
+- **Empty catalogue:** no active repositories after exclusion.
+- **Hosted inaccessible boards:** warning plus PAT-mode guidance.
+
+## Accessibility notes
+
+- Tabs, selects, and tables use MudBlazor keyboard support; do not invent custom focus traps.
+- Status counts and capacity are announced with `aria-live="polite"` on refresh.
+- Colour is not the only stall signal; include day counts in text.
+- Prefer MudBlazor layout primitives and utility `Class` attributes; no new `.razor.css` unless a documented gap remains.
+
+## Responsive behaviour
+
+- Below `md`, the tab strip scrolls horizontally; KPI chips wrap; tables become stacked cards (`MudHidden` / breakpoint classes).
+- Capacity bar remains visible at the top of Planning on all widths.
+
+## Out of scope for this wireframe
+
+- Editing issue body content.
+- Creating new GitHub Projects.
+- Real-time multi-user collaboration.
+- Making private user-owned Projects v2 work under hosted GitHub App sign-in (#293).


### PR DESCRIPTION
## Summary of Changes

Add the Cross-Repo PM Workflow planning pack (wireframe, project plan, test strategy, DEC-029) and update agent contracts so sub-issues and blocking relationships are set via API instead of GitHub UI chores.

## Related Issue(s)

References #272

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [ ] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [ ] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — planning and agent-documentation only.

## Additional Notes

This PR does not implement the PM Workflow UI. Issue bodies for #272–#288 and new children #382–#388 were updated on GitHub directly. User guide `website/content/docs/pm-workflow.md` stays draft until delivery.

Do not close #272 from this PR.


Made with [Cursor](https://cursor.com)