### PR TITLE
[Story] Define excluded repositories for cross-repo PM operations (#287)

### DIFF
--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowBacklog.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowBacklog.razor
@@ -1,0 +1,14 @@
+@page "/pm-workflow/backlog"
+@using SoloDevBoard.App.Components.Features.PmWorkflow
+
+<PageTitle>PM Workflow — Backlog</PageTitle>
+
+<PmWorkflowShell ActiveTab="backlog">
+    <MudStack Spacing="2" data-testid="pm-workflow-backlog-page">
+        <MudText Typo="Typo.h5">Backlog Review</MudText>
+        <MudText Typo="Typo.body1">
+            Cross-repository backlog grouping will appear here once stories #277–#282 ship.
+            Configure repositories and planning thresholds on the Repos tab meanwhile.
+        </MudText>
+    </MudStack>
+</PmWorkflowShell>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowDailyFocus.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowDailyFocus.razor
@@ -1,0 +1,14 @@
+@page "/pm-workflow/daily-focus"
+@using SoloDevBoard.App.Components.Features.PmWorkflow
+
+<PageTitle>PM Workflow — Daily Focus</PageTitle>
+
+<PmWorkflowShell ActiveTab="daily-focus">
+    <MudStack Spacing="2" data-testid="pm-workflow-daily-focus-page">
+        <MudText Typo="Typo.h5">Daily Focus</MudText>
+        <MudText Typo="Typo.body1">
+            Morning recommendations and board occupancy will appear here once story #273 ships.
+            Configure repositories and planning thresholds on the Repos tab meanwhile.
+        </MudText>
+    </MudStack>
+</PmWorkflowShell>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowIndex.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowIndex.razor
@@ -1,0 +1,10 @@
+@page "/pm-workflow"
+@inject NavigationManager NavigationManager
+
+@code {
+    /// <inheritdoc/>
+    protected override void OnInitialized()
+    {
+        NavigationManager.NavigateTo("/pm-workflow/repos", replace: true);
+    }
+}

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowPlanning.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowPlanning.razor
@@ -1,0 +1,14 @@
+@page "/pm-workflow/planning"
+@using SoloDevBoard.App.Components.Features.PmWorkflow
+
+<PageTitle>PM Workflow — Planning</PageTitle>
+
+<PmWorkflowShell ActiveTab="planning">
+    <MudStack Spacing="2" data-testid="pm-workflow-planning-page">
+        <MudText Typo="Typo.h5">Iteration Planning</MudText>
+        <MudText Typo="Typo.body1">
+            Up Next curation and capacity guidance will appear here once stories #283–#286 ship.
+            Configure repositories and planning thresholds on the Repos tab meanwhile.
+        </MudText>
+    </MudStack>
+</PmWorkflowShell>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowRepos.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowRepos.razor
@@ -1,0 +1,8 @@
+@page "/pm-workflow/repos"
+@using SoloDevBoard.App.Components.Features.PmWorkflow
+
+<PageTitle>PM Workflow — Repos</PageTitle>
+
+<PmWorkflowShell ActiveTab="repos">
+    <PmWorkflowReposPanel />
+</PmWorkflowShell>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowChromeState.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowChromeState.cs
@@ -1,0 +1,53 @@
+using SoloDevBoard.Application.Services.PmWorkflow;
+using SoloDevBoard.Application.Services.Repositories;
+
+namespace SoloDevBoard.App.Components.Features.PmWorkflow;
+
+/// <summary>Shared PM Workflow chrome state cascaded to tab pages.</summary>
+public sealed class PmWorkflowChromeState
+{
+    /// <summary>Gets or sets the effective PM settings.</summary>
+    public PmSettingsDto Settings { get; set; } = PmSettingsDefaults.Create();
+
+    /// <summary>Gets or sets the active repositories available for inclusion.</summary>
+    public IReadOnlyList<RepositoryDto> ActiveRepositories { get; set; } = [];
+
+    /// <summary>Gets or sets the discovered planning board options.</summary>
+    public IReadOnlyList<PmPlanningBoardOptionDto> PlanningBoardOptions { get; set; } = [];
+
+    /// <summary>Gets or sets the inaccessible project boards warning, if any.</summary>
+    public string? InaccessibleProjectBoardsWarning { get; set; }
+
+    /// <summary>Gets or sets the UTC timestamp when data was last refreshed.</summary>
+    public DateTimeOffset? LastRefreshedAtUtc { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether chrome data is loading.</summary>
+    public bool IsLoading { get; set; }
+
+    /// <summary>Gets or sets the chrome load error message, if any.</summary>
+    public string? LoadErrorMessage { get; set; }
+
+    /// <summary>Gets the number of active repositories included after exclusions.</summary>
+    public int IncludedRepositoryCount =>
+        ActiveRepositories.Count(repository => !IsRepositoryExcluded(repository.FullName));
+
+    /// <summary>Gets the title of the selected planning board, when known.</summary>
+    public string? SelectedPlanningBoardTitle =>
+        PlanningBoardOptions.FirstOrDefault(option =>
+            option.Id.Equals(Settings.PlanningBoardNodeId, StringComparison.Ordinal))?.Title;
+
+    /// <summary>Gets a value indicating whether a planning board is selected.</summary>
+    public bool HasPlanningBoardSelected => !string.IsNullOrWhiteSpace(Settings.PlanningBoardNodeId);
+
+    /// <summary>Gets or sets the callback used to persist updated settings.</summary>
+    public Func<PmSettingsDto, Task> SaveSettingsAsync { get; set; } = _ => Task.CompletedTask;
+
+    /// <summary>Gets or sets the callback used to reload chrome data.</summary>
+    public Func<Task> RefreshAsync { get; set; } = () => Task.CompletedTask;
+
+    /// <summary>Returns whether the repository is excluded from PM queries.</summary>
+    /// <param name="repositoryFullName">The repository full name.</param>
+    /// <returns><see langword="true" /> when excluded; otherwise <see langword="false" />.</returns>
+    public bool IsRepositoryExcluded(string repositoryFullName) =>
+        Settings.ExcludedRepositories.Contains(repositoryFullName, StringComparer.OrdinalIgnoreCase);
+}

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowChromeState.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowChromeState.cs
@@ -45,6 +45,12 @@ public sealed class PmWorkflowChromeState
     /// <summary>Gets or sets the callback used to reload chrome data.</summary>
     public Func<Task> RefreshAsync { get; set; } = () => Task.CompletedTask;
 
+    /// <summary>Gets a monotonic revision that changes when cascaded chrome data is refreshed or saved.</summary>
+    public int DataRevision { get; private set; }
+
+    /// <summary>Increments <see cref="DataRevision"/> so child panels can resync local state.</summary>
+    public void MarkDataChanged() => DataRevision++;
+
     /// <summary>Returns whether the repository is excluded from PM queries.</summary>
     /// <param name="repositoryFullName">The repository full name.</param>
     /// <returns><see langword="true" /> when excluded; otherwise <see langword="false" />.</returns>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor
@@ -1,0 +1,101 @@
+@using SoloDevBoard.App.Components.Features.PmWorkflow
+
+<MudStack Spacing="3" data-testid="pm-workflow-repos-page">
+    <MudText Typo="Typo.h5">Repo Management</MudText>
+    <MudText Typo="Typo.body1">
+        Choose which repositories participate in PM recommendations and set planning thresholds.
+        Board occupancy on the selected planning board still counts every linked card.
+    </MudText>
+
+    @if (ChromeState is null)
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">PM Workflow chrome is unavailable.</MudAlert>
+    }
+    else
+    {
+        <MudPaper Class="pa-4" Elevation="1" data-testid="pm-workflow-thresholds-region">
+            <MudStack Spacing="2">
+                <MudText Typo="Typo.h6">Planning thresholds</MudText>
+                <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2">
+                    <MudNumericField @bind-Value="capacity"
+                                     Label="Capacity limit"
+                                     Variant="Variant.Outlined"
+                                     Min="1"
+                                     Immediate="false"
+                                     data-testid="pm-workflow-capacity-field" />
+                    <MudNumericField @bind-Value="stallDays"
+                                     Label="Stall days"
+                                     Variant="Variant.Outlined"
+                                     Min="1"
+                                     Immediate="false"
+                                     data-testid="pm-workflow-stall-days-field" />
+                    <MudNumericField @bind-Value="neglectDays"
+                                     Label="Neglect days"
+                                     Variant="Variant.Outlined"
+                                     Min="1"
+                                     Immediate="false"
+                                     data-testid="pm-workflow-neglect-days-field" />
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               OnClick="SaveThresholdsAsync"
+                               data-testid="pm-workflow-save-thresholds-button">
+                        Save thresholds
+                    </MudButton>
+                </MudStack>
+            </MudStack>
+        </MudPaper>
+
+        <MudPaper Class="pa-4" Elevation="1" data-testid="pm-workflow-exclusions-region">
+            <MudStack Spacing="2">
+                <MudText Typo="Typo.h6">Excluded repositories</MudText>
+                <MudText Typo="Typo.body2">
+                    Excluded repositories are omitted from Daily Focus recommendations, Backlog Review, and Planning candidates.
+                    Archived repositories are not offered for inclusion.
+                </MudText>
+
+                <MudStack Row="true" Wrap="Wrap.Wrap" AlignItems="AlignItems.End" Spacing="2">
+                    <MudAutocomplete T="string"
+                                     @bind-Value="repositoryToExclude"
+                                     Label="Search catalogue"
+                                     Variant="Variant.Outlined"
+                                     SearchFunc="SearchIncludedRepositoriesAsync"
+                                     ResetValueOnEmptyText="true"
+                                     CoerceText="true"
+                                     CoerceValue="true"
+                                     Disabled="includedRepositoryOptions.Count == 0"
+                                     data-testid="pm-workflow-exclude-autocomplete" />
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               Disabled="string.IsNullOrWhiteSpace(repositoryToExclude)"
+                               OnClick="() => ExcludeRepositoryAsync(repositoryToExclude)"
+                               data-testid="pm-workflow-exclude-button">
+                        Exclude
+                    </MudButton>
+                </MudStack>
+
+                @if (excludedRepositories.Count == 0)
+                {
+                    <MudText Typo="Typo.body2" data-testid="pm-workflow-no-exclusions-text">
+                        No repositories are excluded.
+                    </MudText>
+                }
+                else
+                {
+                    <MudStack Spacing="1" data-testid="pm-workflow-excluded-list">
+                        @foreach (var repository in excludedRepositories)
+                        {
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                <MudChip T="string" Color="Color.Default" Variant="Variant.Outlined">@repository</MudChip>
+                                <MudButton Variant="Variant.Text"
+                                           OnClick="() => IncludeRepositoryAsync(repository)"
+                                           data-testid="pm-workflow-include-button">
+                                    Include
+                                </MudButton>
+                            </MudStack>
+                        }
+                    </MudStack>
+                }
+            </MudStack>
+        </MudPaper>
+    }
+</MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor
@@ -3,7 +3,7 @@
 <MudStack Spacing="3" data-testid="pm-workflow-repos-page">
     <MudText Typo="Typo.h5">Repo Management</MudText>
     <MudText Typo="Typo.body1">
-        Choose which repositories participate in PM recommendations and set planning thresholds.
+        Control which repositories feed PM recommendations and set planning thresholds.
         Board occupancy on the selected planning board still counts every linked card.
     </MudText>
 
@@ -16,7 +16,10 @@
         <MudPaper Class="pa-4" Elevation="1" data-testid="pm-workflow-thresholds-region">
             <MudStack Spacing="2">
                 <MudText Typo="Typo.h6">Planning thresholds</MudText>
-                <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2">
+                <MudText Typo="Typo.body2">
+                    These values apply when Daily Focus, Backlog, and Planning ship. Save after editing.
+                </MudText>
+                <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2" AlignItems="AlignItems.End">
                     <MudNumericField @bind-Value="capacity"
                                      Label="Capacity limit"
                                      Variant="Variant.Outlined"
@@ -45,56 +48,121 @@
             </MudStack>
         </MudPaper>
 
-        <MudPaper Class="pa-4" Elevation="1" data-testid="pm-workflow-exclusions-region">
-            <MudStack Spacing="2">
-                <MudText Typo="Typo.h6">Excluded repositories</MudText>
-                <MudText Typo="Typo.body2">
-                    Excluded repositories are omitted from Daily Focus recommendations, Backlog Review, and Planning candidates.
-                    Archived repositories are not offered for inclusion.
-                </MudText>
+        <MudPaper Class="pa-4" Elevation="1" data-testid="pm-workflow-participation-region">
+            <MudStack Spacing="3">
+                <MudText Typo="Typo.h6">Repository participation</MudText>
 
-                <MudStack Row="true" Wrap="Wrap.Wrap" AlignItems="AlignItems.End" Spacing="2">
-                    <MudAutocomplete T="string"
-                                     @bind-Value="repositoryToExclude"
-                                     Label="Search catalogue"
-                                     Variant="Variant.Outlined"
-                                     SearchFunc="SearchIncludedRepositoriesAsync"
-                                     ResetValueOnEmptyText="true"
-                                     CoerceText="true"
-                                     CoerceValue="true"
-                                     Disabled="includedRepositoryOptions.Count == 0"
-                                     data-testid="pm-workflow-exclude-autocomplete" />
-                    <MudButton Variant="Variant.Outlined"
-                               Color="Color.Primary"
-                               Disabled="string.IsNullOrWhiteSpace(repositoryToExclude)"
-                               OnClick="() => ExcludeRepositoryAsync(repositoryToExclude)"
-                               data-testid="pm-workflow-exclude-button">
-                        Exclude
-                    </MudButton>
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="pm-workflow-participation-summary">
+                    <strong>@IncludedRepositoryCount included</strong>
+                    · <strong>@excludedRepositories.Count excluded</strong>.
+                    Every active repository participates in PM queries by default.
+                    Remove repositories you do not want in recommendations, backlog, or planning below.
+                    Archived repositories are never offered.
+                </MudAlert>
+
+                <MudStack Spacing="2" data-testid="pm-workflow-included-repositories-region">
+                    <MudText Typo="Typo.subtitle1">Included repositories</MudText>
+                    <MudText Typo="Typo.body2">
+                        These repositories currently participate in PM queries. Select <strong>Exclude</strong> to remove one.
+                    </MudText>
+
+                    @if (includedRepositoryOptions.Count == 0)
+                    {
+                        <MudText Typo="Typo.body2" data-testid="pm-workflow-no-included-text">
+                            No active repositories are available to include.
+                        </MudText>
+                    }
+                    else
+                    {
+                        <MudTextField @bind-Value="includedRepositoryFilter"
+                                      Label="Filter included repositories"
+                                      Placeholder="Type owner/name to narrow the list"
+                                      Variant="Variant.Outlined"
+                                      Adornment="Adornment.Start"
+                                      AdornmentIcon="@Icons.Material.Filled.Search"
+                                      Immediate="true"
+                                      data-testid="pm-workflow-included-filter" />
+
+                        <MudTable T="string"
+                                  Items="FilteredIncludedRepositories"
+                                  Dense="true"
+                                  Hover="true"
+                                  data-testid="pm-workflow-included-table">
+                            <HeaderContent>
+                                <MudTh>Repository</MudTh>
+                                <MudTh Class="text-end">Participation</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Repository">@context</MudTd>
+                                <MudTd DataLabel="Participation" Class="text-end">
+                                    <MudButton Variant="Variant.Outlined"
+                                               Color="Color.Primary"
+                                               Size="Size.Small"
+                                               OnClick="() => ExcludeRepositoryAsync(context)"
+                                               data-testid="pm-workflow-row-exclude-button">
+                                        Exclude
+                                    </MudButton>
+                                </MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                    }
                 </MudStack>
 
-                @if (excludedRepositories.Count == 0)
-                {
-                    <MudText Typo="Typo.body2" data-testid="pm-workflow-no-exclusions-text">
-                        No repositories are excluded.
+                <MudDivider />
+
+                <MudStack Spacing="2" data-testid="pm-workflow-exclusions-region">
+                    <MudText Typo="Typo.subtitle1">Excluded repositories</MudText>
+                    <MudText Typo="Typo.body2">
+                        Excluded repositories are omitted from Daily Focus recommendations, Backlog Review, and Planning candidates.
                     </MudText>
-                }
-                else
-                {
-                    <MudStack Spacing="1" data-testid="pm-workflow-excluded-list">
-                        @foreach (var repository in excludedRepositories)
-                        {
-                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                <MudChip T="string" Color="Color.Default" Variant="Variant.Outlined">@repository</MudChip>
-                                <MudButton Variant="Variant.Text"
-                                           OnClick="() => IncludeRepositoryAsync(repository)"
-                                           data-testid="pm-workflow-include-button">
-                                    Include
-                                </MudButton>
-                            </MudStack>
-                        }
+
+                    <MudStack Row="true" Wrap="Wrap.Wrap" AlignItems="AlignItems.End" Spacing="2">
+                        <MudAutocomplete T="string"
+                                         @bind-Value="repositoryToExclude"
+                                         Label="Quick exclude"
+                                         Placeholder="Search owner/name"
+                                         Variant="Variant.Outlined"
+                                         SearchFunc="SearchIncludedRepositoriesAsync"
+                                         MinCharacters="0"
+                                         ResetValueOnEmptyText="true"
+                                         CoerceText="true"
+                                         CoerceValue="true"
+                                         Adornment="Adornment.Start"
+                                         AdornmentIcon="@Icons.Material.Filled.Search"
+                                         Disabled="includedRepositoryOptions.Count == 0"
+                                         data-testid="pm-workflow-exclude-autocomplete" />
+                        <MudButton Variant="Variant.Outlined"
+                                   Color="Color.Primary"
+                                   Disabled="string.IsNullOrWhiteSpace(repositoryToExclude)"
+                                   OnClick="() => ExcludeRepositoryAsync(repositoryToExclude)"
+                                   data-testid="pm-workflow-exclude-button">
+                            Exclude
+                        </MudButton>
                     </MudStack>
-                }
+
+                    @if (excludedRepositories.Count == 0)
+                    {
+                        <MudText Typo="Typo.body2" data-testid="pm-workflow-no-exclusions-text">
+                            No repositories are excluded. All active repositories participate.
+                        </MudText>
+                    }
+                    else
+                    {
+                        <MudStack Spacing="1" data-testid="pm-workflow-excluded-list">
+                            @foreach (var repository in excludedRepositories)
+                            {
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Wrap="Wrap.Wrap">
+                                    <MudChip T="string" Color="Color.Default" Variant="Variant.Outlined">@repository</MudChip>
+                                    <MudButton Variant="Variant.Text"
+                                               OnClick="() => IncludeRepositoryAsync(repository)"
+                                               data-testid="pm-workflow-include-button">
+                                        Include again
+                                    </MudButton>
+                                </MudStack>
+                            }
+                        </MudStack>
+                    }
+                </MudStack>
             </MudStack>
         </MudPaper>
     }

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor
@@ -80,6 +80,7 @@
                                       Variant="Variant.Outlined"
                                       Adornment="Adornment.Start"
                                       AdornmentIcon="@Icons.Material.Filled.Search"
