### PR TITLE
[Chore] Opt AppHost into the Aspire CLI bundle

### DIFF
--- a/.github/instructions/github-actions-ci-cd-best-practices.instructions.md
+++ b/.github/instructions/github-actions-ci-cd-best-practices.instructions.md
@@ -50,6 +50,7 @@ Use this instruction for authoring and reviewing workflows in this repository.
 - Include rollback-aware operational guidance in deployment comments or documentation.
 - CD uses two tiers via `.github/workflows/cd.yml` and reusable `.github/workflows/aspire-deploy.yml` (DEC-021): **staging** (push to `main`, GitHub App), **production** (push tag `v*`, GitHub App, required reviewers). PAT mode is local or self-hoster `aspire deploy` only — not a hosted CD tier.
 - Production CD uses `aspire deploy` from `SoloDevBoard.AppHost` with OIDC Azure login and `Parameters__*` environment variables for AppHost secrets.
+- The AppHost uses the Aspire CLI bundle (`AspireUseCliBundle=true`). Install Aspire CLI `13.5.0` (matching `Aspire.AppHost.Sdk`) **before** `dotnet build` in deploy and validate workflows: `curl -sSL https://aspire.dev/install.sh | bash -s -- --version 13.5.0` and add `$HOME/.aspire/bin` to `PATH`. General `ci.yml` builds rely on the SDK `dnx` fallback when no CLI is installed.
 - End-user docs publish to GitHub Pages on `v*` tags only (`hugo-deploy.yml`); pull requests validate Hugo builds without publishing (`hugo-validate.yml`).
 - Use `aspire deploy --list-steps --non-interactive` in validation workflows to prove the deployment model without provisioning Azure resources. Validate both `Staging` and `Production` Aspire environments.
 

--- a/.github/workflows/aspire-deploy-validate.yml
+++ b/.github/workflows/aspire-deploy-validate.yml
@@ -36,15 +36,15 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Install Aspire CLI
+        run: |
+          curl -sSL https://aspire.dev/install.sh | bash -s -- --version 13.5.0
+          echo "$HOME/.aspire/bin" >> "$GITHUB_PATH"
+
       - name: Restore and build solution
         run: |
           dotnet restore SoloDevBoard.slnx
           dotnet build SoloDevBoard.slnx --no-restore --configuration Release
-
-      - name: Install Aspire CLI
-        run: |
-          curl -sSL https://aspire.dev/install.sh | bash
-          echo "$HOME/.aspire/bin" >> "$GITHUB_PATH"
 
       - name: Validate Aspire deployment steps
         run: aspire deploy --list-steps --apphost src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj --environment ${{ matrix.aspire_environment }} --non-interactive

--- a/.github/workflows/aspire-deploy.yml
+++ b/.github/workflows/aspire-deploy.yml
@@ -52,15 +52,15 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Install Aspire CLI
+        run: |
+          curl -sSL https://aspire.dev/install.sh | bash -s -- --version 13.5.0
+          echo "$HOME/.aspire/bin" >> "$GITHUB_PATH"
+
       - name: Restore and build solution
         run: |
           dotnet restore SoloDevBoard.slnx
           dotnet build SoloDevBoard.slnx --no-restore --configuration Release
