### PR TITLE
[Chore] Update Aspire to 13.5 and require Aspire skills in Delivery

### DIFF
--- a/.agents/contracts/delivery.md
+++ b/.agents/contracts/delivery.md
@@ -67,7 +67,7 @@ Assume issues created via planning workflows are product-ready. Escalate only wh
 
 Explore the feature area using the `area/` label (see [implement-issue workflow](../workflows/implement-issue.md) for path hints). Identify services, components, and tests to reuse. Produce a touch map of likely files and projects.
 
-Invoke `dotnet-best-practices` for all issues. Invoke `mudblazor` for UI work during the sketch.
+Invoke `dotnet-best-practices` for all issues. Invoke `mudblazor` for UI work during the sketch. Read [`.agents/skills/aspire/SKILL.md`](../skills/aspire/SKILL.md) for all issues (this repo is Aspire-hosted); route to `aspire-orchestration` and `aspire-monitoring` when the AppHost is running or when diagnosing exceptions. Do not invoke `aspire-init` or `aspireify` unless the AppHost is missing or unwired.
 
 #### Step 4: Implementation sketch
 
@@ -158,6 +158,19 @@ Key rules:
 Focus only on work required for the issue.
 
 Avoid scope creep.
+
+#### Aspire runtime
+
+SoloDevBoard is a **.NET Aspire** distributed application. Local orchestration is [`src/SoloDevBoard.AppHost`](../../src/SoloDevBoard.AppHost), not `dotnet run` on the AppHost.
+
+At the start of implement or deliver work, and whenever diagnosing a running app, read [`.agents/skills/aspire/SKILL.md`](../skills/aspire/SKILL.md), then route to [`aspire-orchestration`](../skills/aspire-orchestration/SKILL.md) and [`aspire-monitoring`](../skills/aspire-monitoring/SKILL.md). Leave `aspire-init` and `aspireify` unused unless the AppHost is missing or unwired.
+
+The resource to wait, rebuild, and log is normally **`app`** (`AddProject<…>(AzureName("app"))` in Development).
+
+- On exceptions or unexpected UI, inspect with `aspire describe`, then `aspire otel logs app --search "severity:error"` and `aspire logs app`. Do not guess from a dashboard screenshot alone.
+- After C# or Razor fixes while Aspire is running, run `aspire resource app rebuild` then `aspire wait app`. Do not assume hot reload applied the change. Do not restart the whole AppHost for app-only edits. Re-run `aspire start` only when AppHost model or AppHost code changed.
+- On file locks (`MSB3491` / `CS2012`), run `aspire stop` before a solution rebuild.
+- Do not use `aspire stop --force` unless the user explicitly asked to delete persistent resource data.
 
 ---
 
@@ -253,6 +266,8 @@ Confirm:
 - No obvious architecture violations
 - No obvious coding standard violations
 
+If the AppHost is already running, rebuild the live `app` resource (`aspire resource app rebuild` then `aspire wait app`) so manual testing sees the fix. `dotnet build` / `dotnet test` remain required and are not a substitute for that live rebuild.
+
 Review only files changed by the implementation.
 
 Do not perform a full repository audit.
