### PR TITLE
[Documentation] Add GitHub comment invocation for agent workflows

### DIFF
--- a/.agents/contracts/delivery.md
+++ b/.agents/contracts/delivery.md
@@ -1,7 +1,7 @@
 ---
 role: Delivery
 description: Runs implementation preflight and implements planned GitHub issues, creates tests, updates documentation, prepares work for review, and addresses pull request review feedback.
-triggers: Implement issue #N; preflight issue #N; build feature X; fix bug #N; address PR review comments on PR #N
+triggers: Implement issue #N; preflight issue #N; build feature X; fix bug #N; address PR review comments on PR #N; GitHub Issue "@cursor implement this issue" is deliver-issue (orchestrated with Verify), not this contract alone
 ---
 
 # Delivery Agent

--- a/.agents/contracts/verify.md
+++ b/.agents/contracts/verify.md
@@ -1,7 +1,7 @@
 ---
 role: Verify
 description: Validates completed work (build, tests, docs) and creates a pull request.
-triggers: Verify issue #N; Create PR for issue #N
+triggers: Verify issue #N; Create PR for issue #N; GitHub Issue "@cursor create a PR for this"
 ---
 
 # Verify Agent

--- a/.agents/skills/_REGISTRY.md
+++ b/.agents/skills/_REGISTRY.md
@@ -45,7 +45,7 @@ SoloDevBoard defines specialised role contracts for PM workflows. These orchestr
 
 **Role contracts:** `.agents/contracts/*.md`  
 **Workflow entry points:** `.agents/workflows/*.md` (canonical)  