+                                      AdornmentAriaLabel="Filter included repositories"
                                       Immediate="true"
                                       data-testid="pm-workflow-included-filter" />
 
@@ -129,6 +130,7 @@
                                          CoerceValue="true"
                                          Adornment="Adornment.Start"
                                          AdornmentIcon="@Icons.Material.Filled.Search"
+                                         AdornmentAriaLabel="Search repositories to exclude"
                                          Disabled="includedRepositoryOptions.Count == 0"
                                          data-testid="pm-workflow-exclude-autocomplete" />
                         <MudButton Variant="Variant.Outlined"

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using MudBlazor;
 using SoloDevBoard.Application.Services.PmWorkflow;
 
 namespace SoloDevBoard.App.Components.Features.PmWorkflow;
@@ -12,12 +13,33 @@ public partial class PmWorkflowReposPanel : ComponentBase
     [CascadingParameter(Name = "PmWorkflowDataRevision")]
     public int DataRevision { get; set; }
 
+    [Inject]
+    public ISnackbar Snackbar { get; set; } = default!;
+
     private int capacity = PmSettingsDefaults.Capacity;
     private int stallDays = PmSettingsDefaults.StallDays;
     private int neglectDays = PmSettingsDefaults.NeglectDays;
     private IReadOnlyList<string> includedRepositoryOptions = [];
     private IReadOnlyList<string> excludedRepositories = [];
     private string? repositoryToExclude;
+    private string includedRepositoryFilter = string.Empty;
+
+    private int IncludedRepositoryCount => includedRepositoryOptions.Count;
+
+    private IEnumerable<string> FilteredIncludedRepositories
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(includedRepositoryFilter))
+            {
+                return includedRepositoryOptions;
+            }
+
+            var filter = includedRepositoryFilter.Trim();
+            return includedRepositoryOptions.Where(repository =>
+                repository.Contains(filter, StringComparison.OrdinalIgnoreCase));
+        }
+    }
 
     /// <inheritdoc/>
     protected override void OnParametersSet()
@@ -51,6 +73,8 @@ public partial class PmWorkflowReposPanel : ComponentBase
             StallDays = stallDays,
             NeglectDays = neglectDays,
         });
+
+        Snackbar.Add("Planning thresholds saved.", Severity.Success);
     }
 
     private async Task ExcludeRepositoryAsync(string? repositoryFullName)
@@ -68,6 +92,8 @@ public partial class PmWorkflowReposPanel : ComponentBase
 
         await ChromeState.SaveSettingsAsync(ChromeState.Settings with { ExcludedRepositories = exclusions });
         repositoryToExclude = null;
+        Snackbar.Add($"'{repositoryFullName.Trim()}' excluded from PM queries.", Severity.Success);
+        OnParametersSet();
     }
 
     private async Task IncludeRepositoryAsync(string repositoryFullName)
@@ -82,6 +108,8 @@ public partial class PmWorkflowReposPanel : ComponentBase
             .ToArray();
 
         await ChromeState.SaveSettingsAsync(ChromeState.Settings with { ExcludedRepositories = exclusions });
