### PR TITLE
[Story] Show Daily Focus board occupancy and active load (#273)

### DIFF
--- a/src/App/SoloDevBoard.App/Components/Features/Dashboard/Pages/Dashboard.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Dashboard/Pages/Dashboard.razor
@@ -39,6 +39,7 @@
         new("Board Rules Visualiser", "Inspect project automation flow and board behaviour.", "/board-rules"),
         new("Triage UI", "Process incoming issues quickly with a focused triage experience.", "/triage"),
         new("Workflow Templates", "Apply and maintain workflow templates consistently.", "/workflows"),
+        new("PM Workflow", "See planning-board occupancy and manage which repositories take part in PM operations.", "/pm-workflow"),
     ];
 
     private sealed record FeatureCardModel(string Name, string Description, string Route);

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowBacklog.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowBacklog.razor
@@ -1,14 +1,13 @@
 @page "/pm-workflow/backlog"
+@layout PmWorkflowLayout
 @using SoloDevBoard.App.Components.Features.PmWorkflow
 
 <PageTitle>PM Workflow — Backlog</PageTitle>
 
-<PmWorkflowShell ActiveTab="backlog">
-    <MudStack Spacing="2" data-testid="pm-workflow-backlog-page">
-        <MudText Typo="Typo.h5">Backlog Review</MudText>
-        <MudText Typo="Typo.body1">
-            Cross-repository backlog grouping will appear here once stories #277–#282 ship.
-            Configure repositories and planning thresholds on the Repos tab meanwhile.
-        </MudText>
-    </MudStack>
-</PmWorkflowShell>
+<MudStack Spacing="2" data-testid="pm-workflow-backlog-page">
+    <MudText Typo="Typo.h5">Backlog Review</MudText>
+    <MudText Typo="Typo.body1">
+        Cross-repository backlog grouping will appear here once stories #277–#282 ship.
+        Configure repositories and planning thresholds on the Repos tab meanwhile.
+    </MudText>
+</MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowDailyFocus.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowDailyFocus.razor
@@ -1,8 +1,7 @@
 @page "/pm-workflow/daily-focus"
+@layout PmWorkflowLayout
 @using SoloDevBoard.App.Components.Features.PmWorkflow
 
 <PageTitle>PM Workflow — Daily Focus</PageTitle>
 
-<PmWorkflowShell ActiveTab="daily-focus">
-    <PmWorkflowDailyFocusPanel />
-</PmWorkflowShell>
+<PmWorkflowDailyFocusPanel />

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowDailyFocus.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowDailyFocus.razor
@@ -4,11 +4,5 @@
 <PageTitle>PM Workflow — Daily Focus</PageTitle>
 
 <PmWorkflowShell ActiveTab="daily-focus">
-    <MudStack Spacing="2" data-testid="pm-workflow-daily-focus-page">
-        <MudText Typo="Typo.h5">Daily Focus</MudText>
-        <MudText Typo="Typo.body1">
-            Morning recommendations and board occupancy will appear here once story #273 ships.
-            Configure repositories and planning thresholds on the Repos tab meanwhile.
-        </MudText>
-    </MudStack>
+    <PmWorkflowDailyFocusPanel />
 </PmWorkflowShell>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowIndex.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowIndex.razor
@@ -5,6 +5,6 @@
     /// <inheritdoc/>
     protected override void OnInitialized()
     {
-        NavigationManager.NavigateTo("/pm-workflow/repos", replace: true);
+        NavigationManager.NavigateTo("/pm-workflow/daily-focus", replace: true);
     }
 }

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowPlanning.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowPlanning.razor
@@ -1,14 +1,13 @@
 @page "/pm-workflow/planning"
+@layout PmWorkflowLayout
 @using SoloDevBoard.App.Components.Features.PmWorkflow
 
 <PageTitle>PM Workflow — Planning</PageTitle>
 
-<PmWorkflowShell ActiveTab="planning">
-    <MudStack Spacing="2" data-testid="pm-workflow-planning-page">
-        <MudText Typo="Typo.h5">Iteration Planning</MudText>
-        <MudText Typo="Typo.body1">
-            Up Next curation and capacity guidance will appear here once stories #283–#286 ship.
-            Configure repositories and planning thresholds on the Repos tab meanwhile.
-        </MudText>
-    </MudStack>
-</PmWorkflowShell>
+<MudStack Spacing="2" data-testid="pm-workflow-planning-page">
+    <MudText Typo="Typo.h5">Iteration Planning</MudText>
+    <MudText Typo="Typo.body1">
+        Up Next curation and capacity guidance will appear here once stories #283–#286 ship.
+        Configure repositories and planning thresholds on the Repos tab meanwhile.
+    </MudText>
+</MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowRepos.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowRepos.razor
@@ -1,8 +1,7 @@
 @page "/pm-workflow/repos"
+@layout PmWorkflowLayout
 @using SoloDevBoard.App.Components.Features.PmWorkflow
 
 <PageTitle>PM Workflow — Repos</PageTitle>
 
-<PmWorkflowShell ActiveTab="repos">
-    <PmWorkflowReposPanel />
-</PmWorkflowShell>
+<PmWorkflowReposPanel />

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowChromeCoordinator.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowChromeCoordinator.cs
@@ -1,0 +1,209 @@
+using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Application.Services.PmWorkflow;
+using SoloDevBoard.Application.Services.Repositories;
+
+namespace SoloDevBoard.App.Components.Features.PmWorkflow;
+
+/// <summary>
+/// Scoped coordinator that loads, caches, and cancels PM Workflow chrome data for the current Blazor circuit.
+/// </summary>
+public sealed class PmWorkflowChromeCoordinator
+{
+    private readonly IPmSettingsService _pmSettingsService;
+    private readonly IRepositoryService _repositoryService;
+    private readonly IPmProjectBoardDiscoveryService _projectBoardDiscoveryService;
+    private readonly ILogger<PmWorkflowChromeCoordinator> _logger;
+    private CancellationTokenSource? _loadCancellation;
+    private Task? _inFlightLoad;
+
+    /// <summary>Initialises a new instance of the <see cref="PmWorkflowChromeCoordinator"/> class.</summary>
+    /// <param name="pmSettingsService">The PM settings service.</param>
+    /// <param name="repositoryService">The repository catalogue service.</param>
+    /// <param name="projectBoardDiscoveryService">The planning board discovery service.</param>
+    /// <param name="logger">The logger.</param>
+    public PmWorkflowChromeCoordinator(
+        IPmSettingsService pmSettingsService,
+        IRepositoryService repositoryService,
+        IPmProjectBoardDiscoveryService projectBoardDiscoveryService,
+        ILogger<PmWorkflowChromeCoordinator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(pmSettingsService);
+        ArgumentNullException.ThrowIfNull(repositoryService);
+        ArgumentNullException.ThrowIfNull(projectBoardDiscoveryService);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _pmSettingsService = pmSettingsService;
+        _repositoryService = repositoryService;
+        _projectBoardDiscoveryService = projectBoardDiscoveryService;
+        _logger = logger;
+    }
+
+    /// <summary>Gets the shared chrome state for the current circuit.</summary>
+    public PmWorkflowChromeState State { get; } = new();
+
+    /// <summary>Gets a value indicating whether chrome data has loaded successfully at least once.</summary>
+    public bool HasLoadedOnce { get; private set; }
+
+    /// <summary>Gets the cached Daily Focus board state for the current circuit, if any.</summary>
+    public DailyFocusBoardStateCacheEntry? DailyFocusBoardState { get; private set; }
+
+    /// <summary>Loads chrome data when it has not been loaded yet for this circuit.</summary>
+    /// <returns>A task that completes when the load attempt finishes or is skipped.</returns>
+    public Task EnsureLoadedAsync() =>
+        HasLoadedOnce && string.IsNullOrWhiteSpace(State.LoadErrorMessage)
+            ? Task.CompletedTask
+            : RefreshAsync(forceReload: false);
+
+    /// <summary>Reloads chrome data, reusing in-flight work when already running.</summary>
+    /// <param name="forceReload">When <see langword="true" />, invalidates Daily Focus board cache.</param>
+    /// <returns>A task that completes when the load attempt finishes.</returns>
+    public Task RefreshAsync(bool forceReload = true)
+    {
+        if (_inFlightLoad is { IsCompleted: false })
+        {
+            return _inFlightLoad;
+        }
+
+        if (forceReload)
+        {
+            ClearDailyFocusBoardState();
+        }
+
+        CancelPendingLoad();
+        _loadCancellation = new CancellationTokenSource();
+        var showBlockingLoader = !HasLoadedOnce;
+        _inFlightLoad = LoadCoreAsync(_loadCancellation.Token, showBlockingLoader);
+        return _inFlightLoad;
+    }
+
+    /// <summary>Persists updated PM settings and refreshes the in-memory chrome snapshot.</summary>
+    /// <param name="settings">The settings to save.</param>
+    /// <returns>A task that completes when settings are saved.</returns>
+    public async Task SaveSettingsAsync(PmSettingsDto settings)
+    {
+        await _pmSettingsService.SaveSettingsAsync(settings).ConfigureAwait(false);
+        State.Settings = await _pmSettingsService.GetSettingsAsync().ConfigureAwait(false);
+        State.MarkDataChanged();
+    }
+
+    /// <summary>Stores Daily Focus board state in the circuit cache.</summary>
+    /// <param name="boardId">The planning board node identifier.</param>
+    /// <param name="capacity">The active-load capacity denominator.</param>
+    /// <param name="state">The loaded board state, when successful.</param>
+    /// <param name="errorMessage">The load error message, when unsuccessful.</param>
+    /// <param name="isLoading">Whether a load is currently in flight.</param>
+    public void SetDailyFocusBoardState(
+        string boardId,
+        int capacity,
+        DailyFocusBoardStateDto? state,
+        string? errorMessage,
+        bool isLoading)
+    {
+        DailyFocusBoardState = new DailyFocusBoardStateCacheEntry(
+            boardId,
+            capacity,
+            state,
+            errorMessage,
+            isLoading);
+    }
+
+    /// <summary>Clears cached Daily Focus board state.</summary>
+    public void ClearDailyFocusBoardState() => DailyFocusBoardState = null;
+
+    /// <summary>Cancels any in-flight chrome load, for example when leaving PM Workflow.</summary>
+    public void CancelPendingLoad()
+    {
+        if (_loadCancellation is null)
+        {
+            return;
+        }
+
+        _loadCancellation.Cancel();
+        _loadCancellation.Dispose();
+        _loadCancellation = null;
+        State.IsLoading = false;
+        State.IsRefreshing = false;
+    }
+
+    private async Task LoadCoreAsync(CancellationToken cancellationToken, bool showBlockingLoader)
+    {
+        if (showBlockingLoader)
+        {
+            State.IsLoading = true;
+        }
+        else
+        {
+            State.IsRefreshing = true;
+        }
+
+        State.LoadErrorMessage = null;
+
+        try
+        {
+            State.Settings = await _pmSettingsService.GetSettingsAsync().ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            State.ActiveRepositories = await _repositoryService.GetActiveRepositoriesAsync(cancellationToken)
+                .ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var discovery = await _projectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
+                    State.ActiveRepositories,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            State.PlanningBoardOptions = discovery.Options;
+            State.InaccessibleProjectBoardsWarning = LinkedProjectBoardVisibility.BuildInaccessibleProjectsWarning(
+                discovery.TotalLinkedProjectCount,
+                discovery.InaccessibleLinkedProjectCount);
+
+            var selectedPlanningBoardId = State.Settings.PlanningBoardNodeId ?? string.Empty;
+            if (!State.PlanningBoardOptions.Any(option =>
+                    option.Id.Equals(selectedPlanningBoardId, StringComparison.Ordinal)))
+            {
+                selectedPlanningBoardId = State.PlanningBoardOptions.FirstOrDefault()?.Id ?? string.Empty;
+                if (!string.Equals(State.Settings.PlanningBoardNodeId, selectedPlanningBoardId, StringComparison.Ordinal))
+                {
+                    await SaveSettingsAsync(State.Settings with
+                    {
+                        PlanningBoardNodeId = string.IsNullOrWhiteSpace(selectedPlanningBoardId)
+                            ? null
+                            : selectedPlanningBoardId,
+                    }).ConfigureAwait(false);
+                }
+            }
+
+            State.LastRefreshedAtUtc = DateTimeOffset.UtcNow;
+            State.MarkDataChanged();
+            HasLoadedOnce = true;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogDebug("PM Workflow chrome load cancelled.");
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to load PM Workflow chrome data.");
+            State.LoadErrorMessage =
+                "Unable to load PM Workflow settings. Check your GitHub connection and try again.";
+        }
+        finally
+        {
+            State.IsLoading = false;
+            State.IsRefreshing = false;
+        }
+    }
+}
+
+/// <summary>Cached Daily Focus board state for a planning board within the current circuit.</summary>
+/// <param name="BoardId">The planning board node identifier.</param>
+/// <param name="Capacity">The active-load capacity denominator.</param>
+/// <param name="State">The loaded board state, when successful.</param>
+/// <param name="ErrorMessage">The load error message, when unsuccessful.</param>
+/// <param name="IsLoading">Whether a load is currently in flight.</param>
+public sealed record DailyFocusBoardStateCacheEntry(
+    string BoardId,
+    int Capacity,
+    DailyFocusBoardStateDto? State,
+    string? ErrorMessage,
+    bool IsLoading);

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowChromeState.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowChromeState.cs
@@ -24,6 +24,9 @@ public sealed class PmWorkflowChromeState
     /// <summary>Gets or sets a value indicating whether chrome data is loading.</summary>
     public bool IsLoading { get; set; }
 
+    /// <summary>Gets or sets a value indicating whether chrome data is refreshing in the background.</summary>
+    public bool IsRefreshing { get; set; }
+
     /// <summary>Gets or sets the chrome load error message, if any.</summary>
     public string? LoadErrorMessage { get; set; }
 

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowDailyFocusPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowDailyFocusPanel.razor
@@ -1,0 +1,80 @@
+@using SoloDevBoard.App.Components.Features.PmWorkflow
+@using SoloDevBoard.Application.Services.PmWorkflow
+
+<MudStack Spacing="3" data-testid="pm-workflow-daily-focus-page">
+    <MudText Typo="Typo.h5">Daily Focus</MudText>
+    <MudText Typo="Typo.body1">
+        Morning board occupancy and active load for the selected planning board.
+        Stalled items and recommended work will appear here in later stories.
+    </MudText>
+
+    @if (ChromeState is null)
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">PM Workflow chrome is unavailable.</MudAlert>
+    }
+    else if (!ChromeState.IsLoading && !string.IsNullOrWhiteSpace(ChromeState.LoadErrorMessage))
+    {
+        @* Chrome already shows the error and retry. *@
+    }
+    else if (!ChromeState.HasPlanningBoardSelected && !ChromeState.IsLoading)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="pm-workflow-daily-focus-no-board">
+            Select a planning board to load Daily Focus occupancy.
+        </MudAlert>
+    }
+    else
+    {
+        @if (isLoadingBoardState)
+        {
+            <MudProgressLinear Indeterminate="true" Color="Color.Primary" aria-label="Loading Daily Focus board state" />
+        }
+
+        @if (!string.IsNullOrWhiteSpace(loadErrorMessage))
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" data-testid="pm-workflow-daily-focus-error">
+                @loadErrorMessage
+                <MudButton Variant="Variant.Text" OnClick="LoadBoardStateAsync">Retry</MudButton>
+            </MudAlert>
+        }
+        else if (!isLoadingBoardState && boardState is not null)
+        {
+            <MudPaper Class="pa-4" Elevation="1" data-testid="pm-workflow-daily-focus-board-state">
+                <MudStack Spacing="2">
+                    <MudText Typo="Typo.h6">Board state</MudText>
+                    @if (boardState.Occupancy.Count == 0)
+                    {
+                        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="pm-workflow-daily-focus-empty">
+                            This planning board has no Status options and no items yet.
+                        </MudAlert>
+                    }
+                    else
+                    {
+                        <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1" aria-live="polite">
+                            @foreach (var chip in boardState.Occupancy)
+                            {
+                                <MudChip T="string"
+                                         Value="@chip.StatusName"
+                                         Variant="Variant.Outlined"
+                                         Color="Color.Default"
+                                         data-testid="pm-workflow-occupancy-chip">
+                                    @($"{chip.StatusName} {chip.Count}")
+                                </MudChip>
+                            }
+                        </MudStack>
+                    }
+
+                    <MudText Typo="Typo.body1" aria-live="polite" data-testid="pm-workflow-active-load">
+                        Active load: @boardState.ActiveLoad / @boardState.Capacity (Up Next + In Progress)
+                    </MudText>
+
+                    @if (boardState.ItemCount == 0 && boardState.Occupancy.Count > 0)
+                    {
+                        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="pm-workflow-daily-focus-empty-board">
+                            This planning board has no items.
+                        </MudAlert>
+                    }
+                </MudStack>
+            </MudPaper>
+        }
+    }
+</MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowDailyFocusPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowDailyFocusPanel.razor
@@ -16,10 +16,16 @@
     {
         @* Chrome already shows the error and retry. *@
     }
