### PR TITLE
[Chore] Add deliver-issue delivery loop automation

### DIFF
--- a/.agents/contracts/code-review.md
+++ b/.agents/contracts/code-review.md
@@ -71,18 +71,34 @@ Invoke this agent when you need to review:
 
 ## Review Output
 
-For each issue found:
+### When reviewing an open pull request
+
+Submit findings as a **GitHub Pull Request Review** so they appear as resolvable review conversations (same shape as Copilot or human reviews). Do not post actionable findings as a lone `gh pr comment` issue comment — issue comments cannot be resolved and block the `/address-pr-review-comments` loop.
+
+- Use `gh pr review` with inline comments, or GraphQL review comments, for file- or line-specific findings.
+- Cross-cutting findings with no natural line go in the review body or as a comment on a representative changed file within the same review submission.
+- Include severities and a merge recommendation in the review body:
+  - `Approve`
+  - `Approve with minor concerns`
+  - `Request changes`
+- Use `--request-changes` when Critical or High findings exist; use `--comment` otherwise. Do not use `--approve` via the API unless the maintainer explicitly wants a GitHub approve — prefer `--comment` plus the text recommendation to preserve the manual merge gate.
+- When the review is clean, submit a `COMMENT` review with no inline threads (or an approving summary in the review body only).
+
+### When reviewing a branch with no pull request yet
+
+Provide findings in chat. For each issue found:
+
 - Provide severity: `Critical`, `High`, `Medium`, or `Low`.
 - Explain why it matters.
 - Suggest a concrete improvement.
 
 At the end of the review:
+
 - Summarise the key findings.
 - State whether the branch is ready for merge.
-- Provide a merge recommendation when reviewing a PR:
-  - `Approve`
-  - `Approve with minor concerns`
-  - `Request changes`
+- Provide a merge recommendation (`Approve`, `Approve with minor concerns`, or `Request changes`).
+
+Do not assign Copilot as reviewer. Do not merge the pull request.
 
 ## Integration Points
 - Reference [`AGENTS.md`](../../AGENTS.md) for repository requirements.

--- a/.agents/contracts/delivery.md
+++ b/.agents/contracts/delivery.md
@@ -1,7 +1,7 @@
 ---
 role: Delivery
-description: Runs implementation preflight and implements planned GitHub issues, creates tests, updates documentation, and prepares work for review.
-triggers: Implement issue #N; preflight issue #N; build feature X; fix bug #N
+description: Runs implementation preflight and implements planned GitHub issues, creates tests, updates documentation, prepares work for review, and addresses pull request review feedback.
+triggers: Implement issue #N; preflight issue #N; build feature X; fix bug #N; address PR review comments on PR #N
 ---
 
 # Delivery Agent
@@ -18,7 +18,7 @@ The Delivery Agent focuses on:
 - Tests
 - Documentation
 
-Do NOT manage pull requests, issue closure, project boards, milestones, or release planning.
+Do NOT create pull requests, close issues, manage milestones, update project boards, or perform release planning. Verify Agent owns PR creation. The narrow PR review comment loop in §10 is the only pull-request interaction Delivery performs.
 
 ---
 
@@ -33,6 +33,7 @@ Examples:
 - Build Label Manager UI
 - Fix bug #42
 - Implement issues #100 and #101
+- Address PR review comments on PR #456
 
 ---
 
@@ -258,9 +259,34 @@ Do not perform a full repository audit.
 
 ---
 
+### 10. PR Review Comment Loop
+
+When invoked via [`address-pr-review-comments`](../workflows/address-pr-review-comments.md):
+
+1. Load the pull request: `gh pr view <N> --json number,headRefName,baseRefName,state`.
+2. Checkout the PR head branch locally.
+3. Fetch every unresolved review thread (Copilot, human, agent, or bot) via GraphQL `reviewThreads` or equivalent. Do not stop after the first reviewer.
+4. For each thread, apply the disposition rules in the workflow:
+   - In-scope and valid: implement the fix, reply on the thread, resolve the conversation.
+   - Invalid, duplicate, or out of scope: reply with the reason, resolve the conversation.
+   - Needs maintainer decision: reply, leave unresolved, and stop with a short list for the user.
+5. If no unresolved threads exist, report "No unresolved review conversations" and stop.
+6. Run scoped tests for changed behaviour, then commit and push to the existing PR branch.
+7. Post one final summary issue comment on the pull request.
+
+Rules:
+
+- Stay on the existing PR branch; do not open a replacement PR.
+- Do not treat top-level issue comments as review threads (they cannot be resolved).
+- Do not treat this workflow's own closing summary comment as a finding on a later pass.
+- This path is **exempt from Testing Phase**: commit and push without waiting for manual test acceptance.
+- Reply on and resolve review threads as needed; do not create, merge, or approve pull requests.
+
+---
+
 ## Testing Phase
 
-When the user begins testing:
+When the user begins manual product testing after implementation (not during the PR review comment loop in §10):
 
 - Do not commit
 - Do not push
@@ -296,14 +322,17 @@ Fix testing feedback for issue #184 - diagram labels, layout spacing, error word
 
 Do NOT:
 