+        Snackbar.Add($"'{repositoryFullName}' included in PM queries again.", Severity.Success);
+        OnParametersSet();
     }
 
     private Task<IEnumerable<string>> SearchIncludedRepositoriesAsync(string? value, CancellationToken cancellationToken)

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor.cs
@@ -1,0 +1,98 @@
+using Microsoft.AspNetCore.Components;
+using SoloDevBoard.Application.Services.PmWorkflow;
+
+namespace SoloDevBoard.App.Components.Features.PmWorkflow;
+
+/// <summary>Repo Management panel rendered inside <see cref="PmWorkflowShell"/>.</summary>
+public partial class PmWorkflowReposPanel : ComponentBase
+{
+    [CascadingParameter]
+    public PmWorkflowChromeState? ChromeState { get; set; }
+
+    private int capacity = PmSettingsDefaults.Capacity;
+    private int stallDays = PmSettingsDefaults.StallDays;
+    private int neglectDays = PmSettingsDefaults.NeglectDays;
+    private IReadOnlyList<string> includedRepositoryOptions = [];
+    private IReadOnlyList<string> excludedRepositories = [];
+    private string? repositoryToExclude;
+
+    /// <inheritdoc/>
+    protected override void OnParametersSet()
+    {
+        if (ChromeState is null)
+        {
+            return;
+        }
+
+        capacity = ChromeState.Settings.Capacity;
+        stallDays = ChromeState.Settings.StallDays;
+        neglectDays = ChromeState.Settings.NeglectDays;
+        excludedRepositories = ChromeState.Settings.ExcludedRepositories;
+        includedRepositoryOptions = ChromeState.ActiveRepositories
+            .Select(repository => repository.FullName)
+            .Where(fullName => !ChromeState.IsRepositoryExcluded(fullName))
+            .OrderBy(fullName => fullName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private async Task SaveThresholdsAsync()
+    {
+        if (ChromeState is null)
+        {
+            return;
+        }
+
+        await ChromeState.SaveSettingsAsync(ChromeState.Settings with
+        {
+            Capacity = capacity,
+            StallDays = stallDays,
+            NeglectDays = neglectDays,
+        });
+    }
+
+    private async Task ExcludeRepositoryAsync(string? repositoryFullName)
+    {
+        if (ChromeState is null || string.IsNullOrWhiteSpace(repositoryFullName))
+        {
+            return;
+        }
+
+        var exclusions = ChromeState.Settings.ExcludedRepositories
+            .Append(repositoryFullName.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(repository => repository, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        await ChromeState.SaveSettingsAsync(ChromeState.Settings with { ExcludedRepositories = exclusions });
+        repositoryToExclude = null;
+        OnParametersSet();
+    }
+
+    private async Task IncludeRepositoryAsync(string repositoryFullName)
+    {
+        if (ChromeState is null)
+        {
+            return;
+        }
+
+        var exclusions = ChromeState.Settings.ExcludedRepositories
+            .Where(repository => !repository.Equals(repositoryFullName, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        await ChromeState.SaveSettingsAsync(ChromeState.Settings with { ExcludedRepositories = exclusions });
+        OnParametersSet();
+    }
+
+    private Task<IEnumerable<string>> SearchIncludedRepositoriesAsync(string? value, CancellationToken cancellationToken)
+    {
+        IEnumerable<string> matches = includedRepositoryOptions;
+
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            var filter = value.Trim();
+            matches = matches.Where(repository => repository.Contains(filter, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return Task.FromResult(matches);
+    }
+}

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor.cs
@@ -9,6 +9,9 @@ public partial class PmWorkflowReposPanel : ComponentBase
     [CascadingParameter]
     public PmWorkflowChromeState? ChromeState { get; set; }
 
+    [CascadingParameter(Name = "PmWorkflowDataRevision")]
+    public int DataRevision { get; set; }
+
     private int capacity = PmSettingsDefaults.Capacity;
     private int stallDays = PmSettingsDefaults.StallDays;
     private int neglectDays = PmSettingsDefaults.NeglectDays;
@@ -65,7 +68,6 @@ public partial class PmWorkflowReposPanel : ComponentBase
 
         await ChromeState.SaveSettingsAsync(ChromeState.Settings with { ExcludedRepositories = exclusions });
         repositoryToExclude = null;
-        OnParametersSet();
     }
 
     private async Task IncludeRepositoryAsync(string repositoryFullName)
@@ -80,7 +82,6 @@ public partial class PmWorkflowReposPanel : ComponentBase
             .ToArray();
 
         await ChromeState.SaveSettingsAsync(ChromeState.Settings with { ExcludedRepositories = exclusions });
-        OnParametersSet();
     }
 
     private Task<IEnumerable<string>> SearchIncludedRepositoriesAsync(string? value, CancellationToken cancellationToken)

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor
@@ -1,4 +1,5 @@
 @using SoloDevBoard.App.Components.Features.PmWorkflow
+@using MudBlazor
 
 <MudStack Spacing="3" data-testid="pm-workflow-shell">
     <MudText Typo="Typo.h4">PM Workflow</MudText>
@@ -64,12 +65,16 @@
                 </MudStack>
             </MudStack>
 
-            <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap" data-testid="pm-workflow-tab-strip">
-                <MudNavLink Href="/pm-workflow/daily-focus" Match="NavLinkMatch.All" Class="@TabClass(ActiveTab, "daily-focus")">Daily Focus</MudNavLink>
-                <MudNavLink Href="/pm-workflow/backlog" Match="NavLinkMatch.All" Class="@TabClass(ActiveTab, "backlog")">Backlog</MudNavLink>
-                <MudNavLink Href="/pm-workflow/planning" Match="NavLinkMatch.All" Class="@TabClass(ActiveTab, "planning")">Planning</MudNavLink>
-                <MudNavLink Href="/pm-workflow/repos" Match="NavLinkMatch.All" Class="@TabClass(ActiveTab, "repos")">Repos</MudNavLink>
-            </MudStack>
+            <MudTabs Rounded="true"
+                     ApplyEffectsToContainer="true"
+                     ActivePanelIndex="ActiveTabIndex"
+                     ActivePanelIndexChanged="OnTabIndexChangedAsync"
+                     data-testid="pm-workflow-tab-strip">
+                <MudTabPanel Text="Daily Focus" />
+                <MudTabPanel Text="Backlog" />
+                <MudTabPanel Text="Planning" />
+                <MudTabPanel Text="Repos" />
+            </MudTabs>
         </MudStack>
     </MudPaper>
 

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor
@@ -81,6 +81,8 @@
     }
 
     <CascadingValue Value="chromeState" IsFixed="false">
-        @ChildContent
+        <CascadingValue Value="chromeState.DataRevision" Name="PmWorkflowDataRevision" IsFixed="false">
+            @ChildContent
+        </CascadingValue>
     </CascadingValue>
 </MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor
@@ -1,0 +1,86 @@
+@using SoloDevBoard.App.Components.Features.PmWorkflow
+
+<MudStack Spacing="3" data-testid="pm-workflow-shell">
+    <MudText Typo="Typo.h4">PM Workflow</MudText>
+
+    @if (chromeState.IsLoading)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" aria-label="Loading PM Workflow" />
+    }
+
+    @if (!string.IsNullOrWhiteSpace(chromeState.LoadErrorMessage))
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" data-testid="pm-workflow-chrome-error">
+            @chromeState.LoadErrorMessage
+            <MudButton Variant="Variant.Text" OnClick="RefreshAsync">Retry</MudButton>
+        </MudAlert>
+    }
+
+    @if (!string.IsNullOrWhiteSpace(chromeState.InaccessibleProjectBoardsWarning))
+    {
+        <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" data-testid="pm-workflow-inaccessible-boards-warning">
+            @chromeState.InaccessibleProjectBoardsWarning
+        </MudAlert>
+    }
+
+    <MudPaper Class="pa-4" Elevation="1" data-testid="pm-workflow-shared-chrome">
+        <MudStack Spacing="2">
+            <MudStack Row="true" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="2">
+                <MudSelect T="string"
+                           Label="Planning board"
+                           Variant="Variant.Outlined"
+                           Dense="true"
+                           Value="selectedPlanningBoardId"
+                           ValueChanged="OnPlanningBoardChangedAsync"
+                           Disabled="chromeState.IsLoading || chromeState.PlanningBoardOptions.Count == 0"
+                           data-testid="pm-workflow-board-select">
+                    @if (chromeState.PlanningBoardOptions.Count == 0)
+                    {
+                        <MudSelectItem T="string" Value="@string.Empty">No boards discovered</MudSelectItem>
+                    }
+                    else
+                    {
+                        @foreach (var board in chromeState.PlanningBoardOptions)
+                        {
+                            <MudSelectItem T="string" Value="@board.Id">@board.Title</MudSelectItem>
+                        }
+                    }
+                </MudSelect>
+
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                    <MudText Typo="Typo.body2" aria-live="polite">
+                        Repos: @chromeState.IncludedRepositoryCount included
+                        @if (!string.IsNullOrWhiteSpace(chromeState.SelectedPlanningBoardTitle))
+                        {
+                            <span> · Board: @chromeState.SelectedPlanningBoardTitle</span>
+                        }
+                        · Refreshed @FormatLastRefreshed(chromeState.LastRefreshedAtUtc)
+                    </MudText>
+                    <MudIconButton Icon="@Icons.Material.Filled.Refresh"
+                                   aria-label="Refresh PM Workflow data"
+                                   Disabled="chromeState.IsLoading"
+                                   OnClick="RefreshAsync"
+                                   data-testid="pm-workflow-refresh-button" />
+                </MudStack>
+            </MudStack>
+
+            <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap" data-testid="pm-workflow-tab-strip">
+                <MudNavLink Href="/pm-workflow/daily-focus" Match="NavLinkMatch.All" Class="@TabClass(ActiveTab, "daily-focus")">Daily Focus</MudNavLink>
+                <MudNavLink Href="/pm-workflow/backlog" Match="NavLinkMatch.All" Class="@TabClass(ActiveTab, "backlog")">Backlog</MudNavLink>
+                <MudNavLink Href="/pm-workflow/planning" Match="NavLinkMatch.All" Class="@TabClass(ActiveTab, "planning")">Planning</MudNavLink>
+                <MudNavLink Href="/pm-workflow/repos" Match="NavLinkMatch.All" Class="@TabClass(ActiveTab, "repos")">Repos</MudNavLink>
+            </MudStack>
+        </MudStack>
+    </MudPaper>
+
+    @if (!chromeState.HasPlanningBoardSelected && !chromeState.IsLoading && string.IsNullOrWhiteSpace(chromeState.LoadErrorMessage))
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="pm-workflow-no-board-alert">
+            Select a planning board to load PM Workflow data on future tabs. Repo Management settings can still be edited below.
+        </MudAlert>
+    }
+
+    <CascadingValue Value="chromeState" IsFixed="false">
+        @ChildContent
+    </CascadingValue>
+</MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor.cs
@@ -1,0 +1,117 @@
+using Microsoft.AspNetCore.Components;
+using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Application.Services.PmWorkflow;
+using SoloDevBoard.Application.Services.Repositories;
+
+namespace SoloDevBoard.App.Components.Features.PmWorkflow;
+
+/// <summary>Shared chrome for Cross-Repo PM Workflow tab pages.</summary>
+public partial class PmWorkflowShell : ComponentBase
+{
+    /// <summary>Gets or sets the active tab route segment.</summary>
+    [Parameter]
+    public string ActiveTab { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the tab page content.</summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>Gets or sets the PM settings service.</summary>
+    [Inject]
+    public IPmSettingsService PmSettingsService { get; set; } = default!;
+
+    /// <summary>Gets or sets the repository service.</summary>
+    [Inject]
+    public IRepositoryService RepositoryService { get; set; } = default!;
+
+    /// <summary>Gets or sets the planning board discovery service.</summary>
+    [Inject]
+    public IPmProjectBoardDiscoveryService ProjectBoardDiscoveryService { get; set; } = default!;
+
+    /// <summary>Gets or sets the logger.</summary>
+    [Inject]
+    public ILogger<PmWorkflowShell> Logger { get; set; } = default!;
+
+    private readonly PmWorkflowChromeState chromeState = new();
+    private string selectedPlanningBoardId = string.Empty;
+
+    /// <inheritdoc/>
+    protected override async Task OnInitializedAsync()
+    {
+        chromeState.SaveSettingsAsync = SaveSettingsAsync;
+        chromeState.RefreshAsync = RefreshAsync;
+        await RefreshAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        chromeState.IsLoading = true;
+        chromeState.LoadErrorMessage = null;
+
+        try
+        {
+            chromeState.Settings = await PmSettingsService.GetSettingsAsync();
+            selectedPlanningBoardId = chromeState.Settings.PlanningBoardNodeId ?? string.Empty;
+
+            var repositoriesTask = RepositoryService.GetActiveRepositoriesAsync();
+            var discoveryTask = ProjectBoardDiscoveryService.GetPlanningBoardOptionsAsync();
+            await Task.WhenAll(repositoriesTask, discoveryTask);
+
+            chromeState.ActiveRepositories = await repositoriesTask;
+            var discovery = await discoveryTask;
+            chromeState.PlanningBoardOptions = discovery.Options;
+            chromeState.InaccessibleProjectBoardsWarning = LinkedProjectBoardVisibility.BuildInaccessibleProjectsWarning(
+                discovery.TotalLinkedProjectCount,
+                discovery.InaccessibleLinkedProjectCount);
+
+            if (!chromeState.PlanningBoardOptions.Any(option =>
+                    option.Id.Equals(selectedPlanningBoardId, StringComparison.Ordinal)))
+            {
+                selectedPlanningBoardId = chromeState.PlanningBoardOptions.FirstOrDefault()?.Id ?? string.Empty;
+                if (!string.Equals(chromeState.Settings.PlanningBoardNodeId, selectedPlanningBoardId, StringComparison.Ordinal))
+                {
+                    await SaveSettingsAsync(chromeState.Settings with
+                    {
+                        PlanningBoardNodeId = string.IsNullOrWhiteSpace(selectedPlanningBoardId) ? null : selectedPlanningBoardId,
+                    });
+                }
+            }
+
+            chromeState.LastRefreshedAtUtc = DateTimeOffset.UtcNow;
+        }
+        catch (Exception exception)
+        {
+            Logger.LogError(exception, "Failed to load PM Workflow chrome data.");
+            chromeState.LoadErrorMessage = "Unable to load PM Workflow settings. Check your GitHub connection and try again.";
+        }
+        finally
+        {
+            chromeState.IsLoading = false;
+        }
+    }
+
+    private async Task OnPlanningBoardChangedAsync(string? boardId)
+    {
+        selectedPlanningBoardId = boardId ?? string.Empty;
+        await SaveSettingsAsync(chromeState.Settings with
+        {
+            PlanningBoardNodeId = string.IsNullOrWhiteSpace(selectedPlanningBoardId) ? null : selectedPlanningBoardId,
+        });
+    }
+
+    private async Task SaveSettingsAsync(PmSettingsDto settings)
+    {
+        await PmSettingsService.SaveSettingsAsync(settings);
+        chromeState.Settings = await PmSettingsService.GetSettingsAsync();
+        selectedPlanningBoardId = chromeState.Settings.PlanningBoardNodeId ?? string.Empty;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private static string FormatLastRefreshed(DateTimeOffset? refreshedAtUtc) =>
+        refreshedAtUtc?.ToLocalTime().ToString("g") ?? "Not yet refreshed";
+
+    private static string TabClass(string activeTab, string tabName) =>
+        string.Equals(activeTab, tabName, StringComparison.OrdinalIgnoreCase)
+            ? "mud-tab mud-tab-active"
+            : "mud-tab";
+}

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor.cs
@@ -53,12 +53,9 @@ public partial class PmWorkflowShell : ComponentBase
             chromeState.Settings = await PmSettingsService.GetSettingsAsync();
             selectedPlanningBoardId = chromeState.Settings.PlanningBoardNodeId ?? string.Empty;
 
-            var repositoriesTask = RepositoryService.GetActiveRepositoriesAsync();
-            var discoveryTask = ProjectBoardDiscoveryService.GetPlanningBoardOptionsAsync();
-            await Task.WhenAll(repositoriesTask, discoveryTask);
-
-            chromeState.ActiveRepositories = await repositoriesTask;
-            var discovery = await discoveryTask;
+            chromeState.ActiveRepositories = await RepositoryService.GetActiveRepositoriesAsync();
+            var discovery = await ProjectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
+                chromeState.ActiveRepositories);
             chromeState.PlanningBoardOptions = discovery.Options;
             chromeState.InaccessibleProjectBoardsWarning = LinkedProjectBoardVisibility.BuildInaccessibleProjectsWarning(
                 discovery.TotalLinkedProjectCount,
@@ -78,6 +75,7 @@ public partial class PmWorkflowShell : ComponentBase
             }
 
             chromeState.LastRefreshedAtUtc = DateTimeOffset.UtcNow;
+            chromeState.MarkDataChanged();
         }
         catch (Exception exception)
         {
@@ -104,6 +102,7 @@ public partial class PmWorkflowShell : ComponentBase
         await PmSettingsService.SaveSettingsAsync(settings);
         chromeState.Settings = await PmSettingsService.GetSettingsAsync();
         selectedPlanningBoardId = chromeState.Settings.PlanningBoardNodeId ?? string.Empty;
+        chromeState.MarkDataChanged();
         await InvokeAsync(StateHasChanged);
     }
 

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using MudBlazor;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Application.Services.PmWorkflow;
 using SoloDevBoard.Application.Services.Repositories;
@@ -31,6 +32,14 @@ public partial class PmWorkflowShell : ComponentBase
     /// <summary>Gets or sets the logger.</summary>
     [Inject]
     public ILogger<PmWorkflowShell> Logger { get; set; } = default!;
+
+    /// <summary>Gets or sets the snackbar service.</summary>
+    [Inject]
+    public ISnackbar Snackbar { get; set; } = default!;
+
+    /// <summary>Gets or sets the navigation manager.</summary>
+    [Inject]
+    public NavigationManager NavigationManager { get; set; } = default!;
 
     private readonly PmWorkflowChromeState chromeState = new();
     private string selectedPlanningBoardId = string.Empty;
@@ -95,6 +104,9 @@ public partial class PmWorkflowShell : ComponentBase
         {
             PlanningBoardNodeId = string.IsNullOrWhiteSpace(selectedPlanningBoardId) ? null : selectedPlanningBoardId,
         });
+
+        var boardTitle = chromeState.SelectedPlanningBoardTitle ?? "Planning board";
+        Snackbar.Add($"{boardTitle} selected.", Severity.Success);
     }
 
     private async Task SaveSettingsAsync(PmSettingsDto settings)