-    else if (!ChromeState.HasPlanningBoardSelected && !ChromeState.IsLoading)
+    else if (ChromeState.IsLoading)
+    {
+        <MudText Typo="Typo.body2" data-testid="pm-workflow-daily-focus-loading">
+            Loading planning boards and occupancy.
+        </MudText>
+    }
+    else if (!ChromeState.HasPlanningBoardSelected)
     {
         <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="pm-workflow-daily-focus-no-board">
-            Select a planning board to load Daily Focus occupancy.
+            Select a planning board in the dropdown above to load Daily Focus occupancy.
         </MudAlert>
     }
     else

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowDailyFocusPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowDailyFocusPanel.razor
@@ -33,7 +33,9 @@
         {
             <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" data-testid="pm-workflow-daily-focus-error">
                 @loadErrorMessage
-                <MudButton Variant="Variant.Text" OnClick="LoadBoardStateAsync">Retry</MudButton>
+                <MudButton Variant="Variant.Text"
+                           OnClick="RetryLoadBoardStateAsync"
+                           data-testid="pm-workflow-daily-focus-retry">Retry</MudButton>
             </MudAlert>
         }
         else if (!isLoadingBoardState && boardState is not null)

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowDailyFocusPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowDailyFocusPanel.razor.cs
@@ -1,0 +1,85 @@
+using Microsoft.AspNetCore.Components;
+using SoloDevBoard.Application.Services.PmWorkflow;
+
+namespace SoloDevBoard.App.Components.Features.PmWorkflow;
+
+/// <summary>Daily Focus occupancy panel rendered inside <see cref="PmWorkflowShell"/>.</summary>
+public partial class PmWorkflowDailyFocusPanel : ComponentBase
+{
+    [CascadingParameter]
+    public PmWorkflowChromeState? ChromeState { get; set; }
+
+    [CascadingParameter(Name = "PmWorkflowDataRevision")]
+    public int DataRevision { get; set; }
+
+    [Inject]
+    public IDailyFocusBoardStateService BoardStateService { get; set; } = default!;
+
+    [Inject]
+    public ILogger<PmWorkflowDailyFocusPanel> Logger { get; set; } = default!;
+
+    private DailyFocusBoardStateDto? boardState;
+    private bool isLoadingBoardState;
+    private string? loadErrorMessage;
+    private string? loadedBoardId;
+    private int loadedRevision = -1;
+
+    /// <inheritdoc/>
+    protected override async Task OnParametersSetAsync()
+    {
+        if (ChromeState is null || ChromeState.IsLoading)
+        {
+            return;
+        }
+
+        if (!ChromeState.HasPlanningBoardSelected)
+        {
+            boardState = null;
+            loadErrorMessage = null;
+            loadedBoardId = null;
+            loadedRevision = DataRevision;
+            return;
+        }
+
+        var boardId = ChromeState.Settings.PlanningBoardNodeId;
+        if (string.Equals(loadedBoardId, boardId, StringComparison.Ordinal)
+            && loadedRevision == DataRevision
+            && boardState is not null
+            && string.IsNullOrWhiteSpace(loadErrorMessage))
+        {
+            return;
+        }
+
+        await LoadBoardStateAsync();
+    }
+
+    private async Task LoadBoardStateAsync()
+    {
+        if (ChromeState is null || string.IsNullOrWhiteSpace(ChromeState.Settings.PlanningBoardNodeId))
+        {
+            return;
+        }
+
+        isLoadingBoardState = true;
+        loadErrorMessage = null;
+        loadedBoardId = ChromeState.Settings.PlanningBoardNodeId;
+        loadedRevision = DataRevision;
+
+        try
+        {
+            boardState = await BoardStateService.GetBoardStateAsync(
+                ChromeState.Settings.PlanningBoardNodeId,
+                ChromeState.Settings.Capacity);
+        }
+        catch (Exception exception)
+        {
+            Logger.LogError(exception, "Failed to load Daily Focus board occupancy.");
+            boardState = null;
+            loadErrorMessage = "Unable to load board occupancy. Check your GitHub connection and try again.";
+        }
+        finally
+        {
+            isLoadingBoardState = false;
+        }
+    }
+}

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowDailyFocusPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowDailyFocusPanel.razor.cs
@@ -42,10 +42,7 @@ public partial class PmWorkflowDailyFocusPanel : ComponentBase
         }
 
         var boardId = ChromeState.Settings.PlanningBoardNodeId;
-        if (string.Equals(loadedBoardId, boardId, StringComparison.Ordinal)
-            && loadedRevision == DataRevision
-            && boardState is not null
-            && string.IsNullOrWhiteSpace(loadErrorMessage))
+        if (HasCompletedOrInFlightLoad(boardId))
         {
             return;
         }
@@ -53,9 +50,28 @@ public partial class PmWorkflowDailyFocusPanel : ComponentBase
         await LoadBoardStateAsync();
     }
 
+    private bool HasCompletedOrInFlightLoad(string? boardId) =>
+        string.Equals(loadedBoardId, boardId, StringComparison.Ordinal)
+        && loadedRevision == DataRevision
+        && (isLoadingBoardState
+            || boardState is not null
+            || !string.IsNullOrWhiteSpace(loadErrorMessage));
+
+    private Task RetryLoadBoardStateAsync()
+    {
+        loadedBoardId = null;
+        loadedRevision = -1;
+        return LoadBoardStateAsync();
+    }
+
     private async Task LoadBoardStateAsync()
     {
         if (ChromeState is null || string.IsNullOrWhiteSpace(ChromeState.Settings.PlanningBoardNodeId))
+        {
+            return;
+        }
+
+        if (HasCompletedOrInFlightLoad(ChromeState.Settings.PlanningBoardNodeId))
         {
             return;
         }

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowDailyFocusPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowDailyFocusPanel.razor.cs
@@ -13,6 +13,9 @@ public partial class PmWorkflowDailyFocusPanel : ComponentBase
     public int DataRevision { get; set; }
 
     [Inject]
+    public PmWorkflowChromeCoordinator ChromeCoordinator { get; set; } = default!;
+
+    [Inject]
     public IDailyFocusBoardStateService BoardStateService { get; set; } = default!;
 
     [Inject]
@@ -21,8 +24,6 @@ public partial class PmWorkflowDailyFocusPanel : ComponentBase
     private DailyFocusBoardStateDto? boardState;
     private bool isLoadingBoardState;
     private string? loadErrorMessage;
-    private string? loadedBoardId;
-    private int loadedRevision = -1;
 
     /// <inheritdoc/>
     protected override async Task OnParametersSetAsync()
@@ -36,62 +37,69 @@ public partial class PmWorkflowDailyFocusPanel : ComponentBase
         {
             boardState = null;
             loadErrorMessage = null;
-            loadedBoardId = null;
-            loadedRevision = DataRevision;
             return;
         }
 
-        var boardId = ChromeState.Settings.PlanningBoardNodeId;
-        if (HasCompletedOrInFlightLoad(boardId))
+        var boardId = ChromeState.Settings.PlanningBoardNodeId!;
+        var capacity = ChromeState.Settings.Capacity;
+        if (TryApplyCachedBoardState(boardId, capacity))
         {
             return;
         }
 
-        await LoadBoardStateAsync();
+        await LoadBoardStateAsync(boardId, capacity).ConfigureAwait(false);
     }
 