@@ -272,7 +287,8 @@ When invoked via [`address-pr-review-comments`](../workflows/address-pr-review-c
    - Needs maintainer decision: reply, leave unresolved, and stop with a short list for the user.
 5. If no unresolved threads exist, report "No unresolved review conversations" and stop.
 6. Run scoped tests for changed behaviour, then commit and push to the existing PR branch.
-7. Post one final summary issue comment on the pull request.
+7. If Aspire is running after those fixes, rebuild `app` (`aspire resource app rebuild` then `aspire wait app`) so a live instance matches the branch.
+8. Post one final summary issue comment on the pull request.
 
 Rules:
 
@@ -288,9 +304,10 @@ Rules:
 
 When the user begins manual product testing after implementation (not during the PR review comment loop in §10):
 
-- Do not commit
-- Do not push
-- Apply fixes directly to the working tree
+- Do not commit.
+- Do not push.
+- Apply fixes directly to the working tree.
+- Use the Aspire runtime loop: inspect `aspire otel logs app` / `aspire logs app` on exceptions, then `aspire resource app rebuild` and `aspire wait app` after each C# or Razor fix.
 - Confirm:
 
 ```text

--- a/.agents/skills/_REGISTRY.md
+++ b/.agents/skills/_REGISTRY.md
@@ -40,7 +40,7 @@ Skills not listed as active or optional companion should be removed from `.agent
 SoloDevBoard defines specialised role contracts for PM workflows. These orchestrate skills and enforce quality gates.
 
 - `pm-orchestrator`: GitHub Issues / Project #8 selection → scope validation → technical planning (breakdown-plan) → GitHub issue setup
-- `delivery`: Implementation preflight → code → tests → docs → decision log (if needed) → PR review comment loop
+- `delivery`: Implementation preflight → Aspire runtime (logs, resource rebuild) → code → tests → docs → decision log (if needed) → PR review comment loop
 - `verify`: Quality validation (clean rebuild, package hygiene) → PR creation → issue closure → release impact assessment
 
 **Role contracts:** `.agents/contracts/*.md`  

--- a/.agents/skills/aspire-monitoring/references/monitoring.md
+++ b/.agents/skills/aspire-monitoring/references/monitoring.md
@@ -29,7 +29,9 @@ aspire otel traces [resource] --format Json
 aspire otel spans [resource] --format Json
 aspire otel logs --trace-id <id> --format Json
 aspire otel logs [resource] --search "connection timeout"
-aspire otel spans [resource] --search "/api/products"
+aspire otel traces [resource] --search "/api/products"
+aspire otel logs [resource] --search "severity:error"
+aspire otel spans [resource] --search "@http.method:GET duration:>100"
 aspire logs [resource]
 aspire logs [resource] --search "error"
 ```
@@ -43,6 +45,43 @@ Keep these points in mind:
 - Prefer `--format Json` when another tool or script needs to consume the result, such as a Playwright handoff or endpoint extraction.
 - `[resource]` is optional. Include it to filter results to a single resource; omit it to see all resources.
 - `--search` can be combined with other options like `--format Json`, `--trace-id`, `--limit`, and resource filtering.
+
+## Filtering
+
+The `--search` option filters output by matching text against log content and trace/span content.
+
+- Multiple words are AND'd — all fragments must match.
+- Use `"quoted phrases"` for multi-word fragments: `--search "\"connection timeout\""`.
+- Qualifiers support quoted values: `--search "message:\"connection failed\""`.
+
+### Console Logs (`aspire logs --search`)
+
+Matches against log line text content and resource name. Only free-text is supported (no structured qualifiers).
+
+```bash
+aspire logs redis --search "timeout"
+aspire logs --follow --search "\"connection error\""
+```
+
+### Structured Telemetry (`aspire otel logs/traces/spans --search`)
+
+Supports free-text and structured qualifiers in a single query.
+
+**Free-text** matches against message, resource name, scope, trace/span IDs, severity/status, and all attribute keys/values.
+
+**Structured qualifiers** filter on specific fields with `key:value` syntax:
+
+- Log keys: `severity`, `resource`, `scope`, `message`, `trace-id`, `span-id`, `event`
+- Span/Trace keys: `name`, `resource`, `scope`, `status`, `kind`, `trace-id`, `span-id`, `duration`
+- Custom attributes: `@http.method:GET`, `@db.system:redis`
+- Negation: `-severity:debug`, `-@db.system:redis`
+- Comparison: `duration:>100`, `duration:>=50`
+
+```bash
+aspire otel logs --search "severity:error \"connection failed\""
+aspire otel spans --search "@http.method:GET duration:>100 status:error"
+aspire otel logs --search "resource:api -severity:debug"
+```
 
 ## Scenario: I Need A Sharable Diagnostics Bundle
 

--- a/.agents/skills/dotnet-inspect/SKILL.md
+++ b/.agents/skills/dotnet-inspect/SKILL.md
@@ -1,120 +1,33 @@
 ---
 name: dotnet-inspect
-description: "Query .NET APIs across NuGet packages, platform libraries, and local files. Search for types, list API surfaces, compare and diff versions, find extension methods and implementors. Use whenever you need to answer questions about .NET library contents."
+description: Find evidence for .NET packages, platform libraries, assemblies, APIs, dependencies, SourceLink/source, and API version diffs.
 ---
 
 # dotnet-inspect
 
-Query .NET library APIs — the same commands work across NuGet packages, platform libraries (System.*, Microsoft.AspNetCore.*), and local .dll/.nupkg files.
+Use dotnet-inspect for evidence instead of guesses about .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/source, or version-to-version API changes.
 
-## Quick Decision Tree
-
-- **Code broken?** → `diff --package Foo@old..new` first, then `member --oneline`
-- **Need API surface?** → `member Type --package Foo --oneline` (token-efficient)
-- **Need signatures?** → `member Type --package Foo -m Method` (default shows full signatures + docs)
-- **Need source/IL?** → `member Type --package Foo -m Method -v:d` (adds Source, Lowered C#, IL)
-- **Need constructors?** → `member 'Type<T>' --package Foo -m .ctor` (use `<T>` not `<>`)
-- **Need all overloads?** → `member Type --package Foo --select` (shows `Name:N` indices)
-
-## When to Use This Skill
-
-- **"What types are in this package?"** — `type` discovers types (terse), `find` searches by pattern
-- **"What's the API surface?"** — `type` for discovery, `member` for detailed inspection (docs on)
-- **"What changed between versions?"** — `diff` classifies breaking/additive changes
-- **"This code uses an old API — fix it"** — `diff` the old..new version, then `member --oneline` to see the new API
-- **"What extends this type?"** — `extensions` finds extension methods/properties
-- **"What implements this interface?"** — `implements` finds concrete types
-- **"What does this type depend on?"** — `depends` walks the type hierarchy upward
-- **"What version/metadata does this have?"** — `package` and `library` inspect metadata
-- **"Show me something cool"** — `demo` runs curated showcase queries
-
-## Key Patterns
-
-Use `--oneline` as the default for scanning — it works on `type`, `member`, `find`, `diff`, and `implements`:
-
-```bash
-dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json --oneline  # scan members
-dnx dotnet-inspect -y -- type --package System.Text.Json --oneline                   # scan types
-dnx dotnet-inspect -y -- diff --package System.CommandLine@2.0.0-beta4.22272.1..2.0.3 --oneline  # triage changes
-```
-
-Use `--shape` to understand a type's hierarchy and surface at a glance:
-
-```bash
-dnx dotnet-inspect -y -- type 'HashSet<T>' --platform System.Collections --shape
-```
-
-Use `diff` first when fixing broken code — `--oneline` for triage, then full detail on specific types:
-
-```bash
-dnx dotnet-inspect -y -- diff --package System.CommandLine@2.0.0-beta4.22272.1..2.0.3 --oneline  # what changed?
-dnx dotnet-inspect -y -- diff -t Command --package System.CommandLine@2.0.0-beta4.22272.1..2.0.3  # detail on Command
-dnx dotnet-inspect -y -- member Command --package System.CommandLine@2.0.3 --oneline              # new API surface
-```
-
-## Search Scope
-
-Search commands (`find`, `extensions`, `implements`, `depends`) use scope flags:
-
-- **(no flags)** — platform frameworks + Microsoft.Extensions.AI
-- **`--platform`** — all platform frameworks
-- **`--extensions`** — curated Microsoft.Extensions.* packages
-- **`--aspnetcore`** — curated Microsoft.AspNetCore.* packages
-- **`--package Foo`** — specific NuGet package (combinable with scope flags)
-
-`type`, `member`, `library`, `diff` accept `--platform <name>` as a string for a specific platform library.
-
-## Command Reference
-
-| Command | Purpose |
-| ------- | ------- |
-| `type` | **Discover types** — terse output, no docs, use `--shape` for hierarchy |
-| `member` | **Inspect members** — docs on by default, supports dotted syntax (`-m Type.Member`) |
-| `find` | Search for types by glob pattern across any scope |
-| `diff` | Compare API surfaces between versions — breaking/additive classification |
-| `extensions` | Find extension methods/properties for a type |
-| `implements` | Find types implementing an interface or extending a base class |
-| `depends` | Walk the type dependency hierarchy upward (interfaces, base classes) |
-| `package` | Package metadata, files, versions, dependencies, `search` for NuGet discovery |
-| `library` | Library metadata, symbols, references, dependencies |
-| `demo` | Run curated showcase queries — list, invoke, or feeling-lucky |
-
-## Output Limiting
-
-**Do not pipe output through `head`, `tail`, or `Select-Object`.** The tool has built-in line limiting that preserves headers and formatting:
-
-```bash
-dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json --oneline -10  # first 10 lines
-dnx dotnet-inspect -y -- find "*Logger*" -n 5                                            # first 5 lines
-dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -v:q -s Methods  # select specific section
-```
-
-- **`-n N` or `-N`** — line limit, like `head`. Keeps headers, truncates cleanly.
-- **`-s Section`** — show only a specific section (glob-capable). Use `-s` alone to list available sections.
-- **`-v:q`** — quiet verbosity for compact summary output.
-
-## Key Syntax
-
-- **Generic types** need quotes: `'Option<T>'`, `'IEnumerable<T>'`
-- **Use `<T>` not `<>`** for generic types — `"Option<>"` resolves to the abstract base, `'Option<T>'` resolves to the concrete generic with constructors
-- **`type` uses `-t`** for type filtering, **`member` uses `-m`** for member filtering (not `--filter`)
-- **Dotted syntax** for `member`: `-m JsonSerializer.Deserialize`
-- **Diff ranges** use `..`: `--package System.Text.Json@9.0.0..10.0.0`
-- **Signatures** include `params` and default values from metadata
-- **Derived types** only show their own members — query the base type too (e.g., `RootCommand` inherits `Add()` and `SetAction()` from `Command`)
-
-## Installation
-
-Use `dnx` (like `npx`). Always use `-y` and `--` to prevent interactive prompts:
+Invoke with `dnx` (like `npx`); always pass `-y` and `--` to avoid interactive prompts:
 
 ```bash
 dnx dotnet-inspect -y -- <command>
 ```
 
-## Full Documentation
-
-For comprehensive syntax, edge cases, and the flag compatibility matrix:
+This bundled skill is intentionally only a bootstrapper. For non-trivial work, first run the version-matched embedded guide. It always matches the installed tool, so prefer it whenever commands, output modes, section names, or workflow guidance differ:
 
 ```bash
-dnx dotnet-inspect -y -- llmstxt
+dnx dotnet-inspect -y -- skill
 ```
+
+## Seed commands
+
+| Goal | Command |
+| ---- | ------- |
+| Find where an API lives | `find Pattern` |
+| Inspect types or members | `type Type --package Foo`, then `member Type --package Foo` |
+| Compare versions | `diff --package Foo@old..new --breaking` |
+| Inspect package or library signals | `package Foo -S Signals` or `library Foo -S Signals` |
+| Locate source or implementation | `source Type --package Foo` or `member Type Member:1 -S "Decompiled Source"` |
+| Explore relationships | `depends Type`, `extensions Type`, `implements Interface` |
+
+After `find`, reuse the package, library, or platform scope it reports. Quote generic type names such as `'List<T>'`; use `<T>`, not `<>`.

--- a/.agents/skills/repo-pm-feature-workflow/SKILL.md
+++ b/.agents/skills/repo-pm-feature-workflow/SKILL.md
@@ -20,7 +20,7 @@ Run a deterministic feature workflow so the user can act as product manager whil
 5. Create or update GitHub issues with `repo-github-issues` (use `repo-github-gh-cli` for bulk changes), then sync each issue to the project board with `repo-github-project` skill.
 6. Trigger quality planning with `breakdown-test`.
 7. Run implementation preflight (load context, codebase discovery, sketch). For `size/l+` or enablers, consider standalone `preflight-issue` first.
-8. Implement using repository standards (`dotnet-best-practices`, and `mudblazor` for UI work), with MudBlazor components and utility classes preferred over custom CSS or raw HTML.
+8. Implement using repository standards (`aspire` plus `dotnet-best-practices`, and `mudblazor` for UI work), with MudBlazor components and utility classes preferred over custom CSS or raw HTML. Rebuild the live Aspire `app` resource after C# or Razor fixes; inspect Aspire logs on exceptions.
 9. Record architectural decisions via `repo-decision-log` when introduced.
 10. Update user-facing documentation and index links.
 11. Verify completion gates and then close issue states.

--- a/.agents/workflows/README.md
+++ b/.agents/workflows/README.md
@@ -40,11 +40,11 @@ Orchestration, rituals, and step-by-step guidance live in [`plan/PM_RUNBOOK.md`]
 |----------|--------------------------|----------|----------------|-----------------|
 | [daily-start](daily-start.md) | "Run the daily start workflow" | `pm-orchestrator` | `repo-github-project` (optional) | Session Start |
 | [plan-next-issue](plan-next-issue.md) | "Plan the next item" | `pm-orchestrator` | `breakdown-plan`, `breakdown-test`, `repo-github-issues`, `repo-github-project` | Stage 1: Planning |
-| [preflight-issue](preflight-issue.md) | "Preflight issue #N" | `delivery` | `dotnet-best-practices`, `mudblazor` (on demand) | Stage 2: Implementation (preflight) |
-| [deliver-issue](deliver-issue.md) | "Deliver issue #N" | `delivery`, `verify` | `dotnet-best-practices`, `mudblazor`, etc. (on demand) | Stage 2–3: Delivery happy path |
-| [implement-issue](implement-issue.md) | "Implement issue #N" | `delivery` | `dotnet-best-practices`, `mudblazor`, etc. (on demand) | Stage 2: Implementation |
+| [preflight-issue](preflight-issue.md) | "Preflight issue #N" | `delivery` | `aspire`, `dotnet-best-practices`, `mudblazor` (on demand) | Stage 2: Implementation (preflight) |
+| [deliver-issue](deliver-issue.md) | "Deliver issue #N" | `delivery`, `verify` | `aspire`, `dotnet-best-practices`, `mudblazor`, etc. | Stage 2–3: Delivery happy path |
+| [implement-issue](implement-issue.md) | "Implement issue #N" | `delivery` | `aspire`, `dotnet-best-practices`, `mudblazor`, etc. | Stage 2: Implementation |
 | [verify-and-create-pr](verify-and-create-pr.md) | "Verify issue #N", "Create PR for issue #N" | `verify` | — | Stage 3: Verify and PR |
-| [address-pr-review-comments](address-pr-review-comments.md) | "Address PR review comments on PR #N" | `delivery` | — | PR Review Comment Loop |
+| [address-pr-review-comments](address-pr-review-comments.md) | "Address PR review comments on PR #N" | `delivery` | `aspire` (when AppHost is running) | PR Review Comment Loop |
 | [pm-progress-review](pm-progress-review.md) | "Run the PM progress review" | `pm-orchestrator` | — | Progress Review Rhythm |
 | [sync-status-labels](sync-status-labels.md) | "Clean up status labels", `/sync-status-labels` | `repo-github-gh-cli` | — | Board Hygiene Audit |
 | [code-review](code-review.md) | "Code review PR #N" | `code-review` | — | Stage 3b: Independent code review |

--- a/.agents/workflows/address-pr-review-comments.md
+++ b/.agents/workflows/address-pr-review-comments.md
@@ -2,6 +2,7 @@
 
 **Contract:** [`.agents/contracts/delivery.md`](../contracts/delivery.md) (PR review comment loop section)
 **Runbook:** [`plan/PM_RUNBOOK.md`](../../plan/PM_RUNBOOK.md) — PR Review Comment Loop
+**Skills (required when the AppHost is running):** `aspire`, `aspire-orchestration`, `aspire-monitoring`
 
 ## Easy-to-miss specifics
 
@@ -18,6 +19,7 @@
 - Post one final summary issue comment on the pull request once all addressed threads are handled.
 - This path is exempt from the Delivery Testing Phase (commit and push without waiting for manual test acceptance).
 - Re-run scoped tests after fixes; push to the existing PR branch.
+- If Aspire is running after those fixes, `aspire resource app rebuild` then `aspire wait app`. On exceptions, use `aspire otel logs app` and `aspire logs app`.
 
 ## Invocation
 

--- a/.agents/workflows/deliver-issue.md
+++ b/.agents/workflows/deliver-issue.md
@@ -3,6 +3,7 @@
 **Contracts:** [`.agents/contracts/delivery.md`](../contracts/delivery.md), [`.agents/contracts/verify.md`](../contracts/verify.md)
 **Runbook:** [`plan/PM_RUNBOOK.md`](../../plan/PM_RUNBOOK.md) — Stage 2 and Stage 3 (happy path)
 **Skills (on demand):** Same as `implement-issue` (via Delivery contract)
+**Skills (required):** `aspire` (router), then `aspire-orchestration` and `aspire-monitoring` when running or diagnosing the AppHost
 
 ## Purpose
 
@@ -14,6 +15,7 @@ Orchestrate the delivery happy path in one session: preflight (when required), i
 - Do not implement issues with `status/blocked` or `status/ice-box` — escalate or re-queue first.
 - **Preflight pause:** if `size/m`, `size/l`, `size/xl`, or `type/enabler`, and this session has not already produced **Preflight Complete**, run [`.agents/workflows/preflight-issue.md`](preflight-issue.md) only and stop. If preflight already ran in this chat, treat the proceed gate as satisfied.
 - Otherwise run [`.agents/workflows/implement-issue.md`](implement-issue.md) (includes mandatory preflight; `size/xs`, `size/s`, and `type/bug` auto-continue per the Delivery contract).
+- Follow the Delivery contract **Aspire runtime** section: this repo is Aspire-hosted; rebuild `app` after live C# or Razor fixes; read Aspire logs on exceptions.
 - When Delivery reports **Implementation Complete**, run [`.agents/workflows/verify-and-create-pr.md`](verify-and-create-pr.md).
 - Stop after verify. Do not continue into `/code-review` in this session.
 - Keep `/preflight-issue`, `/implement-issue`, and `/verify-and-create-pr` available for split workflows.

--- a/.agents/workflows/implement-issue.md
+++ b/.agents/workflows/implement-issue.md
@@ -3,6 +3,7 @@
 **Contract:** [`.agents/contracts/delivery.md`](../contracts/delivery.md)
 **Runbook:** [`plan/PM_RUNBOOK.md`](../../plan/PM_RUNBOOK.md) — Stage 2: Implementation
 **Skills (on demand):** `dotnet-best-practices`, `mudblazor`, `csharp-xunit`, `csharp-docs`, `repo-decision-log`, `documentation-writer`
+**Skills (required):** `aspire` (router), then `aspire-orchestration` and `aspire-monitoring` when running or diagnosing the AppHost
 
 ## Easy-to-miss specifics
 
@@ -11,11 +12,12 @@
 - Parse the `## Implementation References` section from the issue body.
 - For UI work, read the linked wireframe from [`plan/wireframes/`](../../plan/wireframes/).
 - Invoke `dotnet-best-practices` during preflight for all issues; invoke `mudblazor` for UI issues.
+- This repo is Aspire-hosted. Read the `aspire` skill at the start of implementation. After C# or Razor fixes while the AppHost is running, `aspire resource app rebuild` then `aspire wait app`. On exceptions, use `aspire otel logs app` and `aspire logs app`.
 - Apply the tiered proceed gate: auto-continue for `size/xs`, `size/s`, and `type/bug`; pause for `size/m+` and all `type/enabler` issues.
 - After the proceed gate, set `status/in-progress` on the issue (see Mark Work Started in the Delivery contract) before creating the feature branch.
 - Do not implement issues with `status/blocked` or `status/ice-box` — escalate or re-queue first.
 - Do not set `status/in-progress` during standalone `/preflight-issue`.
-- Consult other skills when relevant — do not require reading every skill up front.
+- Consult other skills when relevant — do not require reading every skill up front, except the required Aspire skills above.
 
 ### Area label → codebase hints
 

--- a/.agents/workflows/preflight-issue.md
+++ b/.agents/workflows/preflight-issue.md
@@ -3,11 +3,13 @@
 **Contract:** [`.agents/contracts/delivery.md`](../contracts/delivery.md) (Implementation Preflight section only)
 **Runbook:** [`plan/PM_RUNBOOK.md`](../../plan/PM_RUNBOOK.md) — Stage 2: Implementation (preflight sub-step)
 **Skills (on demand):** `dotnet-best-practices`, `mudblazor`
+**Skills (required):** `aspire` (this repo is Aspire-hosted; load during preflight)
 
 ## Easy-to-miss specifics
 
 - Run preflight only — do not create a feature branch, write code, or change issue labels.
 - Follow Implementation Preflight in the Delivery contract (load context, validate readiness, codebase discovery, sketch).
+- Read the `aspire` skill during preflight. SoloDevBoard runs locally via `src/SoloDevBoard.AppHost`.
 - Area label → codebase hints: see [implement-issue workflow](implement-issue.md).
 - Always pause after the **Preflight Complete** output, even for `size/xs` and `size/s` issues.
 - End with: "Ready to implement — run `/implement-issue` or 'Implement issue #N'."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,8 @@ The **`.agents/`** directory holds agent-agnostic AI collaboration artefacts —
 
 Canonical skills live in [`.agents/skills/`](.agents/skills/). See [`.agents/skills/_REGISTRY.md`](.agents/skills/_REGISTRY.md) for the active set, optional companions, and default workflow order.
 
+This repository is a **.NET Aspire** distributed application (`src/SoloDevBoard.AppHost`). Delivery, implement, and live-debug work **must** load the `aspire` skill (then `aspire-orchestration` and `aspire-monitoring` as needed). Do not load every skill up front for PM-only work.
+
 ### Execution gates
 
 1. Do not start coding before planning and issue creation are complete.
@@ -240,7 +242,7 @@ Canonical skills live in [`.agents/skills/`](.agents/skills/). See [`.agents/ski
 - **Contracts:** [`.agents/contracts/`](.agents/contracts/) (role boundaries)
 - **Tool mirrors:** [`.github/prompts/`](.github/prompts/) and [`.cursor/commands/`](.cursor/commands/) — thin pointers only; never duplicate workflow content
 
-Consult the workflow or contract index when entering a PM or delivery mode. Do not load every skill up front.
+Consult the workflow or contract index when entering a PM or delivery mode. Do not load every skill up front for PM-only work. Delivery must still load Aspire skills as above.
 
 ---
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,10 +9,10 @@
   <!-- UI -->
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="1.7.1" />
-    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ContainerRegistry" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.5.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ContainerRegistry" Version="13.5.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="13.5.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="13.5.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.6.0" />
     <PackageVersion Include="MessagePack" Version="3.1.8" />
     <PackageVersion Include="MudBlazor" Version="9.8.0" />

--- a/nuget.config
+++ b/nuget.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />

--- a/plan/ASPIRE_MULTI_PROCESS_FINDINGS.md
+++ b/plan/ASPIRE_MULTI_PROCESS_FINDINGS.md
@@ -324,7 +324,7 @@ A greenfield “Aspire from day one” would have started at step 2 with an empt
 
 - Current AppHost: `src/SoloDevBoard.AppHost/AppHost.cs`.
 - ADR-0016 / DEC-013, DEC-015, DEC-017.
-- Aspire 13.4.6 docs (CLI `aspire docs`): Azure Functions hosting, runtime configuration, supported triggers, Azure Container App Jobs.
+- Aspire 13.4.6 docs (CLI `aspire docs`): Azure Functions hosting, runtime configuration, supported triggers, Azure Container App Jobs. Versions in this note were current at the time of writing (2026-08-14); the repo now targets Aspire 13.5.0.
 - Package discovery: `Aspire.Hosting.Azure.Functions` 13.4.6 via `aspire integration search azure-functions`.
 
 ---

--- a/plan/CURSOR_CLOUD.md
+++ b/plan/CURSOR_CLOUD.md
@@ -12,7 +12,8 @@ Cursor Cloud agents often default to **draft** PRs, `cursor/…` branch names, a
 
 ## Toolchain
 
-- The .NET SDK pinned by `global.json` (`10.0.300`) is installed at `~/.dotnet`; the Aspire CLI (`13.4.6`, matching `Aspire.AppHost.Sdk`) is installed as a global tool at `~/.dotnet/tools`. Both are on `PATH` via `~/.bashrc`. Non-login shells (for example `bash -c`) do not source `~/.bashrc`, so invoke the SDK with the absolute path `~/.dotnet/dotnet` when `dotnet`/`aspire` are not already on `PATH`.
+- The .NET SDK pinned by `global.json` (`10.0.300`) is installed at `~/.dotnet`; the Aspire CLI (`13.5.0`, matching `Aspire.AppHost.Sdk`) is installed as a global tool at `~/.dotnet/tools`. Both are on `PATH` via `~/.bashrc`. Non-login shells (for example `bash -c`) do not source `~/.bashrc`, so invoke the SDK with the absolute path `~/.dotnet/dotnet` when `dotnet`/`aspire` are not already on `PATH`.
+- The AppHost leaves `AspireUseCliBundle` at the SDK default (`false`). Building the AppHost may emit `ASPIRE010`; that is expected and is not a prompt to enable the CLI bundle.
 - The startup update script only runs `dotnet restore SoloDevBoard.slnx` (this also restores the AppHost). Building, testing, linting, and running are left to you.
 
 ---

--- a/plan/PM_RUNBOOK.md
+++ b/plan/PM_RUNBOOK.md
@@ -155,7 +155,9 @@ Implement issue #[number]
 **What it does:**
 - Invokes the **Delivery** contract ([`.agents/contracts/delivery.md`](../.agents/contracts/delivery.md))
 - Runs **implementation preflight** before coding (load context, codebase discovery, touch map, proceed gate)
+- Loads Aspire skills (`aspire`, then `aspire-orchestration` / `aspire-monitoring` when the AppHost is running)
 - Writes code following layered architecture (Domain/Application/Infrastructure/App)
+- After C# or Razor fixes while Aspire is running, rebuilds the live `app` resource (`aspire resource app rebuild` then `aspire wait app`) and inspects `aspire otel logs` / `aspire logs` on exceptions
 - Creates xUnit v3 tests (NSubstitute, `Assert.*`, correct naming)
 - Updates user-facing docs in `website/content/docs/` if needed
 - Records architectural decisions via `repo-decision-log` / `plan/DECISIONS.md` when needed (do not create new `adr/` files)
@@ -447,6 +449,7 @@ START
 **Responsibilities:**
 - Runs implementation preflight (context, codebase discovery, touch map, proceed gate)
 - Sets `status/in-progress` on the implementing issue (Roadmap Sync updates Project #8)
+- Loads Aspire skills and follows the live AppHost loop (logs, `app` resource rebuild)
 - Implements code (Domain/Application/Infrastructure/App layers)
 - Creates xUnit v3 tests (NSubstitute, `Assert.*`)
 - Updates user-facing docs
@@ -802,6 +805,6 @@ Take the next backlog item and run the full PM feature workflow
 
 ---
 
-**Last Updated:** March 5, 2026 (delivery loop: `/deliver-issue`, verify hygiene, review threads)  
+**Last Updated:** August 19, 2026 (Aspire runtime required for Delivery)  
 **Version:** 1.0  
 **Maintained by:** Product Manager (you)

--- a/src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
+++ b/src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Azure.AppContainers" />


### PR DESCRIPTION
## Summary of Changes

Bump the AppHost and Azure hosting packages from Aspire 13.4.6 to 13.5.0, and make Delivery treat SoloDevBoard as an Aspire-hosted app so agents load Aspire skills, inspect logs, and rebuild the live `app` resource after C# or Razor fixes.

Official Aspire agent skills under `.agents/skills/aspire*` were refreshed with `aspire agent init`. Repo-specific Delivery, workflow, and planning guidance was not folded into those upstream skill files.

## Related Issue(s)

Ad-hoc maintenance with no tracking issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [ ] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [ ] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- AppHost API usage did not need a 13.5 migration. Experimental APIs and `AspireUseCliBundle` were left unset.
- Building the AppHost may emit `ASPIRE010` (CLI bundle opt-out). That is expected; see `plan/CURSOR_CLOUD.md`.
- Tests were not added: this is a package bump plus agent/operator documentation.
- Tests were not re-run as part of opening this PR; CI on the branch is the quality gate.
- `aspire doctor` reported only host-environment warnings (`certutil` / VS Code extension), not AppHost failures.