@@ -109,8 +121,30 @@ public partial class PmWorkflowShell : ComponentBase
     private static string FormatLastRefreshed(DateTimeOffset? refreshedAtUtc) =>
         refreshedAtUtc?.ToLocalTime().ToString("g") ?? "Not yet refreshed";
 
-    private static string TabClass(string activeTab, string tabName) =>
-        string.Equals(activeTab, tabName, StringComparison.OrdinalIgnoreCase)
-            ? "mud-tab mud-tab-active"
-            : "mud-tab";
+    private int ActiveTabIndex => ActiveTab.ToLowerInvariant() switch
+    {
+        "daily-focus" => 0,
+        "backlog" => 1,
+        "planning" => 2,
+        "repos" => 3,
+        _ => 3,
+    };
+
+    private Task OnTabIndexChangedAsync(int index)
+    {
+        var route = index switch
+        {
+            0 => "/pm-workflow/daily-focus",
+            1 => "/pm-workflow/backlog",
+            2 => "/pm-workflow/planning",
+            _ => "/pm-workflow/repos",
+        };
+
+        if (!NavigationManager.Uri.EndsWith(route, StringComparison.OrdinalIgnoreCase))
+        {
+            NavigationManager.NavigateTo(route);
+        }
+
+        return Task.CompletedTask;
+    }
 }

--- a/src/App/SoloDevBoard.App/Components/Shell/Layout/NavMenu.razor
+++ b/src/App/SoloDevBoard.App/Components/Shell/Layout/NavMenu.razor
@@ -23,5 +23,8 @@
     <MudNavLink Href="/workflows" Icon="@Icons.Material.Filled.AccountTree">
         Workflows
     </MudNavLink>
+    <MudNavLink Href="/pm-workflow" Icon="@Icons.Material.Filled.ViewWeek">
+        PM Workflow
+    </MudNavLink>
 </MudNavMenu>
 

--- a/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<IPmSettingsService, PmSettingsService>();
         services.AddScoped<IProjectItemCatalogueService, ProjectItemCatalogueService>();
         services.AddScoped<IPmWorkItemCatalogueService, PmWorkItemCatalogueService>();
+        services.AddScoped<IPmProjectBoardDiscoveryService, PmProjectBoardDiscoveryService>();
 
         return services;
     }

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IPmProjectBoardDiscoveryService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IPmProjectBoardDiscoveryService.cs
@@ -1,3 +1,5 @@
+using SoloDevBoard.Application.Services.Repositories;
+
 namespace SoloDevBoard.Application.Services.PmWorkflow;
 
 /// <summary>Discovers Projects v2 boards linked to active repositories for PM Workflow.</summary>
@@ -10,4 +12,14 @@ public interface IPmProjectBoardDiscoveryService
     /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>Distinct board options and linked-board visibility counts.</returns>
     Task<PmProjectBoardDiscoveryDto> GetPlanningBoardOptionsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns distinct planning board options discovered for the supplied active repositories.