-    private bool HasCompletedOrInFlightLoad(string? boardId) =>
-        string.Equals(loadedBoardId, boardId, StringComparison.Ordinal)
-        && loadedRevision == DataRevision
-        && (isLoadingBoardState
-            || boardState is not null
-            || !string.IsNullOrWhiteSpace(loadErrorMessage));
+    private bool TryApplyCachedBoardState(string boardId, int capacity)
+    {
+        var cached = ChromeCoordinator.DailyFocusBoardState;
+        if (cached is null
+            || !cached.BoardId.Equals(boardId, StringComparison.Ordinal)
+            || cached.Capacity != capacity)
+        {
+            return false;
+        }
+
+        isLoadingBoardState = cached.IsLoading;
+        boardState = cached.State;
+        loadErrorMessage = cached.ErrorMessage;
+        return cached.IsLoading || cached.State is not null || !string.IsNullOrWhiteSpace(cached.ErrorMessage);
+    }
 
     private Task RetryLoadBoardStateAsync()
     {
-        loadedBoardId = null;
-        loadedRevision = -1;
-        return LoadBoardStateAsync();
-    }
-
-    private async Task LoadBoardStateAsync()
-    {
         if (ChromeState is null || string.IsNullOrWhiteSpace(ChromeState.Settings.PlanningBoardNodeId))
         {
-            return;
+            return Task.CompletedTask;
         }
 
-        if (HasCompletedOrInFlightLoad(ChromeState.Settings.PlanningBoardNodeId))
+        ChromeCoordinator.ClearDailyFocusBoardState();
+        return LoadBoardStateAsync(ChromeState.Settings.PlanningBoardNodeId, ChromeState.Settings.Capacity);
+    }
+
+    private async Task LoadBoardStateAsync(string boardId, int capacity)
+    {
+        if (TryApplyCachedBoardState(boardId, capacity))
         {
             return;
         }
 
         isLoadingBoardState = true;
         loadErrorMessage = null;
-        loadedBoardId = ChromeState.Settings.PlanningBoardNodeId;
-        loadedRevision = DataRevision;
+        boardState = null;
+        ChromeCoordinator.SetDailyFocusBoardState(boardId, capacity, null, null, isLoading: true);
 
         try
         {
-            boardState = await BoardStateService.GetBoardStateAsync(
-                ChromeState.Settings.PlanningBoardNodeId,
-                ChromeState.Settings.Capacity);
+            boardState = await BoardStateService.GetBoardStateAsync(boardId, capacity).ConfigureAwait(false);
+            ChromeCoordinator.SetDailyFocusBoardState(boardId, capacity, boardState, null, isLoading: false);
         }
         catch (Exception exception)
         {
             Logger.LogError(exception, "Failed to load Daily Focus board occupancy.");
             boardState = null;
             loadErrorMessage = "Unable to load board occupancy. Check your GitHub connection and try again.";
+            ChromeCoordinator.SetDailyFocusBoardState(boardId, capacity, null, loadErrorMessage, isLoading: false);
         }
         finally
         {

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowLayout.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowLayout.razor
@@ -1,0 +1,32 @@
+@inherits LayoutComponentBase
+@namespace SoloDevBoard.App.Components.Features.PmWorkflow
+@using SoloDevBoard.App.Components.Features.PmWorkflow
+@implements IDisposable
+
+<PmWorkflowShell ActiveTab="@ResolveActiveTab()">
+    @Body
+</PmWorkflowShell>
+
+@code {
+    [Inject]
+    private NavigationManager NavigationManager { get; set; } = default!;
+
+    [Inject]
+    private PmWorkflowChromeCoordinator ChromeCoordinator { get; set; } = default!;
+
+    /// <inheritdoc/>
+    public void Dispose() => ChromeCoordinator.CancelPendingLoad();
+
+    private string ResolveActiveTab()
+    {
+        var path = new Uri(NavigationManager.Uri).AbsolutePath.TrimEnd('/');
+        return path switch
+        {
+            "/pm-workflow/daily-focus" => "daily-focus",
+            "/pm-workflow/backlog" => "backlog",
+            "/pm-workflow/planning" => "planning",
+            "/pm-workflow/repos" => "repos",
+            _ => "daily-focus",
+        };
+    }
+}

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowLayout.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowLayout.razor
@@ -1,33 +1,7 @@
 @layout MainLayout
 @inherits LayoutComponentBase
 @namespace SoloDevBoard.App.Components.Features.PmWorkflow
-@using SoloDevBoard.App.Components.Features.PmWorkflow
-@implements IDisposable
 
 <PmWorkflowShell ActiveTab="@ResolveActiveTab()">
     @Body
 </PmWorkflowShell>
-
-@code {
-    [Inject]
-    private NavigationManager NavigationManager { get; set; } = default!;
-
-    [Inject]
-    private PmWorkflowChromeCoordinator ChromeCoordinator { get; set; } = default!;
-
-    /// <inheritdoc/>
-    public void Dispose() => ChromeCoordinator.CancelPendingLoad();
-
-    private string ResolveActiveTab()
-    {
-        var path = new Uri(NavigationManager.Uri).AbsolutePath.TrimEnd('/');
-        return path switch
-        {
-            "/pm-workflow/daily-focus" => "daily-focus",
-            "/pm-workflow/backlog" => "backlog",
-            "/pm-workflow/planning" => "planning",
-            "/pm-workflow/repos" => "repos",
-            _ => "daily-focus",
-        };
-    }
-}

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowLayout.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowLayout.razor
@@ -1,3 +1,4 @@
+@layout MainLayout
 @inherits LayoutComponentBase
 @namespace SoloDevBoard.App.Components.Features.PmWorkflow
 @using SoloDevBoard.App.Components.Features.PmWorkflow

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowLayout.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowLayout.razor.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+
+namespace SoloDevBoard.App.Components.Features.PmWorkflow;
+
+/// <summary>Shared layout that hosts PM Workflow chrome across tab routes.</summary>
+public partial class PmWorkflowLayout : LayoutComponentBase, IDisposable
+{
+    /// <summary>Gets or sets the navigation manager.</summary>
+    [Inject]
+    public NavigationManager NavigationManager { get; set; } = default!;
+
+    /// <summary>Gets or sets the PM Workflow chrome coordinator.</summary>
+    [Inject]
+    public PmWorkflowChromeCoordinator ChromeCoordinator { get; set; } = default!;
+
+    /// <inheritdoc/>
+    protected override void OnInitialized() =>
+        NavigationManager.LocationChanged += OnLocationChanged;
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        NavigationManager.LocationChanged -= OnLocationChanged;
+        CancelIfLeavingPmWorkflow(NavigationManager.Uri);
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs args) =>
+        CancelIfLeavingPmWorkflow(args.Location);
+
+    private void CancelIfLeavingPmWorkflow(string uri)
+    {
+        if (!IsPmWorkflowPath(uri))
+        {
+            ChromeCoordinator.CancelPendingLoad();
+        }
+    }
+
+    private string ResolveActiveTab()
+    {
+        var path = new Uri(NavigationManager.Uri).AbsolutePath.TrimEnd('/');
+        return path switch
+        {
+            "/pm-workflow/daily-focus" => "daily-focus",
+            "/pm-workflow/backlog" => "backlog",
+            "/pm-workflow/planning" => "planning",
+            "/pm-workflow/repos" => "repos",
+            _ => "daily-focus",
+        };
+    }
+
+    /// <summary>Returns whether the URI is a PM Workflow route.</summary>
+    /// <param name="uri">The navigation URI.</param>
+    /// <returns><see langword="true" /> when the path is under <c>/pm-workflow</c>; otherwise, <see langword="false" />.</returns>
+    internal static bool IsPmWorkflowPath(string uri)
+    {
+        if (!Uri.TryCreate(uri, UriKind.Absolute, out var absolute))
+        {
+            return uri.Contains("/pm-workflow", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return absolute.AbsolutePath.StartsWith("/pm-workflow", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor
@@ -4,7 +4,7 @@
     <MudText Typo="Typo.h5">Repo Management</MudText>
     <MudText Typo="Typo.body1">
         Control which repositories feed PM recommendations and set planning thresholds.
-        Board occupancy on the selected planning board still counts every linked card.
+        Board occupancy on the selected planning board still counts mapped Issue and Pull Request cards.
     </MudText>
 
     @if (ChromeState is null)

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor
@@ -17,7 +17,7 @@
             <MudStack Spacing="2">
                 <MudText Typo="Typo.h6">Planning thresholds</MudText>
                 <MudText Typo="Typo.body2">
-                    These values apply when Daily Focus, Backlog, and Planning ship. Save after editing.
+                    Capacity is used now for Daily Focus active load. Stall and neglect days apply when Backlog and Planning ship. Save after editing.
                 </MudText>
                 <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2" AlignItems="AlignItems.End">
                     <MudNumericField @bind-Value="capacity"

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor
@@ -4,23 +4,27 @@
 <MudStack Spacing="3" data-testid="pm-workflow-shell">
     <MudText Typo="Typo.h4">PM Workflow</MudText>
 
-    @if (chromeState.IsLoading)
+    @if (ChromeState.IsLoading)
     {
         <MudProgressLinear Indeterminate="true" Color="Color.Primary" aria-label="Loading PM Workflow" />
     }
+    else if (ChromeState.IsRefreshing)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" aria-label="Refreshing PM Workflow" />
+    }
 
-    @if (!string.IsNullOrWhiteSpace(chromeState.LoadErrorMessage))
+    @if (!string.IsNullOrWhiteSpace(ChromeState.LoadErrorMessage))
     {
         <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" data-testid="pm-workflow-chrome-error">
-            @chromeState.LoadErrorMessage
+            @ChromeState.LoadErrorMessage
             <MudButton Variant="Variant.Text" OnClick="RefreshAsync">Retry</MudButton>
         </MudAlert>
     }
 
-    @if (!string.IsNullOrWhiteSpace(chromeState.InaccessibleProjectBoardsWarning))
+    @if (!string.IsNullOrWhiteSpace(ChromeState.InaccessibleProjectBoardsWarning))
     {
         <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" data-testid="pm-workflow-inaccessible-boards-warning">
-            @chromeState.InaccessibleProjectBoardsWarning
+            @ChromeState.InaccessibleProjectBoardsWarning
         </MudAlert>
     }
 
@@ -33,15 +37,15 @@
                            Dense="true"
                            Value="selectedPlanningBoardId"
                            ValueChanged="OnPlanningBoardChangedAsync"
-                           Disabled="chromeState.IsLoading || chromeState.PlanningBoardOptions.Count == 0"
+                           Disabled="ChromeState.IsLoading || ChromeState.PlanningBoardOptions.Count == 0"
                            data-testid="pm-workflow-board-select">
-                    @if (chromeState.PlanningBoardOptions.Count == 0)
+                    @if (ChromeState.PlanningBoardOptions.Count == 0)
                     {
                         <MudSelectItem T="string" Value="@string.Empty">No boards discovered</MudSelectItem>
                     }
                     else
                     {
-                        @foreach (var board in chromeState.PlanningBoardOptions)
+                        @foreach (var board in ChromeState.PlanningBoardOptions)
                         {
                             <MudSelectItem T="string" Value="@board.Id">@board.Title</MudSelectItem>
                         }
@@ -50,16 +54,16 @@
 
                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                     <MudText Typo="Typo.body2" aria-live="polite">
-                        Repos: @chromeState.IncludedRepositoryCount included
-                        @if (!string.IsNullOrWhiteSpace(chromeState.SelectedPlanningBoardTitle))
+                        Repos: @ChromeState.IncludedRepositoryCount included
+                        @if (!string.IsNullOrWhiteSpace(ChromeState.SelectedPlanningBoardTitle))
                         {
-                            <span> · Board: @chromeState.SelectedPlanningBoardTitle</span>
+                            <span> · Board: @ChromeState.SelectedPlanningBoardTitle</span>
                         }
-                        · Refreshed @FormatLastRefreshed(chromeState.LastRefreshedAtUtc)
+                        · Refreshed @FormatLastRefreshed(ChromeState.LastRefreshedAtUtc)
                     </MudText>
                     <MudIconButton Icon="@Icons.Material.Filled.Refresh"
                                    aria-label="Refresh PM Workflow data"
-                                   Disabled="chromeState.IsLoading"
+                                   Disabled="ChromeState.IsLoading || ChromeState.IsRefreshing"
                                    OnClick="RefreshAsync"
                                    data-testid="pm-workflow-refresh-button" />
                 </MudStack>
@@ -78,15 +82,15 @@
         </MudStack>
     </MudPaper>
 
-    @if (!chromeState.HasPlanningBoardSelected && !chromeState.IsLoading && string.IsNullOrWhiteSpace(chromeState.LoadErrorMessage))
+    @if (!ChromeState.HasPlanningBoardSelected && !ChromeState.IsLoading && string.IsNullOrWhiteSpace(ChromeState.LoadErrorMessage))
     {
         <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="pm-workflow-no-board-alert">
             Select a planning board to load PM Workflow data on future tabs. Repo Management settings can still be edited below.
         </MudAlert>
     }
 
-    <CascadingValue Value="chromeState" IsFixed="false">
-        <CascadingValue Value="chromeState.DataRevision" Name="PmWorkflowDataRevision" IsFixed="false">
+    <CascadingValue Value="ChromeState" IsFixed="false">
+        <CascadingValue Value="ChromeState.DataRevision" Name="PmWorkflowDataRevision" IsFixed="false">
             @ChildContent
         </CascadingValue>
     </CascadingValue>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor
@@ -85,7 +85,8 @@
     @if (!ChromeState.HasPlanningBoardSelected && !ChromeState.IsLoading && string.IsNullOrWhiteSpace(ChromeState.LoadErrorMessage))
     {
         <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="pm-workflow-no-board-alert">
-            Select a planning board to load PM Workflow data on future tabs. Repo Management settings can still be edited below.
+            Select a planning board in the dropdown above to load occupancy on Daily Focus.
+            You can still open the Repos tab to edit exclusions and thresholds.
         </MudAlert>
     }
 

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor.cs
@@ -127,7 +127,7 @@ public partial class PmWorkflowShell : ComponentBase
         "backlog" => 1,
         "planning" => 2,
         "repos" => 3,
-        _ => 3,
+        _ => 0,
     };
 
     private Task OnTabIndexChangedAsync(int index)

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Components;
-using MudBlazor;
 using SoloDevBoard.Application.Services.PmWorkflow;
 
 namespace SoloDevBoard.App.Components.Features.PmWorkflow;
@@ -19,10 +18,6 @@ public partial class PmWorkflowShell : ComponentBase
     [Inject]
     public PmWorkflowChromeCoordinator ChromeCoordinator { get; set; } = default!;
 
-    /// <summary>Gets or sets the snackbar service.</summary>
-    [Inject]
-    public ISnackbar Snackbar { get; set; } = default!;
-
     /// <summary>Gets or sets the navigation manager.</summary>
     [Inject]
     public NavigationManager NavigationManager { get; set; } = default!;
@@ -31,24 +26,14 @@ public partial class PmWorkflowShell : ComponentBase
     private string selectedPlanningBoardId = string.Empty;
 
     /// <inheritdoc/>
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         ChromeState.SaveSettingsAsync = SaveSettingsAsync;
         ChromeState.RefreshAsync = () => ChromeCoordinator.RefreshAsync(forceReload: true);
-        selectedPlanningBoardId = ChromeState.Settings.PlanningBoardNodeId ?? string.Empty;
-    }
 
-    /// <inheritdoc/>
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (!firstRender)
-        {
-            return;
-        }
-
-        await ChromeCoordinator.EnsureLoadedAsync().ConfigureAwait(false);
+        // Start before the first paint so IsLoading is true on Daily Focus entry.
+        await ChromeCoordinator.EnsureLoadedAsync();
         selectedPlanningBoardId = ChromeState.Settings.PlanningBoardNodeId ?? string.Empty;
-        await InvokeAsync(StateHasChanged).ConfigureAwait(false);
     }
 
     private async Task RefreshAsync()
@@ -65,9 +50,6 @@ public partial class PmWorkflowShell : ComponentBase
         {
             PlanningBoardNodeId = string.IsNullOrWhiteSpace(selectedPlanningBoardId) ? null : selectedPlanningBoardId,
         }).ConfigureAwait(false);
-
-        var boardTitle = ChromeState.SelectedPlanningBoardTitle ?? "Planning board";
-        Snackbar.Add($"{boardTitle} selected.", Severity.Success);
     }
 
     private async Task SaveSettingsAsync(PmSettingsDto settings)

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowShell.razor.cs
@@ -1,8 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
-using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Application.Services.PmWorkflow;
-using SoloDevBoard.Application.Services.Repositories;
 
 namespace SoloDevBoard.App.Components.Features.PmWorkflow;
 
@@ -17,21 +15,9 @@ public partial class PmWorkflowShell : ComponentBase
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
-    /// <summary>Gets or sets the PM settings service.</summary>
+    /// <summary>Gets or sets the PM Workflow chrome coordinator.</summary>
     [Inject]
-    public IPmSettingsService PmSettingsService { get; set; } = default!;
-
-    /// <summary>Gets or sets the repository service.</summary>
-    [Inject]
-    public IRepositoryService RepositoryService { get; set; } = default!;
-
-    /// <summary>Gets or sets the planning board discovery service.</summary>
-    [Inject]
-    public IPmProjectBoardDiscoveryService ProjectBoardDiscoveryService { get; set; } = default!;
-
-    /// <summary>Gets or sets the logger.</summary>
-    [Inject]
-    public ILogger<PmWorkflowShell> Logger { get; set; } = default!;
+    public PmWorkflowChromeCoordinator ChromeCoordinator { get; set; } = default!;
 
     /// <summary>Gets or sets the snackbar service.</summary>
     [Inject]
@@ -41,81 +27,54 @@ public partial class PmWorkflowShell : ComponentBase
     [Inject]
     public NavigationManager NavigationManager { get; set; } = default!;
 
-    private readonly PmWorkflowChromeState chromeState = new();
+    private PmWorkflowChromeState ChromeState => ChromeCoordinator.State;
     private string selectedPlanningBoardId = string.Empty;
 
     /// <inheritdoc/>
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
-        chromeState.SaveSettingsAsync = SaveSettingsAsync;
-        chromeState.RefreshAsync = RefreshAsync;
-        await RefreshAsync();
+        ChromeState.SaveSettingsAsync = SaveSettingsAsync;
+        ChromeState.RefreshAsync = () => ChromeCoordinator.RefreshAsync(forceReload: true);
+        selectedPlanningBoardId = ChromeState.Settings.PlanningBoardNodeId ?? string.Empty;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        await ChromeCoordinator.EnsureLoadedAsync().ConfigureAwait(false);
+        selectedPlanningBoardId = ChromeState.Settings.PlanningBoardNodeId ?? string.Empty;
+        await InvokeAsync(StateHasChanged).ConfigureAwait(false);
     }
 
     private async Task RefreshAsync()
     {
-        chromeState.IsLoading = true;
-        chromeState.LoadErrorMessage = null;
-
-        try
-        {
-            chromeState.Settings = await PmSettingsService.GetSettingsAsync();
-            selectedPlanningBoardId = chromeState.Settings.PlanningBoardNodeId ?? string.Empty;
-
-            chromeState.ActiveRepositories = await RepositoryService.GetActiveRepositoriesAsync();
-            var discovery = await ProjectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
-                chromeState.ActiveRepositories);
-            chromeState.PlanningBoardOptions = discovery.Options;
-            chromeState.InaccessibleProjectBoardsWarning = LinkedProjectBoardVisibility.BuildInaccessibleProjectsWarning(
-                discovery.TotalLinkedProjectCount,
-                discovery.InaccessibleLinkedProjectCount);
-
-            if (!chromeState.PlanningBoardOptions.Any(option =>
-                    option.Id.Equals(selectedPlanningBoardId, StringComparison.Ordinal)))
-            {
-                selectedPlanningBoardId = chromeState.PlanningBoardOptions.FirstOrDefault()?.Id ?? string.Empty;
-                if (!string.Equals(chromeState.Settings.PlanningBoardNodeId, selectedPlanningBoardId, StringComparison.Ordinal))
-                {
-                    await SaveSettingsAsync(chromeState.Settings with
-                    {
-                        PlanningBoardNodeId = string.IsNullOrWhiteSpace(selectedPlanningBoardId) ? null : selectedPlanningBoardId,
-                    });
-                }
-            }
-
-            chromeState.LastRefreshedAtUtc = DateTimeOffset.UtcNow;
-            chromeState.MarkDataChanged();
-        }
-        catch (Exception exception)
-        {
-            Logger.LogError(exception, "Failed to load PM Workflow chrome data.");
-            chromeState.LoadErrorMessage = "Unable to load PM Workflow settings. Check your GitHub connection and try again.";
-        }
-        finally
-        {
-            chromeState.IsLoading = false;
-        }
+        await ChromeCoordinator.RefreshAsync(forceReload: true).ConfigureAwait(false);
+        selectedPlanningBoardId = ChromeState.Settings.PlanningBoardNodeId ?? string.Empty;
+        await InvokeAsync(StateHasChanged).ConfigureAwait(false);
     }
 
     private async Task OnPlanningBoardChangedAsync(string? boardId)
     {
         selectedPlanningBoardId = boardId ?? string.Empty;
-        await SaveSettingsAsync(chromeState.Settings with
+        await SaveSettingsAsync(ChromeState.Settings with
         {
             PlanningBoardNodeId = string.IsNullOrWhiteSpace(selectedPlanningBoardId) ? null : selectedPlanningBoardId,
-        });
+        }).ConfigureAwait(false);
 
-        var boardTitle = chromeState.SelectedPlanningBoardTitle ?? "Planning board";
+        var boardTitle = ChromeState.SelectedPlanningBoardTitle ?? "Planning board";
         Snackbar.Add($"{boardTitle} selected.", Severity.Success);
     }
 
     private async Task SaveSettingsAsync(PmSettingsDto settings)
     {
-        await PmSettingsService.SaveSettingsAsync(settings);
-        chromeState.Settings = await PmSettingsService.GetSettingsAsync();
-        selectedPlanningBoardId = chromeState.Settings.PlanningBoardNodeId ?? string.Empty;
-        chromeState.MarkDataChanged();
-        await InvokeAsync(StateHasChanged);
+        await ChromeCoordinator.SaveSettingsAsync(settings).ConfigureAwait(false);
+        selectedPlanningBoardId = ChromeState.Settings.PlanningBoardNodeId ?? string.Empty;
+        await InvokeAsync(StateHasChanged).ConfigureAwait(false);
     }
 
     private static string FormatLastRefreshed(DateTimeOffset? refreshedAtUtc) =>

--- a/src/App/SoloDevBoard.App/Components/_Imports.razor
+++ b/src/App/SoloDevBoard.App/Components/_Imports.razor
@@ -17,6 +17,7 @@
 @using SoloDevBoard.App.Components.Features.Labels.Components
 @using SoloDevBoard.App.Components.Features.Labels.Dialogs
 @using SoloDevBoard.App.Components.Features.Migration.Components
+@using SoloDevBoard.App.Components.Features.PmWorkflow
 @using SoloDevBoard.Application.Services.BoardRules
 @using SoloDevBoard.Application.Services.Audit
 @using SoloDevBoard.Application.Services.Common

--- a/src/App/SoloDevBoard.App/Program.cs
+++ b/src/App/SoloDevBoard.App/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 using MudBlazor;
 using MudBlazor.Services;
 using SoloDevBoard.App.Authentication;
+using SoloDevBoard.App.Components.Features.PmWorkflow;
 using SoloDevBoard.App.Components.Shell;
 using SoloDevBoard.App.PmWorkflow;
 using SoloDevBoard.App.Theming;
@@ -56,6 +57,7 @@ builder.Services.AddScoped<IGitHubAuthenticationSummaryService, GitHubAuthentica
 builder.Services.AddScoped<IThemePreferenceStorage, ThemePreferenceJsStorage>();
 builder.Services.AddScoped<IThemePreferenceService, ThemePreferenceService>();
 builder.Services.AddScoped<IPmSettingsStorage, PmSettingsJsStorage>();