-- Create pull requests
+- Create pull requests (Verify Agent owns PR creation)
 - Close issues
+- Merge or approve pull requests
 - Manage milestones
 - Update project boards (use the `status/in-progress` label transition in §2 instead; Roadmap Sync updates the board)
 - Update release plans
 - Perform roadmap management
 - Implement unplanned scope
 - Edit GitHub issues except the narrow `status/in-progress` transition on the issue being implemented
+
+The PR review comment loop (§10) may reply on and resolve review threads on an existing pull request.
 
 Do NOT commit directly to `main`.
 

--- a/.agents/contracts/verify.md
+++ b/.agents/contracts/verify.md
@@ -60,12 +60,12 @@ Confirm:
 
 ### 3. Test Validation
 
-Validate relevant tests execute successfully.
+Validate relevant tests execute successfully on a clean rebuild.
 
 Suggested command:
 
 ```bash
-dotnet test
+dotnet clean SoloDevBoard.slnx && dotnet test SoloDevBoard.slnx
 ```
 
 Confirm:
@@ -75,9 +75,29 @@ Confirm:
 
 Do not perform exhaustive test audits.
 
+Escalate to Delivery Agent if tests fail. Do not patch code.
+
 ---
 
-### 4. Documentation Validation
+### 4. Package Validation
+
+Before creating the pull request, confirm direct package references introduced or bumped on this branch are current.
+
+Suggested command:
+
+```bash
+dotnet list SoloDevBoard.slnx package --outdated
+```
+
+Rules:
+
+- Compare against `.csproj` files changed on this branch.
+- If a **direct** `PackageReference` added or version-bumped in this branch is not the latest version listed by `dotnet list package --outdated`, escalate to Delivery Agent to bump before opening the PR.
+- Do not block on unrelated pre-existing outdated packages elsewhere in the solution.
+
+---
+
+### 5. Documentation Validation
 
 Only check documentation when:
 
@@ -94,7 +114,7 @@ Do not open archived ADRs, release plans, scope documents, or implementation pla
 
 ---
 
-### 5. Pull Request Creation
+### 6. Pull Request Creation
 
 Create the PR after validation succeeds.
 
@@ -111,7 +131,7 @@ Follow [`plan/PULL_REQUEST_POLICY.md`](../../plan/PULL_REQUEST_POLICY.md) in ful
 
 ---
 
-### 6. Verify Summary
+### 7. Verify Summary
 
 Provide a concise verify summary.
 
@@ -119,12 +139,13 @@ Preferred format:
 
 ```text
 ✅ Build passed
-✅ Tests passed
+✅ Tests passed (clean rebuild)
+✅ Packages validated
 ✅ Documentation validated
 
-PR #123 created.
+PR #123 created: <url>
 
-Ready for merge.
+Next: open a new agent session and run `/code-review` on PR #123 (must submit a GitHub review, not chat only).
 ```
 
 Keep summaries brief.
@@ -159,6 +180,7 @@ Escalate to Delivery Agent if:
 
 - Build fails
 - Tests fail
+- A direct package added or bumped on this branch is outdated
 - Code changes are required
 - Documentation updates are required
 
@@ -169,10 +191,11 @@ Escalate to Delivery Agent if:
 Verify is complete when:
 
 - Build passes
-- Tests pass
+- Clean rebuild tests pass
+- Package validation passes (direct packages introduced or bumped on this branch)
 - Documentation validation passes (if applicable)
 - PR is created
-- User is informed of outcome
+- User is informed of outcome and the `/code-review` handoff
 
 ---
 
@@ -182,12 +205,13 @@ Successful verify:
 
 ```text
 ✅ Build passed
-✅ Tests passed
+✅ Tests passed (clean rebuild)
+✅ Packages validated
 ✅ Documentation validated
 
-PR #123 created.
+PR #123 created: <url>
 
-Ready for merge.
+Next: open a new agent session and run `/code-review` on PR #123.
 ```
 
 Failed verify:

--- a/.agents/skills/_REGISTRY.md
+++ b/.agents/skills/_REGISTRY.md
@@ -40,8 +40,8 @@ Skills not listed as active or optional companion should be removed from `.agent
 SoloDevBoard defines specialised role contracts for PM workflows. These orchestrate skills and enforce quality gates.
 
 - `pm-orchestrator`: GitHub Issues / Project #8 selection → scope validation → technical planning (breakdown-plan) → GitHub issue setup
-- `delivery`: Implementation preflight → code → tests → docs → decision log (if needed)
-- `verify`: Quality validation → PR creation → issue closure → release impact assessment
+- `delivery`: Implementation preflight → code → tests → docs → decision log (if needed) → PR review comment loop
+- `verify`: Quality validation (clean rebuild, package hygiene) → PR creation → issue closure → release impact assessment
 
 **Role contracts:** `.agents/contracts/*.md`  
 **Workflow entry points:** `.agents/workflows/*.md` (canonical)  
@@ -55,11 +55,12 @@ Reusable workflows for PM operations (canonical definitions in `.agents/workflow
 - `daily-start`: Session orientation → issue and project board health → blocker identification → next action recommendation
 - `plan-next-issue`: GitHub Issues / Project #8 selection → scope validation → breakdown-plan → GitHub issue creation
 - `preflight-issue`: Implementation preflight only (context, codebase discovery, sketch) — no coding
+- `deliver-issue`: Preflight (when required) → implementation → verify/PR (happy path orchestration)
 - `implement-issue`: Preflight → implementation → tests → docs → decision log
-- `verify-and-create-pr`: Quality gates → PR creation → issue closure
-- `address-pr-review-comments`: PR review feedback → thread replies → resolved conversations
+- `verify-and-create-pr`: Quality gates (clean rebuild, package hygiene) → PR creation → issue closure
+- `address-pr-review-comments`: PR review feedback (any reviewer) → implement → thread replies → resolved conversations
 - `pm-progress-review`: Milestone health since last review → velocity trends → release confidence → top 3 next-session priorities
-- `code-review`: PR and branch review against repository conventions
+- `code-review`: PR and branch review against repository conventions (GitHub review with resolvable threads)
 - `docs-update`: Documentation refresh and decision log updates
 
 **Workflow definitions:** [`.agents/workflows/`](../../.agents/workflows/)  
@@ -67,7 +68,7 @@ Reusable workflows for PM operations (canonical definitions in `.agents/workflow
 
 ## Tool entry points
 
-Cursor slash commands and Copilot prompts are thin discovery layers only. Examples: `/preflight-issue` → [`.agents/workflows/preflight-issue.md`](../../.agents/workflows/preflight-issue.md) → [`.agents/contracts/delivery.md`](../../.agents/contracts/delivery.md); `/implement-issue` → [`.agents/workflows/implement-issue.md`](../../.agents/workflows/implement-issue.md) → [`.agents/contracts/delivery.md`](../../.agents/contracts/delivery.md)
+Cursor slash commands and Copilot prompts are thin discovery layers only. Examples: `/preflight-issue` → [`.agents/workflows/preflight-issue.md`](../../.agents/workflows/preflight-issue.md) → [`.agents/contracts/delivery.md`](../../.agents/contracts/delivery.md); `/deliver-issue` → [`.agents/workflows/deliver-issue.md`](../../.agents/workflows/deliver-issue.md) → Delivery + Verify contracts; `/implement-issue` → [`.agents/workflows/implement-issue.md`](../../.agents/workflows/implement-issue.md) → [`.agents/contracts/delivery.md`](../../.agents/contracts/delivery.md)
 
 ## Canonical Sources
 

--- a/.agents/workflows/README.md
+++ b/.agents/workflows/README.md
@@ -23,6 +23,7 @@ Orchestration, rituals, and step-by-step guidance live in [`plan/PM_RUNBOOK.md`]
 | Start a working session | "Run the daily start workflow", `/daily-start` | `daily-start` | `pm-orchestrator` |
 | Plan the next feature | "Plan the next item", `/plan-next-issue` | `plan-next-issue` | `pm-orchestrator` |
 | Preflight before implementation | "Preflight issue #N", `/preflight-issue` | `preflight-issue` | `delivery` |
+| Deliver planned work (happy path) | "Deliver issue #N", `/deliver-issue` | `deliver-issue` | `delivery`, `verify` |
 | Implement planned work | "Implement issue #N", `/implement-issue` | `implement-issue` | `delivery` |
 | Validate implementation and open PR | "Verify issue #N", "Create PR for issue #N", `/verify-and-create-pr` | `verify-and-create-pr` | `verify` |
 | Address PR review comments | "Address PR review comments on PR #N", `/address-pr-review-comments` | `address-pr-review-comments` | `delivery` |
@@ -40,10 +41,11 @@ Orchestration, rituals, and step-by-step guidance live in [`plan/PM_RUNBOOK.md`]
 | [daily-start](daily-start.md) | "Run the daily start workflow" | `pm-orchestrator` | `repo-github-project` (optional) | Session Start |
 | [plan-next-issue](plan-next-issue.md) | "Plan the next item" | `pm-orchestrator` | `breakdown-plan`, `breakdown-test`, `repo-github-issues`, `repo-github-project` | Stage 1: Planning |
 | [preflight-issue](preflight-issue.md) | "Preflight issue #N" | `delivery` | `dotnet-best-practices`, `mudblazor` (on demand) | Stage 2: Implementation (preflight) |
+| [deliver-issue](deliver-issue.md) | "Deliver issue #N" | `delivery`, `verify` | `dotnet-best-practices`, `mudblazor`, etc. (on demand) | Stage 2–3: Delivery happy path |
 | [implement-issue](implement-issue.md) | "Implement issue #N" | `delivery` | `dotnet-best-practices`, `mudblazor`, etc. (on demand) | Stage 2: Implementation |
 | [verify-and-create-pr](verify-and-create-pr.md) | "Verify issue #N", "Create PR for issue #N" | `verify` | — | Stage 3: Verify and PR |
 | [address-pr-review-comments](address-pr-review-comments.md) | "Address PR review comments on PR #N" | `delivery` | — | PR Review Comment Loop |
 | [pm-progress-review](pm-progress-review.md) | "Run the PM progress review" | `pm-orchestrator` | — | Progress Review Rhythm |
 | [sync-status-labels](sync-status-labels.md) | "Clean up status labels", `/sync-status-labels` | `repo-github-gh-cli` | — | Board Hygiene Audit |
-| [code-review](code-review.md) | "Code review PR #N" | `code-review` | — | — |
+| [code-review](code-review.md) | "Code review PR #N" | `code-review` | — | Stage 3b: Independent code review |
 | [docs-update](docs-update.md) | "Refresh documentation for X" | `tech-writer` | `documentation-writer` | — |

--- a/.agents/workflows/address-pr-review-comments.md
+++ b/.agents/workflows/address-pr-review-comments.md
@@ -1,15 +1,23 @@
 # Address PR Review Comments
 
-**Contract:** [`.agents/contracts/delivery.md`](../contracts/delivery.md)
+**Contract:** [`.agents/contracts/delivery.md`](../contracts/delivery.md) (PR review comment loop section)
 **Runbook:** [`plan/PM_RUNBOOK.md`](../../plan/PM_RUNBOOK.md) — PR Review Comment Loop
 
 ## Easy-to-miss specifics
 
 - Stay on the existing pull request branch; do not create a replacement PR.
-- Post a reply on each addressed coding review comment thread.
-- Resolve each addressed conversation after the fix is in place.
-- Post one final summary comment on the pull request once all addressed comments are handled.
-- If a comment needs clarification or is intentionally not implemented, reply with the reasoning and leave the conversation unresolved.
+- Checkout the PR head branch before making changes.
+- Fetch **every** unresolved review thread on the PR (Copilot, human, agent, or bot) via GraphQL `reviewThreads` or equivalent — do not stop after the first reviewer.
+- Merge policy blocks merge while **unresolved review conversations** remain. Top-level issue comments are not review threads and cannot be resolved; ignore them except the workflow's own closing summary.
+- **Thread disposition:**
+  - In-scope and valid: implement, reply on the thread, then resolve.
+  - Invalid, duplicate, or out of scope: reply with the reason, then resolve so merge is not blocked.
+  - Needs maintainer decision (security, scope, product): reply, leave unresolved, and stop with a short list for the user.
+- If no unresolved review threads exist, no-op with "No unresolved review conversations" — do not invent work.
+- Do not treat this workflow's closing summary issue comment as a finding on a subsequent pass.
+- Post one final summary issue comment on the pull request once all addressed threads are handled.
+- This path is exempt from the Delivery Testing Phase (commit and push without waiting for manual test acceptance).
+- Re-run scoped tests after fixes; push to the existing PR branch.
 
 ## Invocation
 

--- a/.agents/workflows/code-review.md
+++ b/.agents/workflows/code-review.md
@@ -6,6 +6,9 @@
 
 - Review only — do not modify code; escalate required fixes to Delivery.
 - Do not use for post-implementation PR creation — use `verify-and-create-pr` instead.
+- When reviewing an open PR, submit a **GitHub Pull Request Review** with resolvable inline threads (`gh pr review` / GraphQL). Do not post actionable findings as a lone issue comment.
+- Use `--request-changes` for Critical/High findings; `--comment` otherwise. Prefer `--comment` plus text recommendation over `--approve` to preserve the manual merge gate.
+- A clean review may submit `COMMENT` with no inline threads.
 
 ## Invocation
 

--- a/.agents/workflows/deliver-issue.md
+++ b/.agents/workflows/deliver-issue.md
@@ -1,0 +1,37 @@
+# Deliver Issue
+
+**Contracts:** [`.agents/contracts/delivery.md`](../contracts/delivery.md), [`.agents/contracts/verify.md`](../contracts/verify.md)
+**Runbook:** [`plan/PM_RUNBOOK.md`](../../plan/PM_RUNBOOK.md) — Stage 2 and Stage 3 (happy path)
+**Skills (on demand):** Same as `implement-issue` (via Delivery contract)
+
+## Purpose
+
+Orchestrate the delivery happy path in one session: preflight (when required), implementation, and verify/PR creation. Does not run code review — use a **new** agent session for `/code-review` after the PR exists.
+
+## Easy-to-miss specifics
+
+- Require issue number `N`. Load labels: `gh issue view <N> --json title,body,state,labels`.
+- Do not implement issues with `status/blocked` or `status/ice-box` — escalate or re-queue first.
+- **Preflight pause:** if `size/m`, `size/l`, `size/xl`, or `type/enabler`, and this session has not already produced **Preflight Complete**, run [`.agents/workflows/preflight-issue.md`](preflight-issue.md) only and stop. If preflight already ran in this chat, treat the proceed gate as satisfied.
+- Otherwise run [`.agents/workflows/implement-issue.md`](implement-issue.md) (includes mandatory preflight; `size/xs`, `size/s`, and `type/bug` auto-continue per the Delivery contract).
+- When Delivery reports **Implementation Complete**, run [`.agents/workflows/verify-and-create-pr.md`](verify-and-create-pr.md).
+- Stop after verify. Do not continue into `/code-review` in this session.
+- Keep `/preflight-issue`, `/implement-issue`, and `/verify-and-create-pr` available for split workflows.
+
+## Invocation
+
+Natural language: "Deliver issue #N"
+Slash command: `/deliver-issue [number]`
+
+## Handoff
+
+When verify succeeds, end with:
+
+```text
+Delivery complete for issue #N.
+
+PR #<id>: <url>
+
+Next: open a new agent session and run `/code-review` on PR #<id>.
+If unresolved review threads remain (Copilot, human, or code review), run `/address-pr-review-comments` on that PR.
+```

--- a/.agents/workflows/verify-and-create-pr.md
+++ b/.agents/workflows/verify-and-create-pr.md
@@ -8,6 +8,9 @@
 - Follow [`plan/PULL_REQUEST_POLICY.md`](../../plan/PULL_REQUEST_POLICY.md) for title, body, labels, linking, draft state, assignee, and milestone.
 - Use `gh pr create --fill` so the repository PR template is applied; do not bypass with a custom `--body` unless the platform cannot apply the template — then copy the template headings into the body.
 - Always use the repo's label strategy for the relevant labels. See the [label strategy](../../plan/LABEL_STRATEGY.md).
+- Test gate: `dotnet clean SoloDevBoard.slnx && dotnet test SoloDevBoard.slnx` before PR creation.
+- Package gate: `dotnet list SoloDevBoard.slnx package --outdated` before PR creation. Escalate to Delivery if a direct `PackageReference` added or bumped on this branch is not the latest listed version. Do not block on unrelated pre-existing outdated packages.
+- After PR creation, hand off to a **new** session for `/code-review` (GitHub review with resolvable threads, not chat only).
 
 ## Invocation
 

--- a/.cursor/commands/deliver-issue.md
+++ b/.cursor/commands/deliver-issue.md
@@ -1,0 +1,3 @@
+# Deliver Issue
+
+Follow [`.agents/workflows/deliver-issue.md`](.agents/workflows/deliver-issue.md).

--- a/.github/prompts/deliver-issue.prompt.md
+++ b/.github/prompts/deliver-issue.prompt.md
@@ -1,0 +1,6 @@
+---
+name: Deliver Issue
+description: Orchestrate preflight (when required), implementation, and verify/PR creation for a planned issue.
+---
+
+Follow [`.agents/workflows/deliver-issue.md`](../../.agents/workflows/deliver-issue.md).

--- a/plan/PM_RUNBOOK.md
+++ b/plan/PM_RUNBOOK.md
@@ -12,9 +12,11 @@ This runbook orchestrates [`.agents/contracts/`](../.agents/contracts/) and [`.a
 |------------------------------------------|------------------------------------------------------------|-----------------------------------------------|
 | Start a working session                  | "Run the daily start workflow" or `/daily-start`           | Status summary + next action recommendation   |
 | Plan the next feature                    | "Plan the next item" or `/plan-next-issue`                 | GitHub issues with full metadata + tech spec  |
-| Implement planned work                   | "Implement issue #N" or `/implement-issue`                 | Preflight + code + tests + docs + decision log (if needed) |
+| Deliver planned work (happy path)        | "Deliver issue #N" or `/deliver-issue`                     | Preflight (when required) + code + verify + PR |
+| Implement planned work (split)           | "Implement issue #N" or `/implement-issue`                 | Preflight + code + tests + docs + decision log (if needed) |
 | Preflight before implementation          | "Preflight issue #N" or `/preflight-issue`                  | Context, touch map, approach sketch (no code)              |
 | Verify and create PR                     | "Verify issue #N", "Create PR for issue #N", or `/verify-and-create-pr` | PR + quality validation + issue closure       |
+| Code review (independent session)        | "Code review PR #N" or `/code-review`                      | GitHub review with resolvable threads         |
 | Address PR review comments               | "Address PR review comments on PR #N" or `/address-pr-review-comments` | PR fixes + thread replies + resolved comments |
 | Progress review (since last update)      | "Run the PM progress review" or `/pm-progress-review`        | Executive summary + next-session priorities   |
 | End-to-end feature delivery              | `.agents/skills/repo-pm-feature-workflow/SKILL.md`         | Full workflow from backlog to closure         |
@@ -118,6 +120,18 @@ Plan the [feature name]
 #### Stage 2: Implementation (2-8 hours per feature, varies by size)
 **Trigger:** Planning complete, issues have `status/todo` label.
 
+**Run (happy path — recommended):**
+```
+Deliver issue #[number]
+```
+
+**Run (Cursor happy path):**
+```
+/deliver-issue [number]
+```
+
+This orchestrates preflight (when required), implementation, and verify/PR creation in one session. Use split commands below when you want to pause between stages.
+
 **Run (preflight only — optional, recommended for `size/l+` or enablers):**
 ```
 Preflight issue #[number]
@@ -170,12 +184,12 @@ Implement issue #[number]
 - ✅ Decision log updated (if architectural decision)
 - ✅ UK English verified
 
-**Next action:** Move to Stage 3 (Review).
+**Next action:** If you used `/deliver-issue`, verify and PR creation run in the same session. Otherwise move to Stage 3 (Verify). After the PR exists, open a **new** agent session for `/code-review`.
 
 ---
 
 #### Stage 3: Verify & PR Creation (15-30 minutes per feature)
-**Trigger:** Implementation complete, ready for quality check and PR.
+**Trigger:** Implementation complete, ready for quality check and PR. Skipped when you used `/deliver-issue` (verify runs at the end of that workflow).
 
 **Run:**
 ```
@@ -184,25 +198,53 @@ Verify issue #[number]
 
 **What it does:**
 - Invokes **Verify Agent**
-- Validates all quality gates (code, tests, docs)
+- Validates all quality gates (build, clean rebuild tests, direct package versions on changed projects, docs)
 - Creates pull request with metadata from [`PULL_REQUEST_POLICY.md`](PULL_REQUEST_POLICY.md)
 - Updates issue labels to `status/in-review`
-- Provides verify summary
+- Provides verify summary and hands off to `/code-review` in a new session
 
 **What you produce:**
 - Pull request linked to issue
 - Quality validation report
-- Issue ready for your PR approval
+- Issue ready for independent code review
 
 **Gates before proceeding:**
 - ✅ All quality gates passed
 - ✅ PR created and linked to issue
-- ✅ No compile errors, tests pass
+- ✅ Clean rebuild tests pass (`dotnet clean && dotnet test`)
+- ✅ Direct packages added or bumped on this branch are current
 - ✅ Documentation complete
 - ✅ Backlog synchronised
 - ✅ Roadmap item still has a valid Start Date before merge
 
-**Next action:** **You** approve and merge PR (manual step).
+**Next action:** Open a **new** agent session and run `/code-review` on the PR. You approve and merge manually after manual testing.
+
+---
+
+#### Stage 3b: Independent Code Review (15-30 minutes per feature)
+**Trigger:** Pull request exists and verify has completed.
+
+**Run (new agent session — do not reuse the implement/verify session):**
+```
+/code-review [PR number]
+```
+
+**What it does:**
+- Invokes **Code Review Agent** ([`.agents/contracts/code-review.md`](../.agents/contracts/code-review.md))
+- Audits the PR against architecture, testing, documentation, and UK English conventions
+- Submits a **GitHub Pull Request Review** with resolvable inline threads (not a lone issue comment)
+
+**What you produce:**
+- GitHub review with severities and merge recommendation
+- Resolvable review threads for any findings (same shape as Copilot or human reviews)
+
+**Gates before proceeding:**
+- ✅ Review submitted on GitHub (not chat only)
+- ✅ Actionable findings appear as resolvable review threads
+
+**Next action:** If unresolved review threads remain, run `/address-pr-review-comments`. Then manual product test and merge.
+
+**Optional:** A Cursor Automation on pull request opened (ignore drafts) can run the same `/code-review` prompt in the background. Configure in the Cursor Automations dashboard — not in this repository.
 
 ---
 
@@ -238,9 +280,9 @@ Close issue #[number] after PR #[number] merged
 
 ### PR Review Comment Loop (5-20 minutes per round)
 
-**Goal:** Keep an open pull request moving after coding review feedback arrives, without losing thread history.
+**Goal:** Keep an open pull request moving after coding review feedback arrives, without losing thread history. Merge is blocked while **unresolved review conversations** remain.
 
-**Trigger:** A reviewer leaves coding review comments or requested changes on an open pull request.
+**Trigger:** A reviewer (Copilot, human, `/code-review` agent, or bot) leaves coding review comments or requested changes on an open pull request.
 
 **Run:**
 ```
@@ -248,24 +290,27 @@ Address PR review comments on PR #[number]
 ```
 
 **What it does:**
-- Invokes **Delivery Agent** on the existing pull request branch.
-- Fetches unresolved coding review comments and review conversations.
-- Implements the requested code changes.
-- Posts a reply on each addressed coding review comment.
-- Resolves each addressed conversation.
-- Posts one final summary comment on the pull request once all addressed comments are handled.
+- Invokes **Delivery Agent** on the existing pull request branch ([`.agents/contracts/delivery.md`](../.agents/contracts/delivery.md) §10).
+- Fetches every unresolved review thread on the PR (not only one reviewer).
+- Implements in-scope findings; replies on each thread; resolves conversations.
+- Invalid or out-of-scope threads: reply with the reason, then resolve so merge is not blocked.
+- Threads needing your decision: reply and leave unresolved; stop with a short list.
+- Posts one final summary issue comment when all addressed threads are handled.
+- No-ops when no unresolved review threads exist.
 
 **What you produce:**
 - Updated branch contents on the existing PR.
 - Thread-by-thread reviewer feedback responses.
-- A clean pull request with resolved conversations and a summary comment.
+- A clean pull request with resolved review conversations.
 
 **Gates before returning to review:**
-- ✅ Requested changes implemented.
+- ✅ Requested changes implemented (or declined threads resolved with explanation).
 - ✅ Relevant tests rerun.
 - ✅ Each addressed review thread has a reply.
 - ✅ Each addressed review thread is resolved.
-- ✅ Final PR summary comment posted.
+- ✅ Final PR summary comment posted (informational issue comment — not a review thread).
+
+**Note:** Top-level issue comments are not review threads and cannot be resolved. Actionable work must live on GitHub review conversations.
 
 ---
 
@@ -345,11 +390,15 @@ START
   │   └─> Run daily start workflow → Follow recommendation
   │
   ├─ Have planned issue ready for coding?
-  │   ├─> Large or enabler? → `/preflight-issue` or "Preflight issue #N" (optional)
-  │   └─> `/implement-issue` or "Implement issue #N" (runs preflight, then codes)
+  │   ├─> Happy path → `/deliver-issue` or "Deliver issue #N"
+  │   ├─> Large or enabler? → `/preflight-issue` first (optional), then deliver or implement
+  │   └─> Split workflow → `/implement-issue` or "Implement issue #N"
   │
-  ├─ Have implemented code ready for review?
+  ├─ Have implemented code ready for review (split workflow)?
   │   └─> `/verify-and-create-pr` or "Verify issue #N"
+  │
+  ├─ Have a PR and need independent conventions review?
+  │   └─> New session: `/code-review` on PR #N
   │
   ├─ Has an open PR received coding review comments?
   │   └─> `/address-pr-review-comments` or "Address PR review comments on PR #N"
@@ -367,7 +416,7 @@ START
   │   └─> Run daily start workflow → Get recommendation
   │
   └─ Want end-to-end automation?
-      └─> Use repo-pm-feature-workflow skill (plans + implements + reviews)
+      └─> Use repo-pm-feature-workflow skill (plans + implements + reviews), or `/deliver-issue` for delivery-only happy path
 ```
 
 ---
@@ -393,7 +442,7 @@ START
 ---
 
 ### Delivery ([`.agents/contracts/delivery.md`](../.agents/contracts/delivery.md))
-**Trigger:** "Implement issue #X", "Preflight issue #X", "Build feature X"
+**Trigger:** "Implement issue #X", "Preflight issue #X", "Deliver issue #X", "Address PR review comments on PR #N", "Build feature X"
 
 **Responsibilities:**
 - Runs implementation preflight (context, codebase discovery, touch map, proceed gate)
@@ -404,9 +453,11 @@ START
 - Records architectural decisions via `repo-decision-log` / `plan/DECISIONS.md`
 - Ensures UK English throughout
 - Hands off to Verify Agent when complete
+- Addresses PR review comment threads (implement, reply, resolve) on existing pull requests
 
 **Boundaries:**
 - ❌ Does NOT start without clear acceptance criteria (escalates to PM Orchestrator)
+- ❌ Does NOT create pull requests (Verify Agent's job)
 - ❌ Does NOT close issues (Verify Agent's job)
 - ❌ Does NOT change scope without your approval
 
@@ -416,10 +467,11 @@ START
 **Trigger:** "Verify issue #X", "Create PR for issue #X"
 
 **Responsibilities:**
-- Validates quality gates (code, tests, docs, backlog sync)
+- Validates quality gates (build, clean rebuild tests, direct package hygiene, docs, backlog sync)
 - Creates pull request with metadata from [`PULL_REQUEST_POLICY.md`](PULL_REQUEST_POLICY.md)
 - Updates issue labels (`status/in-review` → `status/done`)
 - Closes issues post-merge
+- Hands off to independent `/code-review` in a new session
 - Suggests next backlog item
 
 **Boundaries:**
@@ -437,6 +489,7 @@ Canonical workflow definitions live in [`.agents/workflows/`](../.agents/workflo
 |----------|----------------|----------------|
 | Daily start | [`daily-start.md`](../.agents/workflows/daily-start.md) | `/daily-start` |
 | Plan next issue | [`plan-next-issue.md`](../.agents/workflows/plan-next-issue.md) | `/plan-next-issue` |
+| Deliver issue | [`deliver-issue.md`](../.agents/workflows/deliver-issue.md) | `/deliver-issue` |
 | Preflight issue | [`preflight-issue.md`](../.agents/workflows/preflight-issue.md) | `/preflight-issue` |
 | Implement issue | [`implement-issue.md`](../.agents/workflows/implement-issue.md) | `/implement-issue` |
 | Verify and create PR | [`verify-and-create-pr.md`](../.agents/workflows/verify-and-create-pr.md) | `/verify-and-create-pr` |
@@ -464,10 +517,11 @@ These gates are defined in [`AGENTS.md`](../AGENTS.md) and enforced by role cont
 - ✅ Issue label set to `status/in-progress` (Roadmap Sync updates the board)
 - ✅ Linked wireframe read for page-producing UI work
 
-### Before PR Creation (Delivery Agent enforces)
-- ✅ All acceptance criteria met
+### Before PR Creation (Verify Agent enforces)
+- ✅ All acceptance criteria met (Delivery handoff)
 - ✅ Code compiles, zero errors/warnings
-- ✅ Tests pass locally
+- ✅ Clean rebuild tests pass (`dotnet clean && dotnet test`)
+- ✅ Direct packages added or bumped on this branch are current (`dotnet list package --outdated`)
 - ✅ Documentation updated (if user-facing)
 - ✅ Decision log updated via `repo-decision-log` (if architectural decision)
 - ✅ UK English verified
@@ -565,7 +619,25 @@ This runbook orchestrates (does NOT duplicate) existing policy:
 
 ## Advanced Usage Patterns
 
-### Pattern 1: End-to-End Automation
+### Pattern 1: Delivery Happy Path
+**Scenario:** You have a planned issue and want to implement and open a PR in one session.
+
+**Command:**
+```
+/deliver-issue [number]
+```
+
+**What happens:**
+1. Preflight (pauses for `size/m+` and enablers unless already completed in this session)
+2. Implementation (Delivery Agent)
+3. Verify and PR creation (Verify Agent)
+4. Handoff to a **new** session for `/code-review`
+
+**Use when:** You have uninterrupted time and want the default delivery loop without chaining slash commands manually.
+
+---
+
+### Pattern 2: End-to-End Automation
 **Scenario:** You want to plan and implement a feature in one go.
 
 **Command:**
@@ -583,7 +655,7 @@ Take the next backlog item and run the full PM feature workflow
 
 ---
 
-### Pattern 2: Milestone Sprint
+### Pattern 3: Milestone Sprint
 **Scenario:** Focus on completing a specific milestone (e.g., Phase 1).
 
 **Session start:**
@@ -597,15 +669,17 @@ Plan next item for Phase 1
 
 ---
 
-### Pattern 3: Hotfix Mode
+### Pattern 4: Hotfix Mode
 **Scenario:** Critical bug needs immediate fix, bypass planning workflow.
 
 **Steps:**
 1. Create issue manually (type/bug, priority/critical)
-2. Run `/implement-issue` or "Implement issue #N" (Delivery contract implements)
-3. Run `/verify-and-create-pr` or "Verify issue #N" (create PR)
-4. Approve and merge immediately
-5. Run `Close issue #X after PR #Y merged`
+2. Run `/deliver-issue` or `/implement-issue` (Delivery contract implements)
+3. If split workflow: run `/verify-and-create-pr` (create PR)
+4. New session: `/code-review` on the PR
+5. `/address-pr-review-comments` if review threads remain
+6. Approve and merge immediately
+7. Run `Close issue #X after PR #Y merged`
 
 **Skip:** Planning workflow (breakdown-plan), test strategy (if time-critical).
 
@@ -641,9 +715,10 @@ Plan next item for Phase 1
 
 - [ ] I run `daily-start` at the start of each working session to get oriented
 - [ ] I use `plan-next-issue` to create technical specs before coding
-- [ ] I use `implement-issue` (workflow prompt or `/implement-issue`) only for planned issues with clear acceptance criteria
+- [ ] I use `/deliver-issue` for the default happy path, or split `/implement-issue` and `/verify-and-create-pr` when I want to pause between stages
 - [ ] `implement-issue` runs preflight before coding; I use `/preflight-issue` first for large items or enablers when I want to review the approach
-- [ ] I use `verify-and-create-pr` to validate quality before PR merge
+- [ ] I run `/code-review` in a **new** agent session after the PR exists (not in the same chat as implement/verify)
+- [ ] I use `/address-pr-review-comments` to implement findings and resolve review threads before merge
 - [ ] I run `pm-progress-review` when I return to the project after a gap or need a governance checkpoint
 - [ ] All my GitHub issues have labels per `plan/LABEL_STRATEGY.md`
 - [ ] All user-facing features have docs in `website/content/docs/`
@@ -668,7 +743,12 @@ Plan the [feature name]
 Plan next item for [milestone]
 ```
 
-**Implementation:**
+**Delivery (happy path):**
+```
+Deliver issue #[number]
+```
+
+**Implementation (split):**
 ```
 Preflight issue #[number]
 Implement issue #[number]
@@ -679,6 +759,16 @@ Build [feature name]
 ```
 Verify issue #[number]
 Create PR for [feature name]
+```
+
+**Code review (new session):**
+```
+Code review PR #[number]
+```
+
+**Address review threads:**
+```
+Address PR review comments on PR #[number]
 ```
 
 **Closure:**
@@ -712,6 +802,6 @@ Take the next backlog item and run the full PM feature workflow
 
 ---
 
-**Last Updated:** March 5, 2026  
+**Last Updated:** March 5, 2026 (delivery loop: `/deliver-issue`, verify hygiene, review threads)  
 **Version:** 1.0  
 **Maintained by:** Product Manager (you)


### PR DESCRIPTION
## Summary of Changes

Adds `/deliver-issue` as the default happy-path orchestration for preflight (when required), implementation, and verify/PR creation. Strengthens Verify with clean-rebuild tests and direct-package hygiene, requires code review to land as resolvable GitHub review threads, and tightens `/address-pr-review-comments` for Copilot, human, and agent reviews before merge.

## Related Issue(s)

Ad-hoc agent workflow improvement (no tracking issue).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — agent workflow and runbook documentation only.

## Additional Notes

- New slash command: `/deliver-issue` (canonical workflow + Cursor/Copilot mirrors).
- Verify contract: `dotnet clean && dotnet test` and `dotnet list package --outdated` for direct packages changed on the branch.
- Code review must submit a GitHub Pull Request Review with resolvable threads.
- Delivery contract §10 documents the PR review comment loop; address workflow updated for merge-on-open-comments policy.

Made with [Cursor](https://cursor.com)