+    /// </summary>
+    /// <param name="repositories">Active repositories to scan for linked project boards.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
+    /// <returns>Distinct board options and linked-board visibility counts.</returns>
+    Task<PmProjectBoardDiscoveryDto> GetPlanningBoardOptionsForRepositoriesAsync(
+        IReadOnlyList<RepositoryDto> repositories,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IPmProjectBoardDiscoveryService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IPmProjectBoardDiscoveryService.cs
@@ -1,0 +1,13 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Discovers Projects v2 boards linked to active repositories for PM Workflow.</summary>
+public interface IPmProjectBoardDiscoveryService
+{
+    /// <summary>
+    /// Returns distinct planning board options discovered across active repositories.
+    /// Archived repositories are not scanned.
+    /// </summary>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
+    /// <returns>Distinct board options and linked-board visibility counts.</returns>
+    Task<PmProjectBoardDiscoveryDto> GetPlanningBoardOptionsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmPlanningBoardOptionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmPlanningBoardOptionDto.cs
@@ -1,0 +1,12 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Represents a Projects v2 board that can be selected as the PM planning board.</summary>
+/// <param name="Id">The GitHub node identifier for the project board.</param>
+/// <param name="Title">The project board title.</param>
+/// <param name="OwnerLogin">The login of the project owner.</param>
+/// <param name="StatusFieldId">The project status-field node identifier.</param>
+public sealed record PmPlanningBoardOptionDto(
+    string Id,
+    string Title,
+    string OwnerLogin,
+    string StatusFieldId);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmProjectBoardDiscoveryDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmProjectBoardDiscoveryDto.cs
@@ -1,0 +1,10 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Planning board options discovered across active repositories.</summary>
+/// <param name="Options">Distinct project boards available for selection.</param>
+/// <param name="TotalLinkedProjectCount">The total linked project count reported by GitHub across scanned repositories.</param>
+/// <param name="InaccessibleLinkedProjectCount">The number of linked boards that could not be read.</param>
+public sealed record PmProjectBoardDiscoveryDto(
+    IReadOnlyList<PmPlanningBoardOptionDto> Options,
+    int TotalLinkedProjectCount,
+    int InaccessibleLinkedProjectCount);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmProjectBoardDiscoveryService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmProjectBoardDiscoveryService.cs
@@ -1,4 +1,6 @@
 using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Application.Services.Repositories;
+using SoloDevBoard.Domain.Entities.Repositories;
 
 namespace SoloDevBoard.Application.Services.PmWorkflow;
 
@@ -11,6 +13,35 @@ public sealed class PmProjectBoardDiscoveryService(IGitHubService gitHubService)
         cancellationToken.ThrowIfCancellationRequested();
 
         var repositories = await gitHubService.GetActiveRepositoriesAsync(cancellationToken).ConfigureAwait(false);
+        return await DiscoverPlanningBoardOptionsAsync(repositories, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public Task<PmProjectBoardDiscoveryDto> GetPlanningBoardOptionsForRepositoriesAsync(
+        IReadOnlyList<RepositoryDto> repositories,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(repositories);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return DiscoverPlanningBoardOptionsAsync(
+            repositories.Select(repository => new RepositoryScanTarget(repository.FullName, repository.Name)),
+            cancellationToken);
+    }
+
+    private async Task<PmProjectBoardDiscoveryDto> DiscoverPlanningBoardOptionsAsync(
+        IReadOnlyList<Repository> repositories,
+        CancellationToken cancellationToken)
+    {
+        return await DiscoverPlanningBoardOptionsAsync(
+            repositories.Select(repository => new RepositoryScanTarget(repository.FullName, repository.Name)),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<PmProjectBoardDiscoveryDto> DiscoverPlanningBoardOptionsAsync(
+        IEnumerable<RepositoryScanTarget> repositories,
+        CancellationToken cancellationToken)
+    {
         var optionsById = new Dictionary<string, PmPlanningBoardOptionDto>(StringComparer.Ordinal);
         var totalLinkedProjectCount = 0;
         var inaccessibleLinkedProjectCount = 0;
@@ -50,4 +81,6 @@ public sealed class PmProjectBoardDiscoveryService(IGitHubService gitHubService)
         var separatorIndex = fullName.IndexOf('/');
         return separatorIndex > 0 ? fullName[..separatorIndex] : fullName;
     }
+
+    private readonly record struct RepositoryScanTarget(string FullName, string Name);
 }

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmProjectBoardDiscoveryService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmProjectBoardDiscoveryService.cs
@@ -1,0 +1,53 @@
+using SoloDevBoard.Application.Services.GitHub;
+
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Discovers Projects v2 boards linked to active repositories.</summary>
+public sealed class PmProjectBoardDiscoveryService(IGitHubService gitHubService) : IPmProjectBoardDiscoveryService
+{
+    /// <inheritdoc/>
+    public async Task<PmProjectBoardDiscoveryDto> GetPlanningBoardOptionsAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var repositories = await gitHubService.GetActiveRepositoriesAsync(cancellationToken).ConfigureAwait(false);
+        var optionsById = new Dictionary<string, PmPlanningBoardOptionDto>(StringComparer.Ordinal);
+        var totalLinkedProjectCount = 0;
+        var inaccessibleLinkedProjectCount = 0;
+
+        foreach (var repository in repositories)
+        {
+            var ownerLogin = ParseOwnerLogin(repository.FullName);
+            var discovery = await gitHubService
+                .GetProjectBoardsForRepositoryAsync(ownerLogin, repository.Name, cancellationToken)
+                .ConfigureAwait(false);
+
+            totalLinkedProjectCount += discovery.TotalLinkedProjectCount;
+            inaccessibleLinkedProjectCount += discovery.InaccessibleLinkedProjectCount;
+
+            foreach (var projectBoard in discovery.SupportedProjectBoards)
+            {
+                if (!optionsById.ContainsKey(projectBoard.Id))
+                {
+                    optionsById[projectBoard.Id] = new PmPlanningBoardOptionDto(
+                        projectBoard.Id,
+                        projectBoard.Title,
+                        projectBoard.OwnerLogin,
+                        projectBoard.StatusFieldId);
+                }
+            }
+        }
+
+        var options = optionsById.Values
+            .OrderBy(option => option.Title, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return new PmProjectBoardDiscoveryDto(options, totalLinkedProjectCount, inaccessibleLinkedProjectCount);
+    }
+
+    private static string ParseOwnerLogin(string fullName)
+    {
+        var separatorIndex = fullName.IndexOf('/');
+        return separatorIndex > 0 ? fullName[..separatorIndex] : fullName;
+    }
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowReposTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowReposTests.cs
@@ -90,11 +90,11 @@ public sealed class PmWorkflowReposTests
         await using var ctx = CreateContext();
         var firstRender = ctx.Render<PmWorkflowRepos>();
 
-        firstRender.WaitForAssertion(() => Assert.Contains("Excluded repositories", firstRender.Markup));
+        firstRender.WaitForAssertion(() => Assert.Contains("Repository participation", firstRender.Markup));
 
         var excludeAutocomplete = firstRender
             .FindComponents<MudAutocomplete<string>>()
-            .First(component => component.Markup.Contains("Search catalogue", StringComparison.Ordinal));
+            .First(component => component.Markup.Contains("Quick exclude", StringComparison.Ordinal));
 
         await firstRender.InvokeAsync(() => excludeAutocomplete.Instance.ValueChanged.InvokeAsync("owner/repo-b"));
         firstRender.Find("[data-testid='pm-workflow-exclude-button']").Click();
@@ -102,7 +102,7 @@ public sealed class PmWorkflowReposTests
         firstRender.WaitForAssertion(() =>
         {
             Assert.Contains("owner/repo-b", firstRender.Markup);
-            Assert.Contains("Include", firstRender.Markup);
+            Assert.Contains("Include again", firstRender.Markup);
         });
 
         await using var reloadContext = CreateContext();
@@ -111,7 +111,7 @@ public sealed class PmWorkflowReposTests
         secondRender.WaitForAssertion(() =>
         {
             Assert.Contains("owner/repo-b", secondRender.Markup);
-            Assert.DoesNotContain("No repositories are excluded", secondRender.Markup);
+            Assert.DoesNotContain("No repositories are excluded. All active repositories participate.", secondRender.Markup);
         });
     }
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowReposTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowReposTests.cs
@@ -24,7 +24,9 @@ public sealed class PmWorkflowReposTests
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
             CreateRepository("owner", "repo-a"),
         ]);
-        _projectBoardDiscoveryService.GetPlanningBoardOptionsAsync(Arg.Any<CancellationToken>()).Returns(
+        _projectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
+            Arg.Any<IReadOnlyList<RepositoryDto>>(),
+            Arg.Any<CancellationToken>()).Returns(
             new PmProjectBoardDiscoveryDto([], 0, 0));
 
         await using var ctx = CreateContext();
@@ -34,6 +36,49 @@ public sealed class PmWorkflowReposTests
         {
             Assert.Contains("Repo Management", cut.Markup);
             Assert.Contains("Select a planning board", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowRepos_Refresh_SyncsThresholdFieldsFromStorage()
+    {
+        ConfigureDefaults();
+        _settingsStorage.StoredJson = """{"capacity":12,"stallDays":5,"neglectDays":21,"excludedRepositories":[]}""";
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<PmWorkflowRepos>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var capacityField = cut.FindComponents<MudNumericField<int>>()
+                .First(component => component.Markup.Contains("Capacity limit", StringComparison.Ordinal));
+#pragma warning disable MUD0012
+            Assert.Equal(12, capacityField.Instance.Value);
+            var stallDaysField = cut.FindComponents<MudNumericField<int>>()
+                .First(component => component.Markup.Contains("Stall days", StringComparison.Ordinal));
+            Assert.Equal(5, stallDaysField.Instance.Value);
+            var neglectDaysField = cut.FindComponents<MudNumericField<int>>()
+                .First(component => component.Markup.Contains("Neglect days", StringComparison.Ordinal));
+            Assert.Equal(21, neglectDaysField.Instance.Value);
+#pragma warning restore MUD0012
+        });
+
+        _settingsStorage.StoredJson = """{"capacity":15,"stallDays":7,"neglectDays":30,"excludedRepositories":[]}""";
+        cut.Find("[data-testid='pm-workflow-refresh-button']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var capacityField = cut.FindComponents<MudNumericField<int>>()
+                .First(component => component.Markup.Contains("Capacity limit", StringComparison.Ordinal));
+#pragma warning disable MUD0012
+            Assert.Equal(15, capacityField.Instance.Value);
+            var stallDaysField = cut.FindComponents<MudNumericField<int>>()
+                .First(component => component.Markup.Contains("Stall days", StringComparison.Ordinal));
+            Assert.Equal(7, stallDaysField.Instance.Value);
+            var neglectDaysField = cut.FindComponents<MudNumericField<int>>()
+                .First(component => component.Markup.Contains("Neglect days", StringComparison.Ordinal));
+            Assert.Equal(30, neglectDaysField.Instance.Value);
+#pragma warning restore MUD0012
         });
     }
 
@@ -77,7 +122,9 @@ public sealed class PmWorkflowReposTests
             CreateRepository("owner", "repo-b"),
         ]);
 