+builder.Services.AddScoped<PmWorkflowChromeCoordinator>();
 
 if (hostedSignInEnabled)
 {

--- a/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<IProjectItemCatalogueService, ProjectItemCatalogueService>();
         services.AddScoped<IPmWorkItemCatalogueService, PmWorkItemCatalogueService>();
         services.AddScoped<IPmProjectBoardDiscoveryService, PmProjectBoardDiscoveryService>();
+        services.AddScoped<IDailyFocusBoardStateService, DailyFocusBoardStateService>();
 
         return services;
     }

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/DailyFocusBoardStateDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/DailyFocusBoardStateDto.cs
@@ -1,0 +1,12 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Read-only Daily Focus board snapshot for occupancy and active load.</summary>
+/// <param name="Occupancy">Item counts per discovered Status option, in board-defined order.</param>
+/// <param name="ActiveLoad">The number of items whose Status name is <c>Up Next</c> or <c>In Progress</c>.</param>
+/// <param name="Capacity">The persisted planning capacity used as the active-load denominator.</param>
+/// <param name="ItemCount">The total number of items on the selected board.</param>
+public sealed record DailyFocusBoardStateDto(
+    IReadOnlyList<DailyFocusOccupancyChipDto> Occupancy,
+    int ActiveLoad,
+    int Capacity,
+    int ItemCount);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/DailyFocusBoardStateDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/DailyFocusBoardStateDto.cs
@@ -4,7 +4,7 @@ namespace SoloDevBoard.Application.Services.PmWorkflow;
 /// <param name="Occupancy">Item counts per discovered Status option, in board-defined order.</param>
 /// <param name="ActiveLoad">The number of items whose Status name is <c>Up Next</c> or <c>In Progress</c>.</param>
 /// <param name="Capacity">The persisted planning capacity used as the active-load denominator.</param>
-/// <param name="ItemCount">The total number of items on the selected board.</param>
+/// <param name="ItemCount">The number of mapped Issue and Pull Request items in the catalogue.</param>
 public sealed record DailyFocusBoardStateDto(
     IReadOnlyList<DailyFocusOccupancyChipDto> Occupancy,
     int ActiveLoad,

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/DailyFocusBoardStateMapper.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/DailyFocusBoardStateMapper.cs
@@ -1,0 +1,114 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Maps a project board item catalogue to Daily Focus occupancy and active-load figures.</summary>
+public static class DailyFocusBoardStateMapper
+{
+    /// <summary>Status option name for committed work that has not started.</summary>
+    /// <remarks>Matched by display name, not a compiled Project option identifier (DEC-029).</remarks>
+    public const string UpNextStatusName = "Up Next";
+
+    /// <summary>Status option name for work currently in flight.</summary>
+    /// <remarks>Matched by display name, not a compiled Project option identifier (DEC-029).</remarks>
+    public const string InProgressStatusName = "In Progress";
+
+    /// <summary>Chip label used when a board item has no Status value.</summary>
+    public const string NoStatusChipName = "No status";
+
+    /// <summary>
+    /// Builds occupancy chips from discovered Status options and computes active load as
+    /// <see cref="UpNextStatusName"/> plus <see cref="InProgressStatusName"/>.
+    /// </summary>
+    /// <param name="statusOptions">Status options discovered on the selected board.</param>
+    /// <param name="items">Items currently on the selected board.</param>
+    /// <param name="capacity">The persisted planning capacity; values less than 1 fall back to the default.</param>
+    /// <returns>The Daily Focus board snapshot.</returns>
+    public static DailyFocusBoardStateDto Map(
+        IReadOnlyList<ProjectBoardStatusOptionDto> statusOptions,
+        IReadOnlyList<ProjectBoardItemDto> items,
+        int capacity)
+    {
+        ArgumentNullException.ThrowIfNull(statusOptions);
+        ArgumentNullException.ThrowIfNull(items);
+
+        var resolvedCapacity = capacity > 0 ? capacity : PmSettingsDefaults.Capacity;
+        var occupancyOptions = statusOptions.Count > 0
+            ? statusOptions
+            : DeriveStatusOptionsFromItems(items);
+
+        var occupancy = occupancyOptions
+            .Select(option => new DailyFocusOccupancyChipDto(
+                option.Name,
+                items.Count(item => MatchesStatusOption(item, option))))
+            .ToList();
+
+        var unstatusedCount = items.Count(static item => item.Status is null);
+        if (unstatusedCount > 0)
+        {
+            occupancy.Add(new DailyFocusOccupancyChipDto(NoStatusChipName, unstatusedCount));
+        }
+
+        var activeLoad = items.Count(static item => IsActiveLoadStatus(item.Status?.Name));
+
+        return new DailyFocusBoardStateDto(occupancy, activeLoad, resolvedCapacity, items.Count);
+    }
+
+    /// <summary>
+    /// Returns whether the Status name counts toward active load.
+    /// </summary>
+    /// <param name="statusName">The Status option display name, or <see langword="null"/> when unset.</param>
+    /// <returns><see langword="true" /> when the name is Up Next or In Progress; otherwise, <see langword="false" />.</returns>
+    public static bool IsActiveLoadStatus(string? statusName)
+    {
+        if (string.IsNullOrWhiteSpace(statusName))
+        {
+            return false;
+        }
+
+        return statusName.Equals(UpNextStatusName, StringComparison.OrdinalIgnoreCase)
+            || statusName.Equals(InProgressStatusName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Builds occupancy chips from item Status names when the board did not return option metadata.</summary>
+    /// <param name="items">Items currently on the selected board.</param>
+    /// <returns>Distinct Status options in first-seen order.</returns>
+    private static IReadOnlyList<ProjectBoardStatusOptionDto> DeriveStatusOptionsFromItems(
+        IReadOnlyList<ProjectBoardItemDto> items)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var derived = new List<ProjectBoardStatusOptionDto>();
+
+        foreach (var item in items)
+        {
+            if (item.Status is null
+                || string.IsNullOrWhiteSpace(item.Status.Name)
+                || !seen.Add(item.Status.Name))
+            {
+                continue;
+            }
+
+            derived.Add(new ProjectBoardStatusOptionDto(item.Status.OptionId, item.Status.Name));
+        }
+
+        return derived;
+    }
+
+    /// <summary>Returns whether an item belongs to a discovered Status option.</summary>
+    /// <param name="item">The board item to match.</param>
+    /// <param name="option">The discovered Status option.</param>
+    /// <returns><see langword="true" /> when the item Status matches the option identifier or name; otherwise, <see langword="false" />.</returns>
+    private static bool MatchesStatusOption(ProjectBoardItemDto item, ProjectBoardStatusOptionDto option)
+    {
+        if (item.Status is null)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(option.OptionId)
+            && !string.IsNullOrWhiteSpace(item.Status.OptionId))
+        {
+            return item.Status.OptionId.Equals(option.OptionId, StringComparison.Ordinal);
+        }
+
+        return item.Status.Name.Equals(option.Name, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/DailyFocusBoardStateService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/DailyFocusBoardStateService.cs
@@ -1,0 +1,31 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Default implementation of <see cref="IDailyFocusBoardStateService"/>.</summary>
+public sealed class DailyFocusBoardStateService : IDailyFocusBoardStateService
+{
+    private readonly IProjectItemCatalogueService _projectItemCatalogueService;
+
+    /// <summary>Initialises a new instance of the <see cref="DailyFocusBoardStateService"/> class.</summary>
+    /// <param name="projectItemCatalogueService">The project board item catalogue service.</param>
+    public DailyFocusBoardStateService(IProjectItemCatalogueService projectItemCatalogueService)
+    {
+        _projectItemCatalogueService = projectItemCatalogueService
+            ?? throw new ArgumentNullException(nameof(projectItemCatalogueService));
+    }
+
+    /// <inheritdoc/>
+    public async Task<DailyFocusBoardStateDto> GetBoardStateAsync(
+        string projectId,
+        int capacity,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+
+        var catalogue = await _projectItemCatalogueService
+            .GetCatalogueAsync(projectId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return DailyFocusBoardStateMapper.Map(catalogue.StatusOptions, catalogue.Items, capacity);
+    }
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/DailyFocusOccupancyChipDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/DailyFocusOccupancyChipDto.cs
@@ -1,0 +1,6 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Read-only occupancy chip for a discovered Status option.</summary>
+/// <param name="StatusName">The Status option display name.</param>
+/// <param name="Count">The number of board items currently in this Status.</param>
+public sealed record DailyFocusOccupancyChipDto(string StatusName, int Count);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IDailyFocusBoardStateService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IDailyFocusBoardStateService.cs
@@ -1,0 +1,15 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Builds the Daily Focus board-state snapshot for a selected planning board.</summary>
+public interface IDailyFocusBoardStateService
+{
+    /// <summary>Loads occupancy chips and active load for the specified project board.</summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="capacity">The persisted planning capacity used as the active-load denominator.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The Daily Focus board snapshot.</returns>
+    Task<DailyFocusBoardStateDto> GetBoardStateAsync(
+        string projectId,
+        int capacity,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardItemCatalogueDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardItemCatalogueDto.cs
@@ -3,4 +3,5 @@ namespace SoloDevBoard.Application.Services.PmWorkflow;
 /// <summary>DTO catalogue of project board items and discovered field identifiers.</summary>
 public sealed record ProjectBoardItemCatalogueDto(
     ProjectBoardFieldIdsDto FieldIds,
+    IReadOnlyList<ProjectBoardStatusOptionDto> StatusOptions,
     IReadOnlyList<ProjectBoardItemDto> Items);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardStatusOptionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectBoardStatusOptionDto.cs
@@ -1,0 +1,6 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>DTO for a Status option discovered on a Projects v2 board.</summary>
+/// <param name="OptionId">The status option node identifier.</param>
+/// <param name="Name">The status option display name.</param>
+public sealed record ProjectBoardStatusOptionDto(string OptionId, string Name);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectItemCatalogueService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/ProjectItemCatalogueService.cs
@@ -80,11 +80,15 @@ public sealed class ProjectItemCatalogueService : IProjectItemCatalogueService
             catalogue.FieldIds.StatusFieldId,
             catalogue.FieldIds.FocusOrderFieldId);
 
+        var statusOptions = catalogue.StatusOptions
+            .Select(static option => new ProjectBoardStatusOptionDto(option.OptionId, option.Name))
+            .ToArray();
+
         var items = catalogue.Items
             .Select(MapItem)
             .ToArray();
 
-        return new ProjectBoardItemCatalogueDto(fieldIds, items);
+        return new ProjectBoardItemCatalogueDto(fieldIds, statusOptions, items);
     }
 
     private static ProjectBoardItemDto MapItem(ProjectBoardItem item)

--- a/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardItemCatalogue.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardItemCatalogue.cs
@@ -6,6 +6,9 @@ public sealed record ProjectBoardItemCatalogue
     /// <summary>Gets the discovered Status and optional Focus Order field identifiers.</summary>
     public ProjectBoardFieldIds FieldIds { get; init; } = new();
 
+    /// <summary>Gets the Status options discovered on the board, in board-defined order.</summary>
+    public IReadOnlyList<ProjectBoardStatusOption> StatusOptions { get; init; } = [];
+
     /// <summary>Gets the project board items included in the catalogue.</summary>
     public IReadOnlyList<ProjectBoardItem> Items { get; init; } = [];
 }

--- a/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardStatusOption.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/PmWorkflow/ProjectBoardStatusOption.cs
@@ -1,0 +1,11 @@
+namespace SoloDevBoard.Domain.Entities.PmWorkflow;
+
+/// <summary>Represents a Status single-select option discovered on a Projects v2 board.</summary>
+public sealed record ProjectBoardStatusOption
+{
+    /// <summary>Gets the status option node identifier.</summary>
+    public string OptionId { get; init; } = string.Empty;
+
+    /// <summary>Gets the status option display name.</summary>
+    public string Name { get; init; } = string.Empty;
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
@@ -616,10 +616,11 @@ public sealed class GitHubService : IGitHubService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
 
-        const string query = "query ProjectBoardItemCatalogue($projectId: ID!, $after: String) { node(id: $projectId) { ... on ProjectV2 { fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name } ... on ProjectV2Field { id name dataType } } } items(first: 100, after: $after, archivedStates: [NOT_ARCHIVED]) { pageInfo { hasNextPage endCursor } nodes { id updatedAt content { __typename ... on Issue { number title url repository { name owner { login } } } ... on PullRequest { number title url repository { name owner { login } } } } status: fieldValueByName(name: \"Status\") { ... on ProjectV2ItemFieldSingleSelectValue { optionId name updatedAt } } focusOrder: fieldValueByName(name: \"Focus Order\") { ... on ProjectV2ItemFieldNumberValue { number } } } } } } }";
+        const string query = "query ProjectBoardItemCatalogue($projectId: ID!, $after: String) { node(id: $projectId) { ... on ProjectV2 { fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } ... on ProjectV2Field { id name dataType } } } items(first: 100, after: $after, archivedStates: [NOT_ARCHIVED]) { pageInfo { hasNextPage endCursor } nodes { id updatedAt content { __typename ... on Issue { number title url repository { name owner { login } } } ... on PullRequest { number title url repository { name owner { login } } } } status: fieldValueByName(name: \"Status\") { ... on ProjectV2ItemFieldSingleSelectValue { optionId name updatedAt } } focusOrder: fieldValueByName(name: \"Focus Order\") { ... on ProjectV2ItemFieldNumberValue { number } } } } } } }";
 
         var client = CreateAuthenticatedClient();
         var fieldIds = new ProjectBoardFieldIds();
+        IReadOnlyList<ProjectBoardStatusOption> statusOptions = [];
         var items = new List<ProjectBoardItem>();
         string? after = null;
         var hasNextPage = true;
@@ -645,6 +646,7 @@ public sealed class GitHubService : IGitHubService
                     throw CreateInvalidResponseException("GraphQL response did not contain a supported Status field.", "/graphql");
                 }
 
+                statusOptions = ToProjectBoardStatusOptions(node?.Fields?.Nodes ?? []);
                 fieldIdsResolved = true;
             }
 
@@ -668,6 +670,7 @@ public sealed class GitHubService : IGitHubService
         return new ProjectBoardItemCatalogue
         {
             FieldIds = fieldIds,
+            StatusOptions = statusOptions,
             Items = items,
         };
     }
@@ -1108,6 +1111,32 @@ public sealed class GitHubService : IGitHubService
             StatusFieldId = statusField?.Id ?? string.Empty,
             FocusOrderFieldId = string.IsNullOrWhiteSpace(focusOrderField?.Id) ? null : focusOrderField.Id,
         };
+    }
+
+    /// <summary>Maps Status single-select options from catalogue field nodes.</summary>
+    /// <param name="fields">Field nodes returned by the item catalogue query.</param>
+    /// <returns>Status options in board-defined order.</returns>
+    private static IReadOnlyList<ProjectBoardStatusOption> ToProjectBoardStatusOptions(
+        IReadOnlyList<ProjectBoardCatalogueFieldDto> fields)
+    {
+        var statusField = fields.FirstOrDefault(field =>
+            !string.IsNullOrWhiteSpace(field.Id)
+            && field.Name.Equals("Status", StringComparison.OrdinalIgnoreCase));
+
+        if (statusField is null)
+        {
+            return [];
+        }
+
+        return statusField.Options
+            .Where(static option =>
+                !string.IsNullOrWhiteSpace(option.Id) && !string.IsNullOrWhiteSpace(option.Name))
+            .Select(static option => new ProjectBoardStatusOption
+            {
+                OptionId = option.Id,
+                Name = option.Name,
+            })
+            .ToArray();
     }
 
     private static ProjectBoardItem? ToProjectBoardItemDomain(ProjectBoardItemNodeDto? node)
@@ -1856,6 +1885,9 @@ public sealed class GitHubService : IGitHubService
 
         [JsonPropertyName("dataType")]
         public string DataType { get; init; } = string.Empty;
+
+        [JsonPropertyName("options")]
+        public IReadOnlyList<ProjectBoardSingleSelectOptionDto> Options { get; init; } = [];
     }
 
     /// <summary>DTO for paginated project board items.</summary>

--- a/tests/App.Tests/SoloDevBoard.App.Tests/DashboardTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/DashboardTests.cs
@@ -17,7 +17,7 @@ public sealed class DashboardTests : BunitContext
     }
 
     [Fact]
-    public void Dashboard_WhenRendered_DisplaysAllSevenFeaturePanels()
+    public void Dashboard_WhenRendered_DisplaysAllEightFeaturePanels()
     {
         // Arrange
 
@@ -32,6 +32,7 @@ public sealed class DashboardTests : BunitContext
         Assert.Contains("Board Rules Visualiser", cut.Markup);
         Assert.Contains("Triage UI", cut.Markup);
         Assert.Contains("Workflow Templates", cut.Markup);
+        Assert.Contains("PM Workflow", cut.Markup);
     }
 
     [Fact]