-**Invocation:** Natural language, [`.github/prompts/`](../../.github/prompts/) (Copilot), [`.cursor/commands/`](../../.cursor/commands/) (Cursor) — all thin mirrors pointing to `.agents/workflows/`  
+**Invocation:** Natural language, GitHub Issue/PR comments (`@cursor` / `@cursoragent` — see [workflow README](../../.agents/workflows/README.md#github-comment-invocation)), [`.github/prompts/`](../../.github/prompts/) (Copilot), [`.cursor/commands/`](../../.cursor/commands/) (Cursor) — all thin mirrors pointing to `.agents/workflows/`  
 **Orchestration:** `plan/PM_RUNBOOK.md` (session and progress-review workflow guide)
 
 ## Workflow Library

--- a/.agents/workflows/README.md
+++ b/.agents/workflows/README.md
@@ -16,15 +16,61 @@ Each workflow has **one** canonical file in this directory. Tool-specific discov
 
 Orchestration, rituals, and step-by-step guidance live in [`plan/PM_RUNBOOK.md`](../../plan/PM_RUNBOOK.md). Role boundaries live in [`.agents/contracts/`](../contracts/). Repo-specific operations live in [`.agents/skills/`](../skills/).
 
+## GitHub comment invocation
+
+Cursor Cloud Agents can be started from a GitHub Issue or Pull Request by commenting `@cursor` or `@cursoragent` plus an instruction ([Cursor Cloud Agent docs](https://cursor.com/docs/cloud-agent)). Put the mention at the **start** of the comment.
+
+Agents must treat those comments as first-class workflow invocations, not as vague chat. Follow this binding and routing before choosing a workflow ([DEC-031](../../plan/DECISIONS.md#dec-031-github-comment-workflow-invocation)).
+
+### Binding
+
+- On an **issue**, "this", "this issue", "the issue", and a missing `#N` mean the issue being commented on.
+- On a **pull request**, "this", "this PR", and a missing PR number mean that pull request. Linked `Closes #N` / `Fixes #N` is the issue for delivery or verify.
+- Do not ask the user for a number that the thread already implies.
+- Each `@cursor` mention on an **issue** starts a **new** agent session. Follow-up on the same issue is not the same conversation. On a **PR**, later `@cursor` comments can continue the branch session.
+- Still refuse `status/blocked` and `status/ice-box` implementation.
+
+### GitHub Issue comment → workflow
+
+| Human-friendly comment (after `@cursor` / `@cursoragent`) | Workflow |
+|-----------------------------------------------------------|----------|
+| implement this issue; implement this; deliver this; do this; work on this; fix this; build this; please implement | `deliver-issue` (happy path: implement + verify + PR) |
+| implement this without a PR; implement only; do not open a pull request | `implement-issue` |
+| preflight this; scout this; discover the codebase; do not write code yet | `preflight-issue` |
+| plan this issue; plan this feature; flesh out this issue; add acceptance criteria and sub-issues | `plan-next-issue` (plan **this** item, not a different backlog pick) |
+| verify this; create a PR for this; open a pull request | `verify-and-create-pr` |
+| refresh the docs; update the user guide for this; update the decision log | `docs-update` |
+| run daily start; what's next from the board | `daily-start` |
+| run a progress review | `pm-progress-review` |
+| clean up status labels | `sync-status-labels` |
+
+Bare "implement this issue" on a GitHub Issue is **`deliver-issue`**, not the split `implement-issue` path. A Cloud Agent started from GitHub is expected to open a pull request unless the comment says otherwise.
+
+### GitHub Pull Request comment → workflow
+
+| Human-friendly comment (after `@cursor` / `@cursoragent`) | Workflow |
+|-----------------------------------------------------------|----------|
+| code review this PR; review this PR for conventions | `code-review` |
+| address the review comments; fix the review threads; address Copilot comments | `address-pr-review-comments` |
+| fix CI; fix the failing checks | Stay on the PR branch and repair CI. This is not a named PM workflow. |
+| verify / create a PR | Do **not** open a second PR. The PR already exists. |
+
+### Ambiguous phrases
+
+- **"Review this issue"** is not code review and not verify. Ask which workflow, or treat as read-only clarification, unless the comment also says "code review" or "conventions".
+- **"Review this PR"** without "code review" or "conventions" is still `code-review` when the comment is on a pull request.
+- **"Verify"** means quality gates and PR creation (`verify-and-create-pr`). It does not mean code review.
+- Slash commands and Copilot prompts in chat keep the split: `/implement-issue` does not open a PR; `/deliver-issue` does.
+
 ## Routing
 
 | User intent | Trigger phrases | Workflow | Contract |
 |-------------|-----------------|----------|----------|
 | Start a working session | "Run the daily start workflow", `/daily-start` | `daily-start` | `pm-orchestrator` |
-| Plan the next feature | "Plan the next item", `/plan-next-issue` | `plan-next-issue` | `pm-orchestrator` |
-| Preflight before implementation | "Preflight issue #N", `/preflight-issue` | `preflight-issue` | `delivery` |
-| Deliver planned work (happy path) | "Deliver issue #N", `/deliver-issue` | `deliver-issue` | `delivery`, `verify` |
-| Implement planned work | "Implement issue #N", `/implement-issue` | `implement-issue` | `delivery` |
+| Plan the next feature | "Plan the next item", `/plan-next-issue`, GitHub: "plan this issue" | `plan-next-issue` | `pm-orchestrator` |
+| Preflight before implementation | "Preflight issue #N", `/preflight-issue`, GitHub: "preflight this" | `preflight-issue` | `delivery` |
+| Deliver planned work (happy path) | "Deliver issue #N", `/deliver-issue`, GitHub: "implement this issue" | `deliver-issue` | `delivery`, `verify` |
+| Implement planned work (no PR) | "Implement issue #N", `/implement-issue`, GitHub: "implement without a PR" | `implement-issue` | `delivery` |
 | Validate implementation and open PR | "Verify issue #N", "Create PR for issue #N", `/verify-and-create-pr` | `verify-and-create-pr` | `verify` |
 | Address PR review comments | "Address PR review comments on PR #N", `/address-pr-review-comments` | `address-pr-review-comments` | `delivery` |
 | Progress review since last update | "Run the PM progress review", `/pm-progress-review` | `pm-progress-review` | `pm-orchestrator` |
@@ -41,8 +87,8 @@ Orchestration, rituals, and step-by-step guidance live in [`plan/PM_RUNBOOK.md`]
 | [daily-start](daily-start.md) | "Run the daily start workflow" | `pm-orchestrator` | `repo-github-project` (optional) | Session Start |
 | [plan-next-issue](plan-next-issue.md) | "Plan the next item" | `pm-orchestrator` | `breakdown-plan`, `breakdown-test`, `repo-github-issues`, `repo-github-project` | Stage 1: Planning |
 | [preflight-issue](preflight-issue.md) | "Preflight issue #N" | `delivery` | `aspire`, `dotnet-best-practices`, `mudblazor` (on demand) | Stage 2: Implementation (preflight) |
-| [deliver-issue](deliver-issue.md) | "Deliver issue #N" | `delivery`, `verify` | `aspire`, `dotnet-best-practices`, `mudblazor`, etc. | Stage 2–3: Delivery happy path |
-| [implement-issue](implement-issue.md) | "Implement issue #N" | `delivery` | `aspire`, `dotnet-best-practices`, `mudblazor`, etc. | Stage 2: Implementation |
+| [deliver-issue](deliver-issue.md) | "Deliver issue #N"; GitHub: "implement this issue" | `delivery`, `verify` | `aspire`, `dotnet-best-practices`, `mudblazor`, etc. | Stage 2–3: Delivery happy path |
+| [implement-issue](implement-issue.md) | "Implement issue #N" (chat/slash; no PR) | `delivery` | `aspire`, `dotnet-best-practices`, `mudblazor`, etc. | Stage 2: Implementation |
 | [verify-and-create-pr](verify-and-create-pr.md) | "Verify issue #N", "Create PR for issue #N" | `verify` | — | Stage 3: Verify and PR |
 | [address-pr-review-comments](address-pr-review-comments.md) | "Address PR review comments on PR #N" | `delivery` | `aspire` (when AppHost is running) | PR Review Comment Loop |
 | [pm-progress-review](pm-progress-review.md) | "Run the PM progress review" | `pm-orchestrator` | — | Progress Review Rhythm |

--- a/.agents/workflows/address-pr-review-comments.md
+++ b/.agents/workflows/address-pr-review-comments.md
@@ -23,4 +23,11 @@
 
 ## Invocation
 
-Natural language: "Address PR review comments on PR #N"
+**Chat:** "Address PR review comments on PR #N".
+**Slash command:** `/address-pr-review-comments [number]`.
+**GitHub Pull Request comment** (mention at the start; `N` is this PR):
+- `@cursor address the review comments`
+- `@cursor fix the review threads`
+- `@cursor address Copilot comments`
+
+Prefer commenting on the PR, not on the linked issue. Each issue `@cursor` mention starts a new session and will not automatically check out the existing PR branch.

--- a/.agents/workflows/code-review.md
+++ b/.agents/workflows/code-review.md
@@ -12,4 +12,10 @@
 
 ## Invocation
 
-Natural language: "Code review PR #N" or "Code review branch feature/X"
+**Chat:** "Code review PR #N" or "Code review branch feature/X".
+**Slash command:** `/code-review [number]`.
+**GitHub Pull Request comment** (mention at the start; `N` is this PR):
+- `@cursor code review this PR`
+- `@cursor review this PR for conventions`
+
+Do not treat "review this issue" on an Issue comment as this workflow.

--- a/.agents/workflows/daily-start.md
+++ b/.agents/workflows/daily-start.md
@@ -16,6 +16,10 @@ Read-only orientation at the **start of a working session** — not tied to a ca
 
 ## Invocation
 
-Natural language: "Run the daily start workflow"
+**Chat:** "Run the daily start workflow".
+**Slash command:** `/daily-start`.
+**GitHub Issue comment** (mention at the start; the current issue is context only, not the work item to implement):
+- `@cursor run daily start`
+- `@cursor what's next from the board`
 
-Slash command: `/daily-start`
+Do not treat this as "implement this issue".

--- a/.agents/workflows/deliver-issue.md
+++ b/.agents/workflows/deliver-issue.md
@@ -19,11 +19,20 @@ Orchestrate the delivery happy path in one session: preflight (when required), i
 - When Delivery reports **Implementation Complete**, run [`.agents/workflows/verify-and-create-pr.md`](verify-and-create-pr.md).
 - Stop after verify. Do not continue into `/code-review` in this session.
 - Keep `/preflight-issue`, `/implement-issue`, and `/verify-and-create-pr` available for split workflows.
+- A GitHub Issue comment that says implement / fix / do / work on **this issue** is this workflow (open a PR), not the split `implement-issue` path. See [GitHub comment invocation](README.md#github-comment-invocation).
 
 ## Invocation
 
-Natural language: "Deliver issue #N"
-Slash command: `/deliver-issue [number]`
+**Chat:** "Deliver issue #N".
+**Slash command:** `/deliver-issue [number]`.
+**GitHub Issue comment** (mention at the start; `N` is this issue):
+- `@cursor implement this issue`
+- `@cursoragent implement this issue`
+- `@cursor fix this`
+- `@cursor deliver this issue`
+- `@cursor work on this`
+
+Do not use this workflow for "implement without a PR". That is `implement-issue`.
 
 ## Handoff
 

--- a/.agents/workflows/docs-update.md
+++ b/.agents/workflows/docs-update.md
@@ -10,4 +10,9 @@
 
 ## Invocation
 
-Natural language: "Refresh documentation for [topic]" or "Update the decision log for [decision]"
+**Chat:** "Refresh documentation for [topic]" or "Update the decision log for [decision]".
+**Slash command:** `/docs-update`.
+**GitHub Issue comment** (mention at the start; the issue supplies the topic unless named):
+- `@cursor refresh the docs for this`
+- `@cursor update the user guide for this`
+- `@cursor update the decision log for [decision]`

--- a/.agents/workflows/implement-issue.md
+++ b/.agents/workflows/implement-issue.md
@@ -18,6 +18,7 @@
 - Do not implement issues with `status/blocked` or `status/ice-box` — escalate or re-queue first.
 - Do not set `status/in-progress` during standalone `/preflight-issue`.
 - Consult other skills when relevant — do not require reading every skill up front, except the required Aspire skills above.
+- If this session started from a GitHub Issue comment that only says implement / fix / do **this issue**, follow [deliver-issue](deliver-issue.md) instead (open a PR). Use this split workflow only from chat `/implement-issue`, or when the comment explicitly says not to open a pull request.
 
 ### Area label → codebase hints
 
@@ -34,4 +35,10 @@
 
 ## Invocation
 
-Natural language: "Implement issue #N"
+**Chat:** "Implement issue #N".
+**Slash command:** `/implement-issue [number]`.
+**GitHub Issue comment** (mention at the start; `N` is this issue):
+- `@cursor implement this issue without opening a PR`
+- `@cursor implement only — do not create a pull request`
+
+Bare `@cursor implement this issue` is **not** this workflow. Route it to [deliver-issue](deliver-issue.md).

--- a/.agents/workflows/plan-next-issue.md
+++ b/.agents/workflows/plan-next-issue.md
@@ -9,7 +9,14 @@
 - A wireframe in `plan/wireframes/` is required before page-producing UI planning is considered complete.
 - Set parent/child sub-issues (MCP `sub_issue_write`) and blocking relationships (`gh api` REST issue-dependencies) as part of planning. Do not leave them for the user. Report a **Manual fallback** table only if those APIs fail.
 - Sync each created issue to Project #8 per the `repo-github-project` skill.
+- A GitHub Issue comment "plan this issue" plans **that** issue. Do not pick a different backlog item unless the comment says "plan the next item".
 
 ## Invocation
 
-Natural language: "Plan the next item" or "Plan the [feature name]"
+**Chat:** "Plan the next item" or "Plan the [feature name]".
+**Slash command:** `/plan-next-issue`.
+**GitHub Issue comment** (mention at the start). When the comment is on an issue, plan **that** item rather than picking a different backlog candidate:
+- `@cursor plan this issue`
+- `@cursor plan this feature`
+- `@cursor flesh out acceptance criteria and sub-issues`
+- `@cursor plan the next item` (board pick; ignore the current thread unless it is the selected item)

--- a/.agents/workflows/pm-progress-review.md
+++ b/.agents/workflows/pm-progress-review.md
@@ -157,6 +157,8 @@ Deliver a concise chat summary with:
 
 ## Invocation
 
-Natural language: "Run the PM progress review" or "Run a progress review since the last update"
-
-Slash command: `/pm-progress-review`
+**Chat:** "Run the PM progress review" or "Run a progress review since the last update".
+**Slash command:** `/pm-progress-review`.
+**GitHub Issue comment** (mention at the start; repo-wide, not limited to this issue):
+- `@cursor run a progress review`
+- `@cursor run the PM progress review`

--- a/.agents/workflows/preflight-issue.md
+++ b/.agents/workflows/preflight-issue.md
@@ -16,4 +16,9 @@
 
 ## Invocation
 
-Natural language: "Preflight issue #N"
+**Chat:** "Preflight issue #N".
+**Slash command:** `/preflight-issue [number]`.
+**GitHub Issue comment** (mention at the start; `N` is this issue):
+- `@cursor preflight this issue`
+- `@cursor scout this — do not write code yet`
+- `@cursor discover the codebase for this issue`

--- a/.agents/workflows/sync-status-labels.md
+++ b/.agents/workflows/sync-status-labels.md
@@ -33,4 +33,8 @@ Canonical `status/*` labels are defined in [`plan/LABEL_STRATEGY.md`](../../plan
 
 ## Invocation
 
-Natural language: "Clean up status labels", "Fix status/done drift on closed issues", `/sync-status-labels`
+**Chat:** "Clean up status labels" or "Fix status/done drift on closed issues".
+**Slash command:** `/sync-status-labels`.
+**GitHub Issue comment** (mention at the start; repo-wide dry-run first):
+- `@cursor clean up status labels`
+- `@cursor fix status/done drift on closed issues`

--- a/.agents/workflows/verify-and-create-pr.md
+++ b/.agents/workflows/verify-and-create-pr.md
@@ -14,4 +14,11 @@
 
 ## Invocation
 
-Natural language: "Verify issue #N" or "Create PR for issue #N"
+**Chat:** "Verify issue #N" or "Create PR for issue #N".
+**Slash command:** `/verify-and-create-pr [number]`.
+**GitHub Issue comment** (mention at the start; `N` is this issue):
+- `@cursor verify this issue`
+- `@cursor create a PR for this`
+- `@cursor open a pull request`
+
+Do not run this from a Pull Request comment to open a second PR. If the PR already exists, stay on that branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,8 @@ This repository is a **.NET Aspire** distributed application (`src/SoloDevBoard.
 
 Consult the workflow or contract index when entering a PM or delivery mode. Do not load every skill up front for PM-only work. Delivery must still load Aspire skills as above.
 
+Cloud Agents started from a GitHub Issue or Pull Request comment (`@cursor` or `@cursoragent`) follow **GitHub comment invocation** in [`.agents/workflows/README.md`](.agents/workflows/README.md) ([DEC-031](plan/DECISIONS.md#dec-031-github-comment-workflow-invocation)). Informal "implement this issue" on an issue comment is `deliver-issue`, not the split `implement-issue` path.
+
 ---
 
 ## Environment-specific guidance

--- a/plan/CURSOR_CLOUD.md
+++ b/plan/CURSOR_CLOUD.md
@@ -70,6 +70,16 @@ Cursor Cloud agents often default to **draft** PRs, `cursor/…` branch names, a
 
 ---
 
+## Starting a Cloud Agent from GitHub
+
+Comment `@cursor` or `@cursoragent` at the **start** of a GitHub Issue or Pull Request comment. The agent binds "this issue" / "this PR" to that thread.
+
+Informal **implement this issue** on an issue is the delivery happy path (code, verify, pull request). Chat `/implement-issue` remains the split path that does not open a PR. Phrase tables live in [`.agents/workflows/README.md`](../.agents/workflows/README.md#github-comment-invocation) ([DEC-031](DECISIONS.md#dec-031-github-comment-workflow-invocation)).
+
+Each `@cursor` mention on an **issue** starts a new session. Follow-ups that should stay on an existing PR belong on the **pull request** thread (`address the review comments`, `code review this PR`, `fix CI`).
+
+---
+
 ## GitHub authentication caveat (important)
 
 - In the default PAT mode the app **fails fast at startup** unless a token is configured, and it resolves your login from the token via `/user` unless `GitHubAuth:OwnerLogin` is set.

--- a/plan/DECISIONS.md
+++ b/plan/DECISIONS.md
@@ -299,6 +299,16 @@ Test coverage expectations for cache-hit, cache-miss, invalidation, TTL expiry, 
 
 ---
 
+### DEC-031: GitHub comment workflow invocation
+
+**Status:** Active  
+**Date:** 2026-08-20  
+**Constitution:** [AGENTS.md — Skills and Workflow](../AGENTS.md#skills-and-workflow)  
+**Related:** [`.agents/workflows/README.md`](../.agents/workflows/README.md)  
+**Summary:** Cursor Cloud Agents started from a GitHub Issue or Pull Request comment (`@cursor` or `@cursoragent` at the start of the comment) must bind "this issue" / "this PR" to that thread and route human-friendly phrasing through the workflow Invocation tables. Informal implement / fix / do / work on **this issue** on an Issue comment is **`deliver-issue`** (implement, verify, and open a PR). Chat `/implement-issue` remains the split path that does not open a PR. Reject treating GitHub "implement this issue" as implement-only, asking for an issue number the thread already implies, or using bare "review this issue" as code review.
+
+---
+
 ## Superseded legacy (archive only)
 
 | Legacy ADR | Superseded by | Notes |

--- a/plan/PM_RUNBOOK.md
+++ b/plan/PM_RUNBOOK.md
@@ -20,6 +20,9 @@ This runbook orchestrates [`.agents/contracts/`](../.agents/contracts/) and [`.a
 | Address PR review comments               | "Address PR review comments on PR #N" or `/address-pr-review-comments` | PR fixes + thread replies + resolved comments |
 | Progress review (since last update)      | "Run the PM progress review" or `/pm-progress-review`        | Executive summary + next-session priorities   |
 | End-to-end feature delivery              | `.agents/skills/repo-pm-feature-workflow/SKILL.md`         | Full workflow from backlog to closure         |
+| Start a Cloud Agent from GitHub          | Comment `@cursor implement this issue` (or another phrase in [workflow README](../.agents/workflows/README.md#github-comment-invocation)) | Same as the matching workflow; `N` is the thread |
+
+**GitHub comments:** Put `@cursor` or `@cursoragent` at the start of the comment. On an issue, "this issue" is that issue. Informal "implement this issue" runs **deliver** (code + PR), not implement-only. See [DEC-031](DECISIONS.md#dec-031-github-comment-workflow-invocation).
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Adds human-friendly GitHub Issue and Pull Request comment phrases to every agent workflow Invocation section, plus a shared routing table so Cloud Agents started with `@cursor` / `@cursoragent` pick the right workflow.

Informal **implement this issue** on an issue comment is now explicitly **`deliver-issue`** (implement, verify, and open a PR). Chat `/implement-issue` remains the split path that does not open a PR. Recorded as DEC-031.

## Related Issue(s)

Ad-hoc process documentation. No tracking issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Canonical phrase tables live in `.agents/workflows/README.md`. Slash commands and Copilot prompts stay thin pointers. A presence check confirmed every workflow file includes `@cursor` examples:

[workflow_invocation_check.log](https://cursor.com/artifacts/c/art-f6353e59-0b97-4c86-ba7f-7ee8cea77213)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7d27f11-fec5-43f2-af86-2706721d4dc8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7d27f11-fec5-43f2-af86-2706721d4dc8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

