### PR TITLE
[Bug] Keep stacked data grids inside phone viewports (#408)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -91,7 +91,7 @@ aspire deploy \
   --non-interactive
 ```
 
-4. Open the Container App FQDN from the Aspire output or Azure portal. Expect the dashboard shell with a **Connected as @login** chip — not the `/welcome` hosted landing page.
+4. Open the Container App FQDN from the Aspire output or Azure portal. Expect the dashboard shell with a **@login** chip — not the `/welcome` hosted landing page.
 5. Optionally verify PAT connectivity: `curl -sf "https://<fqdn>/health/github"`.
 
 Secret parameters (`gh-pat`, and `gh-app-client-secret` when used) are written to the Aspire-provisioned `auth-secrets` Key Vault and referenced by the Container App. You do not create Key Vault secrets by hand.
@@ -538,6 +538,6 @@ az identity delete --name id-solodevboard-cd --resource-group <acr-resource-grou
 | Secret not visible in Container App settings | Key Vault reference | Expected — inspect the `auth-secrets` vault for secret names; values are resolved at runtime |
 | Home dashboard shown without sign-in | Missing login gate or placeholder deploy parameters | Confirm `/` redirects to `/welcome`; redeploy with `Parameters__*` env vars mapped in CD; verify Container App env shows real client ID and allow-list values. CI Playwright `hosted` job asserts this gate with placeholder credentials. |
 | PAT mode shows `/welcome` or requires sign-in | `hosted-sign-in-enabled` still `true` | Set `HOSTED_SIGN_IN_ENABLED` / `Parameters__hosted_sign_in_enabled` to `false` and redeploy |
-| PAT mode starts but GitHub calls fail | Missing or invalid `GH_PAT` | Set a real PAT with required scopes; confirm `/health/github` and the **Connected as @login** chip |
+| PAT mode starts but GitHub calls fail | Missing or invalid `GH_PAT` | Set a real PAT with required scopes; confirm `/health/github` and the **@login** chip |
 
 For local development, see [Getting Started](getting-started.md) (including [PAT-only local trusted mode](getting-started.md#pat-only-local-trusted-mode)). For hosted authentication details, see [Hosted Authentication](hosted-authentication.md). For the Key Vault pattern, see [plan/HOSTED_AUTH_KEY_VAULT_PATTERN.md](../plan/HOSTED_AUTH_KEY_VAULT_PATTERN.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,7 @@ Parameters for the mode you are **not** using can be left unset (or set to `-` w
 | **Admission control** | Not applicable — anyone who can reach the app acts as the PAT owner | Operator allow-lists (`allowed-user-logins` / `allowed-org-logins`); deny-by-default |
 | **GitHub App required?** | No | Yes |
 | **Trust boundary** | Suitable only where you trust every person who can reach the deployment (localhost, private network, or a personal Azure instance you alone use) | Suitable for shared or public endpoints |
-| **Connectivity UX** | App-bar **Connected as @login** chip; recovery at `/auth/connectivity-error` — see [PAT Connectivity](pat-connectivity.md) | Session expiry and re-sign-in — see [Hosted Authentication](hosted-authentication.md) |
+| **Connectivity UX** | App-bar **@login** chip (accessible name **Connected as @login**); recovery at `/auth/connectivity-error` — see [PAT Connectivity](pat-connectivity.md) | Session expiry and re-sign-in — see [Hosted Authentication](hosted-authentication.md) |
 
 > **Security note:** PAT-only mode does **not** provide multi-user isolation. Do not expose a PAT-mode instance on a public URL that others can reach. For shared or public hosting, use hosted sign-in with admission control.
 
@@ -249,7 +249,7 @@ aspire secret set Parameters:gh-pat "<your-token>"
 aspire start --apphost src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
 ```
 
-Your GitHub login is resolved automatically from the PAT at startup. You can also set the token via the Aspire dashboard **Parameters** tab on first run. After the app starts, confirm the shell shows **Connected as @login** — see [PAT Connectivity](pat-connectivity.md).
+Your GitHub login is resolved automatically from the PAT at startup. You can also set the token via the Aspire dashboard **Parameters** tab on first run. After the app starts, confirm the shell shows **@login** with a link icon — see [PAT Connectivity](pat-connectivity.md).
 
 #### Hosted sign-in mode setup
 

--- a/docs/pat-connectivity.md
+++ b/docs/pat-connectivity.md
@@ -18,7 +18,7 @@ When `GitHubAuth:HostedSignInEnabled` is `false`, SoloDevBoard authenticates to 
 
 ## Shell status indicator
 
-- In PAT mode, the application shell shows a **Connected as @login** chip in the app bar.
+- In PAT mode, the application shell shows a **GitHub handle chip** (link icon plus `@login`) in the app bar. The accessible name remains **Connected as @login**.
 - This is the single connectivity indicator for the deployment; it is not repeated on individual feature pages.
 - The chip refreshes when you navigate between pages so runtime connectivity changes are reflected after recovery attempts.
 - This confirms GitHub connectivity before you open Repositories, Labels, or other feature pages.
@@ -42,7 +42,7 @@ Use `/health/github` when you want Container Apps or external monitoring to veri
 ### Manual verification (PAT connectivity)
 
 1. Configure `OwnerLogin` and an invalid `gh-pat` — expect startup to fail with a clear PAT message.
-2. Configure a valid PAT — expect the shell to show **Connected as @login**.
+2. Configure a valid PAT — expect the shell to show **@login** with a link icon.
 3. Revoke the PAT while the app is running, then open **Repositories** — expect redirect to `/auth/connectivity-error`, not a generic feature-page error.
 4. Call `GET /health/github` — expect `Healthy` when the PAT is valid.
 

--- a/plan/wireframes/auth-entry-wireframe.md
+++ b/plan/wireframes/auth-entry-wireframe.md
@@ -50,7 +50,7 @@
 
 ```
 +-------------------------------------------------------------+
-| App Bar: SoloDevBoard                    [ Connected as @login ] |
+| App Bar: SoloDevBoard                              [ @login ] |
 +-------------------------------------------------------------+
 |                                                             |
 | Home                                                        |
@@ -62,7 +62,7 @@
 
 - Shown only when `HostedSignInEnabled` is false (PAT mode).
 - The app bar chip is the single connectivity indicator; it is not duplicated on individual feature pages.
-- App bar chip shows `Connected as @login`.
+- App bar chip shows the GitHub handle (for example `@login`) with a link icon. The accessible name remains `Connected as @login`.
 - Copy references PAT configuration (Aspire `gh-pat`, user secrets) — not hosted sign-in.
 
 ## PAT Connectivity Recovery Page (`/auth/connectivity-error`)
@@ -123,6 +123,6 @@
 ### PAT connectivity (#314)
 
 1. Set `OwnerLogin` and an invalid `gh-pat` — expect startup failure with a clear PAT message.
-2. Set a valid PAT — expect the app bar chip showing `Connected as @login`.
+2. Set a valid PAT — expect the app bar chip showing `@login`.
 3. Revoke the PAT while the app is running, then open Repositories — expect redirect to `/auth/connectivity-error`, not a generic snackbar.
 4. Call `GET /health/github` — expect `Healthy` when PAT is valid, `Unhealthy` when not.

--- a/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor
@@ -181,7 +181,9 @@
                              Items="repositorySummaries"
                              Hover="true"
                              Dense="true"
-                             SortMode="SortMode.Multiple">
+                             SortMode="SortMode.Multiple"
+                             Breakpoint="Breakpoint.Xs"
+                             Class="sdb-responsive-grid">
                     <Columns>
                         <TemplateColumn Title="Repository" SortBy="summary => summary.RepositoryFullName">
                             <CellTemplate>
@@ -220,7 +222,7 @@
                                 }
                                 else
                                 {
-                                    <MudTable T="IssueDto" Items="unlabelledIssues" Dense="true" Hover="true" data-testid="audit-unlabelled-table">
+                                    <MudTable T="IssueDto" Items="unlabelledIssues" Dense="true" Hover="true" Class="sdb-responsive-grid" data-testid="audit-unlabelled-table">
                                         <HeaderContent>
                                             <MudTh>Repository</MudTh>
                                             <MudTh>Issue</MudTh>
@@ -256,7 +258,7 @@
                                 }
                                 else
                                 {
-                                    <MudTable T="PullRequestDto" Items="stalePullRequests" Dense="true" Hover="true" data-testid="audit-stale-table">
+                                    <MudTable T="PullRequestDto" Items="stalePullRequests" Dense="true" Hover="true" Class="sdb-responsive-grid" data-testid="audit-stale-table">
                                         <HeaderContent>
                                             <MudTh>Repository</MudTh>
                                             <MudTh>Pull request</MudTh>
@@ -301,7 +303,7 @@
                                 }
                                 else
                                 {
-                                    <MudTable T="WorkflowRunDto" Items="failingWorkflowRuns" Dense="true" Hover="true" data-testid="audit-workflows-table">
+                                    <MudTable T="WorkflowRunDto" Items="failingWorkflowRuns" Dense="true" Hover="true" Class="sdb-responsive-grid" data-testid="audit-workflows-table">
                                         <HeaderContent>
                                             <MudTh>Repository</MudTh>
                                             <MudTh>Workflow</MudTh>

--- a/src/App/SoloDevBoard.App/Components/Features/Labels/Components/LabelPreviewTable.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Labels/Components/LabelPreviewTable.razor
@@ -4,7 +4,7 @@
 {
     <MudStack Spacing="1">
         <MudText Typo="Typo.subtitle2">@Heading</MudText>
-        <MudTable T="LabelDto" Items="Labels" Dense="true" Hover="true">
+        <MudTable T="LabelDto" Items="Labels" Dense="true" Hover="true" Class="sdb-responsive-grid">
             <HeaderContent>
                 <MudTh>Label</MudTh>
                 <MudTh>Colour</MudTh>

--- a/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor
@@ -146,7 +146,7 @@
                     <MudText Typo="Typo.h6">Apply recommended taxonomy</MudText>
                     <MudText Typo="Typo.body2">Choose a strategy, preview changes, then confirm to apply labels across selected repositories.</MudText>
 
-                    <MudStack Row="true" Spacing="1" data-testid="taxonomy-action-strip">
+                    <MudStack Spacing="2" data-testid="taxonomy-action-strip">
                         <MudSelect T="string"
                                    Label="Recommended label set"
                                    Value="selectedStrategyId"
@@ -160,31 +160,35 @@
                             }
                         </MudSelect>
 
-                        <MudButton Variant="Variant.Outlined"
-                                   Color="Color.Secondary"
-                                   Disabled="@(!CanPreviewRecommendedTaxonomy)"
-                                   OnClick="PreviewRecommendedTaxonomyAsync"
-                                   data-testid="preview-taxonomy-button">
-                            Preview recommended taxonomy
-                        </MudButton>
-
-                        @if (showRecommendedPreview)
-                        {
-                            <MudButton Variant="Variant.Filled"
-                                       Color="Color.Primary"
-                                       Disabled="@(!CanApplyRecommendedTaxonomy)"
-                                       OnClick="ApplyRecommendedTaxonomyAsync"
-                                       data-testid="confirm-apply-taxonomy-button">
-                                Confirm apply taxonomy
+                        <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1">
+                            <MudButton Variant="Variant.Outlined"
+                                       Color="Color.Secondary"
+                                       Disabled="@(!CanPreviewRecommendedTaxonomy)"
+                                       OnClick="PreviewRecommendedTaxonomyAsync"
+                                       aria-label="Preview recommended taxonomy"
+                                       data-testid="preview-taxonomy-button">
+                                Preview
                             </MudButton>
 
-                            <MudButton Variant="Variant.Text"
-                                       Color="Color.Default"
-                                       OnClick="CancelRecommendedPreview"
-                                       data-testid="cancel-apply-taxonomy-button">
-                                Cancel
-                            </MudButton>
-                        }
+                            @if (showRecommendedPreview)
+                            {
+                                <MudButton Variant="Variant.Filled"
+                                           Color="Color.Primary"
+                                           Disabled="@(!CanApplyRecommendedTaxonomy)"
+                                           OnClick="ApplyRecommendedTaxonomyAsync"
+                                           aria-label="Confirm apply taxonomy"
+                                           data-testid="confirm-apply-taxonomy-button">
+                                    Confirm
+                                </MudButton>
+
+                                <MudButton Variant="Variant.Text"
+                                           Color="Color.Default"
+                                           OnClick="CancelRecommendedPreview"
+                                           data-testid="cancel-apply-taxonomy-button">
+                                    Cancel
+                                </MudButton>
+                            }
+                        </MudStack>
                     </MudStack>
 
                     @if (!string.IsNullOrWhiteSpace(SelectedStrategyDescription))
@@ -281,13 +285,14 @@
                             }
                         </MudStack>
 
-                        <MudStack Row="true" Spacing="1">
+                        <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1">
                             <MudButton Variant="Variant.Outlined"
                                        Color="Color.Secondary"
                                        Disabled="@(!CanPreviewLabelSynchronisation)"
                                        OnClick="PreviewLabelSynchronisationAsync"
+                                       aria-label="Preview synchronisation"
                                        data-testid="preview-sync-button">
-                                Preview synchronisation
+                                Preview
                             </MudButton>
 
                             @if (showSyncPreview)
@@ -296,8 +301,9 @@
                                            Color="Color.Primary"
                                            Disabled="@(!CanApplyLabelSynchronisation)"
                                            OnClick="ApplyLabelSynchronisationAsync"
+                                           aria-label="Confirm synchronisation"
                                            data-testid="confirm-sync-button">
-                                    Confirm synchronisation
+                                    Confirm
                                 </MudButton>
 
                                 <MudButton Variant="Variant.Text"

--- a/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor
@@ -93,6 +93,8 @@
                                          Hover="true"
                                          Dense="true"
                                          SortMode="SortMode.Multiple"
+                                         Breakpoint="Breakpoint.Xs"
+                                         Class="sdb-responsive-grid"
                                          data-testid="labels-grid">
                                 <Columns>
                                     <PropertyColumn Property="row => row.Name" Title="Label" Sortable="true" />

--- a/src/App/SoloDevBoard.App/Components/Features/Migration/Components/MilestonePreviewTable.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Migration/Components/MilestonePreviewTable.razor
@@ -4,7 +4,7 @@
 {
     <MudStack Spacing="1">
         <MudText Typo="Typo.subtitle2">@Heading</MudText>
-        <MudTable T="MilestoneDto" Items="Milestones" Dense="true" Hover="true">
+        <MudTable T="MilestoneDto" Items="Milestones" Dense="true" Hover="true" Class="sdb-responsive-grid">
             <HeaderContent>
                 <MudTh>Title</MudTh>
                 <MudTh>State</MudTh>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowReposPanel.razor
@@ -90,6 +90,7 @@
                                   Items="FilteredIncludedRepositories"
                                   Dense="true"
                                   Hover="true"
+                                  Class="sdb-responsive-grid"
                                   data-testid="pm-workflow-included-table">
                             <HeaderContent>
                                 <MudTh>Repository</MudTh>
@@ -231,6 +232,7 @@
                                   Dense="true"
                                   Hover="true"
                                   Breakpoint="Breakpoint.Sm"
+                                  Class="sdb-responsive-grid"
                                   data-testid="pm-workflow-repository-summary-table">
                             <HeaderContent>
                                 <MudTh>Repository</MudTh>

--- a/src/App/SoloDevBoard.App/Components/Features/Repositories/Pages/Repositories.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Repositories/Pages/Repositories.razor
@@ -120,29 +120,33 @@
                 <Columns>
                     <TemplateColumn Title="Repository name" SortBy="repository => repository.Name" Sortable="true">
                         <CellTemplate>
-                            <MudText Typo="Typo.body2" Title="@context.Item.Name">@context.Item.Name</MudText>
+                            <MudTooltip Text="@context.Item.Name">
+                                <MudText Typo="Typo.body2">@context.Item.Name</MudText>
+                            </MudTooltip>
                         </CellTemplate>
                     </TemplateColumn>
                     <TemplateColumn Title="Status">
                         <CellTemplate>
-                            <MudChip T="string"
-                                     Color="@GetRepositoryStatusColour(context.Item)"
-                                     Variant="Variant.Outlined"
-                                     Size="Size.Small"
-                                     Title="@GetRepositoryStatusText(context.Item)">
-                                @GetRepositoryStatusText(context.Item)
-                            </MudChip>
+                            <MudTooltip Text="@GetRepositoryStatusText(context.Item)">
+                                <MudChip T="string"
+                                         Color="@GetRepositoryStatusColour(context.Item)"
+                                         Variant="Variant.Outlined"
+                                         Size="Size.Small">
+                                    @GetRepositoryStatusText(context.Item)
+                                </MudChip>
+                            </MudTooltip>
                         </CellTemplate>
                     </TemplateColumn>
                     <TemplateColumn Title="Type">
                         <CellTemplate>
-                            <MudChip T="string"
-                                     Color="@(context.Item.IsPrivate ? Color.Warning : Color.Success)"
-                                     Variant="Variant.Outlined"
-                                     Size="Size.Small"
-                                     Title="@(context.Item.IsPrivate ? "Private" : "Public")">
-                                @(context.Item.IsPrivate ? "Private" : "Public")
-                            </MudChip>
+                            <MudTooltip Text="@(context.Item.IsPrivate ? "Private" : "Public")">
+                                <MudChip T="string"
+                                         Color="@(context.Item.IsPrivate ? Color.Warning : Color.Success)"
+                                         Variant="Variant.Outlined"
+                                         Size="Size.Small">
+                                    @(context.Item.IsPrivate ? "Private" : "Public")
+                                </MudChip>
+                            </MudTooltip>
                         </CellTemplate>
                     </TemplateColumn>
                     <TemplateColumn Title="Actions">

--- a/src/App/SoloDevBoard.App/Components/Features/Repositories/Pages/Repositories.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Repositories/Pages/Repositories.razor
@@ -108,36 +108,46 @@
     }
     else
     {
-        <MudPaper Class="pa-2" Elevation="1" data-testid="repositories-grid">
+        <MudPaper Class="pa-2 overflow-hidden" Elevation="1" data-testid="repositories-grid">
             <MudDataGrid T="RepositoryDto"
                          Items="FilteredRepositories"
                          Hover="true"
                          Dense="true"
                          SortMode="SortMode.Multiple"
-                         Striped="true">
+                         Striped="true"
+                         Breakpoint="Breakpoint.Xs"
+                         Class="sdb-responsive-grid">
                 <Columns>
-                    <PropertyColumn Property="repository => repository.Name" Title="Repository name" Sortable="true" />
+                    <TemplateColumn Title="Repository name" SortBy="repository => repository.Name" Sortable="true">
+                        <CellTemplate>
+                            <MudText Typo="Typo.body2" Title="@context.Item.Name">@context.Item.Name</MudText>
+                        </CellTemplate>
+                    </TemplateColumn>
                     <TemplateColumn Title="Status">
                         <CellTemplate>
-                            <MudChip Color="@GetRepositoryStatusColour(context.Item)"
+                            <MudChip T="string"
+                                     Color="@GetRepositoryStatusColour(context.Item)"
                                      Variant="Variant.Outlined"
-                                     Size="Size.Small">
+                                     Size="Size.Small"
+                                     Title="@GetRepositoryStatusText(context.Item)">
                                 @GetRepositoryStatusText(context.Item)
                             </MudChip>
                         </CellTemplate>
                     </TemplateColumn>
                     <TemplateColumn Title="Type">
                         <CellTemplate>
-                            <MudChip Color="@(context.Item.IsPrivate ? Color.Warning : Color.Success)"
+                            <MudChip T="string"
+                                     Color="@(context.Item.IsPrivate ? Color.Warning : Color.Success)"
                                      Variant="Variant.Outlined"
-                                     Size="Size.Small">
+                                     Size="Size.Small"
+                                     Title="@(context.Item.IsPrivate ? "Private" : "Public")">
                                 @(context.Item.IsPrivate ? "Private" : "Public")
                             </MudChip>
                         </CellTemplate>
                     </TemplateColumn>
                     <TemplateColumn Title="Actions">
                         <CellTemplate>
-                            <MudStack Row="true" Justify="Justify.FlexEnd" AlignItems="AlignItems.Center" Spacing="0">
+                            <MudStack Row="true" Wrap="Wrap.Wrap" Justify="Justify.FlexEnd" AlignItems="AlignItems.Center" Spacing="0">
                                 <MudTooltip Text="Edit repository">
                                     <MudIconButton Icon="@Icons.Material.Filled.Edit"
                                                    Color="Color.Primary"

--- a/src/App/SoloDevBoard.App/Components/Shell/App.razor
+++ b/src/App/SoloDevBoard.App/Components/Shell/App.razor
@@ -12,6 +12,7 @@
     <ResourcePreloader />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="@Assets["_content/MudBlazor/MudBlazor.min.css"]" />
+    <link rel="stylesheet" href="@Assets["css/app.css"]" />
     <link rel="stylesheet" href="@Assets["SoloDevBoard.App.styles.css"]" />
     <ImportMap />
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />

--- a/src/App/SoloDevBoard.App/Components/Shell/Layout/MainLayout.razor
+++ b/src/App/SoloDevBoard.App/Components/Shell/Layout/MainLayout.razor
@@ -26,7 +26,7 @@
                      Icon="@Icons.Material.Filled.Link"
                      aria-label="@_patConnectionStatus.StatusMessage"
                      data-testid="shell-github-connection-status">
-                @_patConnectionStatus.StatusMessage
+                @ConnectionChipText
             </MudChip>
         }
         @if (ThemePreferenceService.IsInitialised)

--- a/src/App/SoloDevBoard.App/Components/Shell/Layout/MainLayout.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Shell/Layout/MainLayout.razor.cs
@@ -65,6 +65,20 @@ public partial class MainLayout : IDisposable
 
     private void OnThemePreferenceChanged() => _ = InvokeAsync(StateHasChanged);
 
+    private string ConnectionChipText
+    {
+        get
+        {
+            if (_patConnectionStatus is { IsConnected: true } status
+                && !string.IsNullOrWhiteSpace(status.OwnerLogin))
+            {
+                return $"@{status.OwnerLogin}";
+            }
+
+            return _patConnectionStatus?.StatusMessage ?? string.Empty;
+        }
+    }
+
     private async Task LoadShellStateAsync()
     {
         if (GitHubAuthOptions.Value.HostedSignInEnabled)

--- a/src/App/SoloDevBoard.App/wwwroot/css/app.css
+++ b/src/App/SoloDevBoard.App/wwwroot/css/app.css
@@ -1,0 +1,80 @@
+/* Stacked MudBlazor tables use flex + space-between without a min-width
+ * constraint, so long names and chips overflow phone viewports (issue #408).
+ * MudBlazor has no parameter for stacked-cell overflow, so this global
+ * override is required. Apply Class="sdb-responsive-grid" on the grid or table. */
+.sdb-responsive-grid .mud-table-container,
+.sdb-responsive-grid .mud-table-root {
+    max-width: 100%;
+}
+
+@media (max-width: 600px) {
+    .sdb-responsive-grid.mud-xs-table .mud-table-cell,
+    .sdb-responsive-grid .mud-xs-table .mud-table-cell {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        align-items: flex-start;
+        column-gap: 0.75rem;
+        row-gap: 0.25rem;
+        min-width: 0;
+        max-width: 100%;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+        box-sizing: border-box;
+    }
+
+    .sdb-responsive-grid.mud-xs-table .mud-table-cell::before,
+    .sdb-responsive-grid .mud-xs-table .mud-table-cell::before {
+        flex: 0 1 auto;
+        max-width: 100%;
+        margin-right: 0;
+        padding-inline-end: 0.75rem;
+    }
+
+    .sdb-responsive-grid.mud-xs-table .mud-table-cell > *,
+    .sdb-responsive-grid .mud-xs-table .mud-table-cell > * {
+        flex: 1 1 8rem;
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    .sdb-responsive-grid.mud-xs-table .mud-chip,
+    .sdb-responsive-grid .mud-xs-table .mud-chip {
+        max-width: 100%;
+    }
+}
+
+@media (max-width: 960px) {
+    .sdb-responsive-grid.mud-sm-table .mud-table-cell,
+    .sdb-responsive-grid .mud-sm-table .mud-table-cell {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        align-items: flex-start;
+        column-gap: 0.75rem;
+        row-gap: 0.25rem;
+        min-width: 0;
+        max-width: 100%;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+        box-sizing: border-box;
+    }
+
+    .sdb-responsive-grid.mud-sm-table .mud-table-cell::before,
+    .sdb-responsive-grid .mud-sm-table .mud-table-cell::before {
+        flex: 0 1 auto;
+        max-width: 100%;
+        margin-right: 0;
+        padding-inline-end: 0.75rem;
+    }
+
+    .sdb-responsive-grid.mud-sm-table .mud-table-cell > *,
+    .sdb-responsive-grid .mud-sm-table .mud-table-cell > * {
+        flex: 1 1 8rem;
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    .sdb-responsive-grid.mud-sm-table .mud-chip,
+    .sdb-responsive-grid .mud-sm-table .mud-chip {
+        max-width: 100%;
+    }
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
@@ -295,7 +295,7 @@ public sealed class LabelsTests
             Assert.Contains("owner/repo-a", cut.Markup);
             Assert.Contains("Labels to create", cut.Markup);
             Assert.Contains("Labels to update", cut.Markup);
-            Assert.Contains("Confirm apply taxonomy", cut.Markup);
+            Assert.Contains("aria-label=\"Confirm apply taxonomy\"", cut.Markup);
         });
     }
 
@@ -503,7 +503,7 @@ public sealed class LabelsTests
             Assert.Contains("owner/repo-b", cut.Markup);
             Assert.Contains("Labels to create", cut.Markup);
             Assert.Contains("Labels to skip", cut.Markup);
-            Assert.Contains("Confirm synchronisation", cut.Markup);
+            Assert.Contains("aria-label=\"Confirm synchronisation\"", cut.Markup);
         });
     }
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/MainLayoutThemeTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/MainLayoutThemeTests.cs
@@ -94,6 +94,20 @@ public sealed class MainLayoutThemeTests : BunitContext
         await _themePreferenceService.Received(1).CycleAsync();
     }
 
+    [Fact]
+    public void MainLayout_WhenConnectedInPatMode_ShowsHandleWithoutConnectedAsPrefix()
+    {
+        var cut = Render<MainLayout>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var chip = cut.Find("[data-testid='shell-github-connection-status']");
+            Assert.Equal("Connected as @markheydon.", chip.GetAttribute("aria-label"));
+            Assert.Contains("@markheydon", chip.TextContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("Connected as", chip.TextContent, StringComparison.Ordinal);
+        });
+    }
+
     private sealed class UnauthenticatedAuthenticationStateProvider : AuthenticationStateProvider
     {
         public override Task<AuthenticationState> GetAuthenticationStateAsync() =>

--- a/tests/App.Tests/SoloDevBoard.App.Tests/RepositoriesTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/RepositoriesTests.cs
@@ -142,6 +142,40 @@ public sealed class RepositoriesTests
         });
     }
 
+    [Fact]
+    public async Task Repositories_ServiceReturnsLongRepositoryName_KeepsFullNameAccessibleInStackedGrid()
+    {
+        var repositories = new List<RepositoryDto>
+        {
+            new(
+                1,
+                "mhcg-cs-mhcgintegration-platform-service",
+                "owner/mhcg-cs-mhcgintegration-platform-service",
+                string.Empty,
+                string.Empty,
+                false,
+                false,
+                DateTimeOffset.UnixEpoch,
+                new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero)),
+        };
+
+        _repositoryService.GetRepositoriesAsync(Arg.Any<CancellationToken>()).Returns(repositories);
+
+        await using var ctx = CreateContext();
+
+        var cut = ctx.Render<Repositories>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("sdb-responsive-grid", cut.Markup);
+            Assert.Contains("mhcg-cs-mhcgintegration-platform-service", cut.Markup);
+            Assert.Contains("title=\"mhcg-cs-mhcgintegration-platform-service\"", cut.Markup);
+            Assert.Contains("title=\"Connected\"", cut.Markup);
+            Assert.Contains("title=\"Public\"", cut.Markup);
+            Assert.Contains("Edit repository", cut.Markup);
+        });
+    }
+
     private BunitContext CreateContext()
     {
         var ctx = new BunitContext();

--- a/tests/App.Tests/SoloDevBoard.App.Tests/RepositoriesTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/RepositoriesTests.cs
@@ -169,9 +169,8 @@ public sealed class RepositoriesTests
         {
             Assert.Contains("sdb-responsive-grid", cut.Markup);
             Assert.Contains("mhcg-cs-mhcgintegration-platform-service", cut.Markup);
-            Assert.Contains("title=\"mhcg-cs-mhcgintegration-platform-service\"", cut.Markup);
-            Assert.Contains("title=\"Connected\"", cut.Markup);
-            Assert.Contains("title=\"Public\"", cut.Markup);
+            Assert.Contains("Connected", cut.Markup);
+            Assert.Contains("Public", cut.Markup);
             Assert.Contains("Edit repository", cut.Markup);
         });
     }

--- a/tests/E2E/CRITICAL_JOURNEYS.md
+++ b/tests/E2E/CRITICAL_JOURNEYS.md
@@ -37,7 +37,7 @@ For data-driven journeys against a real GitHub account, run the PAT suite locall
 | Journey | Spec | What CI validates |
 |---------|------|-------------------|
 | Audit Dashboard repository selector failure | `audit-dashboard.spec.ts` | Feedback region and unable-to-load message; `/audit` alias. |
-| Repositories command strip and load failure | `repositories.spec.ts` | Refresh control, search field, and error state with retry. |
+| Repositories command strip and load failure | `repositories.spec.ts` | Refresh control, search field, error state with retry, and no horizontal overflow at an iPhone 12 viewport. |
 | One-Click Migration setup shell | `migrate.spec.ts` | Workflow controls, disabled preview, and API failure feedback. |
 | Board Rules selector and compare mode | `board-rules.spec.ts` | Selector region, compare toggle, and repository load failure. |
 | Label Manager taxonomy tabs and empty repository state | `labels.spec.ts` | Tab strip, disabled actions, and no-repositories message. |

--- a/tests/E2E/README.md
+++ b/tests/E2E/README.md
@@ -17,7 +17,7 @@ Published user guides must stay aligned with these tests like-for-like. See [USE
 | `auth-entry.spec.ts` | PAT-mode welcome redirect and connectivity error page |
 | `auth-entry-hosted.spec.ts` | Hosted-mode login gate, welcome landing, and Blazor negotiate |
 | `audit-dashboard.spec.ts` | Audit Dashboard shell and repository load failure; `/audit` alias |
-| `repositories.spec.ts` | Repositories command strip and load failure handling |
+| `repositories.spec.ts` | Repositories command strip, load failure handling, and phone-width overflow guard |
 | `migrate.spec.ts` | One-Click Migration setup shell and API failure feedback |
 | `board-rules.spec.ts` | Board Rules selector region, compare mode, and load failure |
 | `labels.spec.ts` | Label Manager shell, tabs, and empty-repository state |

--- a/tests/E2E/USER_DOCS_ALIGNMENT.md
+++ b/tests/E2E/USER_DOCS_ALIGNMENT.md
@@ -28,7 +28,7 @@ When you add or change an end-user feature, update the user guide, the relevant 
 | [Product landing](../../website/content/_index.md) (Hugo `/` only) | — | — (Hugo `hugo-build.yml` route check) | — | — | Short product-and-project landing (Learn more → About; icon tiles not docs links); not the Blazor app. |
 | [In-app home dashboard](../../website/content/docs/) | `/` | `smoke.spec.ts`, `navigation.spec.ts`, `accessibility.spec.ts` | `dashboard/home.png` | Tier 1 | In-app home lists eight feature cards; About and Appearance are reached via the app bar. |
 | [Audit Dashboard](../../website/content/docs/audit-dashboard.md) | `/audit-dashboard`, `/audit` | `audit-dashboard.spec.ts`, `accessibility.spec.ts` | `audit-dashboard/overview.png` | Tier 2 | Guide describes KPI cards, health sections, auto-refresh, and export; CI asserts shell, feedback region, and `/audit` alias with load failure. |
-| [Repositories](../../website/content/docs/repositories.md) | `/repositories` | `repositories.spec.ts`, `accessibility.spec.ts` | `repositories/overview.png` | Tier 2 | Guide describes command strip, search, and grid; CI asserts refresh, search, and error state with retry. |
+| [Repositories](../../website/content/docs/repositories.md) | `/repositories` | `repositories.spec.ts`, `accessibility.spec.ts` | `repositories/overview.png` | Tier 2 | Guide describes command strip, search, and a phone-safe stacked grid; CI asserts refresh, search, error-state retry, and no horizontal overflow at 390px. |
 | [One-Click Migration](../../website/content/docs/one-click-migration.md) | `/migrate` | `migrate.spec.ts`, `accessibility.spec.ts` | `one-click-migration/overview.png` | Tier 2 | Guide describes preview/apply workflow and conflict strategies; CI asserts setup shell, disabled preview, and API failure feedback. |
 | [Label Manager](../../website/content/docs/label-manager.md) | `/labels` | `labels.spec.ts`, `accessibility.spec.ts` | `label-manager/overview.png` | Tier 2 | Guide describes three tabs and taxonomy workflows; CI asserts tab strip, disabled actions, and no-repositories message. |
 | [Board Rules Visualiser](../../website/content/docs/board-rules-visualiser.md) | `/board-rules` | `board-rules.spec.ts`, `accessibility.spec.ts` | `board-rules-visualiser/overview.png` | Tier 2 | Guide describes compare mode and board selection; CI asserts selector region, compare toggle, and load failure. |
@@ -65,6 +65,14 @@ Use this when extending specs so assertions track documented workflows.
 |---------------|--------------|-------------------------|
 | Three tabs (Labels, Recommended taxonomy, Synchronise) | Tab strip and headings | `docs-capture` |
 | No repositories message | Empty-state text | — |
+
+### Repositories
+
+| Guide section | CI assertion | Loaded-state validation |
+|---------------|--------------|-------------------------|
+| Accessing (`/repositories`) | `repositories.spec.ts` URL and title | `docs-capture` |
+| Command strip, search, and load failure | Refresh control, search field, error state with retry | `prepareRepositoriesForCapture` |
+| Phone-width stacked grid without horizontal overflow | `repositories.spec.ts` 390×844 viewport overflow check (error-state shell in CI) | `docs-capture` plus component tests for long names and chips |
 
 ### Appearance
 

--- a/tests/E2E/tests/labels.spec.ts
+++ b/tests/E2E/tests/labels.spec.ts
@@ -23,6 +23,7 @@ test.describe('Label Manager shell', () => {
 
     await page.getByRole('tab', { name: 'Recommended taxonomy' }).click();
     await expect(page.getByRole('heading', { name: 'Apply recommended taxonomy' })).toBeVisible();
+    await expect(page.getByTestId('preview-taxonomy-button')).toHaveText('Preview');
 
     await page.getByRole('tab', { name: 'Synchronise' }).click();
     await expect(page.getByRole('heading', { name: 'Synchronise labels' })).toBeVisible();

--- a/tests/E2E/tests/repositories.spec.ts
+++ b/tests/E2E/tests/repositories.spec.ts
@@ -13,4 +13,18 @@ test.describe('Repositories shell', () => {
     await expect(page.getByText('Unable to load repositories')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Try again' })).toBeVisible();
   });
+
+  test('phone-width viewport does not introduce horizontal overflow on the repositories shell', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/repositories');
+
+    await expect(page.getByTestId('repositories-loading-state')).toBeHidden({ timeout: 15_000 });
+    await expect(page.getByTestId('repositories-error-state')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Actions' })).toBeVisible();
+
+    const hasHorizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+    );
+    expect(hasHorizontalOverflow).toBeFalsy();
+  });
 });

--- a/website/content/docs/label-manager.md
+++ b/website/content/docs/label-manager.md
@@ -62,7 +62,7 @@ You can apply a recommended label taxonomy to selected repositories using a prev
 
 1. Select one or more active repositories in the repository selector.
 2. Choose a recommended strategy.
-3. Select `Preview recommended taxonomy` to review proposed changes per repository.
+3. Select **Preview** to review proposed changes per repository.
 4. Confirm or cancel before any changes are applied.
 5. Review the per-repository summary after apply completes.
 

--- a/website/content/docs/repositories.md
+++ b/website/content/docs/repositories.md
@@ -25,7 +25,7 @@ From this page you can:
 
 - **Command strip** — Refresh, Add, Remove, and Bulk actions. On mobile these are grouped into a compact actions menu.
 - **Search field** — Filter repositories by name.
-- **Data grid** — Repository name, status chips, and row actions.
+- **Data grid** — Repository name, status chips, visibility chips, and row actions. On phone-width viewports the grid stacks each field so names wrap, chips stay fully visible, and row actions remain tappable without horizontal overflow.
 - **Feedback region** — Loading, empty, success, and error messages.
 
 ## How to use


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Fixes stacked `MudDataGrid` / `MudTable` cells overflowing the right edge on phone-width viewports (iPhone 12 is 390 CSS pixels). MudBlazor's stacked layout uses flex and `space-between` without a min-width constraint, which clipped repository names, status/type chips, and row actions.

Follow-up from the same device session:

- PAT-mode app bar chip now shows the link icon plus `@login` (accessible name remains `Connected as @login`).
- Label Manager taxonomy and synchronise actions use short **Preview** / **Confirm** labels, wrap on narrow widths, and keep the original wording in `aria-label`.

The Repositories grid now wraps stacked values, exposes the full name and chip text via tooltips, and keeps action buttons tappable. The same overflow class is applied to other stacked tables (Labels, Audit, Migration preview, PM Workflow).

A parked follow-up for a proper phone-width pass is [#411](https://github.com/markheydon/solo-dev-board/issues/411).

## Related Issue(s)

Closes #408

References #411

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause application functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Verified at 390×844 (iPhone 12 CSS width) against a live PAT catalogue, filtered to the public example repository.

![Repositories page at iPhone 12 width with stacked row fully visible](https://cursor.com/artifacts/c/art-9d4a66cc-54a9-425f-9022-500a66b2e799)
![Stacked repository row showing Connected, Public, and action icons](https://cursor.com/artifacts/c/art-31c0aa74-12a8-40ac-b65c-e33e2872000a)
![App bar at iPhone 12 width showing @markheydon handle chip](https://cursor.com/artifacts/c/art-57acc4a9-d337-40f7-93ce-9de0c4c28ed9)
![Label Manager taxonomy actions with short Preview button](https://cursor.com/artifacts/c/art-3991f024-2c1d-49a5-b667-a5dd1628ed24)
<a href="https://cursor.com/agents/bc-78a18a69-d6d1-45a5-9467-13700d74c421/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frepositories_iphone12_stacked_grid.mp4"><img src="https://cursor.com/artifacts/c/art-3eca081a-616b-4102-a9d5-decd21b1d499" alt="repositories_iphone12_stacked_grid.mp4" /></a>

## Additional Notes

MudBlazor has no parameter for stacked-cell overflow, so a small global stylesheet (`wwwroot/css/app.css`) is used with `Class="sdb-responsive-grid"` on affected grids.

Automated evidence:

- `SoloDevBoard.App.Tests` — 240 passed, including a long-name stacked-grid case and compact PAT chip text.
- Playwright helper at 390px — document scroll width equals client width; `Connected` / `Public` chips unclipped; PAT chip text `@markheydon`; taxonomy button text `Preview`.
- `dotnet format SoloDevBoard.slnx --verify-no-changes` passed.

CI Playwright still asserts the placeholder-auth error-state shell at 390px, because PAT jobs do not load a live catalogue.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78a18a69-d6d1-45a5-9467-13700d74c421?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78a18a69-d6d1-45a5-9467-13700d74c421&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

