### PR TITLE
[Chore] Fix Playwright E2E CI apt hangs and speed up feedback (#404)

### DIFF
--- a/.github/instructions/github-actions-ci-cd-best-practices.instructions.md
+++ b/.github/instructions/github-actions-ci-cd-best-practices.instructions.md
@@ -39,6 +39,7 @@ Use this instruction for authoring and reviewing workflows in this repository.
 - Ensure pull request workflows also run for Dependabot-authored pull requests to `main`.
 - Fail fast on build/test failures.
 - Surface test outputs clearly in logs and artefacts when useful.
+- Playwright E2E jobs (`e2e-pat`, `e2e-hosted`) must use `npx playwright install chromium` on `ubuntu-latest` — do **not** use `--with-deps` (avoids `apt` mirror hangs). Use the official `mcr.microsoft.com/playwright` job container only if Chromium fails to launch on the runner.
 
 ## Deployment Safety
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
   e2e-pat:
     name: End-to-End (Playwright, PAT mode)
     runs-on: ubuntu-latest
-    needs: build-and-test
     timeout-minutes: 15
 
     steps:
@@ -92,12 +91,6 @@ jobs:
           dotnet restore SoloDevBoard.slnx
           dotnet build src/App/SoloDevBoard.App/SoloDevBoard.App.csproj --no-restore
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('tests/E2E/package-lock.json') }}
-
       - name: Install npm packages
         working-directory: tests/E2E
         env:
@@ -108,7 +101,7 @@ jobs:
         working-directory: tests/E2E
         env:
           NODE_OPTIONS: --dns-result-order=ipv4first
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Run Playwright E2E tests (PAT mode)
         env:
@@ -160,7 +153,6 @@ jobs:
   e2e-hosted:
     name: End-to-End (Playwright, Hosted mode)
     runs-on: ubuntu-latest
-    needs: build-and-test
     timeout-minutes: 15
 
     steps:
@@ -186,12 +178,6 @@ jobs:
           dotnet restore SoloDevBoard.slnx
           dotnet build src/App/SoloDevBoard.App/SoloDevBoard.App.csproj --no-restore
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('tests/E2E/package-lock.json') }}
-
       - name: Install npm packages
         working-directory: tests/E2E
         env:
@@ -202,7 +188,7 @@ jobs:
         working-directory: tests/E2E
         env:
           NODE_OPTIONS: --dns-result-order=ipv4first
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Run Playwright E2E tests (Hosted mode)
         env:

--- a/tests/E2E/README.md
+++ b/tests/E2E/README.md
@@ -110,9 +110,11 @@ Images are written to `website/static/images/<feature-slug>/`. See [DOCS_STRATEG
 
 ## CI
 
-Two jobs in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) run Playwright against placeholder auth configuration:
+Two jobs in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) run Playwright against placeholder auth configuration. They start in parallel with **Build and Test** (no `needs` dependency) so Chromium setup overlaps unit tests.
 
 - **`e2e-pat`** — full suite with PAT mode (`E2E_AUTH_MODE=pat`).
 - **`e2e-hosted`** — hosted login-gate suite (`auth-entry-hosted.spec.ts`) with placeholder GitHub App credentials and no live OAuth.
+
+Both jobs start the app with `dotnet run` on HTTP **port 5080** (not Aspire on 5074). CI installs Chromium with `npx playwright install chromium` only — it does **not** use `--with-deps`, so GitHub-hosted runners never call `apt` for browser OS packages. Local development should still use `npx playwright install --with-deps chromium` so system libraries are present on your machine.
 
 Both jobs capture application logs separately from Playwright output.

--- a/tests/E2E/playwright.config.ts
+++ b/tests/E2E/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: 1,
+  workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI ? 'github' : 'list',
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5080',


### PR DESCRIPTION
## Summary of Changes

Stop Playwright E2E jobs hanging on `apt` during `npx playwright install --with-deps chromium` by installing Chromium only (`npx playwright install chromium`) on `ubuntu-latest`. Run `e2e-pat` and `e2e-hosted` in parallel with **Build and Test**, and use two Playwright workers on CI for faster feedback. Document the approach and keep the official Playwright Docker image as a documented fallback only.

## Related Issue(s)

Closes #404

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [ ] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — CI workflow and E2E developer docs only.

## Additional Notes

### Why not the official Playwright Docker image?

The original issue proposed `mcr.microsoft.com/playwright`. After reviewing Playwright’s CI and Docker docs, `ubuntu-latest` + `install chromium` (no `--with-deps`) is faster on GitHub-hosted runners while still avoiding `apt`. The Docker image skips `apt` but adds a multi-GB pull per job. See the **Approach decision** section on #404 for the full comparison table.

### Changes

- `.github/workflows/ci.yml`: remove `--with-deps`, drop `needs: build-and-test` on E2E jobs.
- `tests/E2E/playwright.config.ts`: `workers: process.env.CI ? 2 : undefined`.
- `tests/E2E/README.md` and GHA instructions: document CI vs local install and 5080 vs 5074.

CI must confirm both `e2e-pat` and `e2e-hosted` pass before merge.

Made with [Cursor](https://cursor.com)