-
-      - name: Install Aspire CLI
-        run: |
-          curl -sSL https://aspire.dev/install.sh | bash
-          echo "$HOME/.aspire/bin" >> "$GITHUB_PATH"
 
       - name: List Aspire deployment steps
         run: aspire deploy --list-steps --apphost src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj --environment ${{ inputs.aspire_environment }} --non-interactive

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ Before you begin, ensure you have the following installed:
 |---|---|---|
 | [.NET SDK](https://dotnet.microsoft.com/download/dotnet/10.0) | 10.0 or later | Required to build and run the application |
 | Git | Any recent version | Required to clone the repository |
-| Aspire CLI | Latest | Required for local orchestration via AppHost |
+| Aspire CLI | 13.5.0 (match `Aspire.AppHost.Sdk`) | Required for local orchestration via AppHost; install with `curl -sSL https://aspire.dev/install.sh \| bash -s -- --version 13.5.0` or `dotnet tool install -g Aspire.Cli --version 13.5.0` |
 | A GitHub account | — | Required for GitHub API access |
 | A GitHub Personal Access Token (PAT) **or** GitHub App | — | Required for API authentication (see below) |
 

--- a/plan/CURSOR_CLOUD.md
+++ b/plan/CURSOR_CLOUD.md
@@ -13,7 +13,7 @@ Cursor Cloud agents often default to **draft** PRs, `cursor/…` branch names, a
 ## Toolchain
 
 - The .NET SDK pinned by `global.json` (`10.0.300`) is installed at `~/.dotnet`; the Aspire CLI (`13.5.0`, matching `Aspire.AppHost.Sdk`) is installed as a global tool at `~/.dotnet/tools`. Both are on `PATH` via `~/.bashrc`. Non-login shells (for example `bash -c`) do not source `~/.bashrc`, so invoke the SDK with the absolute path `~/.dotnet/dotnet` when `dotnet`/`aspire` are not already on `PATH`.
-- The AppHost leaves `AspireUseCliBundle` at the SDK default (`false`). Building the AppHost may emit `ASPIRE010`; that is expected and is not a prompt to enable the CLI bundle.
+- The AppHost sets `AspireUseCliBundle=true`, so Dashboard and DCP come from the CLI bundle. Cloud already installs Aspire CLI `13.5.0`; keep it aligned with `Aspire.AppHost.Sdk` when upgrading.
 - The startup update script only runs `dotnet restore SoloDevBoard.slnx` (this also restores the AppHost). Building, testing, linting, and running are left to you.
 
 ---

--- a/plan/DECISIONS.md
+++ b/plan/DECISIONS.md
@@ -150,6 +150,8 @@ A formal migration to GitHub Spec Kit is planned — see [`plan/SPEC_KIT_MIGRATI
 **Constitution:** [AGENTS.md — Infrastructure](../AGENTS.md#infrastructure)  
 **Summary:** Production deploys via `aspire deploy` from AppHost to Azure Container Apps. Aspire generates deployment Bicep at deploy time. Reject hand-authored `infra/*.bicep` for production hosting (supersedes legacy ADR-0003).
 
+**Clarification (2026-08-19):** The AppHost opts into the Aspire CLI bundle (`AspireUseCliBundle=true`). Dashboard and DCP orchestration binaries come from the Aspire CLI (or the SDK-paired `Aspire.Cli` via `dnx` when no CLI is on `PATH`). Pin the CLI to the same version as `Aspire.AppHost.Sdk` (`13.5.0` today). Reject suppressing `ASPIRE010` while staying on NuGet-restored orchestration.
+
 ---
 
 ### DEC-016: Formalised testing standard — xUnit v3, NSubstitute, Playwright E2E

--- a/src/SoloDevBoard.AppHost/README.md
+++ b/src/SoloDevBoard.AppHost/README.md
@@ -2,6 +2,8 @@
 
 Aspire orchestrates the SoloDevBoard web app for local development, dev containers, Codespaces, and **production deployment to Azure Container Apps** ([DEC-015](../../plan/DECISIONS.md#dec-015-aspire-azure-container-apps-deployment)).
 
+The AppHost opts into the Aspire CLI bundle (`AspireUseCliBundle=true`). Dashboard and DCP orchestration binaries come from the Aspire CLI on `PATH` (or the SDK-paired `Aspire.Cli` via `dnx` when no CLI is installed). Keep your local `aspire` version aligned with `Aspire.AppHost.Sdk` (`13.5.0` today): run `aspire --version` and upgrade with `aspire update --self` when needed.
+
 GitHub authentication is configured through **AppHost parameters**. In local development they are injected into the `app` resource as environment variables. In deploy mode, secret parameters are persisted in Azure Key Vault and referenced by the Container App.
 
 Use `-` on inactive parameters. Shipped defaults are in `src/SoloDevBoard.AppHost/appsettings.json`; staging and production tier defaults are in `appsettings.Staging.json` and `appsettings.Production.json` respectively (hosted sign-in enabled for CD tiers only — no operator hostnames or allow-lists). Operator-specific deploy values (callback URL, custom domain, GitHub App client ID, allow-lists) must be supplied via `Parameters__*` environment variables or GitHub Environment variables — not committed in appsettings. Values saved from the Aspire dashboard are stored in user secrets and **override** those defaults.

--- a/src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
+++ b/src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
@@ -16,6 +16,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>a8f3c2e1-4b5d-6e7f-8a9b-0c1d2e3f4a5b</UserSecretsId>
+    <AspireUseCliBundle>true</AspireUseCliBundle>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary of Changes

Opts the AppHost into the Aspire CLI bundle (`AspireUseCliBundle=true`) so Dashboard and DCP orchestration come from the CLI rather than RID-specific NuGet packages. Pins Aspire CLI `13.5.0` in deploy and validate workflows (installed before `dotnet build`) and documents the choice in AppHost README, getting-started, CURSOR_CLOUD, DEC-015, and GitHub Actions instructions.

## Related Issue(s)

Ad-hoc infrastructure chore (no tracking issue).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — infrastructure and documentation only.

## Additional Notes

Success criteria for CI: no `ASPIRE010` or `ASPIRE009` on AppHost builds; `aspire deploy --list-steps` still passes for Staging and Production. General `ci.yml` relies on the SDK `dnx` fallback when no CLI is installed on the runner.

Made with [Cursor](https://cursor.com)