### PR TITLE
[Enabler] Add PM Workflow project item and work-item catalogues (#382, #384)

### DIFF
--- a/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<ITriageService, TriageService>();
         services.AddScoped<IWorkflowTemplateService, WorkflowTemplateService>();
         services.AddScoped<IPmSettingsService, PmSettingsService>();
+        services.AddScoped<IPmWorkItemCatalogueService, PmWorkItemCatalogueService>();
 
         return services;
     }

--- a/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<ITriageService, TriageService>();
         services.AddScoped<IWorkflowTemplateService, WorkflowTemplateService>();
         services.AddScoped<IPmSettingsService, PmSettingsService>();
+        services.AddScoped<IProjectItemCatalogueService, ProjectItemCatalogueService>();
 
         return services;
     }

--- a/src/Application/SoloDevBoard.Application/Services/GitHub/IGitHubService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/GitHub/IGitHubService.cs
@@ -1,6 +1,7 @@
 using SoloDevBoard.Application.Services.BoardRules;
 using SoloDevBoard.Domain.Entities.Labels;
 using SoloDevBoard.Domain.Entities.Milestones;
+using SoloDevBoard.Domain.Entities.PmWorkflow;
 using SoloDevBoard.Domain.Entities.Repositories;
 using SoloDevBoard.Domain.Entities.Triage;
 using SoloDevBoard.Domain.Entities.Workflows;
@@ -162,6 +163,38 @@ public interface IGitHubService
         string projectItemId,
         string statusFieldId,
         string statusOptionId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves all project board items with Status, optional Focus Order, and linked content.</summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The project board item catalogue including discovered field identifiers.</returns>
+    Task<ProjectBoardItemCatalogue> GetProjectBoardItemsAsync(string projectId, CancellationToken cancellationToken = default);
+
+    /// <summary>Sets the Focus Order number field on a project board item.</summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="projectItemId">The project-item node identifier.</param>
+    /// <param name="focusOrderFieldId">The Focus Order field node identifier.</param>
+    /// <param name="focusOrder">The Focus Order value to set.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous update operation.</returns>
+    Task UpdateProjectBoardItemFocusOrderAsync(
+        string projectId,
+        string projectItemId,
+        string focusOrderFieldId,
+        double focusOrder,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Clears the Focus Order number field on a project board item.</summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="projectItemId">The project-item node identifier.</param>
+    /// <param name="focusOrderFieldId">The Focus Order field node identifier.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous clear operation.</returns>
+    Task ClearProjectBoardItemFocusOrderAsync(
+        string projectId,
+        string projectItemId,
+        string focusOrderFieldId,
         CancellationToken cancellationToken = default);
 
     /// <summary>Closes a triage item as duplicate and records a duplicate reference comment.</summary>

--- a/src/Application/SoloDevBoard.Application/Services/GitHub/IGitHubService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/GitHub/IGitHubService.cs
@@ -1,6 +1,7 @@
 using SoloDevBoard.Application.Services.BoardRules;
 using SoloDevBoard.Domain.Entities.Labels;
 using SoloDevBoard.Domain.Entities.Milestones;
+using SoloDevBoard.Domain.Entities.PmWorkflow;
 using SoloDevBoard.Domain.Entities.Repositories;
 using SoloDevBoard.Domain.Entities.Triage;
 using SoloDevBoard.Domain.Entities.Workflows;
@@ -173,4 +174,30 @@ public interface IGitHubService
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous duplicate closure operation.</returns>
     Task CloseTriageItemAsDuplicateAsync(string owner, string repo, GitHubTriageItemType itemType, int itemNumber, string duplicateReference, CancellationToken cancellationToken = default);
+
+    #region Work-item catalogue methods
+
+    /// <summary>Retrieves review-pending metadata for open pull requests in the specified repository.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>Review metadata keyed by pull request number.</returns>
+    Task<IReadOnlyList<PullRequestReviewMetadata>> GetOpenPullRequestReviewMetadataAsync(
+        string owner,
+        string repo,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves tracked sub-issue summary counts for the specified open issues.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="issueNumbers">Repository-scoped issue numbers to inspect.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>Sub-issue totals for issues that expose tracked sub-issues.</returns>
+    Task<IReadOnlyList<IssueSubIssueSummary>> GetIssueSubIssueSummariesAsync(
+        string owner,
+        string repo,
+        IReadOnlyList<int> issueNumbers,
+        CancellationToken cancellationToken = default);
+
+    #endregion
 }

--- a/src/Application/SoloDevBoard.Application/Services/GitHub/IGitHubService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/GitHub/IGitHubService.cs
@@ -209,7 +209,10 @@ public interface IGitHubService
 
     #region Work-item catalogue methods
 
-    /// <summary>Retrieves review-pending metadata for open pull requests in the specified repository.</summary>
+    /// <summary>
+    /// Retrieves review-pending metadata for open pull requests in the specified repository.
+    /// Paginates through all open pull requests when a repository has more than 100.
+    /// </summary>
     /// <param name="owner">The GitHub account owner login.</param>
     /// <param name="repo">The repository name.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
@@ -219,7 +222,10 @@ public interface IGitHubService
         string repo,
         CancellationToken cancellationToken = default);
 