-        _projectBoardDiscoveryService.GetPlanningBoardOptionsAsync(Arg.Any<CancellationToken>()).Returns(
+        _projectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
+            Arg.Any<IReadOnlyList<RepositoryDto>>(),
+            Arg.Any<CancellationToken>()).Returns(
             new PmProjectBoardDiscoveryDto(
                 [new PmPlanningBoardOptionDto("PVT_board", "Roadmap", "owner", "status-field")],
                 1,

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowReposTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowReposTests.cs
@@ -1,0 +1,121 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MudBlazor;
+using MudBlazor.Services;
+using NSubstitute;
+using SoloDevBoard.App.Components.Features.PmWorkflow.Pages;
+using SoloDevBoard.Application.Services.PmWorkflow;
+using SoloDevBoard.Application.Services.Repositories;
+
+namespace SoloDevBoard.App.Tests;
+
+/// <summary>Component tests for <see cref="PmWorkflowRepos"/>.</summary>
+public sealed class PmWorkflowReposTests
+{
+    private readonly IRepositoryService _repositoryService = Substitute.For<IRepositoryService>();
+    private readonly IPmProjectBoardDiscoveryService _projectBoardDiscoveryService = Substitute.For<IPmProjectBoardDiscoveryService>();
+    private readonly FakePmSettingsStorage _settingsStorage = new();
+
+    [Fact]
+    public async Task PmWorkflowRepos_WhenNoBoardIsSelected_ShowsInstructionalAlert()
+    {
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
+            CreateRepository("owner", "repo-a"),
+        ]);
+        _projectBoardDiscoveryService.GetPlanningBoardOptionsAsync(Arg.Any<CancellationToken>()).Returns(
+            new PmProjectBoardDiscoveryDto([], 0, 0));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<PmWorkflowRepos>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Repo Management", cut.Markup);
+            Assert.Contains("Select a planning board", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowRepos_ExcludeRepository_PersistsAfterReload()
+    {
+        ConfigureDefaults();
+
+        await using var ctx = CreateContext();
+        var firstRender = ctx.Render<PmWorkflowRepos>();
+
+        firstRender.WaitForAssertion(() => Assert.Contains("Excluded repositories", firstRender.Markup));
+
+        var excludeAutocomplete = firstRender
+            .FindComponents<MudAutocomplete<string>>()
+            .First(component => component.Markup.Contains("Search catalogue", StringComparison.Ordinal));
+
+        await firstRender.InvokeAsync(() => excludeAutocomplete.Instance.ValueChanged.InvokeAsync("owner/repo-b"));
+        firstRender.Find("[data-testid='pm-workflow-exclude-button']").Click();
+
+        firstRender.WaitForAssertion(() =>
+        {
+            Assert.Contains("owner/repo-b", firstRender.Markup);
+            Assert.Contains("Include", firstRender.Markup);
+        });
+
+        await using var reloadContext = CreateContext();
+        var secondRender = reloadContext.Render<PmWorkflowRepos>();
+
+        secondRender.WaitForAssertion(() =>
+        {
+            Assert.Contains("owner/repo-b", secondRender.Markup);
+            Assert.DoesNotContain("No repositories are excluded", secondRender.Markup);
+        });
+    }
+
+    private void ConfigureDefaults()
+    {
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
+            CreateRepository("owner", "repo-a"),
+            CreateRepository("owner", "repo-b"),
+        ]);
+
+        _projectBoardDiscoveryService.GetPlanningBoardOptionsAsync(Arg.Any<CancellationToken>()).Returns(
+            new PmProjectBoardDiscoveryDto(
+                [new PmPlanningBoardOptionDto("PVT_board", "Roadmap", "owner", "status-field")],
+                1,
+                0));
+    }
+
+    private BunitContext CreateContext()
+    {
+        var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddMudServices();
+        ctx.Services.AddTestGitHubAuthenticationRecovery();
+        ctx.Services.AddSingleton<IPmSettingsStorage>(_settingsStorage);
+        ctx.Services.AddScoped<IPmSettingsService, PmSettingsService>();
+        ctx.Services.AddScoped(_ => _repositoryService);
+        ctx.Services.AddScoped(_ => _projectBoardDiscoveryService);
+        ctx.Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+
+        ctx.Render<MudPopoverProvider>();
+        ctx.Render<MudDialogProvider>();
+        ctx.Render<MudSnackbarProvider>();
+
+        return ctx;
+    }
+
+    private static RepositoryDto CreateRepository(string owner, string name) =>
+        new(1, name, $"{owner}/{name}", string.Empty, $"https://github.com/{owner}/{name}", false, false, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+    private sealed class FakePmSettingsStorage : IPmSettingsStorage
+    {
+        public string? StoredJson { get; set; }
+
+        public Task<string?> GetStoredJsonAsync() => Task.FromResult(StoredJson);
+
+        public Task SetStoredJsonAsync(string json)
+        {
+            StoredJson = json;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
@@ -49,6 +49,7 @@ public sealed class ApplicationServiceCollectionExtensionsTests
         AssertServiceRegistration<IPmSettingsService, PmSettingsService>(services, ServiceLifetime.Scoped);
         AssertServiceRegistration<IProjectItemCatalogueService, ProjectItemCatalogueService>(services, ServiceLifetime.Scoped);
         AssertServiceRegistration<IPmWorkItemCatalogueService, PmWorkItemCatalogueService>(services, ServiceLifetime.Scoped);
+        AssertServiceRegistration<IPmProjectBoardDiscoveryService, PmProjectBoardDiscoveryService>(services, ServiceLifetime.Scoped);
     }
 
     private static void AssertServiceRegistration<TService, TImplementation>(

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/PmProjectBoardDiscoveryServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/PmProjectBoardDiscoveryServiceTests.cs
@@ -1,0 +1,117 @@
+using NSubstitute;
+using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Application.Services.PmWorkflow;
+using SoloDevBoard.Domain.Entities.Repositories;
+using SoloDevBoard.Domain.Entities.Triage;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="PmProjectBoardDiscoveryService"/>.</summary>
+public sealed class PmProjectBoardDiscoveryServiceTests
+{
+    private readonly IGitHubService _gitHubService = Substitute.For<IGitHubService>();
+
+    [Fact]
+    public async Task GetPlanningBoardOptionsAsync_MultipleRepositories_ReturnsDistinctSortedBoards()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        _gitHubService.GetActiveRepositoriesAsync(cancellationToken).Returns([
+            CreateRepository("owner", "repo-a"),
+            CreateRepository("owner", "repo-b"),
+        ]);
+
+        _gitHubService
+            .GetProjectBoardsForRepositoryAsync("owner", "repo-a", cancellationToken)
+            .Returns(CreateDiscovery("PVT_shared", "Shared Board", total: 2, inaccessible: 1));
+
+        _gitHubService
+            .GetProjectBoardsForRepositoryAsync("owner", "repo-b", cancellationToken)
+            .Returns(CreateDiscovery(
+                "PVT_shared",
+                "Shared Board",
+                total: 1,
+                inaccessible: 0,
+                secondBoardId: "PVT_unique",
+                secondBoardTitle: "Unique Board"));
+
+        var sut = new PmProjectBoardDiscoveryService(_gitHubService);
+
+        var result = await sut.GetPlanningBoardOptionsAsync(cancellationToken);
+
+        Assert.Equal(2, result.Options.Count);
+        Assert.Equal("PVT_shared", result.Options[0].Id);
+        Assert.Equal("Shared Board", result.Options[0].Title);
+        Assert.Equal("PVT_unique", result.Options[1].Id);
+        Assert.Equal(3, result.TotalLinkedProjectCount);
+        Assert.Equal(1, result.InaccessibleLinkedProjectCount);
+    }
+
+    [Fact]
+    public async Task GetPlanningBoardOptionsAsync_NoActiveRepositories_ReturnsEmptyOptions()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        _gitHubService.GetActiveRepositoriesAsync(cancellationToken).Returns(Array.Empty<Repository>());
+
+        var sut = new PmProjectBoardDiscoveryService(_gitHubService);
+
+        var result = await sut.GetPlanningBoardOptionsAsync(cancellationToken);
+
+        Assert.Empty(result.Options);
+        Assert.Equal(0, result.TotalLinkedProjectCount);
+        Assert.Equal(0, result.InaccessibleLinkedProjectCount);
+        await _gitHubService.DidNotReceive().GetProjectBoardsForRepositoryAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static Repository CreateRepository(string owner, string name) => new()
+    {
+        Id = 1,
+        Name = name,
+        FullName = $"{owner}/{name}",
+        Description = string.Empty,
+        Url = $"https://github.com/{owner}/{name}",
+        IsPrivate = false,
+        IsArchived = false,
+        CreatedAt = DateTimeOffset.UtcNow,
+        UpdatedAt = DateTimeOffset.UtcNow,
+    };
+
+    private static RepositoryProjectBoardDiscoveryResult CreateDiscovery(
+        string firstBoardId,
+        string firstBoardTitle,
+        int total,
+        int inaccessible,
+        string? secondBoardId = null,
+        string? secondBoardTitle = null)
+    {
+        var boards = new List<TriageProjectBoard>
+        {
+            new()
+            {
+                Id = firstBoardId,
+                Title = firstBoardTitle,
+                OwnerLogin = "owner",
+                StatusFieldId = "status-field",
+                StatusOptions = [],
+            },
+        };
+
+        if (secondBoardId is not null && secondBoardTitle is not null)
+        {
+            boards.Add(new TriageProjectBoard
+            {
+                Id = secondBoardId,
+                Title = secondBoardTitle,
+                OwnerLogin = "owner",
+                StatusFieldId = "status-field",
+                StatusOptions = [],
+            });
+        }
+
+        return new RepositoryProjectBoardDiscoveryResult(boards, total, inaccessible);
+    }
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/PmProjectBoardDiscoveryServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/PmProjectBoardDiscoveryServiceTests.cs
@@ -1,6 +1,7 @@
 using NSubstitute;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Application.Services.PmWorkflow;
+using SoloDevBoard.Application.Services.Repositories;
 using SoloDevBoard.Domain.Entities.Repositories;
 using SoloDevBoard.Domain.Entities.Triage;
 
@@ -10,6 +11,44 @@ namespace SoloDevBoard.Application.Tests;
 public sealed class PmProjectBoardDiscoveryServiceTests
 {
     private readonly IGitHubService _gitHubService = Substitute.For<IGitHubService>();
+
+    [Fact]
+    public async Task GetPlanningBoardOptionsForRepositoriesAsync_SuppliedRepositories_ReturnsDistinctSortedBoards()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        _gitHubService
+            .GetProjectBoardsForRepositoryAsync("owner", "repo-a", cancellationToken)
+            .Returns(CreateDiscovery("PVT_shared", "Shared Board", total: 2, inaccessible: 1));
+
+        _gitHubService
+            .GetProjectBoardsForRepositoryAsync("owner", "repo-b", cancellationToken)
+            .Returns(CreateDiscovery(
+                "PVT_shared",
+                "Shared Board",
+                total: 1,
+                inaccessible: 0,
+                secondBoardId: "PVT_unique",
+                secondBoardTitle: "Unique Board"));
+
+        var repositories = new[]
+        {
+            CreateRepositoryDto("owner", "repo-a"),
+            CreateRepositoryDto("owner", "repo-b"),
+        };
+
+        var sut = new PmProjectBoardDiscoveryService(_gitHubService);
+
+        var result = await sut.GetPlanningBoardOptionsForRepositoriesAsync(repositories, cancellationToken);
+
+        Assert.Equal(2, result.Options.Count);
+        Assert.Equal("PVT_shared", result.Options[0].Id);
+        Assert.Equal("Shared Board", result.Options[0].Title);
+        Assert.Equal("PVT_unique", result.Options[1].Id);
+        Assert.Equal(3, result.TotalLinkedProjectCount);
+        Assert.Equal(1, result.InaccessibleLinkedProjectCount);
+        await _gitHubService.DidNotReceive().GetActiveRepositoriesAsync(Arg.Any<CancellationToken>());
+    }
 
     [Fact]
     public async Task GetPlanningBoardOptionsAsync_MultipleRepositories_ReturnsDistinctSortedBoards()
@@ -79,6 +118,9 @@ public sealed class PmProjectBoardDiscoveryServiceTests
         CreatedAt = DateTimeOffset.UtcNow,
         UpdatedAt = DateTimeOffset.UtcNow,
     };
+
+    private static RepositoryDto CreateRepositoryDto(string owner, string name) =>
+        new(1, name, $"{owner}/{name}", string.Empty, $"https://github.com/{owner}/{name}", false, false, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
 
     private static RepositoryProjectBoardDiscoveryResult CreateDiscovery(
         string firstBoardId,

--- a/tests/E2E/CRITICAL_JOURNEYS.md
+++ b/tests/E2E/CRITICAL_JOURNEYS.md
@@ -43,6 +43,7 @@ For data-driven journeys against a real GitHub account, run the PAT suite locall
 | Label Manager taxonomy tabs and empty repository state | `labels.spec.ts` | Tab strip, disabled actions, and no-repositories message. |
 | Workflow template browse, filter, and select | `workflows.spec.ts` | Built-in templates load; repository selector shows error. |
 | Triage not-started region without repositories | `triage.spec.ts` | Shell heading and no-repositories alert. |
+| PM Workflow Repo Management shell | `pm-workflow.spec.ts` | Shared chrome, Repos tab content or chrome error with retry. |
 
 ### Tier 3 — Out of CI scope (manual or future)
 

--- a/tests/E2E/README.md
+++ b/tests/E2E/README.md
@@ -23,6 +23,7 @@ Published user guides must stay aligned with these tests like-for-like. See [USE
 | `labels.spec.ts` | Label Manager shell, tabs, and empty-repository state |
 | `workflows.spec.ts` | Built-in template browse/filter/select and repository error state |
 | `triage.spec.ts` | Triage shell and no-repositories alert without a live GitHub connection |
+| `pm-workflow.spec.ts` | PM Workflow Repos tab shell, shared chrome, and threshold/exclusion regions or chrome error |
 | `accessibility.spec.ts` | WCAG 2.1 AA axe-core scan of Tier 1–2 journeys in light and dark mode; labelled shell controls; isolated snackbar contrast scan |
 
 Tests are designed to pass in CI with placeholder auth. The PAT job uses `GitHubAuth__PersonalAccessToken=ci-e2e-placeholder`. The hosted job uses placeholder GitHub App credentials and asserts the login gate without live OAuth. Repository-dependent features assert empty or error states rather than live GitHub data.

--- a/tests/E2E/USER_DOCS_ALIGNMENT.md
+++ b/tests/E2E/USER_DOCS_ALIGNMENT.md
@@ -36,7 +36,7 @@ When you add or change an end-user feature, update the user guide, the relevant 
 | [Workflow Templates](../../website/content/docs/workflow-templates.md) | `/workflows` | `workflows.spec.ts`, `accessibility.spec.ts` | `workflow-templates/overview.png` | Tier 2 | Guide describes browse, parameterise, apply, and drift; CI asserts built-in template browse/filter/select and repository error state. |
 | [Appearance](../../website/content/docs/appearance.md) | App bar (all shell pages) | `appearance.spec.ts`, `accessibility.spec.ts` | `appearance/theme-toggle.png` | Tier 1 | Guide describes Automatic → Light → Dark cycling and persistence; not a drawer route. |
 | [About (in-app)](../../website/content/docs/about.md) | `/about` | `about.spec.ts`, `accessibility.spec.ts` | `about/overview.png` | Tier 1 | Guide describes More options menu access (User Guide external link and About route) and metadata fields. Not the Hugo `/about/` narrative section. |
-| Cross-Repo PM Workflow (`draft: true`) | — | — | — | — | Not published; excluded until Phase 5. |
+| Cross-Repo PM Workflow (`draft: true`, partial) | `/pm-workflow`, `/pm-workflow/repos` | `pm-workflow.spec.ts`, `accessibility.spec.ts` | `pm-workflow/repos.png` (pending) | Tier 2 | Draft guide documents Repo Management only ([#287](https://github.com/markheydon/solo-dev-board/issues/287)); Daily Focus, Backlog, and Planning are placeholders. CI asserts shell, tab strip, and Repos regions or chrome error. |
 
 ### Auth and entry journeys (operator docs, not user guide)
 
@@ -81,6 +81,15 @@ Use this when extending specs so assertions track documented workflows.
 | More options → User Guide | `about.spec.ts` menu link to `https://solodevboard.com/docs/` |
 | More options → About | `about.spec.ts` navigation |
 | Version, build, .NET, auth mode, login, repository link | `about.spec.ts` `data-testid` fields |
+
+### Cross-Repo PM Workflow (partial — Repo Management)
+
+| Guide section | CI assertion | Loaded-state validation |
+|---------------|--------------|-------------------------|
+| Drawer → PM Workflow → Repos | `pm-workflow.spec.ts` URL, title, shell, tab strip | `docs-capture` (pending) |
+| Planning board selector and refresh | `pm-workflow.spec.ts` shared chrome `data-testid`s | `docs-capture` (pending) |
+| Thresholds and exclusions | `pm-workflow.spec.ts` regions and controls, or chrome error | `docs-capture` (pending) |
+| Daily Focus, Backlog, Planning | — | Not shipped |
 
 ## Screenshot hygiene
 

--- a/tests/E2E/USER_DOCS_ALIGNMENT.md
+++ b/tests/E2E/USER_DOCS_ALIGNMENT.md
@@ -87,8 +87,11 @@ Use this when extending specs so assertions track documented workflows.
 | Guide section | CI assertion | Loaded-state validation |
 |---------------|--------------|-------------------------|
 | Drawer → PM Workflow → Repos | `pm-workflow.spec.ts` URL, title, shell, tab strip | `docs-capture` (pending) |
-| Planning board selector and refresh | `pm-workflow.spec.ts` shared chrome `data-testid`s | `docs-capture` (pending) |
-| Thresholds and exclusions | `pm-workflow.spec.ts` regions and controls, or chrome error | `docs-capture` (pending) |
+| Planning board selector, status line, and refresh | `pm-workflow.spec.ts` shared chrome `data-testid`s | `docs-capture` (pending) |
+| Planning thresholds | `pm-workflow-thresholds-region`, capacity field, or chrome error | `docs-capture` (pending) |
+| Repository participation summary | `pm-workflow-participation-summary` | `docs-capture` (pending) |
+| Included repositories table or empty state | `pm-workflow-included-table` / `pm-workflow-no-included-text` | `docs-capture` (pending) |
+| Excluded repositories and quick exclude | `pm-workflow-exclusions-region`, exclude autocomplete | `docs-capture` (pending) |
 | Daily Focus, Backlog, Planning | — | Not shipped |
 
 ## Screenshot hygiene

--- a/tests/E2E/fixtures/accessibility.ts
+++ b/tests/E2E/fixtures/accessibility.ts
@@ -106,6 +106,11 @@ export async function waitForAccessibilityScanReady(page: Page, path: string): P
   if (routePath === '/repositories') {
     await expect(page.getByTestId('repositories-refresh-button')).toBeEnabled({ timeout: 15_000 });
   }
+
+  if (routePath === '/pm-workflow/repos') {
+    await expect(page.getByTestId('pm-workflow-shell')).toBeVisible();
+    await expect(page.locator('[aria-label="Loading PM Workflow"]')).toBeHidden({ timeout: 15_000 });
+  }
 }
 
 /** Seeds the browser theme preference before the next navigation. */

--- a/tests/E2E/fixtures/accessibility.ts
+++ b/tests/E2E/fixtures/accessibility.ts
@@ -15,6 +15,7 @@ export const accessibilityRoutes = [
   { path: '/board-rules', name: 'Board Rules' },
   { path: '/triage', name: 'Triage' },
   { path: '/workflows', name: 'Workflow Templates' },
+  { path: '/pm-workflow/repos', name: 'PM Workflow Repos' },
 ] as const;
 
 const wcagTags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] as const;

--- a/tests/E2E/fixtures/navigation.ts
+++ b/tests/E2E/fixtures/navigation.ts
@@ -8,6 +8,7 @@ export const featureRoutes = [
   { navLabel: 'Board Rules', path: '/board-rules', title: /Board Rules Visualiser/ },
   { navLabel: 'Triage', path: '/triage', title: /Triage UI/ },
   { navLabel: 'Workflows', path: '/workflows', title: /Workflow Templates/ },
+  { navLabel: 'PM Workflow', path: '/pm-workflow/repos', title: /PM Workflow — Repos/ },
 ] as const;
 
 async function ensureDrawerOpen(page: Page): Promise<void> {

--- a/tests/E2E/tests/pm-workflow.spec.ts
+++ b/tests/E2E/tests/pm-workflow.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { navigateViaDrawer } from '../fixtures/navigation';
+
+test.describe('PM Workflow Repo Management', () => {
+  test('drawer navigation opens the Repos tab shell', async ({ page }) => {
+    await page.goto('/');
+
+    await navigateViaDrawer(page, 'PM Workflow');
+
+    await expect(page).toHaveURL(/\/pm-workflow\/repos$/);
+    await expect(page).toHaveTitle(/PM Workflow — Repos/);
+    await expect(page.getByTestId('pm-workflow-shell')).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-tab-strip')).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Repos' })).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-repos-page')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Repo Management' })).toBeVisible();
+  });
+
+  test('repos tab shows threshold and exclusion regions or a chrome error', async ({ page }) => {
+    await page.goto('/pm-workflow/repos');
+
+    await expect(page.getByTestId('pm-workflow-shell')).toBeVisible();
+
+    const chromeError = page.getByTestId('pm-workflow-chrome-error');
+    const thresholdsRegion = page.getByTestId('pm-workflow-thresholds-region');
+    const exclusionsRegion = page.getByTestId('pm-workflow-exclusions-region');
+
+    await expect(chromeError.or(thresholdsRegion)).toBeVisible({ timeout: 15_000 });
+
+    if (await chromeError.isVisible()) {
+      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      return;
+    }
+
+    await expect(thresholdsRegion).toBeVisible();
+    await expect(exclusionsRegion).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-participation-summary')).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-included-table')).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-capacity-field')).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-exclude-autocomplete')).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-no-exclusions-text')).toBeVisible();
+  });
+});