@@ -48,7 +49,7 @@ public sealed class DashboardTests : BunitContext
             .Where(href => !string.IsNullOrWhiteSpace(href))
             .ToList();
 
-        Assert.Equal(7, links.Count);
+        Assert.Equal(8, links.Count);
         Assert.Contains("/audit-dashboard", links);
         Assert.Contains("/repositories", links);
         Assert.Contains("/migrate", links);
@@ -56,5 +57,6 @@ public sealed class DashboardTests : BunitContext
         Assert.Contains("/board-rules", links);
         Assert.Contains("/triage", links);
         Assert.Contains("/workflows", links);
+        Assert.Contains("/pm-workflow", links);
     }
 }

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowChromeCoordinatorTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowChromeCoordinatorTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using SoloDevBoard.App.Components.Features.PmWorkflow;
+using SoloDevBoard.Application.Services.PmWorkflow;
+using SoloDevBoard.Application.Services.Repositories;
+
+namespace SoloDevBoard.App.Tests;
+
+/// <summary>Unit tests for <see cref="PmWorkflowChromeCoordinator"/> load caching and cancellation.</summary>
+public sealed class PmWorkflowChromeCoordinatorTests
+{
+    private readonly IPmSettingsService _pmSettingsService = Substitute.For<IPmSettingsService>();
+    private readonly IRepositoryService _repositoryService = Substitute.For<IRepositoryService>();
+    private readonly IPmProjectBoardDiscoveryService _projectBoardDiscoveryService =
+        Substitute.For<IPmProjectBoardDiscoveryService>();
+
+    [Fact]
+    public async Task EnsureLoadedAsync_WhenAlreadyLoaded_DoesNotCallRepositoryServiceAgain()
+    {
+        ConfigureSuccessfulLoad();
+
+        var coordinator = CreateCoordinator();
+        await coordinator.EnsureLoadedAsync();
+        await coordinator.EnsureLoadedAsync();
+
+        await _repositoryService.Received(1).GetActiveRepositoriesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WhenCalledTwiceWhileInFlight_UsesSingleRepositoryFetch()
+    {
+        ConfigureSuccessfulLoad(delayRepositoryFetch: true);
+
+        var coordinator = CreateCoordinator();
+        var firstRefresh = coordinator.RefreshAsync();
+        var secondRefresh = coordinator.RefreshAsync();
+
+        await Task.WhenAll(firstRefresh, secondRefresh);
+
+        await _repositoryService.Received(1).GetActiveRepositoriesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CancelPendingLoad_WhenLoadIsInFlight_StopsFurtherRepositoryUpdates()
+    {
+        var repositoryTask = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
+        _pmSettingsService.GetSettingsAsync()
+            .Returns(PmSettingsDefaults.Create());
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>())
+            .Returns(repositoryTask.Task);
+
+        var coordinator = CreateCoordinator();
+        var refreshTask = coordinator.RefreshAsync();
+        coordinator.CancelPendingLoad();
+        repositoryTask.SetResult([CreateRepository("owner", "repo-a")]);
+
+        await refreshTask;
+
+        await _projectBoardDiscoveryService.DidNotReceive()
+            .GetPlanningBoardOptionsForRepositoriesAsync(
+                Arg.Any<IReadOnlyList<RepositoryDto>>(),
+                Arg.Any<CancellationToken>());
+        Assert.False(coordinator.HasLoadedOnce);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WithForceReload_ClearsDailyFocusBoardStateCache()
+    {
+        ConfigureSuccessfulLoad();
+
+        var coordinator = CreateCoordinator();
+        await coordinator.EnsureLoadedAsync();
+        coordinator.SetDailyFocusBoardState(
+            "PVT_board",
+            8,
+            new DailyFocusBoardStateDto([], 0, 8, 0),
+            null,
+            isLoading: false);
+
+        await coordinator.RefreshAsync(forceReload: true);
+
+        Assert.Null(coordinator.DailyFocusBoardState);
+    }
+
+    [Fact]
+    public async Task EnsureLoadedAsync_WhenRepositoryFetchFails_DoesNotMarkLoaded()
+    {
+        _pmSettingsService.GetSettingsAsync()
+            .Returns(PmSettingsDefaults.Create());
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("GitHub unavailable"));
+
+        var coordinator = CreateCoordinator();
+        await coordinator.EnsureLoadedAsync();
+
+        Assert.False(coordinator.HasLoadedOnce);
+        Assert.NotNull(coordinator.State.LoadErrorMessage);
+    }
+
+    private void ConfigureSuccessfulLoad(bool delayRepositoryFetch = false)
+    {
+        _pmSettingsService.GetSettingsAsync()
+            .Returns(PmSettingsDefaults.Create());
+
+        if (delayRepositoryFetch)
+        {
+            var repositoryTask = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
+            _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>())
+                .Returns(repositoryTask.Task);
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(50);
+                repositoryTask.SetResult([CreateRepository("owner", "repo-a")]);
+            });
+        }
+        else
+        {
+            _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
+                CreateRepository("owner", "repo-a"),
+            ]);
+        }
+
+        _projectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
+                Arg.Any<IReadOnlyList<RepositoryDto>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new PmProjectBoardDiscoveryDto([], 0, 0));
+    }
+
+    private PmWorkflowChromeCoordinator CreateCoordinator() =>
+        new(
+            _pmSettingsService,
+            _repositoryService,
+            _projectBoardDiscoveryService,
+            NullLogger<PmWorkflowChromeCoordinator>.Instance);
+
+    private static RepositoryDto CreateRepository(string owner, string name) =>
+        new(1, name, $"{owner}/{name}", string.Empty, $"https://github.com/{owner}/{name}", false, false, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowDailyFocusTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowDailyFocusTests.cs
@@ -104,6 +104,39 @@ public sealed class PmWorkflowDailyFocusTests
             Assert.Contains("Unable to load board occupancy.", cut.Markup);
             Assert.Contains("Retry", cut.Markup);
         });
+
+        cut.Render();
+
+        await _boardStateService.Received(1).GetBoardStateAsync("PVT_board", 8, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PmWorkflowDailyFocus_WhenRetryClickedAfterCatalogueFailure_ReloadsBoardState()
+    {
+        ConfigureDefaults();
+        _boardStateService.GetBoardStateAsync("PVT_board", 8, Arg.Any<CancellationToken>())
+            .Returns(
+                _ => throw new InvalidOperationException("GitHub unavailable"),
+                _ => new DailyFocusBoardStateDto(
+                    [new DailyFocusOccupancyChipDto("Todo", 1)],
+                    ActiveLoad: 0,
+                    Capacity: 8,
+                    ItemCount: 1));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<PmWorkflowDailyFocus>();
+
+        cut.WaitForAssertion(() => Assert.Contains("Unable to load board occupancy.", cut.Markup));
+
+        await cut.InvokeAsync(() => cut.Find("[data-testid='pm-workflow-daily-focus-retry']").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Todo 1", cut.Markup);
+            Assert.Contains("Active load: 0 / 8", cut.Markup);
+        });
+
+        await _boardStateService.Received(2).GetBoardStateAsync("PVT_board", 8, Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowDailyFocusTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowDailyFocusTests.cs
@@ -6,6 +6,7 @@ using MudBlazor;
 using MudBlazor.Services;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using SoloDevBoard.App.Components.Features.PmWorkflow;
 using SoloDevBoard.App.Components.Features.PmWorkflow.Pages;
 using SoloDevBoard.Application.Services.PmWorkflow;
 using SoloDevBoard.Application.Services.Repositories;
@@ -32,7 +33,7 @@ public sealed class PmWorkflowDailyFocusTests
             new PmProjectBoardDiscoveryDto([], 0, 0));
 
         await using var ctx = CreateContext();
-        var cut = ctx.Render<PmWorkflowDailyFocus>();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowDailyFocus>();
 
         cut.WaitForAssertion(() =>
         {
@@ -57,7 +58,7 @@ public sealed class PmWorkflowDailyFocusTests
                 ItemCount: 8));
 
         await using var ctx = CreateContext();
-        var cut = ctx.Render<PmWorkflowDailyFocus>();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowDailyFocus>();
 
         cut.WaitForAssertion(() =>
         {
@@ -80,7 +81,7 @@ public sealed class PmWorkflowDailyFocusTests
                 ItemCount: 0));
 
         await using var ctx = CreateContext();
-        var cut = ctx.Render<PmWorkflowDailyFocus>();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowDailyFocus>();
 
         cut.WaitForAssertion(() =>
         {
@@ -97,7 +98,7 @@ public sealed class PmWorkflowDailyFocusTests
             .ThrowsAsync(new InvalidOperationException("GitHub unavailable"));
 
         await using var ctx = CreateContext();
-        var cut = ctx.Render<PmWorkflowDailyFocus>();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowDailyFocus>();
 
         cut.WaitForAssertion(() =>
         {
@@ -124,7 +125,7 @@ public sealed class PmWorkflowDailyFocusTests
                     ItemCount: 1));
 
         await using var ctx = CreateContext();
-        var cut = ctx.Render<PmWorkflowDailyFocus>();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowDailyFocus>();
 
         cut.WaitForAssertion(() => Assert.Contains("Unable to load board occupancy.", cut.Markup));
 
@@ -154,12 +155,33 @@ public sealed class PmWorkflowDailyFocusTests
             .Returns(new DailyFocusBoardStateDto([], 0, 8, 0));
 
         await using var ctx = CreateContext();
-        var cut = ctx.Render<PmWorkflowDailyFocus>();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowDailyFocus>();
 
         cut.WaitForAssertion(() =>
         {
             Assert.Contains("could not be loaded", cut.Markup, StringComparison.OrdinalIgnoreCase);
         });
+    }
+
+    [Fact]
+    public async Task PmWorkflowTabSwitch_WhenChromeAlreadyLoaded_DoesNotFetchRepositoriesAgain()
+    {
+        ConfigureDefaults();
+        _boardStateService.GetBoardStateAsync("PVT_board", 8, Arg.Any<CancellationToken>())
+            .Returns(new DailyFocusBoardStateDto(
+                [new DailyFocusOccupancyChipDto("Todo", 1)],
+                ActiveLoad: 0,
+                Capacity: 8,
+                ItemCount: 1));
+
+        await using var ctx = CreateContext();
+        var dailyFocus = ctx.RenderPmWorkflowPage<PmWorkflowDailyFocus>();
+
+        dailyFocus.WaitForAssertion(() => Assert.Contains("Active load: 0 / 8", dailyFocus.Markup));
+
+        ctx.RenderPmWorkflowPage<PmWorkflowRepos>();
+
+        await _repositoryService.Received(1).GetActiveRepositoriesAsync(Arg.Any<CancellationToken>());
     }
 
     private void ConfigureDefaults()
@@ -187,6 +209,7 @@ public sealed class PmWorkflowDailyFocusTests
         ctx.Services.AddScoped(_ => _repositoryService);
         ctx.Services.AddScoped(_ => _projectBoardDiscoveryService);
         ctx.Services.AddScoped(_ => _boardStateService);
+        ctx.Services.AddScoped<PmWorkflowChromeCoordinator>();
         ctx.Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
 
         ctx.Render<MudPopoverProvider>();

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowDailyFocusTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowDailyFocusTests.cs
@@ -52,7 +52,7 @@ public sealed class PmWorkflowDailyFocusTests
         cut.WaitForAssertion(() =>
         {
             Assert.Contains("Daily Focus", cut.Markup);
-            Assert.Contains("Select a planning board to load Daily Focus occupancy.", cut.Markup);
+            Assert.Contains("Select a planning board in the dropdown above to load Daily Focus occupancy.", cut.Markup);
         });
     }
 
@@ -175,6 +175,67 @@ public sealed class PmWorkflowDailyFocusTests
         {
             Assert.Contains("could not be loaded", cut.Markup, StringComparison.OrdinalIgnoreCase);
         });
+    }
+
+    [Fact]
+    public async Task PmWorkflowDailyFocus_WhenChromeLoadIsInFlight_ShowsLoadingIndicator()
+    {
+        var repositoriesReady = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>())
+            .Returns(repositoriesReady.Task);
+        _projectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
+            Arg.Any<IReadOnlyList<RepositoryDto>>(),
+            Arg.Any<CancellationToken>()).Returns(
+            new PmProjectBoardDiscoveryDto([], 0, 0));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowDailyFocus>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Loading PM Workflow", cut.Markup);
+            Assert.Contains("Loading planning boards and occupancy.", cut.Markup);
+        });
+
+        repositoriesReady.SetResult([CreateRepository("owner", "repo-a")]);
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Select a planning board in the dropdown above to load Daily Focus occupancy.", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowLayout_DisposeWhileStillOnPmWorkflow_DoesNotCancelChromeLoad()
+    {
+        var repositoriesReady = new TaskCompletionSource<IReadOnlyList<RepositoryDto>>();
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>())
+            .Returns(repositoriesReady.Task);
+        _projectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
+            Arg.Any<IReadOnlyList<RepositoryDto>>(),
+            Arg.Any<CancellationToken>()).Returns(
+            new PmProjectBoardDiscoveryDto(
+                [new PmPlanningBoardOptionDto("PVT_board", "Roadmap", "owner", "status-field")],
+                1,
+                0));
+        _boardStateService.GetBoardStateAsync("PVT_board", 8, Arg.Any<CancellationToken>())
+            .Returns(new DailyFocusBoardStateDto(
+                [new DailyFocusOccupancyChipDto("Todo", 1)],
+                ActiveLoad: 0,
+                Capacity: 8,
+                ItemCount: 1));
+
+        await using var ctx = CreateContext();
+        ctx.Services.GetRequiredService<NavigationManager>().NavigateTo("/pm-workflow/daily-focus");
+        var coordinator = ctx.Services.GetRequiredService<PmWorkflowChromeCoordinator>();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowDailyFocus>();
+
+        cut.WaitForAssertion(() => Assert.Contains("Loading PM Workflow", cut.Markup));
+
+        cut.Instance.Dispose();
+        repositoriesReady.SetResult([CreateRepository("owner", "repo-a")]);
+
+        cut.WaitForAssertion(() => Assert.True(coordinator.HasLoadedOnce));
     }
 
     [Fact]

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowDailyFocusTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowDailyFocusTests.cs
@@ -1,4 +1,5 @@
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -8,6 +9,7 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using SoloDevBoard.App.Components.Features.PmWorkflow;
 using SoloDevBoard.App.Components.Features.PmWorkflow.Pages;
+using SoloDevBoard.App.Components.Shell.Layout;
 using SoloDevBoard.Application.Services.PmWorkflow;
 using SoloDevBoard.Application.Services.Repositories;
 
@@ -20,6 +22,18 @@ public sealed class PmWorkflowDailyFocusTests
     private readonly IPmProjectBoardDiscoveryService _projectBoardDiscoveryService = Substitute.For<IPmProjectBoardDiscoveryService>();
     private readonly IDailyFocusBoardStateService _boardStateService = Substitute.For<IDailyFocusBoardStateService>();
     private readonly FakePmSettingsStorage _settingsStorage = new();