-    /// <summary>Retrieves tracked sub-issue summary counts for the specified open issues.</summary>
+    /// <summary>
+    /// Retrieves tracked sub-issue summary counts for the specified open issues.
+    /// Queries only the requested issue numbers and paginates tracked sub-issues for accurate completion counts.
+    /// </summary>
     /// <param name="owner">The GitHub account owner login.</param>
     /// <param name="repo">The repository name.</param>
     /// <param name="issueNumbers">Repository-scoped issue numbers to inspect.</param>

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IPmWorkItemCatalogueService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IPmWorkItemCatalogueService.cs
@@ -1,0 +1,13 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Loads open issues and pull requests across included active repositories for PM views.</summary>
+public interface IPmWorkItemCatalogueService
+{
+    /// <summary>
+    /// Builds the PM work-item catalogue for all active repositories that are not excluded in PM settings.
+    /// Partial per-repository failures are returned alongside successfully loaded items.
+    /// </summary>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The catalogue items and any repository-level failures.</returns>
+    Task<PmWorkItemCatalogueResultDto> GetCatalogueAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IProjectItemCatalogueService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IProjectItemCatalogueService.cs
@@ -1,0 +1,37 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Provides PM workflow access to GitHub Project v2 board item catalogues.</summary>
+public interface IProjectItemCatalogueService
+{
+    /// <summary>Retrieves all items and discovered field identifiers for a project board.</summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The project board item catalogue.</returns>
+    Task<ProjectBoardItemCatalogueDto> GetCatalogueAsync(string projectId, CancellationToken cancellationToken = default);
+
+    /// <summary>Sets the Focus Order number on a project board item.</summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="projectItemId">The project-item node identifier.</param>
+    /// <param name="focusOrderFieldId">The Focus Order field node identifier discovered from the board.</param>
+    /// <param name="focusOrder">The Focus Order value to set.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous update operation.</returns>
+    Task UpdateFocusOrderAsync(
+        string projectId,
+        string projectItemId,
+        string focusOrderFieldId,
+        double focusOrder,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Clears the Focus Order number on a project board item.</summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="projectItemId">The project-item node identifier.</param>
+    /// <param name="focusOrderFieldId">The Focus Order field node identifier discovered from the board.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous clear operation.</returns>
+    Task ClearFocusOrderAsync(
+        string projectId,
+        string projectItemId,
+        string focusOrderFieldId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmLabelHelpers.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmLabelHelpers.cs
@@ -1,0 +1,131 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Parses SoloDevBoard label prefixes used by the PM workflow.</summary>
+public static class PmLabelHelpers
+{
+    /// <summary>The prefix for <c>type/</c> labels.</summary>
+    public const string TypePrefix = "type/";
+
+    /// <summary>The prefix for <c>priority/</c> labels.</summary>
+    public const string PriorityPrefix = "priority/";
+
+    /// <summary>The prefix for <c>status/</c> labels.</summary>
+    public const string StatusPrefix = "status/";
+
+    /// <summary>The blocked status label name.</summary>
+    public const string BlockedStatusLabel = "status/blocked";
+
+    /// <summary>The ice-box status label name.</summary>
+    public const string IceBoxStatusLabel = "status/ice-box";
+
+    /// <summary>The epic type label name.</summary>
+    public const string EpicTypeLabel = "type/epic";
+
+    /// <summary>The feature type label name.</summary>
+    public const string FeatureTypeLabel = "type/feature";
+
+    /// <summary>The critical priority label name.</summary>
+    public const string CriticalPriorityLabel = "priority/critical";
+
+    /// <summary>The high priority label name.</summary>
+    public const string HighPriorityLabel = "priority/high";
+
+    /// <summary>Parses the first <c>type/</c> label from the supplied label names.</summary>
+    /// <param name="labels">Label names to inspect.</param>
+    /// <returns>The matching label name, or <see langword="null"/> when none is present.</returns>
+    public static string? ParseTypeLabel(IReadOnlyList<string> labels)
+        => ParsePrefixedLabel(labels, TypePrefix);
+
+    /// <summary>Parses the first <c>priority/</c> label from the supplied label names.</summary>
+    /// <param name="labels">Label names to inspect.</param>
+    /// <returns>The matching label name, or <see langword="null"/> when none is present.</returns>
+    public static string? ParsePriorityLabel(IReadOnlyList<string> labels)
+        => ParsePrefixedLabel(labels, PriorityPrefix);
+
+    /// <summary>Parses the first <c>status/</c> label from the supplied label names.</summary>
+    /// <param name="labels">Label names to inspect.</param>
+    /// <returns>The matching label name, or <see langword="null"/> when none is present.</returns>
+    public static string? ParseStatusLabel(IReadOnlyList<string> labels)
+        => ParsePrefixedLabel(labels, StatusPrefix);
+
+    /// <summary>Determines whether the item is blocked via <c>status/blocked</c>.</summary>
+    /// <param name="labels">Label names to inspect.</param>
+    /// <returns><see langword="true"/> when the blocked status label is present.</returns>
+    public static bool IsBlocked(IReadOnlyList<string> labels)
+        => ContainsLabel(labels, BlockedStatusLabel);
+
+    /// <summary>Determines whether the item is shelved via <c>status/ice-box</c>.</summary>
+    /// <param name="labels">Label names to inspect.</param>
+    /// <returns><see langword="true"/> when the ice-box status label is present.</returns>
+    public static bool IsIceBoxed(IReadOnlyList<string> labels)
+        => ContainsLabel(labels, IceBoxStatusLabel);
+
+    /// <summary>Determines whether the item is blocked or deferred.</summary>
+    /// <param name="labels">Label names to inspect.</param>
+    /// <returns><see langword="true"/> when a blocked or ice-box status label is present.</returns>
+    public static bool IsBlockedOrDeferred(IReadOnlyList<string> labels)
+        => IsBlocked(labels) || IsIceBoxed(labels);
+
+    /// <summary>Determines whether the item is unblocked for recommendation and ready-to-start groups.</summary>
+    /// <param name="labels">Label names to inspect.</param>
+    /// <returns><see langword="true"/> when neither blocked nor ice-box status labels are present.</returns>
+    public static bool IsUnblocked(IReadOnlyList<string> labels)
+        => !IsBlockedOrDeferred(labels);
+
+    /// <summary>Determines whether the item is missing a core <c>type/</c> or <c>priority/</c> label.</summary>
+    /// <param name="labels">Label names to inspect.</param>
+    /// <returns><see langword="true"/> when either core label prefix is absent.</returns>
+    public static bool IsAwaitingTriage(IReadOnlyList<string> labels)
+        => ParseTypeLabel(labels) is null || ParsePriorityLabel(labels) is null;
+
+    /// <summary>Determines whether the item belongs in the urgent backlog group.</summary>
+    /// <param name="labels">Label names to inspect.</param>
+    /// <returns><see langword="true"/> when a critical or high priority label is present.</returns>
+    public static bool IsUrgent(IReadOnlyList<string> labels)
+    {
+        var priority = ParsePriorityLabel(labels);
+        return priority is CriticalPriorityLabel or HighPriorityLabel;
+    }
+
+    /// <summary>
+    /// Determines whether an open epic or feature is near completion because all tracked sub-issues are closed.
+    /// </summary>
+    /// <param name="labels">Label names to inspect.</param>
+    /// <param name="subIssueTotal">The tracked sub-issue total, when known.</param>
+    /// <param name="subIssueCompleted">The completed tracked sub-issue count, when known.</param>
+    /// <returns><see langword="true"/> when sub-issue counts indicate full completion.</returns>
+    public static bool IsEpicNearComplete(IReadOnlyList<string> labels, int? subIssueTotal, int? subIssueCompleted)
+    {
+        var typeLabel = ParseTypeLabel(labels);
+        if (typeLabel is not EpicTypeLabel and not FeatureTypeLabel)
+        {
+            return false;
+        }
+
+        return subIssueTotal is > 0 && subIssueCompleted == subIssueTotal;
+    }
+
+    private static string? ParsePrefixedLabel(IReadOnlyList<string> labels, string prefix)
+    {
+        ArgumentNullException.ThrowIfNull(labels);
+        ArgumentException.ThrowIfNullOrWhiteSpace(prefix);
+
+        foreach (var label in labels)
+        {
+            if (label.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return label;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool ContainsLabel(IReadOnlyList<string> labels, string expectedLabel)
+    {
+        ArgumentNullException.ThrowIfNull(labels);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedLabel);
+
+        return labels.Any(label => label.Equals(expectedLabel, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmPriorityRanker.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmPriorityRanker.cs
@@ -1,0 +1,45 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Ranks <c>priority/</c> labels for PM workflow ordering.</summary>
+public static class PmPriorityRanker
+{
+    /// <summary>Compares two priority labels for descending urgency (critical first, none last).</summary>
+    /// <param name="left">The left-hand priority label, or <see langword="null"/> for none.</param>
+    /// <param name="right">The right-hand priority label, or <see langword="null"/> for none.</param>
+    /// <returns>A negative value when <paramref name="left"/> is more urgent than <paramref name="right"/>.</returns>
+    public static int ComparePriority(string? left, string? right)
+        => GetRank(left).CompareTo(GetRank(right));
+
+    /// <summary>Returns the rank for a priority label where lower values are more urgent.</summary>
+    /// <param name="priorityLabel">The priority label name, or <see langword="null"/> for none.</param>
+    /// <returns>The rank value.</returns>
+    public static int GetRank(string? priorityLabel)
+    {
+        if (string.IsNullOrWhiteSpace(priorityLabel))
+        {
+            return 4;
+        }
+
+        if (priorityLabel.Equals(PmLabelHelpers.CriticalPriorityLabel, StringComparison.OrdinalIgnoreCase))
+        {
+            return 0;
+        }
+
+        if (priorityLabel.Equals(PmLabelHelpers.HighPriorityLabel, StringComparison.OrdinalIgnoreCase))
+        {
+            return 1;
+        }
+
+        if (priorityLabel.Equals("priority/medium", StringComparison.OrdinalIgnoreCase))
+        {
+            return 2;
+        }
+
+        if (priorityLabel.Equals("priority/low", StringComparison.OrdinalIgnoreCase))
+        {
+            return 3;
+        }
+
+        return 4;
+    }
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmRepositoryCatalogueFailureDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmRepositoryCatalogueFailureDto.cs
@@ -1,0 +1,10 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Describes a partial failure while loading PM work items for one repository.</summary>
+/// <param name="RepositoryFullName">The repository in <c>owner/name</c> form.</param>
+/// <param name="Message">A human-readable summary of what failed.</param>
+/// <param name="HttpStatusCode">The HTTP status code when the failure originated from the GitHub API.</param>
+public sealed record PmRepositoryCatalogueFailureDto(
+    string RepositoryFullName,
+    string Message,
+    int? HttpStatusCode);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmWorkItemCatalogueResultDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmWorkItemCatalogueResultDto.cs
@@ -1,0 +1,8 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Result of loading the cross-repository PM work-item catalogue.</summary>
+/// <param name="Items">Open issues and pull requests from included repositories.</param>
+/// <param name="Failures">Per-repository failures that did not prevent other repositories from loading.</param>
+public sealed record PmWorkItemCatalogueResultDto(
+    IReadOnlyList<PmWorkItemDto> Items,
+    IReadOnlyList<PmRepositoryCatalogueFailureDto> Failures);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmWorkItemCatalogueService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmWorkItemCatalogueService.cs
@@ -1,0 +1,290 @@
+using Microsoft.Extensions.Logging;
+using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Domain.Entities.PmWorkflow;
+using SoloDevBoard.Domain.Entities.Repositories;
+using SoloDevBoard.Domain.Entities.Triage;
+
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Loads open issues and pull requests across included active repositories for PM views.</summary>
+public sealed class PmWorkItemCatalogueService(
+    IGitHubService gitHubService,
+    IPmSettingsService pmSettingsService,
+    ILogger<PmWorkItemCatalogueService> logger) : IPmWorkItemCatalogueService
+{
+    private const string OpenItemState = "open";
+
+    /// <inheritdoc/>
+    public async Task<PmWorkItemCatalogueResultDto> GetCatalogueAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await pmSettingsService.GetSettingsAsync().ConfigureAwait(false);
+        var excludedRepositories = new HashSet<string>(
+            settings.ExcludedRepositories,
+            StringComparer.OrdinalIgnoreCase);
+
+        var repositories = await gitHubService.GetActiveRepositoriesAsync(cancellationToken).ConfigureAwait(false);
+        var includedRepositories = repositories
+            .Where(repository => !excludedRepositories.Contains(repository.FullName))
+            .ToArray();
+
+        var loadTasks = includedRepositories.Select(repository =>
+            LoadRepositoryCatalogueAsync(repository, cancellationToken));
+        var loadResults = await Task.WhenAll(loadTasks).ConfigureAwait(false);
+
+        var items = loadResults.SelectMany(static result => result.Items).ToArray();
+        var failures = loadResults
+            .Select(static result => result.Failure)
+            .Where(static failure => failure is not null)
+            .Select(static failure => failure!)
+            .ToArray();
+
+        return new PmWorkItemCatalogueResultDto(items, failures);
+    }
+
+    private async Task<RepositoryCatalogueLoadResult> LoadRepositoryCatalogueAsync(
+        Repository repository,
+        CancellationToken cancellationToken)
+    {
+        var owner = ParseOwnerLogin(repository.FullName);
+        var repoName = repository.Name;
+        var repositoryFullName = repository.FullName;
+
+        var issueResult = await TryLoadIssuesAsync(owner, repoName, cancellationToken).ConfigureAwait(false);
+        var pullRequestResult = await TryLoadPullRequestsAsync(owner, repoName, cancellationToken).ConfigureAwait(false);
+
+        PmRepositoryCatalogueFailureDto? failure = null;
+        if (issueResult.ErrorMessage is not null || pullRequestResult.ErrorMessage is not null)
+        {
+            failure = new PmRepositoryCatalogueFailureDto(
+                repositoryFullName,
+                CombineFailureMessages(issueResult.ErrorMessage, pullRequestResult.ErrorMessage),
+                issueResult.HttpStatusCode ?? pullRequestResult.HttpStatusCode);
+        }
+
+        var reviewMetadata = await TryLoadReviewMetadataAsync(owner, repoName, repositoryFullName, cancellationToken)
+            .ConfigureAwait(false);
+        var reviewMetadataByNumber = reviewMetadata.ToDictionary(static metadata => metadata.Number);
+
+        var epicFeatureIssueNumbers = issueResult.Items
+            .Where(static issue => IsOpenState(issue.State))
+            .Select(issue => (Issue: issue, Labels: issue.Labels.Select(static label => label.Name).ToArray()))
+            .Where(static pair => IsEpicOrFeature(pair.Labels))
+            .Select(pair => pair.Issue.Number)
+            .Distinct()
+            .ToArray();
+
+        var subIssueSummaries = await TryLoadSubIssueSummariesAsync(
+                owner,
+                repoName,
+                repositoryFullName,
+                epicFeatureIssueNumbers,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var subIssueSummaryByNumber = subIssueSummaries.ToDictionary(static summary => summary.Number);
+
+        var items = new List<PmWorkItemDto>(
+            issueResult.Items.Count(static issue => IsOpenState(issue.State))
+            + pullRequestResult.Items.Count(static pullRequest => IsOpenState(pullRequest.State)));
+
+        foreach (var issue in issueResult.Items.Where(static issue => IsOpenState(issue.State)))
+        {
+            var labels = issue.Labels.Select(static label => label.Name).ToArray();
+            subIssueSummaryByNumber.TryGetValue(issue.Number, out var subIssueSummary);
+
+            items.Add(MapIssue(
+                issue,
+                repositoryFullName,
+                labels,
+                subIssueSummary));
+        }
+
+        foreach (var pullRequest in pullRequestResult.Items.Where(static pullRequest => IsOpenState(pullRequest.State)))
+        {
+            reviewMetadataByNumber.TryGetValue(pullRequest.Number, out var reviewMetadataEntry);
+            var labels = pullRequest.Labels.Select(static label => label.Name).ToArray();
+
+            items.Add(MapPullRequest(
+                pullRequest,
+                repositoryFullName,
+                labels,
+                reviewMetadataEntry));
+        }
+
+        return new RepositoryCatalogueLoadResult(items, failure);
+    }
+
+    private async Task<LoadAttempt<IReadOnlyList<Issue>>> TryLoadIssuesAsync(
+        string owner,
+        string repoName,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var issues = await gitHubService
+                .GetIssuesAsync(owner, repoName, OpenItemState, cancellationToken)
+                .ConfigureAwait(false);
+            return new LoadAttempt<IReadOnlyList<Issue>>(issues, null, null);
+        }
+        catch (HttpRequestException exception)
+        {
+            logger.LogWarning(
+                exception,
+                "Failed to load issues for {RepositoryFullName} while building the PM work-item catalogue.",
+                $"{owner}/{repoName}");
+            return new LoadAttempt<IReadOnlyList<Issue>>([], exception.Message, (int?)exception.StatusCode);
+        }
+    }
+
+    private async Task<LoadAttempt<IReadOnlyList<PullRequest>>> TryLoadPullRequestsAsync(
+        string owner,
+        string repoName,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var pullRequests = await gitHubService
+                .GetPullRequestsAsync(owner, repoName, OpenItemState, cancellationToken)
+                .ConfigureAwait(false);
+            return new LoadAttempt<IReadOnlyList<PullRequest>>(pullRequests, null, null);
+        }
+        catch (HttpRequestException exception)
+        {
+            logger.LogWarning(
+                exception,
+                "Failed to load pull requests for {RepositoryFullName} while building the PM work-item catalogue.",
+                $"{owner}/{repoName}");
+            return new LoadAttempt<IReadOnlyList<PullRequest>>([], exception.Message, (int?)exception.StatusCode);
+        }
+    }
+
+    private async Task<IReadOnlyList<PullRequestReviewMetadata>> TryLoadReviewMetadataAsync(
+        string owner,
+        string repoName,
+        string repositoryFullName,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await gitHubService
+                .GetOpenPullRequestReviewMetadataAsync(owner, repoName, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (HttpRequestException exception)
+        {
+            logger.LogWarning(
+                exception,
+                "Failed to load pull request review metadata for {RepositoryFullName}; continuing without review-pending signals.",
+                repositoryFullName);
+            return [];
+        }
+    }
+
+    private async Task<IReadOnlyList<IssueSubIssueSummary>> TryLoadSubIssueSummariesAsync(
+        string owner,
+        string repoName,
+        string repositoryFullName,
+        IReadOnlyList<int> issueNumbers,
+        CancellationToken cancellationToken)
+    {
+        if (issueNumbers.Count == 0)
+        {
+            return [];
+        }
+
+        try
+        {
+            return await gitHubService
+                .GetIssueSubIssueSummariesAsync(owner, repoName, issueNumbers, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (HttpRequestException exception)
+        {
+            logger.LogWarning(
+                exception,
+                "Failed to load sub-issue summaries for {RepositoryFullName}; continuing without epic completion counts.",
+                repositoryFullName);
+            return [];
+        }
+    }
+
+    private static PmWorkItemDto MapIssue(
+        Issue issue,
+        string repositoryFullName,
+        IReadOnlyList<string> labels,
+        IssueSubIssueSummary? subIssueSummary)
+        => new(
+            PmWorkItemTypeDto.Issue,
+            issue.Number,
+            issue.Title,
+            issue.HtmlUrl,
+            repositoryFullName,
+            labels,
+            issue.Milestone?.Number,
+            issue.Milestone?.Title,
+            issue.CreatedAt,
+            issue.UpdatedAt,
+            IsDraft: null,
+            HasReviewPending: null,
+            SubIssueTotal: subIssueSummary?.TotalCount,
+            SubIssueCompleted: subIssueSummary?.CompletedCount);
+
+    private static PmWorkItemDto MapPullRequest(
+        PullRequest pullRequest,
+        string repositoryFullName,
+        IReadOnlyList<string> labels,
+        PullRequestReviewMetadata? reviewMetadata)
+        => new(
+            PmWorkItemTypeDto.PullRequest,
+            pullRequest.Number,
+            pullRequest.Title,
+            pullRequest.HtmlUrl,
+            repositoryFullName,
+            labels,
+            pullRequest.Milestone?.Number,
+            pullRequest.Milestone?.Title,
+            pullRequest.CreatedAt,
+            pullRequest.UpdatedAt,
+            pullRequest.IsDraft,
+            reviewMetadata?.HasReviewPending,
+            SubIssueTotal: null,
+            SubIssueCompleted: null);
+
+    private static bool IsOpenState(string state)
+        => state.Equals(OpenItemState, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsEpicOrFeature(IReadOnlyList<string> labels)
+    {
+        var typeLabel = PmLabelHelpers.ParseTypeLabel(labels);
+        return typeLabel is PmLabelHelpers.EpicTypeLabel or PmLabelHelpers.FeatureTypeLabel;
+    }
+
+    private static string CombineFailureMessages(string? issueError, string? pullRequestError)
+    {
+        return (issueError, pullRequestError) switch
+        {
+            (null, null) => string.Empty,
+            (not null, null) => $"Issues: {issueError}",
+            (null, not null) => $"Pull requests: {pullRequestError}",
+            (not null, not null) => $"Issues: {issueError}; Pull requests: {pullRequestError}",
+        };
+    }
+
+    private static string ParseOwnerLogin(string repositoryFullName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryFullName);
+
+        var separatorIndex = repositoryFullName.IndexOf('/');
+        if (separatorIndex <= 0 || separatorIndex >= repositoryFullName.Length - 1)
+        {
+            throw new ArgumentException("Repository full name must be in owner/name form.", nameof(repositoryFullName));
+        }
+
+        return repositoryFullName[..separatorIndex];
+    }
+
+    private sealed record LoadAttempt<T>(T Items, string? ErrorMessage, int? HttpStatusCode);
+
+    private sealed record RepositoryCatalogueLoadResult(
+        IReadOnlyList<PmWorkItemDto> Items,
+        PmRepositoryCatalogueFailureDto? Failure);
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmWorkItemDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmWorkItemDto.cs
@@ -1,0 +1,32 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Cross-repository PM work item at the Application→App boundary.</summary>
+/// <param name="ItemType">Whether the item is an issue or pull request.</param>
+/// <param name="Number">The repository-scoped item number.</param>
+/// <param name="Title">The item title.</param>
+/// <param name="HtmlUrl">The browser URL for the item.</param>
+/// <param name="RepositoryFullName">The repository in <c>owner/name</c> form.</param>
+/// <param name="Labels">Label names currently applied to the item.</param>
+/// <param name="MilestoneNumber">The assigned milestone number, when present.</param>
+/// <param name="MilestoneTitle">The assigned milestone title, when present.</param>
+/// <param name="CreatedAt">When the item was created.</param>
+/// <param name="UpdatedAt">When the item was last updated.</param>
+/// <param name="IsDraft">For pull requests, whether the item is a draft; <see langword="null"/> for issues.</param>
+/// <param name="HasReviewPending">For pull requests, whether a review is pending; <see langword="null"/> for issues.</param>
+/// <param name="SubIssueTotal">For open epics and features, the tracked sub-issue total when GitHub provides it.</param>
+/// <param name="SubIssueCompleted">For open epics and features, the completed tracked sub-issue count when GitHub provides it.</param>
+public sealed record PmWorkItemDto(
+    PmWorkItemTypeDto ItemType,
+    int Number,
+    string Title,
+    string HtmlUrl,
+    string RepositoryFullName,
+    IReadOnlyList<string> Labels,
+    int? MilestoneNumber,
+    string? MilestoneTitle,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt,
+    bool? IsDraft,
+    bool? HasReviewPending,
+    int? SubIssueTotal,
+    int? SubIssueCompleted);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmWorkItemTypeDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmWorkItemTypeDto.cs
@@ -1,0 +1,11 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Discriminator for PM work-item catalogue entries.</summary>
+public enum PmWorkItemTypeDto
+{
+    /// <summary>A GitHub issue.</summary>
+    Issue,
+
+    /// <summary>A GitHub pull request.</summary>
+    PullRequest,
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardFieldIdsDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardFieldIdsDto.cs
@@ -1,0 +1,6 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>DTO for discovered GitHub Project v2 field identifiers.</summary>
+public sealed record ProjectBoardFieldIdsDto(
+    string StatusFieldId,
+    string? FocusOrderFieldId);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardItemCatalogueDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardItemCatalogueDto.cs
@@ -1,0 +1,6 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>DTO catalogue of project board items and discovered field identifiers.</summary>
+public sealed record ProjectBoardItemCatalogueDto(
+    ProjectBoardFieldIdsDto FieldIds,
+    IReadOnlyList<ProjectBoardItemDto> Items);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardItemContentDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardItemContentDto.cs
@@ -1,0 +1,10 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>DTO for issue or pull request content linked to a project board item.</summary>
+public sealed record ProjectBoardItemContentDto(
+    ProjectBoardItemContentTypeDto ContentType,
+    int Number,
+    string RepositoryOwner,
+    string RepositoryName,
+    string Title,
+    string Url);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardItemContentTypeDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardItemContentTypeDto.cs
@@ -1,0 +1,11 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Defines the supported project board item content types.</summary>
+public enum ProjectBoardItemContentTypeDto
+{
+    /// <summary>Represents a GitHub issue.</summary>
+    Issue = 0,
+
+    /// <summary>Represents a GitHub pull request.</summary>
+    PullRequest = 1,
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardItemDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardItemDto.cs
@@ -1,0 +1,9 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>DTO for a GitHub Project v2 board item in the PM workflow catalogue.</summary>
+public sealed record ProjectBoardItemDto(
+    string ProjectItemId,
+    ProjectBoardItemStatusDto? Status,
+    double? FocusOrder,
+    ProjectBoardItemContentDto Content,
+    DateTimeOffset ActivityTimestamp);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardItemStatusDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardItemStatusDto.cs
@@ -1,0 +1,6 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>DTO for the Status single-select value on a project board item.</summary>
+public sealed record ProjectBoardItemStatusDto(
+    string OptionId,
+    string Name);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectItemCatalogueService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectItemCatalogueService.cs
@@ -1,0 +1,115 @@
+using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Domain.Entities.PmWorkflow;
+using SoloDevBoard.Domain.Entities.Triage;
+
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Provides a default implementation of <see cref="IProjectItemCatalogueService"/>.</summary>
+public sealed class ProjectItemCatalogueService : IProjectItemCatalogueService
+{
+    private readonly IGitHubService _gitHubService;
+
+    /// <summary>Initialises a new instance of the <see cref="ProjectItemCatalogueService"/> class.</summary>
+    /// <param name="gitHubService">The GitHub service used to retrieve and update project board items.</param>
+    public ProjectItemCatalogueService(IGitHubService gitHubService)
+    {
+        _gitHubService = gitHubService ?? throw new ArgumentNullException(nameof(gitHubService));
+    }
+
+    /// <inheritdoc/>
+    public async Task<ProjectBoardItemCatalogueDto> GetCatalogueAsync(string projectId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+
+        var catalogue = await _gitHubService
+            .GetProjectBoardItemsAsync(projectId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return MapCatalogue(catalogue);
+    }
+
+    /// <inheritdoc/>
+    public async Task UpdateFocusOrderAsync(
+        string projectId,
+        string projectItemId,
+        string focusOrderFieldId,
+        double focusOrder,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectItemId);
+        ValidateFocusOrderFieldId(focusOrderFieldId);
+
+        await _gitHubService
+            .UpdateProjectBoardItemFocusOrderAsync(projectId, projectItemId, focusOrderFieldId, focusOrder, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task ClearFocusOrderAsync(
+        string projectId,
+        string projectItemId,
+        string focusOrderFieldId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectItemId);
+        ValidateFocusOrderFieldId(focusOrderFieldId);
+
+        await _gitHubService
+            .ClearProjectBoardItemFocusOrderAsync(projectId, projectItemId, focusOrderFieldId, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static void ValidateFocusOrderFieldId(string focusOrderFieldId)
+    {
+        if (string.IsNullOrWhiteSpace(focusOrderFieldId))
+        {
+            throw new InvalidOperationException("The project board does not expose a Focus Order field.");
+        }
+    }
+
+    private static ProjectBoardItemCatalogueDto MapCatalogue(ProjectBoardItemCatalogue catalogue)
+    {
+        ArgumentNullException.ThrowIfNull(catalogue);
+
+        var fieldIds = new ProjectBoardFieldIdsDto(
+            catalogue.FieldIds.StatusFieldId,
+            catalogue.FieldIds.FocusOrderFieldId);
+
+        var items = catalogue.Items
+            .Select(MapItem)
+            .ToArray();
+
+        return new ProjectBoardItemCatalogueDto(fieldIds, items);
+    }
+
+    private static ProjectBoardItemDto MapItem(ProjectBoardItem item)
+    {
+        var status = item.Status is null
+            ? null
+            : new ProjectBoardItemStatusDto(item.Status.OptionId, item.Status.Name);
+
+        var contentType = item.Content.ContentType == TriageItemType.PullRequest
+            ? ProjectBoardItemContentTypeDto.PullRequest
+            : ProjectBoardItemContentTypeDto.Issue;
+
+        var content = new ProjectBoardItemContentDto(
+            contentType,
+            item.Content.Number,
+            item.Content.RepositoryOwner,
+            item.Content.RepositoryName,
+            item.Content.Title,
+            item.Content.Url);
+
+        return new ProjectBoardItemDto(
+            item.ProjectItemId,
+            status,
+            item.FocusOrder,
+            content,
+            item.ActivityTimestamp);
+    }
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/IssueSubIssueSummary.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/IssueSubIssueSummary.cs
@@ -1,0 +1,14 @@
+namespace SoloDevBoard.Domain.Entities.PmWorkflow;
+
+/// <summary>Tracked sub-issue counts for an open epic or feature issue.</summary>
+public sealed record IssueSubIssueSummary
+{
+    /// <summary>Gets the repository-scoped issue number.</summary>
+    public int Number { get; init; }
+
+    /// <summary>Gets the total number of tracked sub-issues.</summary>
+    public int TotalCount { get; init; }
+
+    /// <summary>Gets the number of completed tracked sub-issues.</summary>
+    public int CompletedCount { get; init; }
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardFieldIds.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardFieldIds.cs
@@ -1,0 +1,11 @@
+namespace SoloDevBoard.Domain.Entities.PmWorkflow;
+
+/// <summary>Discovered GitHub Project v2 field identifiers for PM workflow board operations.</summary>
+public sealed record ProjectBoardFieldIds
+{
+    /// <summary>Gets the Status single-select field node identifier.</summary>
+    public string StatusFieldId { get; init; } = string.Empty;
+
+    /// <summary>Gets the Focus Order number field node identifier when the board exposes that field.</summary>
+    public string? FocusOrderFieldId { get; init; }
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardItem.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardItem.cs
@@ -1,0 +1,23 @@
+namespace SoloDevBoard.Domain.Entities.PmWorkflow;
+
+/// <summary>Represents a GitHub Project v2 board item with PM workflow catalogue fields.</summary>
+public sealed record ProjectBoardItem
+{
+    /// <summary>Gets the project-item node identifier.</summary>
+    public string ProjectItemId { get; init; } = string.Empty;
+
+    /// <summary>Gets the current Status field value when set.</summary>
+    public ProjectBoardItemStatus? Status { get; init; }
+
+    /// <summary>Gets the Focus Order number when the field is set on the item.</summary>
+    public double? FocusOrder { get; init; }
+
+    /// <summary>Gets the linked issue or pull request content.</summary>
+    public ProjectBoardItemContent Content { get; init; } = new();
+
+    /// <summary>
+    /// Gets the timestamp used for stall detection.
+    /// Prefer the Status field-updated time when available; otherwise fall back to the item <c>updatedAt</c> value.
+    /// </summary>
+    public DateTimeOffset ActivityTimestamp { get; init; }
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardItemCatalogue.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardItemCatalogue.cs
@@ -1,0 +1,11 @@
+namespace SoloDevBoard.Domain.Entities.PmWorkflow;
+
+/// <summary>Catalogue of project board items and discovered field identifiers for PM workflow.</summary>
+public sealed record ProjectBoardItemCatalogue
+{
+    /// <summary>Gets the discovered Status and optional Focus Order field identifiers.</summary>
+    public ProjectBoardFieldIds FieldIds { get; init; } = new();
+
+    /// <summary>Gets the project board items included in the catalogue.</summary>
+    public IReadOnlyList<ProjectBoardItem> Items { get; init; } = [];
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardItemContent.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardItemContent.cs
@@ -1,0 +1,25 @@
+using SoloDevBoard.Domain.Entities.Triage;
+
+namespace SoloDevBoard.Domain.Entities.PmWorkflow;
+
+/// <summary>Represents the GitHub issue or pull request linked to a project board item.</summary>
+public sealed record ProjectBoardItemContent
+{
+    /// <summary>Gets the linked content type.</summary>
+    public TriageItemType ContentType { get; init; }
+
+    /// <summary>Gets the repository-scoped issue or pull request number.</summary>
+    public int Number { get; init; }
+
+    /// <summary>Gets the repository owner login.</summary>
+    public string RepositoryOwner { get; init; } = string.Empty;
+
+    /// <summary>Gets the repository name.</summary>
+    public string RepositoryName { get; init; } = string.Empty;
+
+    /// <summary>Gets the issue or pull request title.</summary>
+    public string Title { get; init; } = string.Empty;
+
+    /// <summary>Gets the canonical GitHub URL for the content.</summary>
+    public string Url { get; init; } = string.Empty;
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardItemStatus.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardItemStatus.cs
@@ -1,0 +1,11 @@
+namespace SoloDevBoard.Domain.Entities.PmWorkflow;
+
+/// <summary>Represents the Status single-select value on a project board item.</summary>
+public sealed record ProjectBoardItemStatus
+{
+    /// <summary>Gets the status option node identifier.</summary>
+    public string OptionId { get; init; } = string.Empty;
+
+    /// <summary>Gets the status option display name.</summary>
+    public string Name { get; init; } = string.Empty;
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/PullRequestReviewMetadata.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/PullRequestReviewMetadata.cs
@@ -1,0 +1,11 @@
+namespace SoloDevBoard.Domain.Entities.PmWorkflow;
+
+/// <summary>Review-pending metadata for an open pull request.</summary>
+public sealed record PullRequestReviewMetadata
+{
+    /// <summary>Gets the repository-scoped pull request number.</summary>
+    public int Number { get; init; }
+
+    /// <summary>Gets a value indicating whether the pull request has a pending review signal.</summary>
+    public bool HasReviewPending { get; init; }
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
@@ -6,6 +6,7 @@ using SoloDevBoard.Application.Services.BoardRules;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Domain.Entities.Labels;
 using SoloDevBoard.Domain.Entities.Milestones;
+using SoloDevBoard.Domain.Entities.PmWorkflow;
 using SoloDevBoard.Domain.Entities.Repositories;
 using SoloDevBoard.Domain.Entities.Triage;
 using SoloDevBoard.Domain.Entities.Workflows;
@@ -611,6 +612,131 @@ public sealed class GitHubService : IGitHubService
     }
 
     /// <inheritdoc/>
+    public async Task<ProjectBoardItemCatalogue> GetProjectBoardItemsAsync(string projectId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+
+        const string query = "query ProjectBoardItemCatalogue($projectId: ID!, $after: String) { node(id: $projectId) { ... on ProjectV2 { fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name } ... on ProjectV2Field { id name dataType } } } items(first: 100, after: $after, archivedStates: [NOT_ARCHIVED]) { pageInfo { hasNextPage endCursor } nodes { id updatedAt content { __typename ... on Issue { number title url repository { name owner { login } } } ... on PullRequest { number title url repository { name owner { login } } } } status: fieldValueByName(name: \"Status\") { ... on ProjectV2ItemFieldSingleSelectValue { optionId name updatedAt } } focusOrder: fieldValueByName(name: \"Focus Order\") { ... on ProjectV2ItemFieldNumberValue { number } } } } } } }";
+
+        var client = CreateAuthenticatedClient();
+        var fieldIds = new ProjectBoardFieldIds();
+        var items = new List<ProjectBoardItem>();
+        string? after = null;
+        var hasNextPage = true;
+        var fieldIdsResolved = false;
+
+        while (hasNextPage)
+        {
+            var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["projectId"] = projectId,
+                ["after"] = after,
+            };
+
+            var payload = await PostGraphQlAsync<GetProjectBoardItemCatalogueResponseDto>(client, query, variables, cancellationToken)
+                .ConfigureAwait(false);
+
+            var node = payload.Data?.Node;
+            if (!fieldIdsResolved)
+            {
+                fieldIds = ToProjectBoardFieldIds(node?.Fields?.Nodes ?? []);
+                if (string.IsNullOrWhiteSpace(fieldIds.StatusFieldId))
+                {
+                    throw CreateInvalidResponseException("GraphQL response did not contain a supported Status field.", "/graphql");
+                }
+
+                fieldIdsResolved = true;
+            }
+
+            var itemsConnection = node?.Items;
+            if (itemsConnection?.Nodes is { Count: > 0 })
+            {
+                foreach (var itemNode in itemsConnection.Nodes)
+                {
+                    var mappedItem = ToProjectBoardItemDomain(itemNode);
+                    if (mappedItem is not null)
+                    {
+                        items.Add(mappedItem);
+                    }
+                }
+            }
+
+            hasNextPage = itemsConnection?.PageInfo?.HasNextPage ?? false;
+            after = itemsConnection?.PageInfo?.EndCursor;
+        }
+
+        return new ProjectBoardItemCatalogue
+        {
+            FieldIds = fieldIds,
+            Items = items,
+        };
+    }
+
+    /// <inheritdoc/>
+    public async Task UpdateProjectBoardItemFocusOrderAsync(
+        string projectId,
+        string projectItemId,
+        string focusOrderFieldId,
+        double focusOrder,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectItemId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(focusOrderFieldId);
+
+        const string mutation = "mutation SetProjectV2FocusOrder($projectId: ID!, $itemId: ID!, $fieldId: ID!, $focusOrder: Float!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { number: $focusOrder } }) { projectV2Item { id } } }";
+
+        var client = CreateAuthenticatedClient();
+        var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["projectId"] = projectId,
+            ["itemId"] = projectItemId,
+            ["fieldId"] = focusOrderFieldId,
+            ["focusOrder"] = focusOrder,
+        };
+
+        var payload = await PostGraphQlAsync<UpdateProjectBoardItemStatusResponseDto>(client, mutation, variables, cancellationToken)
+            .ConfigureAwait(false);
+
+        var updatedItemId = payload.Data?.UpdateProjectV2ItemFieldValue?.ProjectV2Item?.Id;
+        if (string.IsNullOrWhiteSpace(updatedItemId))
+        {
+            throw CreateInvalidResponseException("GraphQL response did not contain the updated project item identifier.", "/graphql");
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task ClearProjectBoardItemFocusOrderAsync(
+        string projectId,
+        string projectItemId,
+        string focusOrderFieldId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectItemId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(focusOrderFieldId);
+
+        const string mutation = "mutation ClearProjectV2FocusOrder($projectId: ID!, $itemId: ID!, $fieldId: ID!) { clearProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId }) { projectV2Item { id } } }";
+
+        var client = CreateAuthenticatedClient();
+        var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["projectId"] = projectId,
+            ["itemId"] = projectItemId,
+            ["fieldId"] = focusOrderFieldId,
+        };
+
+        var payload = await PostGraphQlAsync<ClearProjectBoardItemFieldResponseDto>(client, mutation, variables, cancellationToken)
+            .ConfigureAwait(false);
+
+        var clearedItemId = payload.Data?.ClearProjectV2ItemFieldValue?.ProjectV2Item?.Id;
+        if (string.IsNullOrWhiteSpace(clearedItemId))
+        {
+            throw CreateInvalidResponseException("GraphQL response did not contain the cleared project item identifier.", "/graphql");
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task CloseTriageItemAsDuplicateAsync(string owner, string repo, GitHubTriageItemType itemType, int itemNumber, string duplicateReference, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
@@ -744,6 +870,143 @@ public sealed class GitHubService : IGitHubService
             StatusFieldId = statusField.Id,
             StatusOptions = statusOptions,
         };
+    }
+
+    private static ProjectBoardFieldIds ToProjectBoardFieldIds(IReadOnlyList<ProjectBoardCatalogueFieldDto> fields)
+    {
+        var statusField = fields
+            .FirstOrDefault(field =>
+                !string.IsNullOrWhiteSpace(field.Id)
+                && field.Name.Equals("Status", StringComparison.OrdinalIgnoreCase));
+
+        var focusOrderField = fields
+            .FirstOrDefault(field =>
+                !string.IsNullOrWhiteSpace(field.Id)
+                && field.Name.Equals("Focus Order", StringComparison.OrdinalIgnoreCase)
+                && (string.IsNullOrWhiteSpace(field.DataType)
+                    || field.DataType.Equals("NUMBER", StringComparison.OrdinalIgnoreCase)));
+
+        return new ProjectBoardFieldIds
+        {
+            StatusFieldId = statusField?.Id ?? string.Empty,
+            FocusOrderFieldId = string.IsNullOrWhiteSpace(focusOrderField?.Id) ? null : focusOrderField.Id,
+        };
+    }
+
+    private static ProjectBoardItem? ToProjectBoardItemDomain(ProjectBoardItemNodeDto? node)
+    {
+        if (node is null || string.IsNullOrWhiteSpace(node.Id))
+        {
+            return null;
+        }
+
+        var content = ToProjectBoardItemContent(node.Content);
+        if (content is null)
+        {
+            return null;
+        }
+
+        ProjectBoardItemStatus? status = null;
+        if (node.Status is not null
+            && !string.IsNullOrWhiteSpace(node.Status.OptionId)
+            && !string.IsNullOrWhiteSpace(node.Status.Name))
+        {
+            status = new ProjectBoardItemStatus
+            {
+                OptionId = node.Status.OptionId,
+                Name = node.Status.Name,
+            };
+        }
+
+        var activityTimestamp = node.Status?.UpdatedAt ?? node.UpdatedAt;
+        if (activityTimestamp == default)
+        {
+            return null;
+        }
+
+        return new ProjectBoardItem
+        {
+            ProjectItemId = node.Id,
+            Status = status,
+            FocusOrder = node.FocusOrder?.Number,
+            Content = content,
+            ActivityTimestamp = activityTimestamp,
+        };
+    }
+
+    private static ProjectBoardItemContent? ToProjectBoardItemContent(ProjectBoardItemContentNodeDto? content)
+    {
+        if (content is null || string.IsNullOrWhiteSpace(content.Typename))
+        {
+            return null;
+        }
+
+        if (content.Number <= 0
+            || string.IsNullOrWhiteSpace(content.Title)
+            || string.IsNullOrWhiteSpace(content.Url)
+            || content.Repository is null
+            || string.IsNullOrWhiteSpace(content.Repository.Name)
+            || string.IsNullOrWhiteSpace(content.Repository.Owner?.Login))
+        {
+            return null;
+        }
+
+        var contentType = content.Typename.Equals("PullRequest", StringComparison.Ordinal)
+            ? TriageItemType.PullRequest
+            : content.Typename.Equals("Issue", StringComparison.Ordinal)
+                ? TriageItemType.Issue
+                : (TriageItemType?)null;
+
+        if (contentType is null)
+        {
+            return null;
+        }
+
+        return new ProjectBoardItemContent
+        {
+            ContentType = contentType.Value,
+            Number = content.Number,
+            RepositoryOwner = content.Repository.Owner.Login,
+            RepositoryName = content.Repository.Name,
+            Title = RepairCommonMojibake(content.Title),
+            Url = content.Url,
+        };
+    }
+
+    private async Task<TGraphQlResponse> PostGraphQlAsync<TGraphQlResponse>(
+        HttpClient client,
+        string query,
+        IReadOnlyDictionary<string, object?> variables,
+        CancellationToken cancellationToken)
+    {
+        var requestBody = new GraphQlObjectVariablesRequestDto(query, variables);
+
+        using var response = await client.PostAsJsonAsync("/graphql", requestBody, JsonOptions, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        using var document = JsonDocument.Parse(json);
+        if (document.RootElement.TryGetProperty("errors", out var errorsElement)
+            && errorsElement.ValueKind == JsonValueKind.Array
+            && errorsElement.GetArrayLength() > 0)
+        {
+            var errorMessages = errorsElement
+                .EnumerateArray()
+                .Select(static error => error.TryGetProperty("message", out var message) ? message.GetString() : null)
+                .Where(static message => !string.IsNullOrWhiteSpace(message))
+                .ToArray();
+
+            var combinedErrors = errorMessages.Length > 0
+                ? string.Join("; ", errorMessages)
+                : "Unknown GraphQL error.";
+
+            throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
+        }
+
+        var payload = JsonSerializer.Deserialize<TGraphQlResponse>(json, JsonOptions)
+            ?? throw CreateInvalidResponseException("GraphQL response body was empty.", "/graphql");
+
+        return payload;
     }
 
     /// <summary>Creates an <see cref="HttpRequestException"/> describing an unexpected or empty API response body.</summary>
@@ -1328,6 +1591,170 @@ public sealed class GitHubService : IGitHubService
     private sealed record GraphQlRequestDto(
         [property: JsonPropertyName("query")] string Query,
         [property: JsonPropertyName("variables")] IReadOnlyDictionary<string, string> Variables);
+
+    /// <summary>Request body DTO for GitHub GraphQL requests with object-typed variables.</summary>
+    private sealed record GraphQlObjectVariablesRequestDto(
+        [property: JsonPropertyName("query")] string Query,
+        [property: JsonPropertyName("variables")] IReadOnlyDictionary<string, object?> Variables);
+
+    /// <summary>DTO wrapper for GraphQL project board item catalogue responses.</summary>
+    private sealed record GetProjectBoardItemCatalogueResponseDto
+    {
+        [JsonPropertyName("data")]
+        public GetProjectBoardItemCatalogueDataDto? Data { get; init; }
+
+        [JsonPropertyName("errors")]
+        public IReadOnlyList<GraphQlErrorDto> Errors { get; init; } = [];
+    }
+
+    /// <summary>DTO for GraphQL project board item catalogue data payload.</summary>
+    private sealed record GetProjectBoardItemCatalogueDataDto
+    {
+        [JsonPropertyName("node")]
+        public ProjectBoardCatalogueNodeDto? Node { get; init; }
+    }
+
+    /// <summary>DTO for a project board node in item catalogue queries.</summary>
+    private sealed record ProjectBoardCatalogueNodeDto
+    {
+        [JsonPropertyName("fields")]
+        public ProjectBoardCatalogueFieldConnectionDto? Fields { get; init; }
+
+        [JsonPropertyName("items")]
+        public ProjectBoardItemConnectionDto? Items { get; init; }
+    }
+
+    /// <summary>DTO for project board field nodes in item catalogue queries.</summary>
+    private sealed record ProjectBoardCatalogueFieldConnectionDto
+    {
+        [JsonPropertyName("nodes")]
+        public IReadOnlyList<ProjectBoardCatalogueFieldDto> Nodes { get; init; } = [];
+    }
+
+    /// <summary>DTO for a project board field in item catalogue queries.</summary>
+    private sealed record ProjectBoardCatalogueFieldDto
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = string.Empty;
+
+        [JsonPropertyName("dataType")]
+        public string DataType { get; init; } = string.Empty;
+    }
+
+    /// <summary>DTO for paginated project board items.</summary>
+    private sealed record ProjectBoardItemConnectionDto
+    {
+        [JsonPropertyName("pageInfo")]
+        public GraphQlPageInfoDto? PageInfo { get; init; }
+
+        [JsonPropertyName("nodes")]
+        public IReadOnlyList<ProjectBoardItemNodeDto> Nodes { get; init; } = [];
+    }
+
+    /// <summary>DTO for GraphQL page info.</summary>
+    private sealed record GraphQlPageInfoDto
+    {
+        [JsonPropertyName("hasNextPage")]
+        public bool HasNextPage { get; init; }
+
+        [JsonPropertyName("endCursor")]
+        public string? EndCursor { get; init; }
+    }
+
+    /// <summary>DTO for a project board item node.</summary>
+    private sealed record ProjectBoardItemNodeDto
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = string.Empty;
+
+        [JsonPropertyName("updatedAt")]
+        public DateTimeOffset UpdatedAt { get; init; }
+
+        [JsonPropertyName("content")]
+        public ProjectBoardItemContentNodeDto? Content { get; init; }
+
+        [JsonPropertyName("status")]
+        public ProjectBoardItemStatusValueDto? Status { get; init; }
+
+        [JsonPropertyName("focusOrder")]
+        public ProjectBoardItemFocusOrderValueDto? FocusOrder { get; init; }
+    }
+
+    /// <summary>DTO for linked issue or pull request content on a project board item.</summary>
+    private sealed record ProjectBoardItemContentNodeDto
+    {
+        [JsonPropertyName("__typename")]
+        public string Typename { get; init; } = string.Empty;
+
+        [JsonPropertyName("number")]
+        public int Number { get; init; }
+
+        [JsonPropertyName("title")]
+        public string Title { get; init; } = string.Empty;
+
+        [JsonPropertyName("url")]
+        public string Url { get; init; } = string.Empty;
+
+        [JsonPropertyName("repository")]
+        public ProjectBoardItemRepositoryDto? Repository { get; init; }
+    }
+
+    /// <summary>DTO for repository metadata on project board item content.</summary>
+    private sealed record ProjectBoardItemRepositoryDto
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = string.Empty;
+
+        [JsonPropertyName("owner")]
+        public GraphQlOwnerDto? Owner { get; init; }
+    }
+
+    /// <summary>DTO for Status field values on project board items.</summary>
+    private sealed record ProjectBoardItemStatusValueDto
+    {
+        [JsonPropertyName("optionId")]
+        public string OptionId { get; init; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = string.Empty;
+
+        [JsonPropertyName("updatedAt")]
+        public DateTimeOffset UpdatedAt { get; init; }
+    }
+
+    /// <summary>DTO for Focus Order field values on project board items.</summary>
+    private sealed record ProjectBoardItemFocusOrderValueDto
+    {
+        [JsonPropertyName("number")]
+        public double? Number { get; init; }
+    }
+
+    /// <summary>DTO wrapper for GraphQL clear field responses.</summary>
+    private sealed record ClearProjectBoardItemFieldResponseDto
+    {
+        [JsonPropertyName("data")]
+        public ClearProjectBoardItemFieldDataDto? Data { get; init; }
+
+        [JsonPropertyName("errors")]
+        public IReadOnlyList<GraphQlErrorDto> Errors { get; init; } = [];
+    }
+
+    /// <summary>DTO for GraphQL clear field data payload.</summary>
+    private sealed record ClearProjectBoardItemFieldDataDto
+    {
+        [JsonPropertyName("clearProjectV2ItemFieldValue")]
+        public ClearProjectBoardItemFieldPayloadDto? ClearProjectV2ItemFieldValue { get; init; }
+    }
+
+    /// <summary>DTO for GraphQL clear field mutation payload.</summary>
+    private sealed record ClearProjectBoardItemFieldPayloadDto
+    {
+        [JsonPropertyName("projectV2Item")]
+        public UpdateProjectBoardItemStatusItemDto? ProjectV2Item { get; init; }
+    }
 
     /// <summary>DTO wrapper for GraphQL get-board-rules responses.</summary>
     private sealed record GetBoardRulesResponseDto

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
@@ -695,7 +695,7 @@ public sealed class GitHubService : IGitHubService
             ["focusOrder"] = focusOrder,
         };
 
-        var payload = await PostGraphQlAsync<UpdateProjectBoardItemStatusResponseDto>(client, mutation, variables, cancellationToken)
+        var payload = await PostGraphQlAsync<UpdateProjectBoardItemFocusOrderResponseDto>(client, mutation, variables, cancellationToken)
             .ConfigureAwait(false);
 
         var updatedItemId = payload.Data?.UpdateProjectV2ItemFieldValue?.ProjectV2Item?.Id;
@@ -801,9 +801,13 @@ public sealed class GitHubService : IGitHubService
 
         const string query =
             """
-            query WorkItemCataloguePullRequestReviews($owner: String!, $repo: String!) {
+            query WorkItemCataloguePullRequestReviews($owner: String!, $repo: String!, $after: String) {
               repository(owner: $owner, name: $repo) {
-                pullRequests(first: 100, states: OPEN) {
+                pullRequests(first: 100, states: OPEN, after: $after) {
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
                   nodes {
                     number
                     isDraft
@@ -818,35 +822,52 @@ public sealed class GitHubService : IGitHubService
             """;
 
         var client = CreateAuthenticatedClient();
-        var requestBody = new GraphQlRequestDto(
-            query,
-            new Dictionary<string, string>(StringComparer.Ordinal)
+        var metadata = new List<PullRequestReviewMetadata>();
+        string? after = null;
+        var hasNextPage = true;
+
+        while (hasNextPage)
+        {
+            var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
                 ["owner"] = owner,
                 ["repo"] = repo,
-            });
+                ["after"] = after,
+            };
 
-        using var response = await client.PostAsJsonAsync("/graphql", requestBody, JsonOptions, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+            var payload = await PostGraphQlAsync<WorkItemCataloguePullRequestReviewsResponseDto>(
+                    client,
+                    query,
+                    variables,
+                    cancellationToken)
+                .ConfigureAwait(false);
 
-        var payload = await response.Content.ReadFromJsonAsync<WorkItemCataloguePullRequestReviewsResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
-            ?? throw CreateInvalidResponseException("GraphQL response body was empty.", "/graphql");
+            var pullRequests = payload.Data?.Repository?.PullRequests;
+            if (pullRequests?.Nodes is { Count: > 0 })
+            {
+                foreach (var node in pullRequests.Nodes)
+                {
+                    if (node is null)
+                    {
+                        continue;
+                    }
 
-        if (payload.Errors.Count > 0)
-        {
-            var combinedErrors = string.Join("; ", payload.Errors.Select(static error => error.Message));
-            throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
+                    metadata.Add(new PullRequestReviewMetadata
+                    {
+                        Number = node.Number,
+                        HasReviewPending = IsReviewPending(
+                            node.IsDraft,
+                            node.ReviewDecision,
+                            node.ReviewRequests?.TotalCount ?? 0),
+                    });
+                }
+            }
+
+            hasNextPage = pullRequests?.PageInfo?.HasNextPage ?? false;
+            after = pullRequests?.PageInfo?.EndCursor;
         }
 
-        return payload.Data?.Repository?.PullRequests?.Nodes
-            .Where(static node => node is not null)
-            .Select(static node => node!)
-            .Select(static node => new PullRequestReviewMetadata
-            {
-                Number = node.Number,
-                HasReviewPending = IsReviewPending(node.IsDraft, node.ReviewDecision, node.ReviewRequests?.TotalCount ?? 0),
-            })
-            .ToArray() ?? [];
+        return metadata;
     }
 
     /// <inheritdoc/>
@@ -865,32 +886,44 @@ public sealed class GitHubService : IGitHubService
             return [];
         }
 
+        var client = CreateAuthenticatedClient();
+        var summaries = new List<IssueSubIssueSummary>();
+
+        foreach (var issueNumber in issueNumbers.Distinct())
+        {
+            var summary = await LoadIssueSubIssueSummaryAsync(client, owner, repo, issueNumber, cancellationToken)
+                .ConfigureAwait(false);
+            if (summary is not null)
+            {
+                summaries.Add(summary);
+            }
+        }
+
+        return summaries;
+    }
+
+    private async Task<IssueSubIssueSummary?> LoadIssueSubIssueSummaryAsync(
+        HttpClient client,
+        string owner,
+        string repo,
+        int issueNumber,
+        CancellationToken cancellationToken)
+    {
         const string query =
             """
-            query WorkItemCatalogueSubIssues($owner: String!, $repo: String!) {
+            query WorkItemCatalogueSubIssues($owner: String!, $repo: String!, $issueNumber: Int!, $after: String) {
               repository(owner: $owner, name: $repo) {
-                epics: issues(states: OPEN, first: 100, labels: ["type/epic"]) {
-                  nodes {
-                    number
-                    trackedIssues(first: 100) {
-                      totalCount
-                      nodes {
-                        ... on Issue {
-                          state
-                        }
-                      }
+                issue(number: $issueNumber) {
+                  number
+                  trackedIssues(first: 100, after: $after) {
+                    pageInfo {
+                      hasNextPage
+                      endCursor
                     }
-                  }
-                }
-                features: issues(states: OPEN, first: 100, labels: ["type/feature"]) {
-                  nodes {
-                    number
-                    trackedIssues(first: 100) {
-                      totalCount
-                      nodes {
-                        ... on Issue {
-                          state
-                        }
+                    totalCount
+                    nodes {
+                      ... on Issue {
+                        state
                       }
                     }
                   }
@@ -899,75 +932,59 @@ public sealed class GitHubService : IGitHubService
             }
             """;
 
-        var client = CreateAuthenticatedClient();
-        var requestBody = new GraphQlRequestDto(
-            query,
-            new Dictionary<string, string>(StringComparer.Ordinal)
+        int? totalCount = null;
+        var completedCount = 0;
+        string? after = null;
+        var hasNextPage = true;
+        int? resolvedIssueNumber = null;
+
+        while (hasNextPage)
+        {
+            var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
                 ["owner"] = owner,
                 ["repo"] = repo,
-            });
+                ["issueNumber"] = issueNumber,
+                ["after"] = after,
+            };
 
-        using var response = await client.PostAsJsonAsync("/graphql", requestBody, JsonOptions, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+            var payload = await PostGraphQlAsync<WorkItemCatalogueSubIssuesResponseDto>(
+                    client,
+                    query,
+                    variables,
+                    cancellationToken)
+                .ConfigureAwait(false);
 
-        var payload = await response.Content.ReadFromJsonAsync<WorkItemCatalogueSubIssuesResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
-            ?? throw CreateInvalidResponseException("GraphQL response body was empty.", "/graphql");
-
-        if (payload.Errors.Count > 0)
-        {
-            var combinedErrors = string.Join("; ", payload.Errors.Select(static error => error.Message));
-            throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
-        }
-
-        var requestedNumbers = issueNumbers.ToHashSet();
-        var summaries = new List<IssueSubIssueSummary>();
-        var repository = payload.Data?.Repository;
-        if (repository is null)
-        {
-            return [];
-        }
-
-        AppendSubIssueSummaries(summaries, repository.Epics?.Nodes, requestedNumbers);
-        AppendSubIssueSummaries(summaries, repository.Features?.Nodes, requestedNumbers);
-
-        return summaries;
-    }
-
-    private static void AppendSubIssueSummaries(
-        ICollection<IssueSubIssueSummary> summaries,
-        IReadOnlyList<WorkItemCatalogueIssueNodeDto?>? nodes,
-        ISet<int> requestedNumbers)
-    {
-        if (nodes is null)
-        {
-            return;
-        }
-
-        foreach (var node in nodes)
-        {
-            if (node is null || !requestedNumbers.Contains(node.Number))
+            var issue = payload.Data?.Repository?.Issue;
+            if (issue is null)
             {
-                continue;
+                return null;
             }
 
-            var trackedIssues = node.TrackedIssues;
+            resolvedIssueNumber = issue.Number;
+            var trackedIssues = issue.TrackedIssues;
             if (trackedIssues is null || trackedIssues.TotalCount == 0)
             {
-                continue;
+                return null;
             }
 
-            var completedCount = trackedIssues.Nodes
+            totalCount ??= trackedIssues.TotalCount;
+            completedCount += trackedIssues.Nodes
                 .Count(static child => child is not null
                     && child.State.Equals("CLOSED", StringComparison.OrdinalIgnoreCase));
 
-            summaries.Add(new IssueSubIssueSummary
-            {
-                Number = node.Number,
-                TotalCount = trackedIssues.TotalCount,
-                CompletedCount = completedCount,
-            });
+            hasNextPage = trackedIssues.PageInfo?.HasNextPage ?? false;
+            after = trackedIssues.PageInfo?.EndCursor;
         }
+
+        return resolvedIssueNumber is null || totalCount is null or 0
+            ? null
+            : new IssueSubIssueSummary
+            {
+                Number = resolvedIssueNumber.Value,
+                TotalCount = totalCount.Value,
+                CompletedCount = completedCount,
+            };
     }
 
     private static bool IsReviewPending(bool isDraft, string? reviewDecision, int reviewRequestCount)
@@ -1118,11 +1135,8 @@ public sealed class GitHubService : IGitHubService
             };
         }
 
-        var activityTimestamp = node.Status?.UpdatedAt ?? node.UpdatedAt;
-        if (activityTimestamp == default)
-        {
-            return null;
-        }
+        // Prefer Status field-updated time; fall back to item updatedAt, then Unix epoch when GitHub omits both.
+        var activityTimestamp = node.Status?.UpdatedAt ?? node.UpdatedAt ?? DateTimeOffset.UnixEpoch;
 
         return new ProjectBoardItem
         {
@@ -1871,7 +1885,7 @@ public sealed class GitHubService : IGitHubService
         public string Id { get; init; } = string.Empty;
 
         [JsonPropertyName("updatedAt")]
-        public DateTimeOffset UpdatedAt { get; init; }
+        public DateTimeOffset? UpdatedAt { get; init; }
 
         [JsonPropertyName("content")]
         public ProjectBoardItemContentNodeDto? Content { get; init; }
@@ -2098,6 +2112,30 @@ public sealed class GitHubService : IGitHubService
         public string Name { get; init; } = string.Empty;
     }
 
+    /// <summary>DTO wrapper for GraphQL update-project-item-focus-order responses.</summary>
+    private sealed record UpdateProjectBoardItemFocusOrderResponseDto
+    {
+        [JsonPropertyName("data")]
+        public UpdateProjectBoardItemFocusOrderDataDto? Data { get; init; }
+
+        [JsonPropertyName("errors")]
+        public IReadOnlyList<GraphQlErrorDto> Errors { get; init; } = [];
+    }
+
+    /// <summary>DTO for update-project-item-focus-order GraphQL data payload.</summary>
+    private sealed record UpdateProjectBoardItemFocusOrderDataDto
+    {
+        [JsonPropertyName("updateProjectV2ItemFieldValue")]
+        public UpdateProjectBoardItemFocusOrderPayloadDto? UpdateProjectV2ItemFieldValue { get; init; }
+    }
+
+    /// <summary>DTO for update-project-item-focus-order GraphQL payload.</summary>
+    private sealed record UpdateProjectBoardItemFocusOrderPayloadDto
+    {
+        [JsonPropertyName("projectV2Item")]
+        public UpdateProjectBoardItemStatusItemDto? ProjectV2Item { get; init; }
+    }
+
     /// <summary>DTO wrapper for GraphQL update-project-item-status responses.</summary>
     private sealed record UpdateProjectBoardItemStatusResponseDto
     {
@@ -2165,6 +2203,9 @@ public sealed class GitHubService : IGitHubService
     /// <summary>DTO for pull-request review metadata connections.</summary>
     private sealed record WorkItemCataloguePullRequestConnectionDto
     {
+        [JsonPropertyName("pageInfo")]
+        public GraphQlPageInfoDto? PageInfo { get; init; }
+
         [JsonPropertyName("nodes")]
         public IReadOnlyList<WorkItemCataloguePullRequestNodeDto?> Nodes { get; init; } = [];
     }
@@ -2212,18 +2253,8 @@ public sealed class GitHubService : IGitHubService
     /// <summary>DTO for repository sub-issue summaries.</summary>
     private sealed record WorkItemCatalogueSubIssuesRepositoryDto
     {
-        [JsonPropertyName("epics")]
-        public WorkItemCatalogueIssueConnectionDto? Epics { get; init; }
-
-        [JsonPropertyName("features")]
-        public WorkItemCatalogueIssueConnectionDto? Features { get; init; }
-    }
-
-    /// <summary>DTO for issue connections in sub-issue summary queries.</summary>
-    private sealed record WorkItemCatalogueIssueConnectionDto
-    {
-        [JsonPropertyName("nodes")]
-        public IReadOnlyList<WorkItemCatalogueIssueNodeDto?> Nodes { get; init; } = [];
+        [JsonPropertyName("issue")]
+        public WorkItemCatalogueIssueNodeDto? Issue { get; init; }
     }
 
     /// <summary>DTO for issue nodes in sub-issue summary queries.</summary>
@@ -2239,6 +2270,9 @@ public sealed class GitHubService : IGitHubService
     /// <summary>DTO for tracked-issue connections.</summary>
     private sealed record WorkItemCatalogueTrackedIssueConnectionDto
     {
+        [JsonPropertyName("pageInfo")]
+        public GraphQlPageInfoDto? PageInfo { get; init; }
+
         [JsonPropertyName("totalCount")]
         public int TotalCount { get; init; }
 

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
@@ -6,6 +6,7 @@ using SoloDevBoard.Application.Services.BoardRules;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Domain.Entities.Labels;
 using SoloDevBoard.Domain.Entities.Milestones;
+using SoloDevBoard.Domain.Entities.PmWorkflow;
 using SoloDevBoard.Domain.Entities.Repositories;
 using SoloDevBoard.Domain.Entities.Triage;
 using SoloDevBoard.Domain.Entities.Workflows;
@@ -661,6 +662,206 @@ public sealed class GitHubService : IGitHubService
                 throw new ArgumentOutOfRangeException(nameof(itemType), itemType, "Unsupported triage item type.");
         }
     }
+
+    #region Work-item catalogue methods
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<PullRequestReviewMetadata>> GetOpenPullRequestReviewMetadataAsync(
+        string owner,
+        string repo,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        const string query =
+            """
+            query WorkItemCataloguePullRequestReviews($owner: String!, $repo: String!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequests(first: 100, states: OPEN) {
+                  nodes {
+                    number
+                    isDraft
+                    reviewDecision
+                    reviewRequests(first: 1) {
+                      totalCount
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        var client = CreateAuthenticatedClient();
+        var requestBody = new GraphQlRequestDto(
+            query,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["owner"] = owner,
+                ["repo"] = repo,
+            });
+
+        using var response = await client.PostAsJsonAsync("/graphql", requestBody, JsonOptions, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var payload = await response.Content.ReadFromJsonAsync<WorkItemCataloguePullRequestReviewsResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw CreateInvalidResponseException("GraphQL response body was empty.", "/graphql");
+
+        if (payload.Errors.Count > 0)
+        {
+            var combinedErrors = string.Join("; ", payload.Errors.Select(static error => error.Message));
+            throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
+        }
+
+        return payload.Data?.Repository?.PullRequests?.Nodes
+            .Where(static node => node is not null)
+            .Select(static node => node!)
+            .Select(static node => new PullRequestReviewMetadata
+            {
+                Number = node.Number,
+                HasReviewPending = IsReviewPending(node.IsDraft, node.ReviewDecision, node.ReviewRequests?.TotalCount ?? 0),
+            })
+            .ToArray() ?? [];
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<IssueSubIssueSummary>> GetIssueSubIssueSummariesAsync(
+        string owner,
+        string repo,
+        IReadOnlyList<int> issueNumbers,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentNullException.ThrowIfNull(issueNumbers);
+
+        if (issueNumbers.Count == 0)
+        {
+            return [];
+        }
+
+        const string query =
+            """
+            query WorkItemCatalogueSubIssues($owner: String!, $repo: String!) {
+              repository(owner: $owner, name: $repo) {
+                epics: issues(states: OPEN, first: 100, labels: ["type/epic"]) {
+                  nodes {
+                    number
+                    trackedIssues(first: 100) {
+                      totalCount
+                      nodes {
+                        ... on Issue {
+                          state
+                        }
+                      }
+                    }
+                  }
+                }
+                features: issues(states: OPEN, first: 100, labels: ["type/feature"]) {
+                  nodes {
+                    number
+                    trackedIssues(first: 100) {
+                      totalCount
+                      nodes {
+                        ... on Issue {
+                          state
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        var client = CreateAuthenticatedClient();
+        var requestBody = new GraphQlRequestDto(
+            query,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["owner"] = owner,
+                ["repo"] = repo,
+            });
+
+        using var response = await client.PostAsJsonAsync("/graphql", requestBody, JsonOptions, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var payload = await response.Content.ReadFromJsonAsync<WorkItemCatalogueSubIssuesResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw CreateInvalidResponseException("GraphQL response body was empty.", "/graphql");
+
+        if (payload.Errors.Count > 0)
+        {
+            var combinedErrors = string.Join("; ", payload.Errors.Select(static error => error.Message));
+            throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
+        }
+
+        var requestedNumbers = issueNumbers.ToHashSet();
+        var summaries = new List<IssueSubIssueSummary>();
+        var repository = payload.Data?.Repository;
+        if (repository is null)
+        {
+            return [];
+        }
+
+        AppendSubIssueSummaries(summaries, repository.Epics?.Nodes, requestedNumbers);
+        AppendSubIssueSummaries(summaries, repository.Features?.Nodes, requestedNumbers);
+
+        return summaries;
+    }
+
+    private static void AppendSubIssueSummaries(
+        ICollection<IssueSubIssueSummary> summaries,
+        IReadOnlyList<WorkItemCatalogueIssueNodeDto?>? nodes,
+        ISet<int> requestedNumbers)
+    {
+        if (nodes is null)
+        {
+            return;
+        }
+
+        foreach (var node in nodes)
+        {
+            if (node is null || !requestedNumbers.Contains(node.Number))
+            {
+                continue;
+            }
+
+            var trackedIssues = node.TrackedIssues;
+            if (trackedIssues is null || trackedIssues.TotalCount == 0)
+            {
+                continue;
+            }
+
+            var completedCount = trackedIssues.Nodes
+                .Count(static child => child is not null
+                    && child.State.Equals("CLOSED", StringComparison.OrdinalIgnoreCase));
+
+            summaries.Add(new IssueSubIssueSummary
+            {
+                Number = node.Number,
+                TotalCount = trackedIssues.TotalCount,
+                CompletedCount = completedCount,
+            });
+        }
+    }
+
+    private static bool IsReviewPending(bool isDraft, string? reviewDecision, int reviewRequestCount)
+    {
+        if (isDraft)
+        {
+            return false;
+        }
+
+        if (string.Equals(reviewDecision, "REVIEW_REQUIRED", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return reviewRequestCount > 0
+            && !string.Equals(reviewDecision, "APPROVED", StringComparison.OrdinalIgnoreCase);
+    }
+
+    #endregion
 
     private HttpClient CreateAuthenticatedClient()
     {
@@ -1508,4 +1709,123 @@ public sealed class GitHubService : IGitHubService
         [JsonPropertyName("message")]
         public string Message { get; init; } = string.Empty;
     }
+
+    #region Work-item catalogue GraphQL DTOs
+
+    /// <summary>DTO wrapper for pull-request review metadata GraphQL responses.</summary>
+    private sealed record WorkItemCataloguePullRequestReviewsResponseDto
+    {
+        [JsonPropertyName("data")]
+        public WorkItemCataloguePullRequestReviewsDataDto? Data { get; init; }
+
+        [JsonPropertyName("errors")]
+        public IReadOnlyList<GraphQlErrorDto> Errors { get; init; } = [];
+    }
+
+    /// <summary>DTO for pull-request review metadata GraphQL data payload.</summary>
+    private sealed record WorkItemCataloguePullRequestReviewsDataDto
+    {
+        [JsonPropertyName("repository")]
+        public WorkItemCataloguePullRequestReviewsRepositoryDto? Repository { get; init; }
+    }
+
+    /// <summary>DTO for repository pull-request review metadata.</summary>
+    private sealed record WorkItemCataloguePullRequestReviewsRepositoryDto
+    {
+        [JsonPropertyName("pullRequests")]
+        public WorkItemCataloguePullRequestConnectionDto? PullRequests { get; init; }
+    }
+
+    /// <summary>DTO for pull-request review metadata connections.</summary>
+    private sealed record WorkItemCataloguePullRequestConnectionDto
+    {
+        [JsonPropertyName("nodes")]
+        public IReadOnlyList<WorkItemCataloguePullRequestNodeDto?> Nodes { get; init; } = [];
+    }
+
+    /// <summary>DTO for pull-request review metadata nodes.</summary>
+    private sealed record WorkItemCataloguePullRequestNodeDto
+    {
+        [JsonPropertyName("number")]
+        public int Number { get; init; }
+
+        [JsonPropertyName("isDraft")]
+        public bool IsDraft { get; init; }
+
+        [JsonPropertyName("reviewDecision")]
+        public string? ReviewDecision { get; init; }
+
+        [JsonPropertyName("reviewRequests")]
+        public WorkItemCatalogueReviewRequestConnectionDto? ReviewRequests { get; init; }
+    }
+
+    /// <summary>DTO for review-request connections.</summary>
+    private sealed record WorkItemCatalogueReviewRequestConnectionDto
+    {
+        [JsonPropertyName("totalCount")]
+        public int TotalCount { get; init; }
+    }
+
+    /// <summary>DTO wrapper for sub-issue summary GraphQL responses.</summary>
+    private sealed record WorkItemCatalogueSubIssuesResponseDto
+    {
+        [JsonPropertyName("data")]
+        public WorkItemCatalogueSubIssuesDataDto? Data { get; init; }
+
+        [JsonPropertyName("errors")]
+        public IReadOnlyList<GraphQlErrorDto> Errors { get; init; } = [];
+    }
+
+    /// <summary>DTO for sub-issue summary GraphQL data payload.</summary>
+    private sealed record WorkItemCatalogueSubIssuesDataDto
+    {
+        [JsonPropertyName("repository")]
+        public WorkItemCatalogueSubIssuesRepositoryDto? Repository { get; init; }
+    }
+
+    /// <summary>DTO for repository sub-issue summaries.</summary>
+    private sealed record WorkItemCatalogueSubIssuesRepositoryDto
+    {
+        [JsonPropertyName("epics")]
+        public WorkItemCatalogueIssueConnectionDto? Epics { get; init; }
+
+        [JsonPropertyName("features")]
+        public WorkItemCatalogueIssueConnectionDto? Features { get; init; }
+    }
+
+    /// <summary>DTO for issue connections in sub-issue summary queries.</summary>
+    private sealed record WorkItemCatalogueIssueConnectionDto
+    {
+        [JsonPropertyName("nodes")]
+        public IReadOnlyList<WorkItemCatalogueIssueNodeDto?> Nodes { get; init; } = [];
+    }
+
+    /// <summary>DTO for issue nodes in sub-issue summary queries.</summary>
+    private sealed record WorkItemCatalogueIssueNodeDto
+    {
+        [JsonPropertyName("number")]
+        public int Number { get; init; }
+
+        [JsonPropertyName("trackedIssues")]
+        public WorkItemCatalogueTrackedIssueConnectionDto? TrackedIssues { get; init; }
+    }
+
+    /// <summary>DTO for tracked-issue connections.</summary>
+    private sealed record WorkItemCatalogueTrackedIssueConnectionDto
+    {
+        [JsonPropertyName("totalCount")]
+        public int TotalCount { get; init; }
+
+        [JsonPropertyName("nodes")]
+        public IReadOnlyList<WorkItemCatalogueTrackedIssueNodeDto?> Nodes { get; init; } = [];
+    }
+
+    /// <summary>DTO for tracked-issue nodes.</summary>
+    private sealed record WorkItemCatalogueTrackedIssueNodeDto
+    {
+        [JsonPropertyName("state")]
+        public string State { get; init; } = string.Empty;
+    }
+
+    #endregion
 }

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
@@ -47,6 +47,7 @@ public sealed class ApplicationServiceCollectionExtensionsTests
         AssertServiceRegistration<ITriageService, TriageService>(services, ServiceLifetime.Scoped);
         AssertServiceRegistration<IWorkflowTemplateService, WorkflowTemplateService>(services, ServiceLifetime.Scoped);
         AssertServiceRegistration<IPmSettingsService, PmSettingsService>(services, ServiceLifetime.Scoped);
+        AssertServiceRegistration<IPmWorkItemCatalogueService, PmWorkItemCatalogueService>(services, ServiceLifetime.Scoped);
     }
 
     private static void AssertServiceRegistration<TService, TImplementation>(

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
@@ -47,6 +47,7 @@ public sealed class ApplicationServiceCollectionExtensionsTests
         AssertServiceRegistration<ITriageService, TriageService>(services, ServiceLifetime.Scoped);
         AssertServiceRegistration<IWorkflowTemplateService, WorkflowTemplateService>(services, ServiceLifetime.Scoped);
         AssertServiceRegistration<IPmSettingsService, PmSettingsService>(services, ServiceLifetime.Scoped);
+        AssertServiceRegistration<IProjectItemCatalogueService, ProjectItemCatalogueService>(services, ServiceLifetime.Scoped);
     }
 
     private static void AssertServiceRegistration<TService, TImplementation>(

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/PmLabelHelpersTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/PmLabelHelpersTests.cs
@@ -1,0 +1,106 @@
+using SoloDevBoard.Application.Services.PmWorkflow;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="PmLabelHelpers"/>.</summary>
+public sealed class PmLabelHelpersTests
+{
+    [Theory]
+    [InlineData(new[] { "type/story", "priority/high" }, "type/story")]
+    [InlineData(new[] { "TYPE/EPIC" }, "TYPE/EPIC")]
+    [InlineData(new[] { "bug" }, null)]
+    public void ParseTypeLabel_VariousLabels_ReturnsExpected(string[] labels, string? expected)
+    {
+        var result = PmLabelHelpers.ParseTypeLabel(labels);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(new[] { "priority/critical", "type/story" }, "priority/critical")]
+    [InlineData(new[] { "priority/low" }, "priority/low")]
+    [InlineData(new[] { "type/story" }, null)]
+    public void ParsePriorityLabel_VariousLabels_ReturnsExpected(string[] labels, string? expected)
+    {
+        var result = PmLabelHelpers.ParsePriorityLabel(labels);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(new[] { "status/blocked", "type/story" }, "status/blocked")]
+    [InlineData(new[] { "status/in-progress" }, "status/in-progress")]
+    [InlineData(new[] { "type/story" }, null)]
+    public void ParseStatusLabel_VariousLabels_ReturnsExpected(string[] labels, string? expected)
+    {
+        var result = PmLabelHelpers.ParseStatusLabel(labels);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(new[] { "status/blocked" }, true)]
+    [InlineData(new[] { "STATUS/BLOCKED" }, true)]
+    [InlineData(new[] { "status/ice-box" }, false)]
+    [InlineData(new[] { "type/story" }, false)]
+    public void IsBlocked_VariousLabels_ReturnsExpected(string[] labels, bool expected)
+    {
+        Assert.Equal(expected, PmLabelHelpers.IsBlocked(labels));
+    }
+
+    [Theory]
+    [InlineData(new[] { "status/ice-box" }, true)]
+    [InlineData(new[] { "status/blocked" }, false)]
+    public void IsIceBoxed_VariousLabels_ReturnsExpected(string[] labels, bool expected)
+    {
+        Assert.Equal(expected, PmLabelHelpers.IsIceBoxed(labels));
+    }
+
+    [Theory]
+    [InlineData(new[] { "status/blocked" }, true)]
+    [InlineData(new[] { "status/ice-box" }, true)]
+    [InlineData(new[] { "type/story", "priority/high" }, false)]
+    public void IsBlockedOrDeferred_VariousLabels_ReturnsExpected(string[] labels, bool expected)
+    {
+        Assert.Equal(expected, PmLabelHelpers.IsBlockedOrDeferred(labels));
+    }
+
+    [Theory]
+    [InlineData(new[] { "type/story", "priority/high" }, true)]
+    [InlineData(new[] { "status/blocked" }, false)]
+    [InlineData(new[] { "status/ice-box" }, false)]
+    public void IsUnblocked_VariousLabels_ReturnsExpected(string[] labels, bool expected)
+    {
+        Assert.Equal(expected, PmLabelHelpers.IsUnblocked(labels));
+    }
+
+    [Theory]
+    [InlineData(new[] { "type/story" }, true)]
+    [InlineData(new[] { "priority/high" }, true)]
+    [InlineData(new[] { "type/story", "priority/high" }, false)]
+    public void IsAwaitingTriage_VariousLabels_ReturnsExpected(string[] labels, bool expected)
+    {
+        Assert.Equal(expected, PmLabelHelpers.IsAwaitingTriage(labels));
+    }
+
+    [Theory]
+    [InlineData(new[] { "priority/critical" }, true)]
+    [InlineData(new[] { "priority/high" }, true)]
+    [InlineData(new[] { "priority/medium" }, false)]
+    public void IsUrgent_VariousLabels_ReturnsExpected(string[] labels, bool expected)
+    {
+        Assert.Equal(expected, PmLabelHelpers.IsUrgent(labels));
+    }
+
+    [Theory]
+    [InlineData("type/epic", 3, 3, true)]
+    [InlineData("type/feature", 2, 1, false)]
+    [InlineData("type/story", 3, 3, false)]
+    [InlineData("type/epic", 0, 0, false)]
+    public void IsEpicNearComplete_VariousCounts_ReturnsExpected(string typeLabel, int total, int completed, bool expected)
+    {
+        var result = PmLabelHelpers.IsEpicNearComplete([typeLabel, "priority/high"], total, completed);
+
+        Assert.Equal(expected, result);
+    }
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/PmPriorityRankerTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/PmPriorityRankerTests.cs
@@ -1,0 +1,39 @@
+using SoloDevBoard.Application.Services.PmWorkflow;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="PmPriorityRanker"/>.</summary>
+public sealed class PmPriorityRankerTests
+{
+    [Theory]
+    [InlineData("priority/critical", "priority/high", -1)]
+    [InlineData("priority/high", "priority/medium", -1)]
+    [InlineData("priority/medium", "priority/low", -1)]
+    [InlineData("priority/low", null, -1)]
+    [InlineData(null, "priority/critical", 1)]
+    [InlineData("priority/high", "priority/high", 0)]
+    public void ComparePriority_VariousLabels_ReturnsExpectedOrder(string? left, string? right, int expectedSign)
+    {
+        var comparison = PmPriorityRanker.ComparePriority(left, right);
+
+        Assert.True(Math.Sign(comparison) == expectedSign);
+    }
+
+    [Fact]
+    public void GetRank_AllKnownPriorities_ReturnsDescendingUrgencyOrder()
+    {
+        var ranks = new[]
+        {
+            PmPriorityRanker.GetRank("priority/critical"),
+            PmPriorityRanker.GetRank("priority/high"),
+            PmPriorityRanker.GetRank("priority/medium"),
+            PmPriorityRanker.GetRank("priority/low"),
+            PmPriorityRanker.GetRank(null),
+        };
+
+        Assert.True(ranks[0] < ranks[1]);
+        Assert.True(ranks[1] < ranks[2]);
+        Assert.True(ranks[2] < ranks[3]);
+        Assert.True(ranks[3] < ranks[4]);
+    }
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/PmWorkItemCatalogueServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/PmWorkItemCatalogueServiceTests.cs
@@ -1,0 +1,267 @@
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Application.Services.PmWorkflow;
+using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Domain.Entities.Milestones;
+using SoloDevBoard.Domain.Entities.PmWorkflow;
+using SoloDevBoard.Domain.Entities.Repositories;
+using SoloDevBoard.Domain.Entities.Triage;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="PmWorkItemCatalogueService"/>.</summary>
+public sealed class PmWorkItemCatalogueServiceTests
+{
+    private const string OpenItemState = "open";
+
+    private readonly IGitHubService _gitHubService = Substitute.For<IGitHubService>();
+    private readonly IPmSettingsService _pmSettingsService = Substitute.For<IPmSettingsService>();
+    private readonly PmWorkItemCatalogueService _sut;
+
+    public PmWorkItemCatalogueServiceTests()
+    {
+        _pmSettingsService.GetSettingsAsync().Returns(PmSettingsDefaults.Create());
+        _sut = new PmWorkItemCatalogueService(
+            _gitHubService,
+            _pmSettingsService,
+            NullLogger<PmWorkItemCatalogueService>.Instance);
+    }
+
+    [Fact]
+    public async Task GetCatalogueAsync_ActiveRepositoriesExist_ReturnsMappedOpenItems()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        _gitHubService.GetActiveRepositoriesAsync(cancellationToken).Returns(
+        [
+            new Repository { Id = 1, Name = "repo-a", FullName = "owner/repo-a" },
+            new Repository { Id = 2, Name = "repo-b", FullName = "owner/repo-b" },
+        ]);
+
+        _gitHubService
+            .GetIssuesAsync("owner", "repo-a", OpenItemState, cancellationToken)
+            .Returns(
+            [
+                CreateIssue(10, "Epic parent", ["type/epic", "priority/high"], milestoneTitle: "v1.1.0"),
+                CreateIssue(11, "Closed issue", ["type/story", "priority/medium"], state: "closed"),
+            ]);
+        _gitHubService
+            .GetPullRequestsAsync("owner", "repo-a", OpenItemState, cancellationToken)
+            .Returns(
+            [
+                CreatePullRequest(20, "Review me", ["type/story", "priority/medium"], isDraft: false),
+            ]);
+        _gitHubService
+            .GetOpenPullRequestReviewMetadataAsync("owner", "repo-a", cancellationToken)
+            .Returns([new PullRequestReviewMetadata { Number = 20, HasReviewPending = true }]);
+        _gitHubService
+            .GetIssueSubIssueSummariesAsync("owner", "repo-a", Arg.Is<IReadOnlyList<int>>(numbers => numbers.SequenceEqual(new[] { 10 })), cancellationToken)
+            .Returns([new IssueSubIssueSummary { Number = 10, TotalCount = 2, CompletedCount = 1 }]);
+
+        _gitHubService
+            .GetIssuesAsync("owner", "repo-b", OpenItemState, cancellationToken)
+            .Returns([]);
+        _gitHubService
+            .GetPullRequestsAsync("owner", "repo-b", OpenItemState, cancellationToken)
+            .Returns([]);
+        _gitHubService
+            .GetOpenPullRequestReviewMetadataAsync("owner", "repo-b", cancellationToken)
+            .Returns([]);
+        _gitHubService
+            .GetIssueSubIssueSummariesAsync("owner", "repo-b", Arg.Any<IReadOnlyList<int>>(), cancellationToken)
+            .Returns([]);
+
+        var result = await _sut.GetCatalogueAsync(cancellationToken);
+
+        Assert.Empty(result.Failures);
+        Assert.Equal(2, result.Items.Count);
+
+        var issue = Assert.Single(result.Items, item => item.ItemType == PmWorkItemTypeDto.Issue);
+        Assert.Equal(10, issue.Number);
+        Assert.Equal("Epic parent", issue.Title);
+        Assert.Equal("owner/repo-a", issue.RepositoryFullName);
+        Assert.Equal("v1.1.0", issue.MilestoneTitle);
+        Assert.Null(issue.IsDraft);
+        Assert.Null(issue.HasReviewPending);
+        Assert.Equal(2, issue.SubIssueTotal);
+        Assert.Equal(1, issue.SubIssueCompleted);
+
+        var pullRequest = Assert.Single(result.Items, item => item.ItemType == PmWorkItemTypeDto.PullRequest);
+        Assert.Equal(20, pullRequest.Number);
+        Assert.False(pullRequest.IsDraft);
+        Assert.True(pullRequest.HasReviewPending);
+        Assert.Null(pullRequest.SubIssueTotal);
+    }
+
+    [Fact]
+    public async Task GetCatalogueAsync_ExcludedRepositoryConfigured_OmitsExcludedRepository()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        _pmSettingsService.GetSettingsAsync().Returns(new PmSettingsDto(
+            PlanningBoardNodeId: null,
+            ExcludedRepositories: ["owner/excluded"],
+            Capacity: PmSettingsDefaults.Capacity,
+            StallDays: PmSettingsDefaults.StallDays,
+            NeglectDays: PmSettingsDefaults.NeglectDays));
+
+        _gitHubService.GetActiveRepositoriesAsync(cancellationToken).Returns(
+        [
+            new Repository { Id = 1, Name = "included", FullName = "owner/included" },
+            new Repository { Id = 2, Name = "excluded", FullName = "owner/excluded" },
+        ]);
+
+        _gitHubService
+            .GetIssuesAsync("owner", "included", OpenItemState, cancellationToken)
+            .Returns([CreateIssue(1, "Included issue", ["type/story", "priority/low"])]);
+        _gitHubService
+            .GetPullRequestsAsync("owner", "included", OpenItemState, cancellationToken)
+            .Returns([]);
+        _gitHubService
+            .GetOpenPullRequestReviewMetadataAsync("owner", "included", cancellationToken)
+            .Returns([]);
+        _gitHubService
+            .GetIssueSubIssueSummariesAsync("owner", "included", Arg.Any<IReadOnlyList<int>>(), cancellationToken)
+            .Returns([]);
+
+        var result = await _sut.GetCatalogueAsync(cancellationToken);
+
+        Assert.Single(result.Items);
+        Assert.Equal("owner/included", result.Items[0].RepositoryFullName);
+        await _gitHubService.DidNotReceive().GetIssuesAsync("owner", "excluded", OpenItemState, cancellationToken);
+        await _gitHubService.DidNotReceive().GetPullRequestsAsync("owner", "excluded", OpenItemState, cancellationToken);
+    }
+
+    [Fact]
+    public async Task GetCatalogueAsync_PartialRepositoryFailure_ReturnsFailureAndSuccessfulItems()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        _gitHubService.GetActiveRepositoriesAsync(cancellationToken).Returns(
+        [
+            new Repository { Id = 1, Name = "healthy", FullName = "owner/healthy" },
+            new Repository { Id = 2, Name = "broken", FullName = "owner/broken" },
+        ]);
+
+        _gitHubService
+            .GetIssuesAsync("owner", "healthy", OpenItemState, cancellationToken)
+            .Returns([CreateIssue(1, "Healthy issue", ["type/story", "priority/medium"])]);
+        _gitHubService
+            .GetPullRequestsAsync("owner", "healthy", OpenItemState, cancellationToken)
+            .Returns([]);
+        _gitHubService
+            .GetOpenPullRequestReviewMetadataAsync("owner", "healthy", cancellationToken)
+            .Returns([]);
+        _gitHubService
+            .GetIssueSubIssueSummariesAsync("owner", "healthy", Arg.Any<IReadOnlyList<int>>(), cancellationToken)
+            .Returns([]);
+
+        _gitHubService
+            .GetIssuesAsync("owner", "broken", OpenItemState, cancellationToken)
+            .Throws(new HttpRequestException("Issues unavailable", null, HttpStatusCode.Forbidden));
+        _gitHubService
+            .GetPullRequestsAsync("owner", "broken", OpenItemState, cancellationToken)
+            .Returns([CreatePullRequest(99, "Still loaded", ["type/story", "priority/low"], isDraft: false)]);
+        _gitHubService
+            .GetOpenPullRequestReviewMetadataAsync("owner", "broken", cancellationToken)
+            .Returns([]);
+        _gitHubService
+            .GetIssueSubIssueSummariesAsync("owner", "broken", Arg.Any<IReadOnlyList<int>>(), cancellationToken)
+            .Returns([]);
+
+        var result = await _sut.GetCatalogueAsync(cancellationToken);
+
+        Assert.Equal(2, result.Items.Count);
+        Assert.Contains(result.Items, item => item.RepositoryFullName == "owner/healthy");
+        Assert.Contains(result.Items, item => item.RepositoryFullName == "owner/broken" && item.Number == 99);
+
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal("owner/broken", failure.RepositoryFullName);
+        Assert.Equal((int)HttpStatusCode.Forbidden, failure.HttpStatusCode);
+        Assert.Contains("Issues:", failure.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetCatalogueAsync_GroupingPredicates_AreAvailableOnReturnedLabels()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        _gitHubService.GetActiveRepositoriesAsync(cancellationToken).Returns(
+        [
+            new Repository { Id = 1, Name = "repo", FullName = "owner/repo" },
+        ]);
+        _gitHubService
+            .GetIssuesAsync("owner", "repo", OpenItemState, cancellationToken)
+            .Returns(
+            [
+                CreateIssue(1, "Urgent ready story", ["type/story", "priority/critical"]),
+                CreateIssue(2, "Awaiting triage", ["type/story"]),
+                CreateIssue(3, "Blocked", ["type/story", "priority/high", "status/blocked"]),
+            ]);
+        _gitHubService
+            .GetPullRequestsAsync("owner", "repo", OpenItemState, cancellationToken)
+            .Returns([]);
+        _gitHubService
+            .GetOpenPullRequestReviewMetadataAsync("owner", "repo", cancellationToken)
+            .Returns([]);
+        _gitHubService
+            .GetIssueSubIssueSummariesAsync("owner", "repo", Arg.Any<IReadOnlyList<int>>(), cancellationToken)
+            .Returns([]);
+
+        var result = await _sut.GetCatalogueAsync(cancellationToken);
+
+        var urgentReady = result.Items.Single(item => item.Number == 1);
+        Assert.True(PmLabelHelpers.IsUrgent(urgentReady.Labels));
+        Assert.True(PmLabelHelpers.IsUnblocked(urgentReady.Labels));
+        Assert.False(PmLabelHelpers.IsAwaitingTriage(urgentReady.Labels));
+
+        var awaitingTriage = result.Items.Single(item => item.Number == 2);
+        Assert.True(PmLabelHelpers.IsAwaitingTriage(awaitingTriage.Labels));
+
+        var blocked = result.Items.Single(item => item.Number == 3);
+        Assert.True(PmLabelHelpers.IsBlockedOrDeferred(blocked.Labels));
+        Assert.False(PmLabelHelpers.IsUnblocked(blocked.Labels));
+    }
+
+    private static Issue CreateIssue(
+        int number,
+        string title,
+        IReadOnlyList<string> labelNames,
+        string state = "open",
+        string? milestoneTitle = null)
+        => new()
+        {
+            Id = number,
+            Number = number,
+            Title = title,
+            HtmlUrl = $"https://example.test/{number}",
+            State = state,
+            Labels = labelNames.Select(name => new Label { Name = name }).ToArray(),
+            Milestone = milestoneTitle is null
+                ? null
+                : new Milestone { Number = 4, Title = milestoneTitle },
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-5),
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1),
+        };
+
+    private static PullRequest CreatePullRequest(
+        int number,
+        string title,
+        IReadOnlyList<string> labelNames,
+        bool isDraft)
+        => new()
+        {
+            Id = number,
+            Number = number,
+            Title = title,
+            HtmlUrl = $"https://example.test/pr/{number}",
+            State = "open",
+            IsDraft = isDraft,
+            Labels = labelNames.Select(name => new Label { Name = name }).ToArray(),
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-3),
+            UpdatedAt = DateTimeOffset.UtcNow.AddHours(-2),
+        };
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/PmWorkItemCatalogueServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/PmWorkItemCatalogueServiceTests.cs
@@ -226,6 +226,93 @@ public sealed class PmWorkItemCatalogueServiceTests
         Assert.False(PmLabelHelpers.IsUnblocked(blocked.Labels));
     }
 
+    [Fact]
+    public async Task GetCatalogueAsync_ReviewMetadataLoadFails_ReturnsItemsWithoutReviewPending()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        _gitHubService.GetActiveRepositoriesAsync(cancellationToken).Returns(
+        [
+            new Repository { Id = 1, Name = "repo", FullName = "owner/repo" },
+        ]);
+        _gitHubService
+            .GetIssuesAsync("owner", "repo", OpenItemState, cancellationToken)
+            .Returns([]);
+        _gitHubService
+            .GetPullRequestsAsync("owner", "repo", OpenItemState, cancellationToken)
+            .Returns([CreatePullRequest(30, "Needs review", ["type/story", "priority/medium"], isDraft: false)]);
+        _gitHubService
+            .GetOpenPullRequestReviewMetadataAsync("owner", "repo", cancellationToken)
+            .Throws(new HttpRequestException("Review metadata unavailable"));
+        _gitHubService
+            .GetIssueSubIssueSummariesAsync("owner", "repo", Arg.Any<IReadOnlyList<int>>(), cancellationToken)
+            .Returns([]);
+
+        var result = await _sut.GetCatalogueAsync(cancellationToken);
+
+        var pullRequest = Assert.Single(result.Items);
+        Assert.Equal(30, pullRequest.Number);
+        Assert.Null(pullRequest.HasReviewPending);
+        Assert.Empty(result.Failures);
+    }
+
+    [Fact]
+    public async Task GetCatalogueAsync_SubIssueSummaryLoadFails_ReturnsItemsWithoutSubIssueCounts()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        _gitHubService.GetActiveRepositoriesAsync(cancellationToken).Returns(
+        [
+            new Repository { Id = 1, Name = "repo", FullName = "owner/repo" },
+        ]);
+        _gitHubService
+            .GetIssuesAsync("owner", "repo", OpenItemState, cancellationToken)
+            .Returns([CreateIssue(10, "Epic parent", ["type/epic", "priority/high"])]);
+        _gitHubService
+            .GetPullRequestsAsync("owner", "repo", OpenItemState, cancellationToken)
+            .Returns([]);
+        _gitHubService
+            .GetOpenPullRequestReviewMetadataAsync("owner", "repo", cancellationToken)
+            .Returns([]);
+        _gitHubService
+            .GetIssueSubIssueSummariesAsync("owner", "repo", Arg.Is<IReadOnlyList<int>>(numbers => numbers.SequenceEqual(new[] { 10 })), cancellationToken)
+            .Throws(new HttpRequestException("Sub-issue summaries unavailable"));
+
+        var result = await _sut.GetCatalogueAsync(cancellationToken);
+
+        var issue = Assert.Single(result.Items);
+        Assert.Equal(10, issue.Number);
+        Assert.Null(issue.SubIssueTotal);
+        Assert.Null(issue.SubIssueCompleted);
+        Assert.Empty(result.Failures);
+    }
+
+    [Fact]
+    public async Task GetCatalogueAsync_BothIssueAndPullRequestLoadFail_ReturnsFailureWithCombinedMessage()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        _gitHubService.GetActiveRepositoriesAsync(cancellationToken).Returns(
+        [
+            new Repository { Id = 1, Name = "broken", FullName = "owner/broken" },
+        ]);
+        _gitHubService
+            .GetIssuesAsync("owner", "broken", OpenItemState, cancellationToken)
+            .Throws(new HttpRequestException("Issues unavailable", null, HttpStatusCode.Forbidden));
+        _gitHubService
+            .GetPullRequestsAsync("owner", "broken", OpenItemState, cancellationToken)
+            .Throws(new HttpRequestException("Pull requests unavailable", null, HttpStatusCode.ServiceUnavailable));
+
+        var result = await _sut.GetCatalogueAsync(cancellationToken);
+
+        Assert.Empty(result.Items);
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal("owner/broken", failure.RepositoryFullName);
+        Assert.Contains("Issues:", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("Pull requests:", failure.Message, StringComparison.Ordinal);
+        Assert.Equal((int)HttpStatusCode.Forbidden, failure.HttpStatusCode);
+    }
+
     private static Issue CreateIssue(
         int number,
         string title,

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/ProjectItemCatalogueServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/ProjectItemCatalogueServiceTests.cs
@@ -1,0 +1,186 @@
+using NSubstitute;
+using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Application.Services.PmWorkflow;
+using SoloDevBoard.Domain.Entities.PmWorkflow;
+using SoloDevBoard.Domain.Entities.Triage;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="ProjectItemCatalogueService"/>.</summary>
+public sealed class ProjectItemCatalogueServiceTests
+{
+    private readonly IGitHubService _gitHubService = Substitute.For<IGitHubService>();
+
+    [Fact]
+    public void Constructor_GitHubServiceIsNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        IGitHubService? gitHubService = null;
+
+        // Act
+        var action = () => _ = new ProjectItemCatalogueService(gitHubService!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(action);
+    }
+
+    [Fact]
+    public async Task GetCatalogueAsync_CatalogueReturned_MapsDomainRecordsToDto()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var activityTimestamp = new DateTimeOffset(2026, 3, 10, 9, 0, 0, TimeSpan.Zero);
+        var catalogue = new ProjectBoardItemCatalogue
+        {
+            FieldIds = new ProjectBoardFieldIds
+            {
+                StatusFieldId = "PVTF_status",
+                FocusOrderFieldId = "PVTF_focus",
+            },
+            Items = [
+                new ProjectBoardItem
+                {
+                    ProjectItemId = "PVTI_item",
+                    Status = new ProjectBoardItemStatus { OptionId = "option-up-next", Name = "Up Next" },
+                    FocusOrder = 2,
+                    Content = new ProjectBoardItemContent
+                    {
+                        ContentType = TriageItemType.Issue,
+                        Number = 40,
+                        RepositoryOwner = "markheydon",
+                        RepositoryName = "solo-dev-board",
+                        Title = "Daily Focus",
+                        Url = "https://github.com/markheydon/solo-dev-board/issues/40",
+                    },
+                    ActivityTimestamp = activityTimestamp,
+                },
+            ],
+        };
+
+        _gitHubService
+            .GetProjectBoardItemsAsync("project-id", cancellationToken)
+            .Returns(catalogue);
+
+        var sut = new ProjectItemCatalogueService(_gitHubService);
+
+        // Act
+        var result = await sut.GetCatalogueAsync("project-id", cancellationToken);
+
+        // Assert
+        Assert.Equal("PVTF_status", result.FieldIds.StatusFieldId);
+        Assert.Equal("PVTF_focus", result.FieldIds.FocusOrderFieldId);
+        Assert.Single(result.Items);
+        Assert.Equal("PVTI_item", result.Items[0].ProjectItemId);
+        Assert.Equal("Up Next", result.Items[0].Status?.Name);
+        Assert.Equal(2, result.Items[0].FocusOrder);
+        Assert.Equal(ProjectBoardItemContentTypeDto.Issue, result.Items[0].Content.ContentType);
+        Assert.Equal(40, result.Items[0].Content.Number);
+        Assert.Equal(activityTimestamp, result.Items[0].ActivityTimestamp);
+        await _gitHubService.Received(1).GetProjectBoardItemsAsync("project-id", cancellationToken);
+    }
+
+    [Fact]
+    public async Task GetCatalogueAsync_MissingFocusOrderFieldId_MapsNullFocusOrderFieldId()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var catalogue = new ProjectBoardItemCatalogue
+        {
+            FieldIds = new ProjectBoardFieldIds
+            {
+                StatusFieldId = "PVTF_status",
+                FocusOrderFieldId = null,
+            },
+            Items = [],
+        };
+
+        _gitHubService
+            .GetProjectBoardItemsAsync("project-id", cancellationToken)
+            .Returns(catalogue);
+
+        var sut = new ProjectItemCatalogueService(_gitHubService);
+
+        // Act
+        var result = await sut.GetCatalogueAsync("project-id", cancellationToken);
+
+        // Assert
+        Assert.Null(result.FieldIds.FocusOrderFieldId);
+        Assert.Empty(result.Items);
+    }
+
+    [Fact]
+    public async Task UpdateFocusOrderAsync_FocusOrderFieldIdMissing_ThrowsInvalidOperationException()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var sut = new ProjectItemCatalogueService(_gitHubService);
+
+        // Act
+        var action = async () => await sut.UpdateFocusOrderAsync("project-id", "item-id", " ", 1, cancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(action);
+        await _gitHubService.DidNotReceive().UpdateProjectBoardItemFocusOrderAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<double>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateFocusOrderAsync_ValidRequest_DelegatesToGitHubService()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var sut = new ProjectItemCatalogueService(_gitHubService);
+
+        // Act
+        await sut.UpdateFocusOrderAsync("project-id", "item-id", "focus-field-id", 3, cancellationToken);
+
+        // Assert
+        await _gitHubService.Received(1).UpdateProjectBoardItemFocusOrderAsync(
+            "project-id",
+            "item-id",
+            "focus-field-id",
+            3,
+            cancellationToken);
+    }
+
+    [Fact]
+    public async Task ClearFocusOrderAsync_FocusOrderFieldIdMissing_ThrowsInvalidOperationException()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var sut = new ProjectItemCatalogueService(_gitHubService);
+
+        // Act
+        var action = async () => await sut.ClearFocusOrderAsync("project-id", "item-id", string.Empty, cancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(action);
+        await _gitHubService.DidNotReceive().ClearProjectBoardItemFocusOrderAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ClearFocusOrderAsync_ValidRequest_DelegatesToGitHubService()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var sut = new ProjectItemCatalogueService(_gitHubService);
+
+        // Act
+        await sut.ClearFocusOrderAsync("project-id", "item-id", "focus-field-id", cancellationToken);
+
+        // Assert
+        await _gitHubService.Received(1).ClearProjectBoardItemFocusOrderAsync(
+            "project-id",
+            "item-id",
+            "focus-field-id",
+            cancellationToken);
+    }
+}

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -1826,6 +1826,368 @@ public sealed class GitHubServiceTests
     }
 
     [Fact]
+    public async Task GetOpenPullRequestReviewMetadataAsync_ReviewRequired_ReturnsPendingMetadata()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "pageInfo": { "hasNextPage": false, "endCursor": null },
+                            "nodes": [
+                                {
+                                    "number": 20,
+                                    "isDraft": false,
+                                    "reviewDecision": "REVIEW_REQUIRED",
+                                    "reviewRequests": { "totalCount": 0 }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        var result = await sut.GetOpenPullRequestReviewMetadataAsync("owner", "repo", cancellationToken);
+
+        var metadata = Assert.Single(result);
+        Assert.Equal(20, metadata.Number);
+        Assert.True(metadata.HasReviewPending);
+    }
+
+    [Fact]
+    public async Task GetOpenPullRequestReviewMetadataAsync_DraftPullRequest_ReturnsNotPending()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "pageInfo": { "hasNextPage": false, "endCursor": null },
+                            "nodes": [
+                                {
+                                    "number": 21,
+                                    "isDraft": true,
+                                    "reviewDecision": "REVIEW_REQUIRED",
+                                    "reviewRequests": { "totalCount": 2 }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        var result = await sut.GetOpenPullRequestReviewMetadataAsync("owner", "repo", cancellationToken);
+
+        var metadata = Assert.Single(result);
+        Assert.False(metadata.HasReviewPending);
+    }
+
+    [Fact]
+    public async Task GetOpenPullRequestReviewMetadataAsync_ApprovedWithRequests_ReturnsNotPending()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "pageInfo": { "hasNextPage": false, "endCursor": null },
+                            "nodes": [
+                                {
+                                    "number": 22,
+                                    "isDraft": false,
+                                    "reviewDecision": "APPROVED",
+                                    "reviewRequests": { "totalCount": 1 }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        var result = await sut.GetOpenPullRequestReviewMetadataAsync("owner", "repo", cancellationToken);
+
+        var metadata = Assert.Single(result);
+        Assert.False(metadata.HasReviewPending);
+    }
+
+    [Fact]
+    public async Task GetOpenPullRequestReviewMetadataAsync_HasNextPage_FetchesAllPages()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "pageInfo": { "hasNextPage": true, "endCursor": "cursor-one" },
+                            "nodes": [
+                                {
+                                    "number": 1,
+                                    "isDraft": false,
+                                    "reviewDecision": null,
+                                    "reviewRequests": { "totalCount": 1 }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "pageInfo": { "hasNextPage": false, "endCursor": null },
+                            "nodes": [
+                                {
+                                    "number": 2,
+                                    "isDraft": false,
+                                    "reviewDecision": "REVIEW_REQUIRED",
+                                    "reviewRequests": { "totalCount": 0 }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        var result = await sut.GetOpenPullRequestReviewMetadataAsync("owner", "repo", cancellationToken);
+
+        Assert.Equal(2, result.Count);
+        Assert.True(result[0].HasReviewPending);
+        Assert.True(result[1].HasReviewPending);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task GetIssueSubIssueSummariesAsync_TrackedIssuesPresent_ReturnsSummary()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "number": 10,
+                            "trackedIssues": {
+                                "pageInfo": { "hasNextPage": false, "endCursor": null },
+                                "totalCount": 2,
+                                "nodes": [
+                                    { "state": "CLOSED" },
+                                    { "state": "OPEN" }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        var result = await sut.GetIssueSubIssueSummariesAsync("owner", "repo", [10], cancellationToken);
+
+        var summary = Assert.Single(result);
+        Assert.Equal(10, summary.Number);
+        Assert.Equal(2, summary.TotalCount);
+        Assert.Equal(1, summary.CompletedCount);
+    }
+
+    [Fact]
+    public async Task GetIssueSubIssueSummariesAsync_TrackedIssuesHasNextPage_CountsAllCompleted()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "number": 10,
+                            "trackedIssues": {
+                                "pageInfo": { "hasNextPage": true, "endCursor": "cursor-one" },
+                                "totalCount": 2,
+                                "nodes": [
+                                    { "state": "CLOSED" }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "number": 10,
+                            "trackedIssues": {
+                                "pageInfo": { "hasNextPage": false, "endCursor": null },
+                                "totalCount": 2,
+                                "nodes": [
+                                    { "state": "CLOSED" }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        var result = await sut.GetIssueSubIssueSummariesAsync("owner", "repo", [10], cancellationToken);
+
+        var summary = Assert.Single(result);
+        Assert.Equal(2, summary.TotalCount);
+        Assert.Equal(2, summary.CompletedCount);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task GetIssueSubIssueSummariesAsync_MultipleIssueNumbers_QueriesEachRequestedIssue()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "number": 10,
+                            "trackedIssues": {
+                                "pageInfo": { "hasNextPage": false, "endCursor": null },
+                                "totalCount": 1,
+                                "nodes": [ { "state": "CLOSED" } ]
+                            }
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "number": 20,
+                            "trackedIssues": {
+                                "pageInfo": { "hasNextPage": false, "endCursor": null },
+                                "totalCount": 1,
+                                "nodes": [ { "state": "OPEN" } ]
+                            }
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        var result = await sut.GetIssueSubIssueSummariesAsync("owner", "repo", [10, 20], cancellationToken);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task GetProjectBoardItemsAsync_MissingUpdatedAt_UsesUnixEpochActivityTimestamp()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "node": {
+                        "fields": {
+                            "nodes": [
+                                { "id": "PVTF_status", "name": "Status", "dataType": "SINGLE_SELECT" }
+                            ]
+                        },
+                        "items": {
+                            "pageInfo": { "hasNextPage": false, "endCursor": null },
+                            "nodes": [
+                                {
+                                    "id": "PVTI_item-one",
+                                    "updatedAt": null,
+                                    "content": {
+                                        "__typename": "Issue",
+                                        "number": 5,
+                                        "title": "No timestamps",
+                                        "url": "https://github.com/markheydon/solo-dev-board/issues/5",
+                                        "repository": {
+                                            "name": "solo-dev-board",
+                                            "owner": { "login": "markheydon" }
+                                        }
+                                    },
+                                    "status": null,
+                                    "focusOrder": null
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        var result = await sut.GetProjectBoardItemsAsync("project-id", cancellationToken);
+
+        Assert.Single(result.Items);
+        Assert.Equal(DateTimeOffset.UnixEpoch, result.Items[0].ActivityTimestamp);
+    }
+
+    [Fact]
     public async Task CloseTriageItemAsDuplicateAsync_Issue_PostsCommentAndClosesIssue()
     {
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using NSubstitute;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Domain.Entities.Triage;
 using SoloDevBoard.Infrastructure.GitHub;
 
 namespace SoloDevBoard.Infrastructure.Tests;
@@ -1535,6 +1536,293 @@ public sealed class GitHubServiceTests
         // Assert
         var exception = await Assert.ThrowsAsync<HttpRequestException>(action);
         Assert.Contains("GitHub GraphQL request failed", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetProjectBoardItemsAsync_StatusAndFocusOrderPresent_ReturnsMappedCatalogue()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "node": {
+                        "fields": {
+                            "nodes": [
+                                { "id": "PVTF_status", "name": "Status", "dataType": "SINGLE_SELECT" },
+                                { "id": "PVTF_focus", "name": "Focus Order", "dataType": "NUMBER" }
+                            ]
+                        },
+                        "items": {
+                            "pageInfo": { "hasNextPage": false, "endCursor": null },
+                            "nodes": [
+                                {
+                                    "id": "PVTI_item-one",
+                                    "updatedAt": "2026-03-01T10:00:00Z",
+                                    "content": {
+                                        "__typename": "Issue",
+                                        "number": 40,
+                                        "title": "Daily Focus",
+                                        "url": "https://github.com/markheydon/solo-dev-board/issues/40",
+                                        "repository": {
+                                            "name": "solo-dev-board",
+                                            "owner": { "login": "markheydon" }
+                                        }
+                                    },
+                                    "status": {
+                                        "optionId": "option-up-next",
+                                        "name": "Up Next",
+                                        "updatedAt": "2026-03-05T12:00:00Z"
+                                    },
+                                    "focusOrder": { "number": 2 }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        var result = await sut.GetProjectBoardItemsAsync("project-id", cancellationToken);
+
+        // Assert
+        Assert.Equal("PVTF_status", result.FieldIds.StatusFieldId);
+        Assert.Equal("PVTF_focus", result.FieldIds.FocusOrderFieldId);
+        Assert.Single(result.Items);
+        Assert.Equal("PVTI_item-one", result.Items[0].ProjectItemId);
+        Assert.Equal("Up Next", result.Items[0].Status?.Name);
+        Assert.Equal("option-up-next", result.Items[0].Status?.OptionId);
+        Assert.Equal(2, result.Items[0].FocusOrder);
+        Assert.Equal(TriageItemType.Issue, result.Items[0].Content.ContentType);
+        Assert.Equal(40, result.Items[0].Content.Number);
+        Assert.Equal(new DateTimeOffset(2026, 3, 5, 12, 0, 0, TimeSpan.Zero), result.Items[0].ActivityTimestamp);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task GetProjectBoardItemsAsync_MissingFocusOrderField_ReturnsCatalogueWithoutFocusOrderFieldId()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "node": {
+                        "fields": {
+                            "nodes": [
+                                { "id": "PVTF_status", "name": "Status", "dataType": "SINGLE_SELECT" }
+                            ]
+                        },
+                        "items": {
+                            "pageInfo": { "hasNextPage": false, "endCursor": null },
+                            "nodes": [
+                                {
+                                    "id": "PVTI_item-one",
+                                    "updatedAt": "2026-03-01T10:00:00Z",
+                                    "content": {
+                                        "__typename": "PullRequest",
+                                        "number": 12,
+                                        "title": "PM workflow PR",
+                                        "url": "https://github.com/markheydon/solo-dev-board/pull/12",
+                                        "repository": {
+                                            "name": "solo-dev-board",
+                                            "owner": { "login": "markheydon" }
+                                        }
+                                    },
+                                    "status": null,
+                                    "focusOrder": null
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        var result = await sut.GetProjectBoardItemsAsync("project-id", cancellationToken);
+
+        // Assert
+        Assert.Equal("PVTF_status", result.FieldIds.StatusFieldId);
+        Assert.Null(result.FieldIds.FocusOrderFieldId);
+        Assert.Single(result.Items);
+        Assert.Null(result.Items[0].Status);
+        Assert.Null(result.Items[0].FocusOrder);
+        Assert.Equal(TriageItemType.PullRequest, result.Items[0].Content.ContentType);
+        Assert.Equal(new DateTimeOffset(2026, 3, 1, 10, 0, 0, TimeSpan.Zero), result.Items[0].ActivityTimestamp);
+    }
+
+    [Fact]
+    public async Task GetProjectBoardItemsAsync_HasNextPage_FetchesAllPages()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "node": {
+                        "fields": {
+                            "nodes": [
+                                { "id": "PVTF_status", "name": "Status", "dataType": "SINGLE_SELECT" }
+                            ]
+                        },
+                        "items": {
+                            "pageInfo": { "hasNextPage": true, "endCursor": "cursor-one" },
+                            "nodes": [
+                                {
+                                    "id": "PVTI_item-one",
+                                    "updatedAt": "2026-03-01T10:00:00Z",
+                                    "content": {
+                                        "__typename": "Issue",
+                                        "number": 1,
+                                        "title": "First",
+                                        "url": "https://github.com/markheydon/solo-dev-board/issues/1",
+                                        "repository": {
+                                            "name": "solo-dev-board",
+                                            "owner": { "login": "markheydon" }
+                                        }
+                                    },
+                                    "status": null,
+                                    "focusOrder": null
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "node": {
+                        "fields": {
+                            "nodes": [
+                                { "id": "PVTF_status", "name": "Status", "dataType": "SINGLE_SELECT" }
+                            ]
+                        },
+                        "items": {
+                            "pageInfo": { "hasNextPage": false, "endCursor": null },
+                            "nodes": [
+                                {
+                                    "id": "PVTI_item-two",
+                                    "updatedAt": "2026-03-02T10:00:00Z",
+                                    "content": {
+                                        "__typename": "Issue",
+                                        "number": 2,
+                                        "title": "Second",
+                                        "url": "https://github.com/markheydon/solo-dev-board/issues/2",
+                                        "repository": {
+                                            "name": "solo-dev-board",
+                                            "owner": { "login": "markheydon" }
+                                        }
+                                    },
+                                    "status": null,
+                                    "focusOrder": null
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        var result = await sut.GetProjectBoardItemsAsync("project-id", cancellationToken);
+
+        // Assert
+        Assert.Equal(2, result.Items.Count);
+        Assert.Equal("PVTI_item-one", result.Items[0].ProjectItemId);
+        Assert.Equal("PVTI_item-two", result.Items[1].ProjectItemId);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task UpdateProjectBoardItemFocusOrderAsync_ValidResponse_PostsGraphQlMutation()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "updateProjectV2ItemFieldValue": {
+                        "projectV2Item": { "id": "PVTI_item-one" }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        await sut.UpdateProjectBoardItemFocusOrderAsync("project-id", "project-item-id", "focus-field-id", 4, cancellationToken);
+
+        // Assert
+        Assert.Single(handler.Requests);
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync(cancellationToken);
+        using var document = JsonDocument.Parse(payload);
+        var variables = document.RootElement.GetProperty("variables");
+        Assert.Equal("project-id", variables.GetProperty("projectId").GetString());
+        Assert.Equal("project-item-id", variables.GetProperty("itemId").GetString());
+        Assert.Equal("focus-field-id", variables.GetProperty("fieldId").GetString());
+        Assert.Equal(4, variables.GetProperty("focusOrder").GetDouble());
+    }
+
+    [Fact]
+    public async Task ClearProjectBoardItemFocusOrderAsync_ValidResponse_PostsGraphQlMutation()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "clearProjectV2ItemFieldValue": {
+                        "projectV2Item": { "id": "PVTI_item-one" }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        // Act
+        await sut.ClearProjectBoardItemFocusOrderAsync("project-id", "project-item-id", "focus-field-id", cancellationToken);
+
+        // Assert
+        Assert.Single(handler.Requests);
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync(cancellationToken);
+        using var document = JsonDocument.Parse(payload);
+        var variables = document.RootElement.GetProperty("variables");
+        Assert.Equal("project-id", variables.GetProperty("projectId").GetString());
+        Assert.Equal("project-item-id", variables.GetProperty("itemId").GetString());
+        Assert.Equal("focus-field-id", variables.GetProperty("fieldId").GetString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary of Changes

Adds the two infrastructure enablers for Cross-Repo PM Workflow that unblock Daily Focus, Backlog Review, and Iteration Planning.

**#382 — Projects v2 item catalogue:** GraphQL read model for board items (Status, optional Focus Order, content links, stall timestamps) with dynamic field discovery, Focus Order set/clear writes, and `IProjectItemCatalogueService` DTO mapping (DEC-008). No Project #8 field ids are compiled into Application or App.

**#384 — Cross-repo work-item catalogue:** `IPmWorkItemCatalogueService` fans out open issues and pull requests across included active repositories, honours PM settings exclusions, collects per-repository failures for retry UI, and exposes label helpers (`type/`, `priority/`, `status/`) plus priority ranking. GraphQL enrichment adds PR review-pending signals and epic/feature sub-issue counts.

## Related Issue(s)

Closes #382
Closes #384

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [ ] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — infrastructure enablers only; no UI changes in this PR.

## Additional Notes

- Parallel implementation on separate branches was merged into `feature/issue-382-project-item-catalogue`; registration conflicts in `ApplicationServiceCollectionExtensions` were resolved to register both services.
- **Verify:** `dotnet build` — 0 warnings; `dotnet test SoloDevBoard.slnx` — 622 passed, 0 failed.
- Issue/PR lists are not cached (DEC-018). Stall timestamp prefers Status field-updated time with item `updatedAt` fallback (documented in XML comments).
- End-user guide (`website/content/docs/pm-workflow.md`) remains draft until page-producing stories ship.