--- a/tests/E2E/tests/pm-workflow.spec.ts
+++ b/tests/E2E/tests/pm-workflow.spec.ts
@@ -35,7 +35,9 @@ test.describe('PM Workflow Repo Management', () => {
     await expect(thresholdsRegion).toBeVisible();
     await expect(exclusionsRegion).toBeVisible();
     await expect(page.getByTestId('pm-workflow-participation-summary')).toBeVisible();
-    await expect(page.getByTestId('pm-workflow-included-table')).toBeVisible();
+    await expect(
+      page.getByTestId('pm-workflow-included-table').or(page.getByTestId('pm-workflow-no-included-text')),
+    ).toBeVisible();
     await expect(page.getByTestId('pm-workflow-capacity-field')).toBeVisible();
     await expect(page.getByTestId('pm-workflow-exclude-autocomplete')).toBeVisible();
     await expect(page.getByTestId('pm-workflow-no-exclusions-text')).toBeVisible();

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -12,7 +12,7 @@ Guides for using SoloDevBoard in the app. Developer and operator material (local
 
 ## Coming later
 
-- Cross-Repo PM Workflow — structured project management and daily/weekly operating modes across multiple repositories (draft retained in source; not published yet).
+- Cross-Repo PM Workflow — full PM Mode and Work Mode across four tabs (user guide remains `draft: true`; **Repo Management** is available in the app under **PM Workflow** in the drawer).
 
 ## Related repository docs
 

--- a/website/content/docs/pm-workflow.md
+++ b/website/content/docs/pm-workflow.md
@@ -2,69 +2,153 @@
 title: Cross-Repo PM Workflow
 draft: true
 weight: 110
+guideStatus: Partially Available
 ---
 
-> ⚠️ **Under Development** — This feature is planned for **v1.1.0**. This page will be updated as the feature progresses.
+> ⚠️ **Partial delivery** — Repo Management is available in the app under **PM Workflow** in the navigation drawer. Daily Focus, Backlog Review, and Iteration Planning are not shipped yet. This guide remains a draft until all four tabs match the wireframe; only the sections below describe current behaviour.
 
 ---
 
 ## Overview
 
-The Cross-Repo PM Workflow brings a structured, two-mode operating system into SoloDevBoard, replacing the manual AI prompts and scripts in [markheydon/github-workflows](https://github.com/markheydon/github-workflows) with a proper visual interface.
+The Cross-Repo PM Workflow brings a structured, two-mode operating system into SoloDevBoard, replacing the manual AI prompts and scripts in [markheydon/github-workflows](https://github.com/markheydon/github-workflows) with a visual interface.
 
 The system is built around two modes of operation:
 
 - **PM Mode** (weekly or fortnightly) — Active curation: review your backlog across all repositories, resolve stalled work, and populate your project board with a realistic set of committed items for the next few days.
-- **Work Mode** (daily) — Execution: the project board is the single pane of glass. Open it, pick the next item, and get things done. The optional Daily Focus view provides a quick morning nudge on what is most urgent today.
+- **Work Mode** (daily) — Execution: the project board is the single pane of glass. Open it, pick the next item, and get things done. The optional Daily Focus view will provide a quick morning nudge on what is most urgent today.
+
+### What is available now
+
+| Tab | Route | Status |
+|-----|-------|--------|
+| **Repos** | `/pm-workflow/repos` | **Available** — planning board selection, thresholds, and repository exclusions. |
+| Daily Focus | `/pm-workflow/daily-focus` | Placeholder — story [#273](https://github.com/markheydon/solo-dev-board/issues/273). |
+| Backlog | `/pm-workflow/backlog` | Placeholder — story [#277](https://github.com/markheydon/solo-dev-board/issues/277). |
+| Planning | `/pm-workflow/planning` | Placeholder — story [#283](https://github.com/markheydon/solo-dev-board/issues/283). |
+
+Open **PM Workflow** from the navigation drawer. The hub redirects to **Repos** until Daily Focus ships.
 
 ---
 
-## Key Capabilities
+## Repo Management (available)
+
+Repo Management controls which repositories and which Projects v2 board participate in PM operations. Settings persist in your browser (see [Configuration](#configuration)).
+
+### Accessing
+
+1. Open the navigation drawer.
+2. Select **PM Workflow**.
+3. You land on the **Repos** tab (`/pm-workflow/repos`).
+
+Shared chrome on every PM Workflow tab includes:
+
+- **Planning board** selector — choose a Projects v2 board discovered from your active repositories (same discovery model as Triage and Board Rules).
+- **Repos included** count — active repositories minus exclusions.
+- **Refresh** — reload board options and repository catalogue.
+- **Tab strip** — Daily Focus, Backlog, Planning, and Repos (only Repos is functional today).
+
+If GitHub reports linked project boards that cannot be read with your current sign-in (common for private user-owned boards under GitHub App sign-in), a warning appears at the top of the page. See [plan/GITHUB_PROJECTS_V2_ACCESS.md](https://github.com/markheydon/solo-dev-board/blob/main/plan/GITHUB_PROJECTS_V2_ACCESS.md) in the repository.
+
+### Select a planning board
+
+1. Open the **Planning board** dropdown in the shared chrome.
+2. Choose a board title from the list (boards are discovered across active, non-archived repositories).
+3. The selection is saved automatically.
+
+Until a board is selected, an informational alert explains that future tabs need a board. You can still edit Repo Management settings below.
+
+Board occupancy on the selected board will count **every** linked card when Daily Focus ships. Recommendations, backlog queries, and planning candidates will honour repository exclusions.
+
+### Set planning thresholds
+
+Under **Planning thresholds**:
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| **Capacity limit** | 8 | Maximum combined Up Next + In Progress items for planning warnings (used on the Planning tab when shipped). |
+| **Stall days** | 3 | Days before an Up Next item is treated as stalled. |
+| **Neglect days** | 14 | Days before a repository is treated as neglected in backlog views. |
+
+1. Adjust the numeric fields.
+2. Select **Save thresholds**.
+
+### Exclude or include repositories
+
+Excluded repositories are omitted from Daily Focus recommendations, Backlog Review, Planning candidates, and per-repository summaries. Archived repositories are never offered for inclusion.
+
+**To exclude a repository:**
+
+1. Under **Excluded repositories**, search the catalogue for an active `owner/name` repository.
+2. Select **Exclude**.
+
+**To include a repository again:**
+
+1. Find the repository in the **Currently excluded** list.
+2. Select **Include**.
+
+Exclusions persist immediately in browser storage.
+
+> **Scope note** — The per-repository summary table (open issue and PR counts) is tracked on story [#288](https://github.com/markheydon/solo-dev-board/issues/288) and is not shown yet.
+
+---
+
+## Key Capabilities (planned)
+
+The following sections describe the full v1.1.0 feature set. They are **not** available in the app yet.
 
 ### Daily Focus
 
 A quick morning summary that answers "what should I work on right now?":
 
-- Project board state: item count per status column and current active load
-- Stalled items: anything in your Up Next column for three or more days
-- Stalled PR reviews: pull requests in review for three or more days that need a merge, close, or return-to-progress decision
-- Top three recommended work items, ranked by priority across all your repositories
+- Project board state: item count per status column and current active load.
+- Stalled items: anything in your Up Next column for three or more days.
+- Stalled PR reviews: pull requests in review for three or more days that need a merge, close, or return-to-progress decision.
+- Top three recommended work items, ranked by priority across included repositories.
 
 ### Backlog Review
 
 A cross-repository prioritised view of all your open work:
 
-- Urgent items (high-priority issues and PRs surfaced at the top)
-- Items ready to start (unlabelled, unblocked stories and bugs across all repos)
-- Blocked and deferred items (parked in Blocked or Ice Box)
-- Neglected repositories (no issue or PR activity in the past 14 days, surfaced so nothing falls silently through the cracks)
-- Items awaiting triage (no core label applied)
+- Urgent items (high-priority issues and PRs surfaced at the top).
+- Items ready to start (unblocked stories and bugs across included repos).
+- Blocked and deferred items (parked in Blocked or Ice Box).
+- Neglected repositories (no issue or PR activity within the neglect threshold).
+- Items awaiting triage (missing `type/` or `priority/` labels).
 
 ### Iteration Planning
 
 A guided planning session that populates your project board's Up Next column:
 
-- Shows current board capacity (Up Next + In Progress combined)
-- Surfaces stalled Up Next items and asks you to resolve them before adding new work
-- Lets you select issues and pull requests from across your repositories to commit to this week
-- Optionally assigns a milestone to all planned items in a single step
-- Configurable capacity limit to prevent over-committing
-
-### Repo Management
-
-Settings for cross-repo PM behaviour:
-
-- Define a list of excluded repositories (personal, archived, or irrelevant repos that should not appear in PM operations)
-- Repository health summary: issue and PR counts per repo at a glance
-
----
-
-## How to Use
-
-*Coming soon — this section will describe the step-by-step usage once the feature is built.*
+- Shows current board capacity (Up Next + In Progress combined).
+- Surfaces stalled Up Next items and asks you to resolve them before adding new work.
+- Lets you select issues and pull requests from across included repositories.
+- Optionally assigns a milestone to planned items in a single step.
+- Configurable capacity limit with a confirmation dialog when exceeded.
 
 ---
 
 ## Configuration
 
-*Coming soon — this section will describe capacity limits, excluded repos, and staleness thresholds.*
+PM Workflow preferences are stored in **browser localStorage** on the device you use (same pattern as theme preference). There is no server-side database for these settings.
+
+Persisted fields:
+
+| Setting | Description |
+|---------|-------------|
+| Planning board node id | GitHub GraphQL node id for the selected Projects v2 board. |
+| Excluded repositories | `owner/name` values omitted from PM queries. |
+| Capacity limit | Active load ceiling for planning (default 8). |
+| Stall days | Up Next stall threshold (default 3). |
+| Neglect days | Repository neglect threshold (default 14). |
+
+Clearing site data for SoloDevBoard resets PM settings to defaults. Settings do not sync across browsers or devices.
+
+There are no `appsettings.json` entries for PM Workflow user preferences.
+
+---
+
+## Related documentation
+
+- Wireframe: [`plan/wireframes/pm-workflow-wireframe.md`](https://github.com/markheydon/solo-dev-board/blob/main/plan/wireframes/pm-workflow-wireframe.md)
+- Decision: [DEC-029](https://github.com/markheydon/solo-dev-board/blob/main/plan/DECISIONS.md#dec-029-cross-repo-pm-workflow-board-selection-and-local-settings) (board selection and local settings)

--- a/website/content/docs/pm-workflow.md
+++ b/website/content/docs/pm-workflow.md
@@ -44,8 +44,7 @@ Repo Management controls which repositories and which Projects v2 board particip
 Shared chrome on every PM Workflow tab includes:
 
 - **Planning board** selector — choose a Projects v2 board discovered from your active repositories (same discovery model as Triage and Board Rules).
-- **Repos included** count — active repositories minus exclusions.
-- **Refresh** — reload board options and repository catalogue.
+- **Status line** — `Repos: N included`, selected board title (when chosen), last refreshed time, and a **Refresh** control to reload board options and the repository catalogue.
 - **Tab strip** — Daily Focus, Backlog, Planning, and Repos (only Repos is functional today).
 
 If GitHub reports linked project boards that cannot be read with your current sign-in (common for private user-owned boards under GitHub App sign-in), a warning appears at the top of the page. See [plan/GITHUB_PROJECTS_V2_ACCESS.md](https://github.com/markheydon/solo-dev-board/blob/main/plan/GITHUB_PROJECTS_V2_ACCESS.md) in the repository.
@@ -73,23 +72,30 @@ Under **Planning thresholds**:
 1. Adjust the numeric fields.
 2. Select **Save thresholds**.
 
-### Exclude or include repositories
+### Manage repository participation
 
-Excluded repositories are omitted from Daily Focus recommendations, Backlog Review, Planning candidates, and per-repository summaries. Archived repositories are never offered for inclusion.
+The **Repository participation** section shows how many repositories are included and excluded. Every active repository participates in PM queries by default. Archived repositories are never offered.
 
-**To exclude a repository:**
+Excluded repositories are omitted from Daily Focus recommendations, Backlog Review, and Planning candidates.
 
-1. Under **Excluded repositories**, search the catalogue for an active `owner/name` repository.
+**Included repositories** lists active `owner/name` values that currently participate:
+
+1. Optionally narrow the list with **Filter included repositories**.
+2. Select **Exclude** on the row you want to remove.
+
+**Quick exclude** under **Excluded repositories** offers the same action via search:
+
+1. Type an `owner/name` value in **Quick exclude**.
 2. Select **Exclude**.
 
 **To include a repository again:**
 
-1. Find the repository in the **Currently excluded** list.
-2. Select **Include**.
+1. Find the repository in the **Excluded repositories** list.
+2. Select **Include again**.
 
 Exclusions persist immediately in browser storage.
 
-> **Scope note** — The per-repository summary table (open issue and PR counts) is tracked on story [#288](https://github.com/markheydon/solo-dev-board/issues/288) and is not shown yet.
+> **Scope note** — Open issue and PR counts plus last-activity columns for each repository are tracked on story [#288](https://github.com/markheydon/solo-dev-board/issues/288) and are not shown yet. The included repositories table lists participation only today.
 
 ---
 


### PR DESCRIPTION
## Summary of Changes

Adds the PM Workflow **Repos** route (`/pm-workflow/repos`) with shared shell chrome (planning board selector, tab navigation, refresh status), threshold settings (capacity, stall days, neglect days), and exclude/include controls for active repositories. Settings persist through the existing `IPmSettingsService` localStorage pattern. Introduces `IPmProjectBoardDiscoveryService` to discover planning boards across active repositories.

## Related Issue(s)

Closes #287

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [ ] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — UI to be captured when docs-capture mode runs with test issue #388.

## Additional Notes

- Per-repository summary table is intentionally deferred to #288.
- Full `website/content/docs/pm-workflow.md` publication remains with feature #272 close-out; Playwright coverage is tracked on test issue #388.
- `dotnet clean SoloDevBoard.slnx && dotnet test SoloDevBoard.slnx` passed locally.