+
+    [Fact]
+    public void PmWorkflowLayout_UsesMainLayoutAsParent()
+    {
+        var layoutAttribute = typeof(PmWorkflowLayout)
+            .GetCustomAttributes(typeof(LayoutAttribute), inherit: true)
+            .Cast<LayoutAttribute>()
+            .FirstOrDefault();
+
+        Assert.NotNull(layoutAttribute);
+        Assert.Equal(typeof(MainLayout), layoutAttribute.LayoutType);
+    }
 
     [Fact]
     public async Task PmWorkflowDailyFocus_WhenNoBoardIsSelected_ShowsInstructionalAlert()

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowDailyFocusTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowDailyFocusTests.cs
@@ -1,0 +1,181 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MudBlazor;
+using MudBlazor.Services;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using SoloDevBoard.App.Components.Features.PmWorkflow.Pages;
+using SoloDevBoard.Application.Services.PmWorkflow;
+using SoloDevBoard.Application.Services.Repositories;
+
+namespace SoloDevBoard.App.Tests;
+
+/// <summary>Component tests for Daily Focus occupancy on <see cref="PmWorkflowDailyFocus"/>.</summary>
+public sealed class PmWorkflowDailyFocusTests
+{
+    private readonly IRepositoryService _repositoryService = Substitute.For<IRepositoryService>();
+    private readonly IPmProjectBoardDiscoveryService _projectBoardDiscoveryService = Substitute.For<IPmProjectBoardDiscoveryService>();
+    private readonly IDailyFocusBoardStateService _boardStateService = Substitute.For<IDailyFocusBoardStateService>();
+    private readonly FakePmSettingsStorage _settingsStorage = new();
+
+    [Fact]
+    public async Task PmWorkflowDailyFocus_WhenNoBoardIsSelected_ShowsInstructionalAlert()
+    {
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
+            CreateRepository("owner", "repo-a"),
+        ]);
+        _projectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
+            Arg.Any<IReadOnlyList<RepositoryDto>>(),
+            Arg.Any<CancellationToken>()).Returns(
+            new PmProjectBoardDiscoveryDto([], 0, 0));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<PmWorkflowDailyFocus>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Daily Focus", cut.Markup);
+            Assert.Contains("Select a planning board to load Daily Focus occupancy.", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowDailyFocus_WhenBoardHasItems_ShowsOccupancyAndActiveLoad()
+    {
+        ConfigureDefaults();
+        _boardStateService.GetBoardStateAsync("PVT_board", 8, Arg.Any<CancellationToken>())
+            .Returns(new DailyFocusBoardStateDto(
+                [
+                    new DailyFocusOccupancyChipDto("Todo", 2),
+                    new DailyFocusOccupancyChipDto("Up Next", 4),
+                    new DailyFocusOccupancyChipDto("In Progress", 2),
+                ],
+                ActiveLoad: 6,
+                Capacity: 8,
+                ItemCount: 8));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<PmWorkflowDailyFocus>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Todo 2", cut.Markup);
+            Assert.Contains("Up Next 4", cut.Markup);
+            Assert.Contains("In Progress 2", cut.Markup);
+            Assert.Contains("Active load: 6 / 8 (Up Next + In Progress)", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowDailyFocus_WhenBoardHasNoItems_ShowsEmptyAlert()
+    {
+        ConfigureDefaults();
+        _boardStateService.GetBoardStateAsync("PVT_board", 8, Arg.Any<CancellationToken>())
+            .Returns(new DailyFocusBoardStateDto(
+                [new DailyFocusOccupancyChipDto("Todo", 0)],
+                ActiveLoad: 0,
+                Capacity: 8,
+                ItemCount: 0));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<PmWorkflowDailyFocus>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("This planning board has no items.", cut.Markup);
+            Assert.Contains("Active load: 0 / 8", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowDailyFocus_WhenCatalogueFails_ShowsErrorWithRetry()
+    {
+        ConfigureDefaults();
+        _boardStateService.GetBoardStateAsync("PVT_board", 8, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("GitHub unavailable"));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<PmWorkflowDailyFocus>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Unable to load board occupancy.", cut.Markup);
+            Assert.Contains("Retry", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowDailyFocus_WhenLinkedBoardsAreInaccessible_ShowsWarning()
+    {
+        ConfigureDefaults();
+        _projectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
+            Arg.Any<IReadOnlyList<RepositoryDto>>(),
+            Arg.Any<CancellationToken>()).Returns(
+            new PmProjectBoardDiscoveryDto(
+                [new PmPlanningBoardOptionDto("PVT_board", "Roadmap", "owner", "status-field")],
+                2,
+                1));
+        _boardStateService.GetBoardStateAsync("PVT_board", 8, Arg.Any<CancellationToken>())
+            .Returns(new DailyFocusBoardStateDto([], 0, 8, 0));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<PmWorkflowDailyFocus>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("could not be loaded", cut.Markup, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    private void ConfigureDefaults()
+    {
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
+            CreateRepository("owner", "repo-a"),
+        ]);
+        _projectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
+            Arg.Any<IReadOnlyList<RepositoryDto>>(),
+            Arg.Any<CancellationToken>()).Returns(
+            new PmProjectBoardDiscoveryDto(
+                [new PmPlanningBoardOptionDto("PVT_board", "Roadmap", "owner", "status-field")],
+                1,
+                0));
+    }
+
+    private BunitContext CreateContext()
+    {
+        var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddMudServices();
+        ctx.Services.AddTestGitHubAuthenticationRecovery();
+        ctx.Services.AddSingleton<IPmSettingsStorage>(_settingsStorage);
+        ctx.Services.AddScoped<IPmSettingsService, PmSettingsService>();
+        ctx.Services.AddScoped(_ => _repositoryService);
+        ctx.Services.AddScoped(_ => _projectBoardDiscoveryService);
+        ctx.Services.AddScoped(_ => _boardStateService);
+        ctx.Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+
+        ctx.Render<MudPopoverProvider>();
+        ctx.Render<MudDialogProvider>();
+        ctx.Render<MudSnackbarProvider>();
+
+        return ctx;
+    }
+
+    private static RepositoryDto CreateRepository(string owner, string name) =>
+        new(1, name, $"{owner}/{name}", string.Empty, $"https://github.com/{owner}/{name}", false, false, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+    private sealed class FakePmSettingsStorage : IPmSettingsStorage
+    {
+        public string? StoredJson { get; set; }
+
+        public Task<string?> GetStoredJsonAsync() => Task.FromResult(StoredJson);
+
+        public Task SetStoredJsonAsync(string json)
+        {
+            StoredJson = json;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowLayoutTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowLayoutTests.cs
@@ -1,0 +1,16 @@
+using SoloDevBoard.App.Components.Features.PmWorkflow;
+
+namespace SoloDevBoard.App.Tests;
+
+/// <summary>Tests for <see cref="PmWorkflowLayout"/> path helpers.</summary>
+public sealed class PmWorkflowLayoutTests
+{
+    [Theory]
+    [InlineData("https://localhost/pm-workflow/daily-focus", true)]
+    [InlineData("https://localhost/pm-workflow/repos", true)]
+    [InlineData("https://localhost/pm-workflow", true)]
+    [InlineData("https://localhost/", false)]
+    [InlineData("https://localhost/audit-dashboard", false)]
+    public void IsPmWorkflowPath_Uri_ExpectedOutcome(string uri, bool expected) =>
+        Assert.Equal(expected, PmWorkflowLayout.IsPmWorkflowPath(uri));
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowReposTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowReposTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using MudBlazor;
 using MudBlazor.Services;
 using NSubstitute;
+using SoloDevBoard.App.Components.Features.PmWorkflow;
 using SoloDevBoard.App.Components.Features.PmWorkflow.Pages;
 using SoloDevBoard.Application.Services.PmWorkflow;
 using SoloDevBoard.Application.Services.Repositories;
@@ -30,7 +31,7 @@ public sealed class PmWorkflowReposTests
             new PmProjectBoardDiscoveryDto([], 0, 0));
 
         await using var ctx = CreateContext();
-        var cut = ctx.Render<PmWorkflowRepos>();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowRepos>();
 
         cut.WaitForAssertion(() =>
         {
@@ -46,7 +47,7 @@ public sealed class PmWorkflowReposTests
         _settingsStorage.StoredJson = """{"capacity":12,"stallDays":5,"neglectDays":21,"excludedRepositories":[]}""";
 
         await using var ctx = CreateContext();
-        var cut = ctx.Render<PmWorkflowRepos>();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowRepos>();
 
         cut.WaitForAssertion(() =>
         {
@@ -88,7 +89,7 @@ public sealed class PmWorkflowReposTests
         ConfigureDefaults();
 
         await using var ctx = CreateContext();
-        var firstRender = ctx.Render<PmWorkflowRepos>();
+        var firstRender = ctx.RenderPmWorkflowPage<PmWorkflowRepos>();
 
         firstRender.WaitForAssertion(() => Assert.Contains("Repository participation", firstRender.Markup));
 
@@ -106,7 +107,7 @@ public sealed class PmWorkflowReposTests
         });
 
         await using var reloadContext = CreateContext();
-        var secondRender = reloadContext.Render<PmWorkflowRepos>();
+        var secondRender = reloadContext.RenderPmWorkflowPage<PmWorkflowRepos>();
 
         secondRender.WaitForAssertion(() =>
         {
@@ -141,6 +142,7 @@ public sealed class PmWorkflowReposTests
         ctx.Services.AddScoped<IPmSettingsService, PmSettingsService>();
         ctx.Services.AddScoped(_ => _repositoryService);
         ctx.Services.AddScoped(_ => _projectBoardDiscoveryService);
+        ctx.Services.AddScoped<PmWorkflowChromeCoordinator>();
         ctx.Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
 
         ctx.Render<MudPopoverProvider>();

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowTestContextExtensions.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowTestContextExtensions.cs
@@ -1,0 +1,24 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using SoloDevBoard.App.Components.Features.PmWorkflow;
+
+namespace SoloDevBoard.App.Tests;
+
+/// <summary>Shared bUnit helpers for PM Workflow layout-backed pages.</summary>
+internal static class PmWorkflowTestContextExtensions
+{
+    /// <summary>Renders a PM Workflow page inside <see cref="PmWorkflowLayout"/>.</summary>
+    /// <typeparam name="TPage">The routable page component type.</typeparam>
+    /// <param name="context">The bUnit test context.</param>
+    /// <returns>The rendered layout fragment containing the page.</returns>
+    internal static IRenderedComponent<PmWorkflowLayout> RenderPmWorkflowPage<TPage>(this BunitContext context)
+        where TPage : IComponent
+        => context.Render<PmWorkflowLayout>(parameters =>
+            parameters.Add(
+                layout => layout.Body,
+                (RenderFragment)(builder =>
+                {
+                    builder.OpenComponent<TPage>(0);
+                    builder.CloseComponent();
+                })));
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
@@ -50,6 +50,7 @@ public sealed class ApplicationServiceCollectionExtensionsTests
         AssertServiceRegistration<IProjectItemCatalogueService, ProjectItemCatalogueService>(services, ServiceLifetime.Scoped);
         AssertServiceRegistration<IPmWorkItemCatalogueService, PmWorkItemCatalogueService>(services, ServiceLifetime.Scoped);
         AssertServiceRegistration<IPmProjectBoardDiscoveryService, PmProjectBoardDiscoveryService>(services, ServiceLifetime.Scoped);
+        AssertServiceRegistration<IDailyFocusBoardStateService, DailyFocusBoardStateService>(services, ServiceLifetime.Scoped);
     }
 
     private static void AssertServiceRegistration<TService, TImplementation>(

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/DailyFocusBoardStateMapperTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/DailyFocusBoardStateMapperTests.cs
@@ -1,0 +1,171 @@
+using SoloDevBoard.Application.Services.PmWorkflow;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="DailyFocusBoardStateMapper"/>.</summary>
+public sealed class DailyFocusBoardStateMapperTests
+{
+    [Fact]
+    public void Map_DiscoveredStatusOptions_IncludesEmptyColumnsInBoardOrder()
+    {
+        var statusOptions = new[]
+        {
+            new ProjectBoardStatusOptionDto("opt-todo", "Todo"),
+            new ProjectBoardStatusOptionDto("opt-up-next", "Up Next"),
+            new ProjectBoardStatusOptionDto("opt-in-progress", "In Progress"),
+            new ProjectBoardStatusOptionDto("opt-blocked", "Blocked"),
+            new ProjectBoardStatusOptionDto("opt-ice-box", "Ice Box"),
+            new ProjectBoardStatusOptionDto("opt-done", "Done"),
+            new ProjectBoardStatusOptionDto("opt-waiting", "Waiting on review"),
+        };
+
+        var items = new[]
+        {
+            CreateItem("opt-todo", "Todo"),
+            CreateItem("opt-todo", "Todo"),
+            CreateItem("opt-up-next", "Up Next"),
+            CreateItem("opt-in-progress", "In Progress"),
+            CreateItem("opt-in-progress", "In Progress"),
+            CreateItem("opt-waiting", "Waiting on review"),
+        };
+
+        var result = DailyFocusBoardStateMapper.Map(statusOptions, items, capacity: 8);
+
+        Assert.Equal(7, result.Occupancy.Count);
+        Assert.Equal("Todo", result.Occupancy[0].StatusName);
+        Assert.Equal(2, result.Occupancy[0].Count);
+        Assert.Equal("Up Next", result.Occupancy[1].StatusName);
+        Assert.Equal(1, result.Occupancy[1].Count);
+        Assert.Equal("In Progress", result.Occupancy[2].StatusName);
+        Assert.Equal(2, result.Occupancy[2].Count);
+        Assert.Equal("Blocked", result.Occupancy[3].StatusName);
+        Assert.Equal(0, result.Occupancy[3].Count);
+        Assert.Equal("Ice Box", result.Occupancy[4].StatusName);
+        Assert.Equal(0, result.Occupancy[4].Count);
+        Assert.Equal("Done", result.Occupancy[5].StatusName);
+        Assert.Equal(0, result.Occupancy[5].Count);
+        Assert.Equal("Waiting on review", result.Occupancy[6].StatusName);
+        Assert.Equal(1, result.Occupancy[6].Count);
+        Assert.Equal(6, result.ItemCount);
+    }
+
+    [Fact]
+    public void Map_UpNextAndInProgressItems_ActiveLoadEqualsSum()
+    {
+        var statusOptions = new[]
+        {
+            new ProjectBoardStatusOptionDto("opt-up-next", "Up Next"),
+            new ProjectBoardStatusOptionDto("opt-in-progress", "In Progress"),
+            new ProjectBoardStatusOptionDto("opt-todo", "Todo"),
+        };
+
+        var items = new[]
+        {
+            CreateItem("opt-up-next", "Up Next"),
+            CreateItem("opt-up-next", "Up Next"),
+            CreateItem("opt-up-next", "Up Next"),
+            CreateItem("opt-up-next", "Up Next"),
+            CreateItem("opt-in-progress", "In Progress"),
+            CreateItem("opt-in-progress", "In Progress"),
+            CreateItem("opt-todo", "Todo"),
+        };
+
+        var result = DailyFocusBoardStateMapper.Map(statusOptions, items, capacity: 8);
+
+        Assert.Equal(6, result.ActiveLoad);
+        Assert.Equal(8, result.Capacity);
+    }
+
+    [Fact]
+    public void Map_CapacityLessThanOne_UsesDefaultCapacity()
+    {
+        var result = DailyFocusBoardStateMapper.Map([], [], capacity: 0);
+
+        Assert.Equal(0, result.ActiveLoad);
+        Assert.Equal(PmSettingsDefaults.Capacity, result.Capacity);
+        Assert.Empty(result.Occupancy);
+    }
+
+    [Fact]
+    public void Map_ItemsWithoutStatus_AddsNoStatusChip()
+    {
+        var statusOptions = new[]
+        {
+            new ProjectBoardStatusOptionDto("opt-todo", "Todo"),
+        };
+
+        var items = new[]
+        {
+            CreateItem("opt-todo", "Todo"),
+            CreateItem(null, null),
+        };
+
+        var result = DailyFocusBoardStateMapper.Map(statusOptions, items, capacity: 8);
+
+        Assert.Equal(2, result.Occupancy.Count);
+        Assert.Equal("Todo", result.Occupancy[0].StatusName);
+        Assert.Equal(1, result.Occupancy[0].Count);
+        Assert.Equal(DailyFocusBoardStateMapper.NoStatusChipName, result.Occupancy[1].StatusName);
+        Assert.Equal(1, result.Occupancy[1].Count);
+        Assert.Equal(0, result.ActiveLoad);
+    }
+
+    [Fact]
+    public void Map_NoDiscoveredOptions_DerivesChipsFromItemStatusNames()
+    {
+        var items = new[]
+        {
+            CreateItem("opt-ready", "Ready"),
+            CreateItem("opt-ready", "Ready"),
+            CreateItem("opt-parked", "Parked"),
+        };
+
+        var result = DailyFocusBoardStateMapper.Map([], items, capacity: 5);
+
+        Assert.Equal(2, result.Occupancy.Count);
+        Assert.Equal("Ready", result.Occupancy[0].StatusName);
+        Assert.Equal(2, result.Occupancy[0].Count);
+        Assert.Equal("Parked", result.Occupancy[1].StatusName);
+        Assert.Equal(1, result.Occupancy[1].Count);
+        Assert.Equal(0, result.ActiveLoad);
+        Assert.Equal(5, result.Capacity);
+    }
+
+    [Fact]
+    public void Map_NullArguments_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => DailyFocusBoardStateMapper.Map(null!, [], 8));
+        Assert.Throws<ArgumentNullException>(() => DailyFocusBoardStateMapper.Map([], null!, 8));
+    }
+
+    [Theory]
+    [InlineData("Up Next", true)]
+    [InlineData("up next", true)]
+    [InlineData("In Progress", true)]
+    [InlineData("Todo", false)]
+    [InlineData(null, false)]
+    public void IsActiveLoadStatus_StatusName_ExpectedOutcome(string? statusName, bool expected)
+    {
+        Assert.Equal(expected, DailyFocusBoardStateMapper.IsActiveLoadStatus(statusName));
+    }
+
+    private static ProjectBoardItemDto CreateItem(string? optionId, string? statusName)
+    {
+        var status = optionId is null || statusName is null
+            ? null
+            : new ProjectBoardItemStatusDto(optionId, statusName);
+
+        return new ProjectBoardItemDto(
+            "PVTI_item",
+            status,
+            FocusOrder: null,
+            new ProjectBoardItemContentDto(
+                ProjectBoardItemContentTypeDto.Issue,
+                1,
+                "owner",
+                "repo",
+                "Title",
+                "https://github.com/owner/repo/issues/1"),
+            DateTimeOffset.UnixEpoch);
+    }
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/DailyFocusBoardStateServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/DailyFocusBoardStateServiceTests.cs
@@ -1,0 +1,67 @@
+using NSubstitute;
+using SoloDevBoard.Application.Services.PmWorkflow;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="DailyFocusBoardStateService"/>.</summary>
+public sealed class DailyFocusBoardStateServiceTests
+{
+    private readonly IProjectItemCatalogueService _catalogueService = Substitute.For<IProjectItemCatalogueService>();
+
+    [Fact]
+    public void Constructor_CatalogueServiceIsNull_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => _ = new DailyFocusBoardStateService(null!));
+    }
+
+    [Fact]
+    public async Task GetBoardStateAsync_ProjectIdIsBlank_ThrowsArgumentException()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var sut = new DailyFocusBoardStateService(_catalogueService);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            sut.GetBoardStateAsync(" ", 8, cancellationToken));
+    }
+
+    [Fact]
+    public async Task GetBoardStateAsync_CatalogueReturned_MapsOccupancyAndActiveLoad()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var catalogue = new ProjectBoardItemCatalogueDto(
+            new ProjectBoardFieldIdsDto("PVTF_status", null),
+            [
+                new ProjectBoardStatusOptionDto("opt-up-next", "Up Next"),
+                new ProjectBoardStatusOptionDto("opt-in-progress", "In Progress"),
+            ],
+            [
+                CreateItem("opt-up-next", "Up Next"),
+                CreateItem("opt-in-progress", "In Progress"),
+            ]);
+
+        _catalogueService.GetCatalogueAsync("project-id", cancellationToken).Returns(catalogue);
+
+        var sut = new DailyFocusBoardStateService(_catalogueService);
+
+        var result = await sut.GetBoardStateAsync("project-id", 10, cancellationToken);
+
+        Assert.Equal(2, result.ActiveLoad);
+        Assert.Equal(10, result.Capacity);
+        Assert.Equal(2, result.Occupancy.Count);
+        await _catalogueService.Received(1).GetCatalogueAsync("project-id", cancellationToken);
+    }
+
+    private static ProjectBoardItemDto CreateItem(string optionId, string statusName) =>
+        new(
+            "PVTI_item",
+            new ProjectBoardItemStatusDto(optionId, statusName),
+            FocusOrder: null,
+            new ProjectBoardItemContentDto(
+                ProjectBoardItemContentTypeDto.Issue,
+                1,
+                "owner",
+                "repo",
+                "Title",
+                "https://github.com/owner/repo/issues/1"),
+            DateTimeOffset.UnixEpoch);
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/ProjectItemCatalogueServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/ProjectItemCatalogueServiceTests.cs
@@ -37,6 +37,10 @@ public sealed class ProjectItemCatalogueServiceTests
                 StatusFieldId = "PVTF_status",
                 FocusOrderFieldId = "PVTF_focus",
             },
+            StatusOptions = [
+                new ProjectBoardStatusOption { OptionId = "option-up-next", Name = "Up Next" },
+                new ProjectBoardStatusOption { OptionId = "option-todo", Name = "Todo" },
+            ],
             Items = [
                 new ProjectBoardItem
                 {
@@ -72,6 +76,9 @@ public sealed class ProjectItemCatalogueServiceTests
         Assert.Single(result.Items);
         Assert.Equal("PVTI_item", result.Items[0].ProjectItemId);
         Assert.Equal("Up Next", result.Items[0].Status?.Name);
+        Assert.Equal(2, result.StatusOptions.Count);
+        Assert.Equal("option-up-next", result.StatusOptions[0].OptionId);
+        Assert.Equal("Todo", result.StatusOptions[1].Name);
         Assert.Equal(2, result.Items[0].FocusOrder);
         Assert.Equal(ProjectBoardItemContentTypeDto.Issue, result.Items[0].Content.ContentType);
         Assert.Equal(40, result.Items[0].Content.Number);

--- a/tests/E2E/CRITICAL_JOURNEYS.md
+++ b/tests/E2E/CRITICAL_JOURNEYS.md
@@ -24,7 +24,7 @@ For data-driven journeys against a real GitHub account, run the PAT suite locall
 | Journey | Spec | What CI validates |
 |---------|------|-------------------|
 | Health endpoint responds before browser tests run | `smoke.spec.ts` | `GET /health` returns `Healthy`. |
-| Home dashboard renders and lists all feature entry points | `navigation.spec.ts`, `smoke.spec.ts` | Title, navigation shell, and all seven feature cards. |
+| Home dashboard renders and lists all feature entry points | `navigation.spec.ts`, `smoke.spec.ts` | Title, navigation shell, and all eight feature cards. |
 | Drawer navigation reaches every primary feature route | `navigation.spec.ts` | URL and page title for each route in `fixtures/navigation.ts`. |
 | Appearance theme control cycles modes and persists preference | `appearance.spec.ts` | Automatic → Light → Dark cycle and browser storage persistence per [Appearance](../../website/content/docs/appearance.md). |
 | About page shows deployment metadata | `about.spec.ts` | Version, auth mode, and repository link from the shell menu. |
@@ -43,7 +43,7 @@ For data-driven journeys against a real GitHub account, run the PAT suite locall
 | Label Manager taxonomy tabs and empty repository state | `labels.spec.ts` | Tab strip, disabled actions, and no-repositories message. |
 | Workflow template browse, filter, and select | `workflows.spec.ts` | Built-in templates load; repository selector shows error. |
 | Triage not-started region without repositories | `triage.spec.ts` | Shell heading and no-repositories alert. |
-| PM Workflow Repo Management shell | `pm-workflow.spec.ts` | Shared chrome, Repos tab content or chrome error with retry. |
+| PM Workflow Daily Focus and Repo Management shells | `pm-workflow.spec.ts` | Shared chrome, Daily Focus occupancy or empty/error copy, Repos tab content or chrome error with retry. |
 
 ### Tier 3 — Out of CI scope (manual or future)
 

--- a/tests/E2E/README.md
+++ b/tests/E2E/README.md
@@ -23,7 +23,7 @@ Published user guides must stay aligned with these tests like-for-like. See [USE
 | `labels.spec.ts` | Label Manager shell, tabs, and empty-repository state |
 | `workflows.spec.ts` | Built-in template browse/filter/select and repository error state |
 | `triage.spec.ts` | Triage shell and no-repositories alert without a live GitHub connection |
-| `pm-workflow.spec.ts` | PM Workflow Repos tab shell, shared chrome, and threshold/exclusion regions or chrome error |
+| `pm-workflow.spec.ts` | PM Workflow Daily Focus occupancy shell and Repos tab threshold/exclusion regions or chrome error |
 | `accessibility.spec.ts` | WCAG 2.1 AA axe-core scan of Tier 1–2 journeys in light and dark mode; labelled shell controls; isolated snackbar contrast scan |
 
 Tests are designed to pass in CI with placeholder auth. The PAT job uses `GitHubAuth__PersonalAccessToken=ci-e2e-placeholder`. The hosted job uses placeholder GitHub App credentials and asserts the login gate without live OAuth. Repository-dependent features assert empty or error states rather than live GitHub data.

--- a/tests/E2E/USER_DOCS_ALIGNMENT.md
+++ b/tests/E2E/USER_DOCS_ALIGNMENT.md
@@ -26,7 +26,7 @@ When you add or change an end-user feature, update the user guide, the relevant 
 | User guide / site page | App route(s) | Playwright spec (CI) | Docs-capture screenshot | CI tier | Notes |
 |------------|--------------|----------------------|-------------------------|---------|-------|
 | [Product landing](../../website/content/_index.md) (Hugo `/` only) | — | — (Hugo `hugo-build.yml` route check) | — | — | Short product-and-project landing (Learn more → About; icon tiles not docs links); not the Blazor app. |
-| [In-app home dashboard](../../website/content/docs/) | `/` | `smoke.spec.ts`, `navigation.spec.ts`, `accessibility.spec.ts` | `dashboard/home.png` | Tier 1 | In-app home lists seven feature cards; About and Appearance are reached via the app bar. |
+| [In-app home dashboard](../../website/content/docs/) | `/` | `smoke.spec.ts`, `navigation.spec.ts`, `accessibility.spec.ts` | `dashboard/home.png` | Tier 1 | In-app home lists eight feature cards; About and Appearance are reached via the app bar. |
 | [Audit Dashboard](../../website/content/docs/audit-dashboard.md) | `/audit-dashboard`, `/audit` | `audit-dashboard.spec.ts`, `accessibility.spec.ts` | `audit-dashboard/overview.png` | Tier 2 | Guide describes KPI cards, health sections, auto-refresh, and export; CI asserts shell, feedback region, and `/audit` alias with load failure. |
 | [Repositories](../../website/content/docs/repositories.md) | `/repositories` | `repositories.spec.ts`, `accessibility.spec.ts` | `repositories/overview.png` | Tier 2 | Guide describes command strip, search, and grid; CI asserts refresh, search, and error state with retry. |
 | [One-Click Migration](../../website/content/docs/one-click-migration.md) | `/migrate` | `migrate.spec.ts`, `accessibility.spec.ts` | `one-click-migration/overview.png` | Tier 2 | Guide describes preview/apply workflow and conflict strategies; CI asserts setup shell, disabled preview, and API failure feedback. |
@@ -36,7 +36,7 @@ When you add or change an end-user feature, update the user guide, the relevant 
 | [Workflow Templates](../../website/content/docs/workflow-templates.md) | `/workflows` | `workflows.spec.ts`, `accessibility.spec.ts` | `workflow-templates/overview.png` | Tier 2 | Guide describes browse, parameterise, apply, and drift; CI asserts built-in template browse/filter/select and repository error state. |
 | [Appearance](../../website/content/docs/appearance.md) | App bar (all shell pages) | `appearance.spec.ts`, `accessibility.spec.ts` | `appearance/theme-toggle.png` | Tier 1 | Guide describes Automatic → Light → Dark cycling and persistence; not a drawer route. |
 | [About (in-app)](../../website/content/docs/about.md) | `/about` | `about.spec.ts`, `accessibility.spec.ts` | `about/overview.png` | Tier 1 | Guide describes More options menu access (User Guide external link and About route) and metadata fields. Not the Hugo `/about/` narrative section. |
-| Cross-Repo PM Workflow (`draft: true`, partial) | `/pm-workflow`, `/pm-workflow/repos` | `pm-workflow.spec.ts`, `accessibility.spec.ts` | `pm-workflow/repos.png` (pending) | Tier 2 | Draft guide documents Repo Management only ([#287](https://github.com/markheydon/solo-dev-board/issues/287)); Daily Focus, Backlog, and Planning are placeholders. CI asserts shell, tab strip, and Repos regions or chrome error. |
+| Cross-Repo PM Workflow (`draft: true`, partial) | `/pm-workflow`, `/pm-workflow/daily-focus`, `/pm-workflow/repos` | `pm-workflow.spec.ts`, `accessibility.spec.ts` | `pm-workflow/daily-focus.png` and `pm-workflow/repos.png` (pending) | Tier 2 | Draft guide documents Daily Focus occupancy plus Repo Management ([#273](https://github.com/markheydon/solo-dev-board/issues/273), [#287](https://github.com/markheydon/solo-dev-board/issues/287)); Backlog and Planning remain placeholders. CI asserts shell, tab strip, Daily Focus occupancy region or empty/error copy, and Repos regions or chrome error. |
 
 ### Auth and entry journeys (operator docs, not user guide)
 
@@ -82,17 +82,18 @@ Use this when extending specs so assertions track documented workflows.
 | More options → About | `about.spec.ts` navigation |
 | Version, build, .NET, auth mode, login, repository link | `about.spec.ts` `data-testid` fields |
 
-### Cross-Repo PM Workflow (partial — Repo Management)
+### Cross-Repo PM Workflow (partial — Daily Focus occupancy and Repo Management)
 
 | Guide section | CI assertion | Loaded-state validation |
 |---------------|--------------|-------------------------|
-| Drawer → PM Workflow → Repos | `pm-workflow.spec.ts` URL, title, shell, tab strip | `docs-capture` (pending) |
+| Drawer or Home → PM Workflow → Daily Focus | `pm-workflow.spec.ts` URL, title, shell, tab strip | `docs-capture` (pending) |
 | Planning board selector, status line, and refresh | `pm-workflow.spec.ts` shared chrome `data-testid`s | `docs-capture` (pending) |
+| Occupancy chips, active load, empty board, or catalogue error | `pm-workflow-daily-focus-board-state` / empty or error copy, or chrome error | `docs-capture` (pending) |
 | Planning thresholds | `pm-workflow-thresholds-region`, capacity field, or chrome error | `docs-capture` (pending) |
 | Repository participation summary | `pm-workflow-participation-summary` | `docs-capture` (pending) |
 | Included repositories table or empty state | `pm-workflow-included-table` / `pm-workflow-no-included-text` | `docs-capture` (pending) |
 | Excluded repositories and quick exclude | `pm-workflow-exclusions-region`, exclude autocomplete | `docs-capture` (pending) |
-| Daily Focus, Backlog, Planning | — | Not shipped |
+| Daily Focus stall and recommendations, Backlog, Planning | — | Not shipped |
 
 ## Screenshot hygiene
 

--- a/tests/E2E/fixtures/accessibility.ts
+++ b/tests/E2E/fixtures/accessibility.ts
@@ -15,7 +15,7 @@ export const accessibilityRoutes = [
   { path: '/board-rules', name: 'Board Rules' },
   { path: '/triage', name: 'Triage' },
   { path: '/workflows', name: 'Workflow Templates' },
-  { path: '/pm-workflow/repos', name: 'PM Workflow Repos' },
+  { path: '/pm-workflow/daily-focus', name: 'PM Workflow Daily Focus' },
 ] as const;
 
 const wcagTags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] as const;
@@ -107,7 +107,7 @@ export async function waitForAccessibilityScanReady(page: Page, path: string): P
     await expect(page.getByTestId('repositories-refresh-button')).toBeEnabled({ timeout: 15_000 });
   }
 
-  if (routePath === '/pm-workflow/repos') {
+  if (routePath === '/pm-workflow/daily-focus' || routePath === '/pm-workflow/repos') {
     await expect(page.getByTestId('pm-workflow-shell')).toBeVisible();
     await expect(page.locator('[aria-label="Loading PM Workflow"]')).toBeHidden({ timeout: 15_000 });
   }

--- a/tests/E2E/fixtures/navigation.ts
+++ b/tests/E2E/fixtures/navigation.ts
@@ -8,7 +8,7 @@ export const featureRoutes = [
   { navLabel: 'Board Rules', path: '/board-rules', title: /Board Rules Visualiser/ },
   { navLabel: 'Triage', path: '/triage', title: /Triage UI/ },
   { navLabel: 'Workflows', path: '/workflows', title: /Workflow Templates/ },
-  { navLabel: 'PM Workflow', path: '/pm-workflow/repos', title: /PM Workflow — Repos/ },
+  { navLabel: 'PM Workflow', path: '/pm-workflow/daily-focus', title: /PM Workflow — Daily Focus/ },
 ] as const;
 
 async function ensureDrawerOpen(page: Page): Promise<void> {

--- a/tests/E2E/tests/navigation.spec.ts
+++ b/tests/E2E/tests/navigation.spec.ts
@@ -13,6 +13,7 @@ test.describe('Feature navigation', () => {
     await expect(page.getByRole('link', { name: 'Open Board Rules Visualiser' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Open Triage UI' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Open Workflow Templates' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Open PM Workflow' })).toBeVisible();
   });
 
   test('home feature cards navigate to the matching feature page', async ({ page }) => {
@@ -24,6 +25,7 @@ test.describe('Feature navigation', () => {
       { linkName: 'Open Board Rules Visualiser', path: '/board-rules', title: /Board Rules Visualiser/ },
       { linkName: 'Open Triage UI', path: '/triage', title: /Triage UI/ },
       { linkName: 'Open Workflow Templates', path: '/workflows', title: /Workflow Templates/ },
+      { linkName: 'Open PM Workflow', path: '/pm-workflow/daily-focus', title: /PM Workflow — Daily Focus/ },
     ] as const;
 
     for (const feature of featureCards) {

--- a/tests/E2E/tests/pm-workflow.spec.ts
+++ b/tests/E2E/tests/pm-workflow.spec.ts
@@ -1,19 +1,44 @@
 import { test, expect } from '@playwright/test';
 import { navigateViaDrawer } from '../fixtures/navigation';
 
-test.describe('PM Workflow Repo Management', () => {
-  test('drawer navigation opens the Repos tab shell', async ({ page }) => {
+test.describe('PM Workflow', () => {
+  test('drawer navigation opens the Daily Focus tab shell', async ({ page }) => {
     await page.goto('/');
 
     await navigateViaDrawer(page, 'PM Workflow');
 
-    await expect(page).toHaveURL(/\/pm-workflow\/repos$/);
-    await expect(page).toHaveTitle(/PM Workflow — Repos/);
+    await expect(page).toHaveURL(/\/pm-workflow\/daily-focus$/);
+    await expect(page).toHaveTitle(/PM Workflow — Daily Focus/);
     await expect(page.getByTestId('pm-workflow-shell')).toBeVisible();
     await expect(page.getByTestId('pm-workflow-tab-strip')).toBeVisible();
-    await expect(page.getByRole('tab', { name: 'Repos' })).toBeVisible();
-    await expect(page.getByTestId('pm-workflow-repos-page')).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Repo Management' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Daily Focus' })).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-daily-focus-page')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Daily Focus' })).toBeVisible();
+  });
+
+  test('daily focus shows occupancy region, empty copy, or a load error', async ({ page }) => {
+    await page.goto('/pm-workflow/daily-focus');
+
+    await expect(page.getByTestId('pm-workflow-shell')).toBeVisible();
+
+    const chromeError = page.getByTestId('pm-workflow-chrome-error');
+    const noBoardAlert = page.getByTestId('pm-workflow-daily-focus-no-board');
+    const occupancyRegion = page.getByTestId('pm-workflow-daily-focus-board-state');
+    const occupancyError = page.getByTestId('pm-workflow-daily-focus-error');
+
+    await expect(chromeError.or(noBoardAlert).or(occupancyRegion).or(occupancyError)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    if (await chromeError.isVisible()) {
+      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      return;
+    }
+
+    if (await occupancyError.isVisible()) {
+      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(occupancyError).toContainText('Unable to load board occupancy');
+    }
   });
 
   test('repos tab shows threshold and exclusion regions or a chrome error', async ({ page }) => {

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -1551,7 +1551,7 @@ public sealed class GitHubServiceTests
                     "node": {
                         "fields": {
                             "nodes": [
-                                { "id": "PVTF_status", "name": "Status", "dataType": "SINGLE_SELECT" },
+                                { "id": "PVTF_status", "name": "Status", "dataType": "SINGLE_SELECT", "options": [ { "id": "option-up-next", "name": "Up Next" }, { "id": "option-todo", "name": "Todo" } ] },
                                 { "id": "PVTF_focus", "name": "Focus Order", "dataType": "NUMBER" }
                             ]
                         },
@@ -1595,6 +1595,9 @@ public sealed class GitHubServiceTests
         // Assert
         Assert.Equal("PVTF_status", result.FieldIds.StatusFieldId);
         Assert.Equal("PVTF_focus", result.FieldIds.FocusOrderFieldId);
+        Assert.Equal(2, result.StatusOptions.Count);
+        Assert.Equal("option-up-next", result.StatusOptions[0].OptionId);
+        Assert.Equal("Todo", result.StatusOptions[1].Name);
         Assert.Single(result.Items);
         Assert.Equal("PVTI_item-one", result.Items[0].ProjectItemId);
         Assert.Equal("Up Next", result.Items[0].Status?.Name);

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -12,7 +12,7 @@ Guides for using SoloDevBoard in the app. Developer and operator material (local
 
 ## Coming later
 
-- Cross-Repo PM Workflow — full PM Mode and Work Mode across four tabs (user guide remains `draft: true`; **Repo Management** is available in the app under **PM Workflow** in the drawer).
+- Cross-Repo PM Workflow — Daily Focus occupancy and Repo Management are in the app; the user guide remains `draft: true` until Backlog and Planning ship.
 
 ## Related repository docs
 

--- a/website/content/docs/pm-workflow.md
+++ b/website/content/docs/pm-workflow.md
@@ -58,7 +58,7 @@ After a board is selected, Daily Focus shows:
 - **Status chips** — one chip per Status option discovered on that board (including empty columns), with the item count. Option identifiers are not hard-coded to any one GitHub project.
 - **Active load** — `Up Next` plus `In Progress` item counts over the persisted **Capacity limit** (default 8).
 
-Board occupancy counts **every** linked card on the selected board. Repository exclusions do not change these counts; they will apply to recommendations when that panel ships.
+Board occupancy counts mapped **Issue** and **Pull Request** cards on the selected board. Notes, draft issues, and redacted items are omitted. Repository exclusions do not change these counts; they will apply to recommendations when that panel ships.
 
 If the catalogue cannot be loaded, an error alert includes **Retry**. An empty board still lists Status chips at zero and explains that there are no items.
 
@@ -85,7 +85,7 @@ The same shared chrome described under Daily Focus appears on this tab.
 
 Until a board is selected, an informational alert explains that other tabs need a board. You can still edit Repo Management settings below.
 
-Board occupancy on Daily Focus counts **every** linked card. Recommendations, backlog queries, and planning candidates will honour repository exclusions.
+Board occupancy on Daily Focus counts mapped Issue and Pull Request cards. Recommendations, backlog queries, and planning candidates will honour repository exclusions.
 
 ### Set planning thresholds
 

--- a/website/content/docs/pm-workflow.md
+++ b/website/content/docs/pm-workflow.md
@@ -49,7 +49,9 @@ Shared chrome on every PM Workflow tab includes:
 
 If GitHub reports linked project boards that cannot be read with your current sign-in (common for private user-owned boards under GitHub App sign-in), a warning appears at the top of the page. See [plan/GITHUB_PROJECTS_V2_ACCESS.md](https://github.com/markheydon/solo-dev-board/blob/main/plan/GITHUB_PROJECTS_V2_ACCESS.md) in the repository.
 
-Until a board is selected, an informational alert explains that Daily Focus needs a planning board. Use the **Repos** tab to keep editing settings meanwhile.
+Until a board is selected, an informational alert points at the **Planning board** dropdown. Occupancy loads as soon as you open Daily Focus when a board is already stored, or as soon as you choose one. Use the **Repos** tab to edit exclusions and thresholds.
+
+A progress bar at the top of the page shows while planning boards are discovered. Switching tabs does not restart that load.
 
 ### Board occupancy and active load
 

--- a/website/content/docs/pm-workflow.md
+++ b/website/content/docs/pm-workflow.md
@@ -5,7 +5,7 @@ weight: 110
 guideStatus: Partially Available
 ---
 
-> ⚠️ **Partial delivery** — Repo Management is available in the app under **PM Workflow** in the navigation drawer. Daily Focus, Backlog Review, and Iteration Planning are not shipped yet. This guide remains a draft until all four tabs match the wireframe; only the sections below describe current behaviour.
+> ⚠️ **Partial delivery** — Daily Focus board occupancy and Repo Management are available in the app under **PM Workflow**. Backlog Review, Iteration Planning, and Daily Focus stall/recommendation panels are not shipped yet. This guide remains a draft until all four tabs match the wireframe; only the sections below describe current behaviour.
 
 ---
 
@@ -16,18 +16,53 @@ The Cross-Repo PM Workflow brings a structured, two-mode operating system into S
 The system is built around two modes of operation:
 
 - **PM Mode** (weekly or fortnightly) — Active curation: review your backlog across all repositories, resolve stalled work, and populate your project board with a realistic set of committed items for the next few days.
-- **Work Mode** (daily) — Execution: the project board is the single pane of glass. Open it, pick the next item, and get things done. The optional Daily Focus view will provide a quick morning nudge on what is most urgent today.
+- **Work Mode** (daily) — Execution: the project board is the single pane of glass. Open it, pick the next item, and get things done. Daily Focus currently shows board occupancy and active load so you can start the day without opening GitHub.
 
 ### What is available now
 
 | Tab | Route | Status |
 |-----|-------|--------|
-| **Repos** | `/pm-workflow/repos` | **Available** — planning board selection, thresholds, and repository exclusions. |
-| Daily Focus | `/pm-workflow/daily-focus` | Placeholder — story [#273](https://github.com/markheydon/solo-dev-board/issues/273). |
+| **Daily Focus** | `/pm-workflow/daily-focus` | **Partial** — Status occupancy chips and active load. Stalled items and recommendations are still planned. |
 | Backlog | `/pm-workflow/backlog` | Placeholder — story [#277](https://github.com/markheydon/solo-dev-board/issues/277). |
 | Planning | `/pm-workflow/planning` | Placeholder — story [#283](https://github.com/markheydon/solo-dev-board/issues/283). |
+| **Repos** | `/pm-workflow/repos` | **Available** — planning board selection, thresholds, and repository exclusions. |
 
-Open **PM Workflow** from the navigation drawer. The hub redirects to **Repos** until Daily Focus ships.
+Open **PM Workflow** from the Home card or the navigation drawer. The hub redirects to **Daily Focus**.
+
+---
+
+## Daily Focus (partial)
+
+Daily Focus is a read-only morning snapshot of the selected planning board. It answers how busy the board is today; stall clocks and ranked recommendations will follow in later stories.
+
+### Accessing
+
+1. Open the navigation drawer, or open **PM Workflow** from Home.
+2. Select **PM Workflow** if you used the drawer.
+3. You land on the **Daily Focus** tab (`/pm-workflow/daily-focus`).
+
+Shared chrome on every PM Workflow tab includes:
+
+- **Planning board** selector — choose a Projects v2 board discovered from your active repositories (same discovery model as Triage and Board Rules).
+- **Status line** — `Repos: N included`, selected board title (when chosen), last refreshed time, and a **Refresh** control to reload board options and the repository catalogue.
+- **Tab strip** — Daily Focus, Backlog, Planning, and Repos.
+
+If GitHub reports linked project boards that cannot be read with your current sign-in (common for private user-owned boards under GitHub App sign-in), a warning appears at the top of the page. See [plan/GITHUB_PROJECTS_V2_ACCESS.md](https://github.com/markheydon/solo-dev-board/blob/main/plan/GITHUB_PROJECTS_V2_ACCESS.md) in the repository.
+
+Until a board is selected, an informational alert explains that Daily Focus needs a planning board. Use the **Repos** tab to keep editing settings meanwhile.
+
+### Board occupancy and active load
+
+After a board is selected, Daily Focus shows:
+
+- **Status chips** — one chip per Status option discovered on that board (including empty columns), with the item count. Option identifiers are not hard-coded to any one GitHub project.
+- **Active load** — `Up Next` plus `In Progress` item counts over the persisted **Capacity limit** (default 8).
+
+Board occupancy counts **every** linked card on the selected board. Repository exclusions do not change these counts; they will apply to recommendations when that panel ships.
+
+If the catalogue cannot be loaded, an error alert includes **Retry**. An empty board still lists Status chips at zero and explains that there are no items.
+
+> **Scope note** — Stalled Up Next items, stalled review pull requests, and the top-three recommended list are tracked on stories [#274](https://github.com/markheydon/solo-dev-board/issues/274)–[#276](https://github.com/markheydon/solo-dev-board/issues/276) and are not shown yet.
 
 ---
 
@@ -37,17 +72,10 @@ Repo Management controls which repositories and which Projects v2 board particip
 
 ### Accessing
 
-1. Open the navigation drawer.
-2. Select **PM Workflow**.
-3. You land on the **Repos** tab (`/pm-workflow/repos`).
+1. Open **PM Workflow**.
+2. Select the **Repos** tab (`/pm-workflow/repos`).
 
-Shared chrome on every PM Workflow tab includes:
-
-- **Planning board** selector — choose a Projects v2 board discovered from your active repositories (same discovery model as Triage and Board Rules).
-- **Status line** — `Repos: N included`, selected board title (when chosen), last refreshed time, and a **Refresh** control to reload board options and the repository catalogue.
-- **Tab strip** — Daily Focus, Backlog, Planning, and Repos (only Repos is functional today).
-
-If GitHub reports linked project boards that cannot be read with your current sign-in (common for private user-owned boards under GitHub App sign-in), a warning appears at the top of the page. See [plan/GITHUB_PROJECTS_V2_ACCESS.md](https://github.com/markheydon/solo-dev-board/blob/main/plan/GITHUB_PROJECTS_V2_ACCESS.md) in the repository.
+The same shared chrome described under Daily Focus appears on this tab.
 
 ### Select a planning board
 
@@ -55,9 +83,9 @@ If GitHub reports linked project boards that cannot be read with your current si
 2. Choose a board title from the list (boards are discovered across active, non-archived repositories).
 3. The selection is saved automatically.
 
-Until a board is selected, an informational alert explains that future tabs need a board. You can still edit Repo Management settings below.
+Until a board is selected, an informational alert explains that other tabs need a board. You can still edit Repo Management settings below.
 
-Board occupancy on the selected board will count **every** linked card when Daily Focus ships. Recommendations, backlog queries, and planning candidates will honour repository exclusions.
+Board occupancy on Daily Focus counts **every** linked card. Recommendations, backlog queries, and planning candidates will honour repository exclusions.
 
 ### Set planning thresholds
 
@@ -65,7 +93,7 @@ Under **Planning thresholds**:
 
 | Field | Default | Purpose |
 |-------|---------|---------|
-| **Capacity limit** | 8 | Maximum combined Up Next + In Progress items for planning warnings (used on the Planning tab when shipped). |
+| **Capacity limit** | 8 | Denominator for Daily Focus active load, and the planned ceiling for Planning warnings. |
 | **Stall days** | 3 | Days before an Up Next item is treated as stalled. |
 | **Neglect days** | 14 | Days before a repository is treated as neglected in backlog views. |
 
@@ -103,11 +131,10 @@ Exclusions persist immediately in browser storage.
 
 The following sections describe the full v1.1.0 feature set. They are **not** available in the app yet.
 
-### Daily Focus
+### Daily Focus (remaining)
 
-A quick morning summary that answers "what should I work on right now?":
+A quick morning summary that will also answer "what should I work on right now?":
 
-- Project board state: item count per status column and current active load.
 - Stalled items: anything in your Up Next column for three or more days.
 - Stalled PR reviews: pull requests in review for three or more days that need a merge, close, or return-to-progress decision.
 - Top three recommended work items, ranked by priority across included repositories.


### PR DESCRIPTION
## Summary of Changes

Add a read-only Daily Focus board snapshot: Status occupancy chips from discovered project options, and active load as Up Next plus In Progress over persisted capacity. Restore a Home card for PM Workflow so it matches the drawer item from PR 394. The hub now lands on Daily Focus.

## Related Issue(s)

Closes #273

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Not captured in this PR. Docs-capture screenshots for Daily Focus remain pending (public-only, light theme).

## Additional Notes

- Occupancy counts mapped Issue and Pull Request cards on the selected board (DEC-029). Notes, draft issues, and redacted items are omitted. Repository exclusions do not apply to these counts.
- Status chips use discovered option names and identifiers; Project #8 option ids are not compiled in.
- Stall clocks and top-three recommendations remain out of scope (#274–#276). Test issue #385 was deferred so it can cover those stories later.
- End-user guide `website/content/docs/pm-workflow.md` stays `draft: true` / partially available.
- Playwright specs assert Daily Focus navigation and occupancy/empty/error copy under placeholder auth.