### PR TITLE
[Story] Add label consistency warnings to the Audit Dashboard (#290)

### DIFF
--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -56,7 +56,7 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 
 **Milestone:** v0.2.0
 
-**Status:** Complete. Core Label Manager and Audit Dashboard features are delivered, including Audit Dashboard auto-refresh ([#258](https://github.com/markheydon/solo-dev-board/issues/258)) and Markdown export ([#259](https://github.com/markheydon/solo-dev-board/issues/259)). Label consistency warnings remain deferred — see [#290](https://github.com/markheydon/solo-dev-board/issues/290).
+**Status:** Complete. Core Label Manager and Audit Dashboard features are delivered, including Audit Dashboard auto-refresh ([#258](https://github.com/markheydon/solo-dev-board/issues/258)), Markdown export ([#259](https://github.com/markheydon/solo-dev-board/issues/259)), and label consistency warnings ([#290](https://github.com/markheydon/solo-dev-board/issues/290)).
 
 ### Key Tasks
 
@@ -80,7 +80,7 @@ All planned front-end delivery after ADR-0012 uses MudBlazor as the sole UI comp
 - [x] Implement `AuditDashboardService` in `Application` (aggregate data from multiple repositories)
 - [x] Build MudBlazor UI components for the Audit Dashboard
 - [x] Implement health indicators: unlabelled issues, stale PRs, failing workflows
-- [ ] Implement label consistency warnings _(deferred to v1.1.0 — [#290](https://github.com/markheydon/solo-dev-board/issues/290))_
+- [x] Implement label consistency warnings _(v1.1.0 — [#290](https://github.com/markheydon/solo-dev-board/issues/290))_
 - [x] Write unit tests for `AuditDashboardService`
 - [x] Update `website/content/docs/audit-dashboard.md`
 

--- a/plan/SCOPE.md
+++ b/plan/SCOPE.md
@@ -29,7 +29,7 @@ Public-release hardening is in scope for v1.0.0, including:
 
 ### 1. Audit Dashboard
 
-A consolidated view of repository health: open issues, stale PRs, and GitHub Actions workflow statuses across selected repositories. Label consistency warnings are in scope for **v1.1.0** ([#290](https://github.com/markheydon/solo-dev-board/issues/290)), not v1.0.0.
+A consolidated view of repository health: open issues, stale PRs, GitHub Actions workflow statuses, and label consistency warnings ([#290](https://github.com/markheydon/solo-dev-board/issues/290)) across selected repositories.
 
 ### 2. One-Click Migration
 
@@ -121,5 +121,5 @@ The following are explicitly **not** in scope for the current version of SoloDev
 | 2026-07-25 | V1 auth polish bundle clarified: hosted sign-in entry UX (#249) and PAT-mode GitHub connectivity readiness (#314) split from operator documentation (#247, #248). In-app secret editing remains out of scope; operator configuration stays via Aspire parameters, user secrets, and Key Vault. | Solo developer |
 | 2026-07-25 | PAT-only local trusted mode and self-hoster PAT Azure deploy path formalised in docs (#247, #248; PR #324). Scope bullet now links to getting-started and deployment guides. | Solo developer |
 | 2026-08-16 | Public product site on GitHub Pages: landing, User Guide, About narrative, canonical `solodevboard.com`, source tree `website/` (DEC-023). | Solo developer |
-| 2026-08-18 | Post-1.0 backlog cleanup: one open milestone (`v1.1.0`); Cross-Repo PM Workflow and deferred slices consolidated there; bucket epic #289 closed; unused v1.2.0 milestone closed and deleted; #293 unmilestoned (DEC-027). | Solo developer |
+| 2026-08-20 | Label consistency warnings delivered on the Audit Dashboard ([#290](https://github.com/markheydon/solo-dev-board/issues/290)). | Solo developer |
 

--- a/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor
@@ -83,7 +83,7 @@
                     <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
                         <MudButton Variant="Variant.Outlined"
                                    Color="Color.Primary"
-                                   Disabled="@(!hasLoadedAuditSummary || isLoadingAuditData || isRefreshingAuditData || isLoadingWorkflowHealth)"
+                                   Disabled="@(!hasLoadedAuditSummary || isLoadingAuditData || isRefreshingAuditData || isLoadingWorkflowHealth || isLoadingLabelConsistency)"
                                    OnClick="ExportMarkdownSummaryAsync"
                                    data-testid="audit-export-markdown-button">
                             Export Markdown
@@ -141,25 +141,25 @@
                 <MudStack Spacing="2">
                     <MudText Typo="Typo.h6">KPI summary</MudText>
                     <MudGrid>
-                        <MudItem xs="12" sm="6" md="3">
+                        <MudItem xs="12" sm="6" md="4">
                             <MudPaper Class="pa-3" Outlined="true" data-testid="audit-total-issues-card">
                                 <MudText Typo="Typo.caption">Total open issues</MudText>
                                 <MudText Typo="Typo.h5">@totalOpenIssues</MudText>
                             </MudPaper>
                         </MudItem>
-                        <MudItem xs="12" sm="6" md="3">
+                        <MudItem xs="12" sm="6" md="4">
                             <MudPaper Class="pa-3" Outlined="true" data-testid="audit-total-prs-card">
                                 <MudText Typo="Typo.caption">Total open pull requests</MudText>
                                 <MudText Typo="Typo.h5">@totalOpenPullRequests</MudText>
                             </MudPaper>
                         </MudItem>
-                        <MudItem xs="12" sm="6" md="3">
+                        <MudItem xs="12" sm="6" md="4">
                             <MudPaper Class="pa-3" Outlined="true" data-testid="audit-unlabelled-kpi-card">
                                 <MudText Typo="Typo.caption">Unlabelled issues</MudText>
                                 <MudText Typo="Typo.h5">@totalUnlabelledIssues</MudText>
                             </MudPaper>
                         </MudItem>
-                        <MudItem xs="12" sm="6" md="3">
+                        <MudItem xs="12" sm="6" md="4">
                             <MudPaper Class="pa-3" Outlined="true" data-testid="audit-failing-workflows-kpi-card">
                                 <MudText Typo="Typo.caption">Failing workflows</MudText>
                                 @if (isLoadingWorkflowHealth)
@@ -169,6 +169,19 @@
                                 else
                                 {
                                     <MudText Typo="Typo.h5">@totalFailingWorkflows</MudText>
+                                }
+                            </MudPaper>
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="4">
+                            <MudPaper Class="pa-3" Outlined="true" data-testid="audit-label-consistency-kpi-card">
+                                <MudText Typo="Typo.caption">Label consistency warnings</MudText>
+                                @if (isLoadingLabelConsistency)
+                                {
+                                    <MudSkeleton Height="32px" Width="48px" Animation="Animation.Wave" />
+                                }
+                                else
+                                {
+                                    <MudText Typo="Typo.h5">@totalLabelConsistencyWarnings</MudText>
                                 }
                             </MudPaper>
                         </MudItem>
@@ -319,6 +332,51 @@
                                                     Open run
                                                 </MudLink>
                                             </MudTd>
+                                        </RowTemplate>
+                                    </MudTable>
+                                }
+                            </ChildContent>
+                        </MudExpansionPanel>
+
+                        <MudExpansionPanel Expanded="true" data-testid="audit-label-consistency-section">
+                            <TitleContent>
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                    <MudText Typo="Typo.subtitle1">Label Consistency</MudText>
+                                    <MudBadge Color="Color.Warning" Content="@labelConsistencyWarnings.Count" />
+                                </MudStack>
+                            </TitleContent>
+                            <ChildContent>
+                                <MudText Typo="Typo.body2" Class="mb-2">
+                                    Compared with the SoloDevBoard canonical taxonomy. Extra repository labels are not reported.
+                                    Use
+                                    <MudLink Href="/labels">Label Manager</MudLink>
+                                    to apply the taxonomy.
+                                </MudText>
+                                @if (isLoadingLabelConsistency)
+                                {
+                                    <MudStack Spacing="1" data-testid="audit-label-consistency-loading">
+                                        <MudText Typo="Typo.body2">Loading label consistency...</MudText>
+                                        <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+                                    </MudStack>
+                                }
+                                else if (labelConsistencyWarnings.Count == 0)
+                                {
+                                    <MudText Typo="Typo.body2" data-testid="audit-label-consistency-empty">Labels match the SoloDevBoard taxonomy — great!</MudText>
+                                }
+                                else
+                                {
+                                    <MudTable T="LabelConsistencyWarningDto" Items="labelConsistencyWarnings" Dense="true" Hover="true" Class="sdb-responsive-grid" data-testid="audit-label-consistency-table">
+                                        <HeaderContent>
+                                            <MudTh>Repository</MudTh>
+                                            <MudTh>Label</MudTh>
+                                            <MudTh>Warning</MudTh>
+                                            <MudTh>Detail</MudTh>
+                                        </HeaderContent>
+                                        <RowTemplate>
+                                            <MudTd DataLabel="Repository">@context.RepositoryFullName</MudTd>
+                                            <MudTd DataLabel="Label">@context.LabelName</MudTd>
+                                            <MudTd DataLabel="Warning">@FormatWarningKind(context.Kind)</MudTd>
+                                            <MudTd DataLabel="Detail">@context.Detail</MudTd>
                                         </RowTemplate>
                                     </MudTable>
                                 }

--- a/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor
@@ -83,7 +83,7 @@
                     <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
                         <MudButton Variant="Variant.Outlined"
                                    Color="Color.Primary"
-                                   Disabled="@(!hasLoadedAuditSummary || isLoadingAuditData || isRefreshingAuditData || isLoadingWorkflowHealth || isLoadingLabelConsistency)"
+                                   Disabled="@(!hasLoadedAuditSummary || isLoadingAuditData || isRefreshingAuditData || isLoadingWorkflowHealth || isLoadingLabelConsistency || workflowHealthLoadFailed || labelConsistencyLoadFailed)"
                                    OnClick="ExportMarkdownSummaryAsync"
                                    data-testid="audit-export-markdown-button">
                             Export Markdown

--- a/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor.cs
@@ -46,16 +46,19 @@ public partial class Audit : ComponentBase, IAsyncDisposable
     private IReadOnlyList<IssueDto> unlabelledIssues = [];
     private IReadOnlyList<PullRequestDto> stalePullRequests = [];
     private IReadOnlyList<WorkflowRunDto> failingWorkflowRuns = [];
+    private IReadOnlyList<LabelConsistencyWarningDto> labelConsistencyWarnings = [];
     private IReadOnlyList<string> repositoryOptions = [];
     private HashSet<string> selectedRepositories = new(StringComparer.OrdinalIgnoreCase);
     private int totalOpenIssues;
     private int totalOpenPullRequests;
     private int totalUnlabelledIssues;
     private int totalFailingWorkflows;
+    private int totalLabelConsistencyWarnings;
     private bool isLoadingRepositories = true;
     private bool isLoadingAuditData;
     private bool isRefreshingAuditData;
     private bool isLoadingWorkflowHealth;
+    private bool isLoadingLabelConsistency;
     private bool hasLoadedAuditSummary;
     private string? repositoryLoadErrorMessage;
     private string? auditLoadErrorMessage;
@@ -224,46 +227,18 @@ public partial class Audit : ComponentBase, IAsyncDisposable
             hasLoadedAuditSummary = true;
             isLoadingAuditData = false;
             isLoadingWorkflowHealth = true;
+            isLoadingLabelConsistency = true;
             await InvokeAsync(StateHasChanged);
 
-            try
-            {
-                var failingRuns = await AuditDashboardService.GetFailingWorkflowRunsAsync(selectedRepoNames);
-                failingWorkflowRuns = failingRuns
-                    .OrderBy(workflowRun => workflowRun.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
-                    .ThenBy(workflowRun => workflowRun.WorkflowName, StringComparer.OrdinalIgnoreCase)
-                    .ToArray();
-                ApplyWorkflowCountsToSummaries();
-                totalFailingWorkflows = repositorySummaries.Sum(result => result.FailingWorkflowCount);
-            }
-            catch (HttpRequestException ex)
-            {
-                Logger.LogWarning(ex, "Failed to load workflow health for selected audit repositories.");
-                if (isBackgroundRefresh)
-                {
-                    Snackbar.Add($"Workflow health refresh failed. {ex.Message}", Severity.Warning);
-                }
-                else
-                {
-                    Snackbar.Add($"Workflow health could not be loaded. {ex.Message}", Severity.Warning);
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning(ex, "Failed to load workflow health for selected audit repositories.");
-                if (isBackgroundRefresh)
-                {
-                    Snackbar.Add("Workflow health refresh failed due to an unexpected error.", Severity.Warning);
-                }
-                else
-                {
-                    Snackbar.Add("Workflow health could not be loaded due to an unexpected error.", Severity.Warning);
-                }
-            }
-            finally
-            {
-                isLoadingWorkflowHealth = false;
-            }
+            var workflowHealthTask = FetchFailingWorkflowRunsAsync(selectedRepoNames, isBackgroundRefresh);
+            var labelConsistencyTask = FetchLabelConsistencyWarningsAsync(selectedRepoNames, isBackgroundRefresh);
+            await Task.WhenAll(workflowHealthTask, labelConsistencyTask);
+
+            failingWorkflowRuns = workflowHealthTask.Result;
+            labelConsistencyWarnings = labelConsistencyTask.Result;
+            ApplySecondaryHealthCountsToSummaries();
+            isLoadingWorkflowHealth = false;
+            isLoadingLabelConsistency = false;
         }
         catch (Exception ex) when (ex is HostedAuthenticationRequiredException or GitHubPatConnectivityRequiredException)
         {
@@ -309,7 +284,7 @@ public partial class Audit : ComponentBase, IAsyncDisposable
 
     private async Task ExportMarkdownSummaryAsync()
     {
-        if (!hasLoadedAuditSummary || isLoadingWorkflowHealth)
+        if (!hasLoadedAuditSummary || isLoadingWorkflowHealth || isLoadingLabelConsistency)
         {
             Snackbar.Add("Load an audit summary before exporting Markdown.", Severity.Warning);
             return;
@@ -345,11 +320,13 @@ public partial class Audit : ComponentBase, IAsyncDisposable
             unlabelledIssues,
             stalePullRequests,
             failingWorkflowRuns,
+            labelConsistencyWarnings,
             selectedRepositoryNames,
             totalOpenIssues,
             totalOpenPullRequests,
             totalUnlabelledIssues,
             totalFailingWorkflows,
+            totalLabelConsistencyWarnings,
             StalePullRequestDays,
             DateTimeOffset.UtcNow);
 
@@ -378,20 +355,93 @@ public partial class Audit : ComponentBase, IAsyncDisposable
         totalOpenPullRequests = repositorySummaries.Sum(result => result.OpenPullRequestCount);
         totalUnlabelledIssues = repositorySummaries.Sum(result => result.UnlabelledIssueCount);
         totalFailingWorkflows = repositorySummaries.Sum(result => result.FailingWorkflowCount);
+        totalLabelConsistencyWarnings = repositorySummaries.Sum(result => result.LabelConsistencyWarningCount);
     }
 
-    private void ApplyWorkflowCountsToSummaries()
+    private async Task<IReadOnlyList<WorkflowRunDto>> FetchFailingWorkflowRunsAsync(IReadOnlyList<string> selectedRepoNames, bool isBackgroundRefresh)
+    {
+        try
+        {
+            var failingRuns = await AuditDashboardService.GetFailingWorkflowRunsAsync(selectedRepoNames);
+            return failingRuns
+                .OrderBy(workflowRun => workflowRun.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(workflowRun => workflowRun.WorkflowName, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogWarning(ex, "Failed to load workflow health for selected audit repositories.");
+            Snackbar.Add(
+                isBackgroundRefresh
+                    ? $"Workflow health refresh failed. {ex.Message}"
+                    : $"Workflow health could not be loaded. {ex.Message}",
+                Severity.Warning);
+            return [];
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to load workflow health for selected audit repositories.");
+            Snackbar.Add(
+                isBackgroundRefresh
+                    ? "Workflow health refresh failed due to an unexpected error."
+                    : "Workflow health could not be loaded due to an unexpected error.",
+                Severity.Warning);
+            return [];
+        }
+    }
+
+    private async Task<IReadOnlyList<LabelConsistencyWarningDto>> FetchLabelConsistencyWarningsAsync(IReadOnlyList<string> selectedRepoNames, bool isBackgroundRefresh)
+    {
+        try
+        {
+            var warnings = await AuditDashboardService.GetLabelConsistencyWarningsAsync(selectedRepoNames);
+            return warnings
+                .OrderBy(warning => warning.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(warning => warning.LabelName, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogWarning(ex, "Failed to load label consistency for selected audit repositories.");
+            Snackbar.Add(
+                isBackgroundRefresh
+                    ? $"Label consistency refresh failed. {ex.Message}"
+                    : $"Label consistency could not be loaded. {ex.Message}",
+                Severity.Warning);
+            return [];
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to load label consistency for selected audit repositories.");
+            Snackbar.Add(
+                isBackgroundRefresh
+                    ? "Label consistency refresh failed due to an unexpected error."
+                    : "Label consistency could not be loaded due to an unexpected error.",
+                Severity.Warning);
+            return [];
+        }
+    }
+
+    private void ApplySecondaryHealthCountsToSummaries()
     {
         var failingWorkflowCountByRepository = failingWorkflowRuns
             .GroupBy(workflowRun => workflowRun.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+
+        var warningCountByRepository = labelConsistencyWarnings
+            .GroupBy(warning => warning.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
 
         repositorySummaries = repositorySummaries
             .Select(summary => summary with
             {
                 FailingWorkflowCount = failingWorkflowCountByRepository.GetValueOrDefault(summary.RepositoryFullName),
+                LabelConsistencyWarningCount = warningCountByRepository.GetValueOrDefault(summary.RepositoryFullName),
             })
             .ToArray();
+
+        totalFailingWorkflows = repositorySummaries.Sum(result => result.FailingWorkflowCount);
+        totalLabelConsistencyWarnings = repositorySummaries.Sum(result => result.LabelConsistencyWarningCount);
     }
 
     private async Task StartAutoRefreshAsync()
@@ -464,11 +514,21 @@ public partial class Audit : ComponentBase, IAsyncDisposable
         unlabelledIssues = [];
         stalePullRequests = [];
         failingWorkflowRuns = [];
+        labelConsistencyWarnings = [];
         totalOpenIssues = 0;
         totalOpenPullRequests = 0;
         totalUnlabelledIssues = 0;
         totalFailingWorkflows = 0;
+        totalLabelConsistencyWarnings = 0;
     }
+
+    private static string FormatWarningKind(LabelConsistencyWarningKind kind)
+        => kind switch
+        {
+            LabelConsistencyWarningKind.Missing => "Missing",
+            LabelConsistencyWarningKind.Divergent => "Divergent",
+            _ => kind.ToString(),
+        };
 
     private static int GetDaysBetween(DateTimeOffset value)
     {

--- a/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Audit/Pages/Audit.razor.cs
@@ -59,6 +59,8 @@ public partial class Audit : ComponentBase, IAsyncDisposable
     private bool isRefreshingAuditData;
     private bool isLoadingWorkflowHealth;
     private bool isLoadingLabelConsistency;
+    private bool workflowHealthLoadFailed;
+    private bool labelConsistencyLoadFailed;
     private bool hasLoadedAuditSummary;
     private string? repositoryLoadErrorMessage;
     private string? auditLoadErrorMessage;
@@ -228,14 +230,21 @@ public partial class Audit : ComponentBase, IAsyncDisposable
             isLoadingAuditData = false;
             isLoadingWorkflowHealth = true;
             isLoadingLabelConsistency = true;
+            workflowHealthLoadFailed = false;
+            labelConsistencyLoadFailed = false;
             await InvokeAsync(StateHasChanged);
 
             var workflowHealthTask = FetchFailingWorkflowRunsAsync(selectedRepoNames, isBackgroundRefresh);
             var labelConsistencyTask = FetchLabelConsistencyWarningsAsync(selectedRepoNames, isBackgroundRefresh);
             await Task.WhenAll(workflowHealthTask, labelConsistencyTask);
 
-            failingWorkflowRuns = workflowHealthTask.Result;
-            labelConsistencyWarnings = labelConsistencyTask.Result;
+            var workflowHealthResult = await workflowHealthTask;
+            var labelConsistencyResult = await labelConsistencyTask;
+
+            failingWorkflowRuns = workflowHealthResult.Items;
+            workflowHealthLoadFailed = workflowHealthResult.LoadFailed;
+            labelConsistencyWarnings = labelConsistencyResult.Items;
+            labelConsistencyLoadFailed = labelConsistencyResult.LoadFailed;
             ApplySecondaryHealthCountsToSummaries();
             isLoadingWorkflowHealth = false;
             isLoadingLabelConsistency = false;
@@ -290,6 +299,12 @@ public partial class Audit : ComponentBase, IAsyncDisposable
             return;
         }
 
+        if (workflowHealthLoadFailed || labelConsistencyLoadFailed)
+        {
+            Snackbar.Add("Workflow health and label consistency must finish loading before exporting Markdown.", Severity.Warning);
+            return;
+        }
+
         if (auditClipboardModule is null)
         {
             Snackbar.Add("Clipboard export is not ready yet. Please try again.", Severity.Warning);
@@ -328,7 +343,9 @@ public partial class Audit : ComponentBase, IAsyncDisposable
             totalFailingWorkflows,
             totalLabelConsistencyWarnings,
             StalePullRequestDays,
-            DateTimeOffset.UtcNow);
+            DateTimeOffset.UtcNow,
+            workflowHealthLoadFailed,
+            labelConsistencyLoadFailed);
 
     private void ApplySnapshot(AuditDashboardSnapshotDto snapshot)
     {
@@ -358,15 +375,17 @@ public partial class Audit : ComponentBase, IAsyncDisposable
         totalLabelConsistencyWarnings = repositorySummaries.Sum(result => result.LabelConsistencyWarningCount);
     }
 
-    private async Task<IReadOnlyList<WorkflowRunDto>> FetchFailingWorkflowRunsAsync(IReadOnlyList<string> selectedRepoNames, bool isBackgroundRefresh)
+    private async Task<SecondaryFetchResult<WorkflowRunDto>> FetchFailingWorkflowRunsAsync(IReadOnlyList<string> selectedRepoNames, bool isBackgroundRefresh)
     {
         try
         {
             var failingRuns = await AuditDashboardService.GetFailingWorkflowRunsAsync(selectedRepoNames);
-            return failingRuns
-                .OrderBy(workflowRun => workflowRun.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
-                .ThenBy(workflowRun => workflowRun.WorkflowName, StringComparer.OrdinalIgnoreCase)
-                .ToArray();
+            return new SecondaryFetchResult<WorkflowRunDto>(
+                failingRuns
+                    .OrderBy(workflowRun => workflowRun.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(workflowRun => workflowRun.WorkflowName, StringComparer.OrdinalIgnoreCase)
+                    .ToArray(),
+                LoadFailed: false);
         }
         catch (HttpRequestException ex)
         {
@@ -376,7 +395,7 @@ public partial class Audit : ComponentBase, IAsyncDisposable
                     ? $"Workflow health refresh failed. {ex.Message}"
                     : $"Workflow health could not be loaded. {ex.Message}",
                 Severity.Warning);
-            return [];
+            return new SecondaryFetchResult<WorkflowRunDto>([], LoadFailed: true);
         }
         catch (Exception ex)
         {
@@ -386,19 +405,21 @@ public partial class Audit : ComponentBase, IAsyncDisposable
                     ? "Workflow health refresh failed due to an unexpected error."
                     : "Workflow health could not be loaded due to an unexpected error.",
                 Severity.Warning);
-            return [];
+            return new SecondaryFetchResult<WorkflowRunDto>([], LoadFailed: true);
         }
     }
 
-    private async Task<IReadOnlyList<LabelConsistencyWarningDto>> FetchLabelConsistencyWarningsAsync(IReadOnlyList<string> selectedRepoNames, bool isBackgroundRefresh)
+    private async Task<SecondaryFetchResult<LabelConsistencyWarningDto>> FetchLabelConsistencyWarningsAsync(IReadOnlyList<string> selectedRepoNames, bool isBackgroundRefresh)
     {
         try
         {
             var warnings = await AuditDashboardService.GetLabelConsistencyWarningsAsync(selectedRepoNames);
-            return warnings
-                .OrderBy(warning => warning.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
-                .ThenBy(warning => warning.LabelName, StringComparer.OrdinalIgnoreCase)
-                .ToArray();
+            return new SecondaryFetchResult<LabelConsistencyWarningDto>(
+                warnings
+                    .OrderBy(warning => warning.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(warning => warning.LabelName, StringComparer.OrdinalIgnoreCase)
+                    .ToArray(),
+                LoadFailed: false);
         }
         catch (HttpRequestException ex)
         {
@@ -408,7 +429,7 @@ public partial class Audit : ComponentBase, IAsyncDisposable
                     ? $"Label consistency refresh failed. {ex.Message}"
                     : $"Label consistency could not be loaded. {ex.Message}",
                 Severity.Warning);
-            return [];
+            return new SecondaryFetchResult<LabelConsistencyWarningDto>([], LoadFailed: true);
         }
         catch (Exception ex)
         {
@@ -418,7 +439,7 @@ public partial class Audit : ComponentBase, IAsyncDisposable
                     ? "Label consistency refresh failed due to an unexpected error."
                     : "Label consistency could not be loaded due to an unexpected error.",
                 Severity.Warning);
-            return [];
+            return new SecondaryFetchResult<LabelConsistencyWarningDto>([], LoadFailed: true);
         }
     }
 
@@ -520,7 +541,11 @@ public partial class Audit : ComponentBase, IAsyncDisposable
         totalUnlabelledIssues = 0;
         totalFailingWorkflows = 0;
         totalLabelConsistencyWarnings = 0;
+        workflowHealthLoadFailed = false;
+        labelConsistencyLoadFailed = false;
     }
+
+    private sealed record SecondaryFetchResult<T>(IReadOnlyList<T> Items, bool LoadFailed);
 
     private static string FormatWarningKind(LabelConsistencyWarningKind kind)
         => kind switch

--- a/src/Application/SoloDevBoard.Application/Services/Audit/AuditDashboardMarkdownExportRequest.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Audit/AuditDashboardMarkdownExportRequest.cs
@@ -5,11 +5,13 @@ namespace SoloDevBoard.Application.Services.Audit;
 /// <param name="UnlabelledIssues">Open unlabelled issues across the selected repositories.</param>
 /// <param name="StalePullRequests">Stale open pull requests across the selected repositories.</param>
 /// <param name="FailingWorkflowRuns">Failing or cancelled workflow runs across the selected repositories.</param>
+/// <param name="LabelConsistencyWarnings">Missing or divergent SoloDevBoard taxonomy labels across the selected repositories.</param>
 /// <param name="SelectedRepositories">The repository names included in the export.</param>
 /// <param name="TotalOpenIssues">The total number of open issues across selected repositories.</param>
 /// <param name="TotalOpenPullRequests">The total number of open pull requests across selected repositories.</param>
 /// <param name="TotalUnlabelledIssues">The total number of unlabelled issues across selected repositories.</param>
 /// <param name="TotalFailingWorkflows">The total number of failing workflows across selected repositories.</param>
+/// <param name="TotalLabelConsistencyWarnings">The total number of label consistency warnings across selected repositories.</param>
 /// <param name="StalePullRequestDays">The number of days after which a pull request is considered stale.</param>
 /// <param name="GeneratedAtUtc">The UTC timestamp when the export was generated.</param>
 public sealed record AuditDashboardMarkdownExportRequest(
@@ -17,10 +19,12 @@ public sealed record AuditDashboardMarkdownExportRequest(
     IReadOnlyList<IssueDto> UnlabelledIssues,
     IReadOnlyList<PullRequestDto> StalePullRequests,
     IReadOnlyList<WorkflowRunDto> FailingWorkflowRuns,
+    IReadOnlyList<LabelConsistencyWarningDto> LabelConsistencyWarnings,
     IReadOnlyList<string> SelectedRepositories,
     int TotalOpenIssues,
     int TotalOpenPullRequests,
     int TotalUnlabelledIssues,
     int TotalFailingWorkflows,
+    int TotalLabelConsistencyWarnings,
     int StalePullRequestDays,
     DateTimeOffset GeneratedAtUtc);

--- a/src/Application/SoloDevBoard.Application/Services/Audit/AuditDashboardMarkdownExportRequest.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Audit/AuditDashboardMarkdownExportRequest.cs
@@ -14,6 +14,8 @@ namespace SoloDevBoard.Application.Services.Audit;
 /// <param name="TotalLabelConsistencyWarnings">The total number of label consistency warnings across selected repositories.</param>
 /// <param name="StalePullRequestDays">The number of days after which a pull request is considered stale.</param>
 /// <param name="GeneratedAtUtc">The UTC timestamp when the export was generated.</param>
+/// <param name="WorkflowHealthLoadFailed">Indicates whether workflow health data could not be loaded for the export.</param>
+/// <param name="LabelConsistencyLoadFailed">Indicates whether label consistency data could not be loaded for the export.</param>
 public sealed record AuditDashboardMarkdownExportRequest(
     IReadOnlyList<RepositoryAuditSummaryDto> RepositorySummaries,
     IReadOnlyList<IssueDto> UnlabelledIssues,
@@ -27,4 +29,6 @@ public sealed record AuditDashboardMarkdownExportRequest(
     int TotalFailingWorkflows,
     int TotalLabelConsistencyWarnings,
     int StalePullRequestDays,
-    DateTimeOffset GeneratedAtUtc);
+    DateTimeOffset GeneratedAtUtc,
+    bool WorkflowHealthLoadFailed = false,
+    bool LabelConsistencyLoadFailed = false);

--- a/src/Application/SoloDevBoard.Application/Services/Audit/AuditDashboardMarkdownExporter.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Audit/AuditDashboardMarkdownExporter.cs
@@ -27,8 +27,8 @@ public sealed class AuditDashboardMarkdownExporter : IAuditDashboardMarkdownExpo
         AppendRepositorySummary(builder, request.RepositorySummaries);
         AppendUnlabelledIssues(builder, request.UnlabelledIssues, generatedAtUtc);
         AppendStalePullRequests(builder, request.StalePullRequests, request.StalePullRequestDays, generatedAtUtc);
-        AppendFailingWorkflows(builder, request.FailingWorkflowRuns);
-        AppendLabelConsistencyWarnings(builder, request.LabelConsistencyWarnings);
+        AppendFailingWorkflows(builder, request.FailingWorkflowRuns, request.WorkflowHealthLoadFailed);
+        AppendLabelConsistencyWarnings(builder, request.LabelConsistencyWarnings, request.LabelConsistencyLoadFailed);
 
         return builder.ToString().TrimEnd();
     }
@@ -122,10 +122,20 @@ public sealed class AuditDashboardMarkdownExporter : IAuditDashboardMarkdownExpo
         builder.AppendLine();
     }
 
-    private static void AppendFailingWorkflows(StringBuilder builder, IReadOnlyList<WorkflowRunDto> failingWorkflowRuns)
+    private static void AppendFailingWorkflows(
+        StringBuilder builder,
+        IReadOnlyList<WorkflowRunDto> failingWorkflowRuns,
+        bool workflowHealthLoadFailed)
     {
         builder.AppendLine("## Failing workflows");
         builder.AppendLine();
+
+        if (workflowHealthLoadFailed)
+        {
+            builder.AppendLine("Workflow health could not be loaded for this export.");
+            builder.AppendLine();
+            return;
+        }
 
         if (failingWorkflowRuns.Count == 0)
         {
@@ -145,12 +155,22 @@ public sealed class AuditDashboardMarkdownExporter : IAuditDashboardMarkdownExpo
         builder.AppendLine();
     }
 
-    private static void AppendLabelConsistencyWarnings(StringBuilder builder, IReadOnlyList<LabelConsistencyWarningDto> warnings)
+    private static void AppendLabelConsistencyWarnings(
+        StringBuilder builder,
+        IReadOnlyList<LabelConsistencyWarningDto> warnings,
+        bool labelConsistencyLoadFailed)
     {
         builder.AppendLine("## Label consistency warnings");
         builder.AppendLine();
         builder.AppendLine("Compared against the SoloDevBoard canonical taxonomy. Extra repository labels are not reported.");
         builder.AppendLine();
+
+        if (labelConsistencyLoadFailed)
+        {
+            builder.AppendLine("Label consistency could not be loaded for this export.");
+            builder.AppendLine();
+            return;
+        }
 
         if (warnings.Count == 0)
         {

--- a/src/Application/SoloDevBoard.Application/Services/Audit/AuditDashboardMarkdownExporter.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Audit/AuditDashboardMarkdownExporter.cs
@@ -28,6 +28,7 @@ public sealed class AuditDashboardMarkdownExporter : IAuditDashboardMarkdownExpo
         AppendUnlabelledIssues(builder, request.UnlabelledIssues, generatedAtUtc);
         AppendStalePullRequests(builder, request.StalePullRequests, request.StalePullRequestDays, generatedAtUtc);
         AppendFailingWorkflows(builder, request.FailingWorkflowRuns);
+        AppendLabelConsistencyWarnings(builder, request.LabelConsistencyWarnings);
 
         return builder.ToString().TrimEnd();
     }
@@ -42,6 +43,7 @@ public sealed class AuditDashboardMarkdownExporter : IAuditDashboardMarkdownExpo
         builder.AppendLine($"| Total open pull requests | {request.TotalOpenPullRequests} |");
         builder.AppendLine($"| Unlabelled issues | {request.TotalUnlabelledIssues} |");
         builder.AppendLine($"| Failing workflows | {request.TotalFailingWorkflows} |");
+        builder.AppendLine($"| Label consistency warnings | {request.TotalLabelConsistencyWarnings} |");
         builder.AppendLine();
     }
 
@@ -142,6 +144,39 @@ public sealed class AuditDashboardMarkdownExporter : IAuditDashboardMarkdownExpo
 
         builder.AppendLine();
     }
+
+    private static void AppendLabelConsistencyWarnings(StringBuilder builder, IReadOnlyList<LabelConsistencyWarningDto> warnings)
+    {
+        builder.AppendLine("## Label consistency warnings");
+        builder.AppendLine();
+        builder.AppendLine("Compared against the SoloDevBoard canonical taxonomy. Extra repository labels are not reported.");
+        builder.AppendLine();
+
+        if (warnings.Count == 0)
+        {
+            builder.AppendLine("Labels match the SoloDevBoard taxonomy — great!");
+            builder.AppendLine();
+            return;
+        }
+
+        builder.AppendLine("| Repository | Label | Warning | Detail |");
+        builder.AppendLine("| --- | --- | --- | --- |");
+
+        foreach (var warning in warnings)
+        {
+            builder.AppendLine($"| {warning.RepositoryFullName} | {EscapeMarkdownTableCell(warning.LabelName)} | {FormatWarningKind(warning.Kind)} | {EscapeMarkdownTableCell(warning.Detail)} |");
+        }
+
+        builder.AppendLine();
+    }
+
+    private static string FormatWarningKind(LabelConsistencyWarningKind kind)
+        => kind switch
+        {
+            LabelConsistencyWarningKind.Missing => "Missing",
+            LabelConsistencyWarningKind.Divergent => "Divergent",
+            _ => kind.ToString(),
+        };
 
     private static int GetDaysBetween(DateTimeOffset value, DateTimeOffset referenceUtc)
     {

--- a/src/Application/SoloDevBoard.Application/Services/Audit/AuditDashboardService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Audit/AuditDashboardService.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Microsoft.Extensions.Logging;
 using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Application.Services.Labels;
 using SoloDevBoard.Domain.Entities.Triage;
 using SoloDevBoard.Domain.Entities.Workflows;
 
@@ -14,23 +15,28 @@ public sealed class AuditDashboardService : IAuditDashboardService
     private const string OpenItemState = "open";
 
     private readonly IGitHubService _gitHubService;
+    private readonly ILabelRepository _labelRepository;
     private readonly ICurrentUserContext _currentUserContext;
     private readonly ILogger<AuditDashboardService> _logger;
 
     /// <summary>Initialises a new instance of the <see cref="AuditDashboardService"/> class.</summary>
     /// <param name="gitHubService">The GitHub service used for repository data retrieval.</param>
+    /// <param name="labelRepository">The repository used to retrieve GitHub labels for consistency analysis.</param>
     /// <param name="currentUserContext">The current user context used to resolve the owner login.</param>
     /// <param name="logger">The logger used for audit dashboard diagnostics.</param>
     public AuditDashboardService(
         IGitHubService gitHubService,
+        ILabelRepository labelRepository,
         ICurrentUserContext currentUserContext,
         ILogger<AuditDashboardService> logger)
     {
         ArgumentNullException.ThrowIfNull(gitHubService);
+        ArgumentNullException.ThrowIfNull(labelRepository);
         ArgumentNullException.ThrowIfNull(currentUserContext);
         ArgumentNullException.ThrowIfNull(logger);
 
         _gitHubService = gitHubService;
+        _labelRepository = labelRepository;
         _currentUserContext = currentUserContext;
         _logger = logger;
     }
@@ -183,6 +189,24 @@ public sealed class AuditDashboardService : IAuditDashboardService
         return workflowRunsByRepository.SelectMany(static workflowRuns => workflowRuns).ToArray();
     }
 
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<LabelConsistencyWarningDto>> GetLabelConsistencyWarningsAsync(IReadOnlyList<string> repos, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(repos);
+
+        var repositoryReferences = GetRepositoryReferences(repos);
+        var taxonomyLabels = RecommendedLabelTaxonomyCatalog.SoloDevBoard;
+        var warningTasks = repositoryReferences.Select(repositoryReference =>
+            BuildLabelConsistencyWarningsAsync(repositoryReference, taxonomyLabels, cancellationToken));
+        var warningsByRepository = await Task.WhenAll(warningTasks).ConfigureAwait(false);
+
+        return warningsByRepository
+            .SelectMany(static warnings => warnings)
+            .OrderBy(static warning => warning.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static warning => warning.LabelName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
     private static IssueDto MapIssue(Issue issue, string repositoryFullName)
         => new(
             issue.Number,
@@ -313,6 +337,31 @@ public sealed class AuditDashboardService : IAuditDashboardService
 
     private static bool IsSkippableGitHubStatus(HttpStatusCode? statusCode)
         => statusCode is HttpStatusCode.NotFound or HttpStatusCode.Forbidden or HttpStatusCode.Gone;
+
+    private async Task<IReadOnlyList<LabelConsistencyWarningDto>> BuildLabelConsistencyWarningsAsync(
+        RepositoryReference repositoryReference,
+        IReadOnlyList<LabelDto> taxonomyLabels,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var labels = await _labelRepository
+                .GetLabelsAsync(repositoryReference.Owner, repositoryReference.RepoName, cancellationToken)
+                .ConfigureAwait(false);
+
+            return LabelConsistencyAnalyser.Analyse(repositoryReference.FullName, labels, taxonomyLabels);
+        }
+        catch (HttpRequestException ex) when (IsSkippableGitHubStatus(ex.StatusCode))
+        {
+            _logger.LogWarning(
+                ex,
+                "Skipping {ResourceName} for {RepositoryFullName} because the GitHub API returned {StatusCode}.",
+                "labels",
+                repositoryReference.FullName,
+                ex.StatusCode);
+            return [];
+        }
+    }
 
     private async Task<RepositoryAuditSummaryDto> BuildRepositoryAuditSummaryAsync(string owner, string repoName, CancellationToken cancellationToken)
     {

--- a/src/Application/SoloDevBoard.Application/Services/Audit/IAuditDashboardService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Audit/IAuditDashboardService.cs
@@ -53,4 +53,13 @@ public interface IAuditDashboardService
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>A read-only list of failing or cancelled workflow runs.</returns>
     Task<IReadOnlyList<WorkflowRunDto>> GetFailingWorkflowRunsAsync(IReadOnlyList<string> repos, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves label consistency warnings for the specified repositories against the SoloDevBoard canonical taxonomy.
+    /// Extra repository labels that are not in the taxonomy are not reported.
+    /// </summary>
+    /// <param name="repos">A read-only list of repository names.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A read-only list of missing or divergent taxonomy labels.</returns>
+    Task<IReadOnlyList<LabelConsistencyWarningDto>> GetLabelConsistencyWarningsAsync(IReadOnlyList<string> repos, CancellationToken cancellationToken = default);
 }

--- a/src/Application/SoloDevBoard.Application/Services/Audit/LabelConsistencyAnalyser.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Audit/LabelConsistencyAnalyser.cs
@@ -38,11 +38,8 @@ public static class LabelConsistencyAnalyser
                 continue;
             }
 
-            var colourMatches = ColoursMatch(taxonomyLabel.Colour, existing.Colour);
-            var descriptionMatches = string.Equals(
-                taxonomyLabel.Description ?? string.Empty,
-                existing.Description ?? string.Empty,
-                StringComparison.Ordinal);
+            var colourMatches = LabelValueComparer.ColoursMatch(taxonomyLabel.Colour, existing.Colour);
+            var descriptionMatches = LabelValueComparer.DescriptionsMatch(taxonomyLabel.Description, existing.Description);
 
             if (colourMatches && descriptionMatches)
             {
@@ -69,28 +66,14 @@ public static class LabelConsistencyAnalyser
     {
         if (!colourMatches && !descriptionMatches)
         {
-            return $"Colour and description differ (expected #{NormaliseColour(taxonomyLabel.Colour)}, found #{NormaliseColour(existing.Colour)}).";
+            return $"Colour and description differ (expected #{LabelValueComparer.NormaliseColour(taxonomyLabel.Colour)}, found #{LabelValueComparer.NormaliseColour(existing.Colour)}).";
         }
 
         if (!colourMatches)
         {
-            return $"Colour differs (expected #{NormaliseColour(taxonomyLabel.Colour)}, found #{NormaliseColour(existing.Colour)}).";
+            return $"Colour differs (expected #{LabelValueComparer.NormaliseColour(taxonomyLabel.Colour)}, found #{LabelValueComparer.NormaliseColour(existing.Colour)}).";
         }
 
         return "Description differs from the taxonomy.";
-    }
-
-    private static bool ColoursMatch(string left, string right)
-        => string.Equals(NormaliseColour(left), NormaliseColour(right), StringComparison.OrdinalIgnoreCase);
-
-    private static string NormaliseColour(string colour)
-    {
-        var trimmed = colour.Trim();
-        if (trimmed.StartsWith('#'))
-        {
-            return trimmed[1..];
-        }
-
-        return trimmed;
     }
 }

--- a/src/Application/SoloDevBoard.Application/Services/Audit/LabelConsistencyAnalyser.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Audit/LabelConsistencyAnalyser.cs
@@ -1,0 +1,96 @@
+using SoloDevBoard.Application.Services.Labels;
+using SoloDevBoard.Domain.Entities.Labels;
+
+namespace SoloDevBoard.Application.Services.Audit;
+
+/// <summary>Compares repository labels against a recommended taxonomy.</summary>
+public static class LabelConsistencyAnalyser
+{
+    /// <summary>
+    /// Builds warnings for labels that are missing from a repository or that differ in colour or description.
+    /// Extra repository labels that are not in the taxonomy are ignored.
+    /// </summary>
+    /// <param name="repositoryFullName">The fully-qualified repository name in owner/name format.</param>
+    /// <param name="existingLabels">The labels currently present in the repository.</param>
+    /// <param name="taxonomyLabels">The canonical taxonomy labels to compare against.</param>
+    /// <returns>A read-only list of consistency warnings for the repository.</returns>
+    public static IReadOnlyList<LabelConsistencyWarningDto> Analyse(
+        string repositoryFullName,
+        IReadOnlyList<Label> existingLabels,
+        IReadOnlyList<LabelDto> taxonomyLabels)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryFullName);
+        ArgumentNullException.ThrowIfNull(existingLabels);
+        ArgumentNullException.ThrowIfNull(taxonomyLabels);
+
+        var existingByName = existingLabels.ToDictionary(static label => label.Name, StringComparer.OrdinalIgnoreCase);
+        var warnings = new List<LabelConsistencyWarningDto>();
+
+        foreach (var taxonomyLabel in taxonomyLabels)
+        {
+            if (!existingByName.TryGetValue(taxonomyLabel.Name, out var existing))
+            {
+                warnings.Add(new LabelConsistencyWarningDto(
+                    repositoryFullName,
+                    taxonomyLabel.Name,
+                    LabelConsistencyWarningKind.Missing,
+                    "Missing from the repository."));
+                continue;
+            }
+
+            var colourMatches = ColoursMatch(taxonomyLabel.Colour, existing.Colour);
+            var descriptionMatches = string.Equals(
+                taxonomyLabel.Description ?? string.Empty,
+                existing.Description ?? string.Empty,
+                StringComparison.Ordinal);
+
+            if (colourMatches && descriptionMatches)
+            {
+                continue;
+            }
+
+            warnings.Add(new LabelConsistencyWarningDto(
+                repositoryFullName,
+                taxonomyLabel.Name,
+                LabelConsistencyWarningKind.Divergent,
+                BuildDivergentDetail(taxonomyLabel, existing, colourMatches, descriptionMatches)));
+        }
+
+        return warnings
+            .OrderBy(static warning => warning.LabelName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string BuildDivergentDetail(
+        LabelDto taxonomyLabel,
+        Label existing,
+        bool colourMatches,
+        bool descriptionMatches)
+    {
+        if (!colourMatches && !descriptionMatches)
+        {
+            return $"Colour and description differ (expected #{NormaliseColour(taxonomyLabel.Colour)}, found #{NormaliseColour(existing.Colour)}).";
+        }
+
+        if (!colourMatches)
+        {
+            return $"Colour differs (expected #{NormaliseColour(taxonomyLabel.Colour)}, found #{NormaliseColour(existing.Colour)}).";
+        }
+
+        return "Description differs from the taxonomy.";
+    }
+
+    private static bool ColoursMatch(string left, string right)
+        => string.Equals(NormaliseColour(left), NormaliseColour(right), StringComparison.OrdinalIgnoreCase);
+
+    private static string NormaliseColour(string colour)
+    {
+        var trimmed = colour.Trim();
+        if (trimmed.StartsWith('#'))
+        {
+            return trimmed[1..];
+        }
+
+        return trimmed;
+    }
+}

--- a/src/Application/SoloDevBoard.Application/Services/Audit/LabelConsistencyWarningDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Audit/LabelConsistencyWarningDto.cs
@@ -1,0 +1,12 @@
+namespace SoloDevBoard.Application.Services.Audit;
+
+/// <summary>Represents a label that diverges from the SoloDevBoard canonical taxonomy.</summary>
+/// <param name="RepositoryFullName">The fully-qualified repository name in owner/name format.</param>
+/// <param name="LabelName">The taxonomy label name that is missing or divergent.</param>
+/// <param name="Kind">Whether the label is missing or present with different values.</param>
+/// <param name="Detail">A UK English description of the divergence.</param>
+public sealed record LabelConsistencyWarningDto(
+    string RepositoryFullName,
+    string LabelName,
+    LabelConsistencyWarningKind Kind,
+    string Detail);

--- a/src/Application/SoloDevBoard.Application/Services/Audit/LabelConsistencyWarningKind.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Audit/LabelConsistencyWarningKind.cs
@@ -1,0 +1,11 @@
+namespace SoloDevBoard.Application.Services.Audit;
+
+/// <summary>Classifies a label consistency warning against the canonical taxonomy.</summary>
+public enum LabelConsistencyWarningKind
+{
+    /// <summary>The taxonomy label is not present in the repository.</summary>
+    Missing = 0,
+
+    /// <summary>The label exists but its colour or description differs from the taxonomy.</summary>
+    Divergent = 1,
+}

--- a/src/Application/SoloDevBoard.Application/Services/Audit/RepositoryAuditSummaryDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Audit/RepositoryAuditSummaryDto.cs
@@ -7,10 +7,12 @@ namespace SoloDevBoard.Application.Services.Audit;
 /// <param name="UnlabelledIssueCount">The number of open issues with no labels.</param>
 /// <param name="StalePullRequestCount">The number of stale open pull requests.</param>
 /// <param name="FailingWorkflowCount">The number of workflows whose most recent run is failing or cancelled.</param>
+/// <param name="LabelConsistencyWarningCount">The number of missing or divergent SoloDevBoard taxonomy labels.</param>
 public sealed record RepositoryAuditSummaryDto(
     string RepositoryFullName,
     int OpenIssueCount,
     int OpenPullRequestCount,
     int UnlabelledIssueCount,
     int StalePullRequestCount,
-    int FailingWorkflowCount);
+    int FailingWorkflowCount,
+    int LabelConsistencyWarningCount = 0);

--- a/src/Application/SoloDevBoard.Application/Services/Labels/LabelService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Labels/LabelService.cs
@@ -490,9 +490,7 @@ public sealed class LabelService : ILabelManagerService
     /// <param name="right">The second label to compare.</param>
     /// <returns><see langword="true" /> if labels are equivalent; otherwise, <see langword="false" />.</returns>
     private static bool HasSameValues(Label left, Label right)
-        => string.Equals(left.Name, right.Name, StringComparison.OrdinalIgnoreCase)
-            && string.Equals(left.Colour, right.Colour, StringComparison.OrdinalIgnoreCase)
-            && string.Equals(left.Description, right.Description, StringComparison.Ordinal);
+        => LabelValueComparer.HaveSameValues(left, right);
 
     /// <summary>Represents split owner/repository coordinates.</summary>
     private sealed record RepositoryCoordinates(string Owner, string Name);

--- a/src/Application/SoloDevBoard.Application/Services/Labels/LabelService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Labels/LabelService.cs
@@ -5,64 +5,6 @@ namespace SoloDevBoard.Application.Services.Labels;
 /// <summary>Default implementation of <see cref="ILabelManagerService"/>.</summary>
 public sealed class LabelService : ILabelManagerService
 {
-    private static readonly IReadOnlyList<LabelDto> SoloDevBoardRecommendedTaxonomy =
-    [
-        new("type/epic", "6f42c1", "A high-level grouping of related features (spans a full phase)", string.Empty),
-        new("type/feature", "0075ca", "A Feature - groups related stories within an epic", string.Empty),
-        new("type/story", "1d76db", "A user-facing Story delivering a discrete piece of value", string.Empty),
-        new("type/enabler", "e4e669", "An Enabler - technical prerequisite that unblocks stories", string.Empty),
-        new("type/test", "bfd4f2", "A Test issue - test coverage deliverable (unit, component, integration)", string.Empty),
-        new("type/bug", "d73a4a", "A bug or unexpected behaviour", string.Empty),
-        new("type/chore", "fef2c0", "Maintenance, dependency updates, or technical debt", string.Empty),
-        new("type/documentation", "0052cc", "Documentation additions or improvements", string.Empty),
-
-        new("priority/critical", "b60205", "Blocking - must be resolved immediately", string.Empty),
-        new("priority/high", "d93f0b", "Should be addressed in the current sprint or release", string.Empty),
-        new("priority/medium", "fbca04", "Should be addressed soon but is not blocking", string.Empty),
-        new("priority/low", "c2e0c6", "Nice to have; can be deferred", string.Empty),
-
-        new("status/todo", "ffffff", "Ready to be worked on; not yet started", string.Empty),
-        new("status/in-progress", "0e8a16", "Currently being worked on", string.Empty),
-        new("status/blocked", "e11d48", "Cannot proceed; waiting on something external", string.Empty),
-        new("status/ice-box", "8b949e", "Shelved for later; not in the active delivery queue", string.Empty),
-        new("status/in-review", "1d76db", "Pull request open; awaiting code review", string.Empty),
-        new("status/done", "cfd3d7", "Completed and closed", string.Empty),
-
-        new("area/dashboard", "bfd4f2", "Audit Dashboard feature", string.Empty),
-        new("area/migration", "d4c5f9", "One-Click Migration feature", string.Empty),
-        new("area/labels", "c5def5", "Label Manager feature", string.Empty),
-        new("area/board-rules", "fef2c0", "Board Rules Visualiser feature", string.Empty),
-        new("area/triage", "f9d0c4", "Triage UI feature", string.Empty),
-        new("area/workflows", "c5def5", "Workflow Templates feature", string.Empty),
-        new("area/infrastructure", "e4e669", "Azure infrastructure, CI/CD, deployment", string.Empty),
-        new("area/docs", "0052cc", "Documentation, user guides, ADRs, planning docs", string.Empty),
-
-        new("size/xs", "dde8c9", "Trivial - less than 1 hour (e.g. typo fix, config change)", string.Empty),
-        new("size/s", "c5def5", "Small - less than half a day", string.Empty),
-        new("size/m", "fef2c0", "Medium - half a day to one day", string.Empty),
-        new("size/l", "f9d0c4", "Large - two to three days", string.Empty),
-        new("size/xl", "d4c5f9", "Extra-large - more than three days; consider splitting", string.Empty),
-    ];
-
-    private static readonly IReadOnlyList<LabelDto> GitHubDefaultTaxonomy =
-    [
-        new("bug", "d73a4a", "Something is not working", string.Empty),
-        new("documentation", "0075ca", "Improvements or additions to documentation", string.Empty),
-        new("duplicate", "cfd3d7", "This issue or pull request already exists", string.Empty),
-        new("enhancement", "a2eeef", "New feature or request", string.Empty),
-        new("good first issue", "7057ff", "Good for newcomers", string.Empty),
-        new("help wanted", "008672", "Extra attention is needed", string.Empty),
-        new("invalid", "e4e669", "This does not appear to be valid", string.Empty),
-        new("question", "d876e3", "Further information is requested", string.Empty),
-        new("wontfix", "ffffff", "This will not be worked on", string.Empty),
-    ];
-
-    private static readonly IReadOnlyList<RecommendedLabelStrategyDto> RecommendedStrategies =
-        BuildRecommendedStrategies();
-
-    private static readonly IReadOnlyDictionary<string, IReadOnlyList<LabelDto>> RecommendedStrategyLabelsById =
-        BuildRecommendedStrategyLabelsById();
-
     private readonly ILabelRepository _labelRepository;
 
     /// <summary>Initialises a new instance of the <see cref="LabelService"/> class.</summary>
@@ -279,14 +221,14 @@ public sealed class LabelService : ILabelManagerService
     public Task<IReadOnlyList<LabelDto>> GetRecommendedTaxonomyAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return Task.FromResult<IReadOnlyList<LabelDto>>(SoloDevBoardRecommendedTaxonomy.ToArray());
+        return Task.FromResult<IReadOnlyList<LabelDto>>(RecommendedLabelTaxonomyCatalog.SoloDevBoard.ToArray());
     }
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<RecommendedLabelStrategyDto>> GetRecommendedLabelStrategiesAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return Task.FromResult<IReadOnlyList<RecommendedLabelStrategyDto>>(RecommendedStrategies.ToArray());
+        return Task.FromResult<IReadOnlyList<RecommendedLabelStrategyDto>>(RecommendedLabelTaxonomyCatalog.Strategies.ToArray());
     }
 
     /// <inheritdoc/>
@@ -382,7 +324,7 @@ public sealed class LabelService : ILabelManagerService
     /// <exception cref="ArgumentException">Thrown when the strategy identifier is unsupported.</exception>
     private static IReadOnlyList<LabelDto> ResolveRecommendedStrategyLabels(string strategyId)
     {
-        if (RecommendedStrategyLabelsById.TryGetValue(strategyId, out var labels))
+        if (RecommendedLabelTaxonomyCatalog.TryGetLabels(strategyId, out var labels))
         {
             return labels;
         }
@@ -420,38 +362,6 @@ public sealed class LabelService : ILabelManagerService
             .ToArray();
 
         return new RecommendedTaxonomyRepositoryPreviewDto(repositoryFullName, toCreate, toUpdate, skipped);
-    }
-
-    /// <summary>Builds available recommended strategy descriptors.</summary>
-    /// <returns>A read-only list of recommended strategy descriptors.</returns>
-    private static IReadOnlyList<RecommendedLabelStrategyDto> BuildRecommendedStrategies()
-        =>
-        [
-            new("solodevboard", "SoloDevBoard", "The SoloDevBoard canonical taxonomy covering type, priority, status, area, and size labels."),
-            new("github-default", "GitHub default", "GitHub's default label set for new repositories."),
-        ];
-
-    /// <summary>Builds a strategy-to-label-set map keyed by strategy identifier.</summary>
-    /// <returns>A read-only dictionary from strategy identifier to strategy labels.</returns>
-    private static IReadOnlyDictionary<string, IReadOnlyList<LabelDto>> BuildRecommendedStrategyLabelsById()
-    {
-        var labelsById = new Dictionary<string, IReadOnlyList<LabelDto>>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["solodevboard"] = SoloDevBoardRecommendedTaxonomy,
-            ["github-default"] = GitHubDefaultTaxonomy,
-        };
-
-        var strategyIds = RecommendedStrategies.Select(strategy => strategy.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var unresolvedIds = strategyIds
-            .Where(strategyId => !labelsById.ContainsKey(strategyId))
-            .ToArray();
-
-        if (unresolvedIds.Length > 0)
-        {
-            throw new InvalidOperationException($"Missing label definitions for recommended strategies: {string.Join(", ", unresolvedIds)}.");
-        }
-
-        return labelsById;
     }
 
     /// <summary>Maps an application label DTO to a domain label record.</summary>

--- a/src/Application/SoloDevBoard.Application/Services/Labels/LabelValueComparer.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Labels/LabelValueComparer.cs
@@ -1,0 +1,58 @@
+using SoloDevBoard.Domain.Entities.Labels;
+
+namespace SoloDevBoard.Application.Services.Labels;
+
+/// <summary>Compares GitHub label values for synchronisation and consistency analysis.</summary>
+public static class LabelValueComparer
+{
+    /// <summary>Determines whether two labels have equivalent values for synchronisation purposes.</summary>
+    /// <param name="left">The first label to compare.</param>
+    /// <param name="right">The second label to compare.</param>
+    /// <returns><see langword="true" /> if labels are equivalent; otherwise, <see langword="false" />.</returns>
+    public static bool HaveSameValues(Label left, Label right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+
+        return NamesMatch(left.Name, right.Name)
+            && ColoursMatch(left.Colour, right.Colour)
+            && DescriptionsMatch(left.Description, right.Description);
+    }
+
+    /// <summary>Determines whether two label names are equivalent.</summary>
+    /// <param name="left">The first label name.</param>
+    /// <param name="right">The second label name.</param>
+    /// <returns><see langword="true" /> when the names match case-insensitively; otherwise, <see langword="false" />.</returns>
+    public static bool NamesMatch(string left, string right)
+        => string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Determines whether two label colours are equivalent.</summary>
+    /// <param name="left">The first colour value.</param>
+    /// <param name="right">The second colour value.</param>
+    /// <returns><see langword="true" /> when the colours match after normalisation; otherwise, <see langword="false" />.</returns>
+    public static bool ColoursMatch(string left, string right)
+        => string.Equals(NormaliseColour(left), NormaliseColour(right), StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Determines whether two label descriptions are equivalent.</summary>
+    /// <param name="left">The first description.</param>
+    /// <param name="right">The second description.</param>
+    /// <returns><see langword="true" /> when the descriptions match; otherwise, <see langword="false" />.</returns>
+    public static bool DescriptionsMatch(string? left, string? right)
+        => string.Equals(left ?? string.Empty, right ?? string.Empty, StringComparison.Ordinal);
+
+    /// <summary>Normalises a GitHub label colour for comparison and display.</summary>
+    /// <param name="colour">The colour value to normalise.</param>
+    /// <returns>The normalised six-character colour without a leading hash.</returns>
+    public static string NormaliseColour(string colour)
+    {
+        ArgumentNullException.ThrowIfNull(colour);
+
+        var trimmed = colour.Trim();
+        if (trimmed.StartsWith('#'))
+        {
+            return trimmed[1..];
+        }
+
+        return trimmed;
+    }
+}

--- a/src/Application/SoloDevBoard.Application/Services/Labels/RecommendedLabelTaxonomyCatalog.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Labels/RecommendedLabelTaxonomyCatalog.cs
@@ -1,0 +1,96 @@
+namespace SoloDevBoard.Application.Services.Labels;
+
+/// <summary>Provides the built-in recommended label taxonomies shared by Label Manager and Audit Dashboard.</summary>
+public static class RecommendedLabelTaxonomyCatalog
+{
+    /// <summary>The identifier for the SoloDevBoard canonical taxonomy.</summary>
+    public const string SoloDevBoardStrategyId = "solodevboard";
+
+    /// <summary>The identifier for GitHub's default new-repository label set.</summary>
+    public const string GitHubDefaultStrategyId = "github-default";
+
+    /// <summary>Gets the SoloDevBoard canonical taxonomy labels.</summary>
+    public static IReadOnlyList<LabelDto> SoloDevBoard { get; } =
+    [
+        new("type/epic", "6f42c1", "A high-level grouping of related features (spans a full phase)", string.Empty),
+        new("type/feature", "0075ca", "A Feature - groups related stories within an epic", string.Empty),
+        new("type/story", "1d76db", "A user-facing Story delivering a discrete piece of value", string.Empty),
+        new("type/enabler", "e4e669", "An Enabler - technical prerequisite that unblocks stories", string.Empty),
+        new("type/test", "bfd4f2", "A Test issue - test coverage deliverable (unit, component, integration)", string.Empty),
+        new("type/bug", "d73a4a", "A bug or unexpected behaviour", string.Empty),
+        new("type/chore", "fef2c0", "Maintenance, dependency updates, or technical debt", string.Empty),
+        new("type/documentation", "0052cc", "Documentation additions or improvements", string.Empty),
+
+        new("priority/critical", "b60205", "Blocking - must be resolved immediately", string.Empty),
+        new("priority/high", "d93f0b", "Should be addressed in the current sprint or release", string.Empty),
+        new("priority/medium", "fbca04", "Should be addressed soon but is not blocking", string.Empty),
+        new("priority/low", "c2e0c6", "Nice to have; can be deferred", string.Empty),
+
+        new("status/todo", "ffffff", "Ready to be worked on; not yet started", string.Empty),
+        new("status/in-progress", "0e8a16", "Currently being worked on", string.Empty),
+        new("status/blocked", "e11d48", "Cannot proceed; waiting on something external", string.Empty),
+        new("status/ice-box", "8b949e", "Shelved for later; not in the active delivery queue", string.Empty),
+        new("status/in-review", "1d76db", "Pull request open; awaiting code review", string.Empty),
+        new("status/done", "cfd3d7", "Completed and closed", string.Empty),
+
+        new("area/dashboard", "bfd4f2", "Audit Dashboard feature", string.Empty),
+        new("area/migration", "d4c5f9", "One-Click Migration feature", string.Empty),
+        new("area/labels", "c5def5", "Label Manager feature", string.Empty),
+        new("area/board-rules", "fef2c0", "Board Rules Visualiser feature", string.Empty),
+        new("area/triage", "f9d0c4", "Triage UI feature", string.Empty),
+        new("area/workflows", "c5def5", "Workflow Templates feature", string.Empty),
+        new("area/infrastructure", "e4e669", "Azure infrastructure, CI/CD, deployment", string.Empty),
+        new("area/docs", "0052cc", "Documentation, user guides, ADRs, planning docs", string.Empty),
+
+        new("size/xs", "dde8c9", "Trivial - less than 1 hour (e.g. typo fix, config change)", string.Empty),
+        new("size/s", "c5def5", "Small - less than half a day", string.Empty),
+        new("size/m", "fef2c0", "Medium - half a day to one day", string.Empty),
+        new("size/l", "f9d0c4", "Large - two to three days", string.Empty),
+        new("size/xl", "d4c5f9", "Extra-large - more than three days; consider splitting", string.Empty),
+    ];
+
+    /// <summary>Gets GitHub's default new-repository label set.</summary>
+    public static IReadOnlyList<LabelDto> GitHubDefault { get; } =
+    [
+        new("bug", "d73a4a", "Something is not working", string.Empty),
+        new("documentation", "0075ca", "Improvements or additions to documentation", string.Empty),
+        new("duplicate", "cfd3d7", "This issue or pull request already exists", string.Empty),
+        new("enhancement", "a2eeef", "New feature or request", string.Empty),
+        new("good first issue", "7057ff", "Good for newcomers", string.Empty),
+        new("help wanted", "008672", "Extra attention is needed", string.Empty),
+        new("invalid", "e4e669", "This does not appear to be valid", string.Empty),
+        new("question", "d876e3", "Further information is requested", string.Empty),
+        new("wontfix", "ffffff", "This will not be worked on", string.Empty),
+    ];
+
+    /// <summary>Gets the available built-in recommended strategies.</summary>
+    public static IReadOnlyList<RecommendedLabelStrategyDto> Strategies { get; } =
+    [
+        new(SoloDevBoardStrategyId, "SoloDevBoard", "The SoloDevBoard canonical taxonomy covering type, priority, status, area, and size labels."),
+        new(GitHubDefaultStrategyId, "GitHub default", "GitHub's default label set for new repositories."),
+    ];
+
+    /// <summary>Attempts to resolve the label set for a recommended strategy identifier.</summary>
+    /// <param name="strategyId">The strategy identifier to resolve.</param>
+    /// <param name="labels">When this method returns <see langword="true"/>, the matching label set.</param>
+    /// <returns><see langword="true"/> when the strategy identifier is recognised; otherwise, <see langword="false"/>.</returns>
+    public static bool TryGetLabels(string strategyId, out IReadOnlyList<LabelDto> labels)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(strategyId);
+
+        if (strategyId.Equals(SoloDevBoardStrategyId, StringComparison.OrdinalIgnoreCase))
+        {
+            labels = SoloDevBoard;
+            return true;
+        }
+
+        if (strategyId.Equals(GitHubDefaultStrategyId, StringComparison.OrdinalIgnoreCase))
+        {
+            labels = GitHubDefault;
+            return true;
+        }
+
+        labels = [];
+        return false;
+    }
+}

--- a/src/Application/SoloDevBoard.Application/Services/Labels/RecommendedLabelTaxonomyCatalog.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Labels/RecommendedLabelTaxonomyCatalog.cs
@@ -12,7 +12,7 @@ public static class RecommendedLabelTaxonomyCatalog
     /// <summary>Gets the SoloDevBoard canonical taxonomy labels.</summary>
     public static IReadOnlyList<LabelDto> SoloDevBoard { get; } =
     [
-        new("type/epic", "6f42c1", "A high-level grouping of related features (spans a full phase)", string.Empty),
+        new("type/epic", "6f42c1", "A named product theme spanning multiple features or a major increment - not a milestone bucket", string.Empty),
         new("type/feature", "0075ca", "A Feature - groups related stories within an epic", string.Empty),
         new("type/story", "1d76db", "A user-facing Story delivering a discrete piece of value", string.Empty),
         new("type/enabler", "e4e669", "An Enabler - technical prerequisite that unblocks stories", string.Empty),

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
@@ -97,8 +97,8 @@ public sealed class AuditTests
             Assert.Contains("Unlabelled issues", cut.Markup);
             Assert.Contains("Failing workflows", cut.Markup);
             Assert.Contains("Label consistency warnings", cut.Markup);
-            Assert.Contains(">5<", cut.Markup);
-            Assert.Contains(">5<", cut.Markup);
+            Assert.Contains("audit-total-issues-card", cut.Markup);
+            Assert.Contains("audit-total-prs-card", cut.Markup);
 
             var links = cut.FindAll("a")
                 .Select(link => link.GetAttribute("href"))
@@ -147,6 +147,39 @@ public sealed class AuditTests
 
         await cut.InvokeAsync(() => snapshotCompletionSource.SetResult(CreateSnapshot([new RepositoryAuditSummaryDto("owner/repo-a", 1, 1, 0, 0, 0)])));
         cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-summary-table']")));
+    }
+
+    [Fact]
+    public async Task Audit_WhenLabelConsistencyIsLoading_ShowsKpiSkeleton()
+    {
+        // Arrange
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo-a")]);
+        _auditDashboardService
+            .GetDashboardSnapshotAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<int>(), false, Arg.Any<CancellationToken>())
+            .Returns(CreateSnapshot([new RepositoryAuditSummaryDto("owner/repo-a", 1, 1, 0, 0, 0)]));
+
+        var labelConsistencyCompletionSource = new TaskCompletionSource<IReadOnlyList<LabelConsistencyWarningDto>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var ctx = CreateContext();
+        _auditDashboardService
+            .GetLabelConsistencyWarningsAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(labelConsistencyCompletionSource.Task);
+
+        // Act
+        var cut = ctx.Render<Audit>();
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-command-surface']")));
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo-a" }));
+        cut.Find("[data-testid='audit-load-selected-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='audit-label-consistency-kpi-card'] .mud-skeleton"));
+        });
+
+        await cut.InvokeAsync(() => labelConsistencyCompletionSource.SetResult([]));
+        cut.WaitForAssertion(() => Assert.Empty(cut.FindAll("[data-testid='audit-label-consistency-kpi-card'] .mud-skeleton")));
     }
 
     [Fact]
@@ -264,11 +297,11 @@ public sealed class AuditTests
         _auditDashboardService
             .GetDashboardSnapshotAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<int>(), false, Arg.Any<CancellationToken>())
             .Returns(CreateSnapshot(summary, issues));
+
+        await using var ctx = CreateContext();
         _auditDashboardService
             .GetFailingWorkflowRunsAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
             .Returns<Task<IReadOnlyList<WorkflowRunDto>>>(_ => throw new HttpRequestException("GitHub API request failed."));
-
-        await using var ctx = CreateContext();
 
         // Act
         var cut = ctx.Render<Audit>();
@@ -284,6 +317,55 @@ public sealed class AuditTests
             Assert.Contains("Needs triage", cut.Markup);
             Assert.DoesNotContain("Unable to load audit summary", cut.Markup);
             Assert.Contains("No failing workflows — great!", cut.Markup);
+            var workflowHealthLoadFailed = (bool)typeof(Audit)
+                .GetField("workflowHealthLoadFailed", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(cut.Instance)!;
+            Assert.True(workflowHealthLoadFailed);
+        });
+    }
+
+    [Fact]
+    public async Task Audit_WhenLabelConsistencyFails_KeepsCoreAuditDataVisibleAndDisablesExport()
+    {
+        // Arrange
+        var summary = new List<RepositoryAuditSummaryDto>
+        {
+            new("owner/repo-a", 2, 1, 1, 0, 0),
+        };
+
+        var issues = new List<IssueDto>
+        {
+            new(12, "Needs triage", "https://github.com/owner/repo-a/issues/12", "owner/repo-a", DateTimeOffset.UtcNow.AddDays(-5), DateTimeOffset.UtcNow.AddDays(-2)),
+        };
+
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo-a")]);
+        _auditDashboardService
+            .GetDashboardSnapshotAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<int>(), false, Arg.Any<CancellationToken>())
+            .Returns(CreateSnapshot(summary, issues));
+
+        await using var ctx = CreateContext();
+        _auditDashboardService
+            .GetLabelConsistencyWarningsAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<LabelConsistencyWarningDto>>>(_ => throw new HttpRequestException("GitHub API request failed."));
+
+        // Act
+        var cut = ctx.Render<Audit>();
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-command-surface']")));
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo-a" }));
+        cut.Find("[data-testid='audit-load-selected-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='audit-summary-table']"));
+            Assert.Contains("Needs triage", cut.Markup);
+            Assert.DoesNotContain("Unable to load audit summary", cut.Markup);
+            Assert.Contains("Labels match the SoloDevBoard taxonomy — great!", cut.Markup);
+            var labelConsistencyLoadFailed = (bool)typeof(Audit)
+                .GetField("labelConsistencyLoadFailed", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(cut.Instance)!;
+            Assert.True(labelConsistencyLoadFailed);
         });
     }
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AuditTests.cs
@@ -96,6 +96,7 @@ public sealed class AuditTests
             Assert.Contains("Total open pull requests", cut.Markup);
             Assert.Contains("Unlabelled issues", cut.Markup);
             Assert.Contains("Failing workflows", cut.Markup);
+            Assert.Contains("Label consistency warnings", cut.Markup);
             Assert.Contains(">5<", cut.Markup);
             Assert.Contains(">5<", cut.Markup);
 
@@ -194,6 +195,7 @@ public sealed class AuditTests
             Assert.Contains("Unlabelled Issues", cut.Markup);
             Assert.Contains("Stale Pull Requests", cut.Markup);
             Assert.Contains("Failing Workflows", cut.Markup);
+            Assert.Contains("Label Consistency", cut.Markup);
             Assert.Contains("Needs triage", cut.Markup);
             Assert.Contains("Update docs", cut.Markup);
             Assert.Contains("Open run", cut.Markup);
@@ -206,6 +208,41 @@ public sealed class AuditTests
             Assert.Contains("https://github.com/owner/repo-a/issues/12", links);
             Assert.Contains("https://github.com/owner/repo-a/pull/44", links);
             Assert.Contains("https://github.com/owner/repo-a/actions/runs/123", links);
+        });
+    }
+
+    [Fact]
+    public async Task Audit_WhenLabelConsistencyWarningsExist_ShowsWarningRowsAndLabelManagerLink()
+    {
+        var summary = new List<RepositoryAuditSummaryDto>
+        {
+            new("owner/repo-a", 1, 0, 0, 0, 0),
+        };
+
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([CreateRepository("owner", "repo-a")]);
+        _auditDashboardService.GetDashboardSnapshotAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<int>(), false, Arg.Any<CancellationToken>()).Returns(CreateSnapshot(summary));
+
+        await using var ctx = CreateContext();
+        _auditDashboardService
+            .GetLabelConsistencyWarningsAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                new LabelConsistencyWarningDto("owner/repo-a", "type/bug", LabelConsistencyWarningKind.Missing, "Missing from the repository."),
+            ]);
+
+        var cut = ctx.Render<Audit>();
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='audit-command-surface']")));
+        var selector = cut.FindComponent<RepositorySelector>();
+        await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(new[] { "owner/repo-a" }));
+        cut.Find("[data-testid='audit-load-selected-button']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(cut.FindAll("[data-testid='audit-label-consistency-section']"));
+            Assert.Single(cut.FindAll("[data-testid='audit-label-consistency-kpi-card']"));
+            Assert.Contains("type/bug", cut.Markup);
+            Assert.Contains("Missing from the repository.", cut.Markup);
+            Assert.Contains("href=\"/labels\"", cut.Markup);
         });
     }
 
@@ -278,6 +315,7 @@ public sealed class AuditTests
             Assert.Contains("No unlabelled issues — great!", cut.Markup);
             Assert.Contains("No stale pull requests — great!", cut.Markup);
             Assert.Contains("No failing workflows — great!", cut.Markup);
+            Assert.Contains("Labels match the SoloDevBoard taxonomy — great!", cut.Markup);
         });
     }
 
@@ -547,6 +585,9 @@ public sealed class AuditTests
         _auditDashboardService
             .GetFailingWorkflowRunsAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<WorkflowRunDto>());
+        _auditDashboardService
+            .GetLabelConsistencyWarningsAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<LabelConsistencyWarningDto>());
 
         ctx.Render<MudPopoverProvider>();
         ctx.Render<MudDialogProvider>();

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardMarkdownExporterTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardMarkdownExporterTests.cs
@@ -30,11 +30,16 @@ public sealed class AuditDashboardMarkdownExporterTests
             [
                 new WorkflowRunDto("build", "completed", "failure", "https://github.com/owner/repo-a/actions/runs/123", "owner/repo-a", "main"),
             ],
+            LabelConsistencyWarnings:
+            [
+                new LabelConsistencyWarningDto("owner/repo-a", "type/bug", LabelConsistencyWarningKind.Missing, "Missing from the repository."),
+            ],
             SelectedRepositories: ["owner/repo-a", "owner/repo-b"],
             TotalOpenIssues: 5,
             TotalOpenPullRequests: 3,
             TotalUnlabelledIssues: 1,
             TotalFailingWorkflows: 1,
+            TotalLabelConsistencyWarnings: 1,
             StalePullRequestDays: 14,
             GeneratedAtUtc: GeneratedAt);
 
@@ -53,6 +58,9 @@ public sealed class AuditDashboardMarkdownExporterTests
         Assert.Contains("[#44](https://github.com/owner/repo-a/pull/44)", markdown);
         Assert.Contains("| owner/repo-a | [#44](https://github.com/owner/repo-a/pull/44) | Update docs | mark | 20 |", markdown);
         Assert.Contains("[Open run](https://github.com/owner/repo-a/actions/runs/123)", markdown);
+        Assert.Contains("| Label consistency warnings | 1 |", markdown);
+        Assert.Contains("## Label consistency warnings", markdown);
+        Assert.Contains("| owner/repo-a | type/bug | Missing | Missing from the repository. |", markdown);
     }
 
     [Fact]
@@ -64,11 +72,13 @@ public sealed class AuditDashboardMarkdownExporterTests
             UnlabelledIssues: [],
             StalePullRequests: [],
             FailingWorkflowRuns: [],
+            LabelConsistencyWarnings: [],
             SelectedRepositories: ["owner/repo-a"],
             TotalOpenIssues: 1,
             TotalOpenPullRequests: 1,
             TotalUnlabelledIssues: 0,
             TotalFailingWorkflows: 0,
+            TotalLabelConsistencyWarnings: 0,
             StalePullRequestDays: 14,
             GeneratedAtUtc: GeneratedAt);
 
@@ -79,6 +89,7 @@ public sealed class AuditDashboardMarkdownExporterTests
         Assert.Contains("No unlabelled issues — great!", markdown);
         Assert.Contains("No stale pull requests — great!", markdown);
         Assert.Contains("No failing workflows — great!", markdown);
+        Assert.Contains("Labels match the SoloDevBoard taxonomy — great!", markdown);
     }
 
     [Fact]

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardMarkdownExporterTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardMarkdownExporterTests.cs
@@ -93,6 +93,37 @@ public sealed class AuditDashboardMarkdownExporterTests
     }
 
     [Fact]
+    public void GenerateSummaryMarkdown_WhenSecondaryHealthLoadsFailed_IncludesUnavailableMessages()
+    {
+        // Arrange
+        var request = new AuditDashboardMarkdownExportRequest(
+            RepositorySummaries: [new RepositoryAuditSummaryDto("owner/repo-a", 1, 1, 0, 0, 0)],
+            UnlabelledIssues: [],
+            StalePullRequests: [],
+            FailingWorkflowRuns: [],
+            LabelConsistencyWarnings: [],
+            SelectedRepositories: ["owner/repo-a"],
+            TotalOpenIssues: 1,
+            TotalOpenPullRequests: 1,
+            TotalUnlabelledIssues: 0,
+            TotalFailingWorkflows: 0,
+            TotalLabelConsistencyWarnings: 0,
+            StalePullRequestDays: 14,
+            GeneratedAtUtc: GeneratedAt,
+            WorkflowHealthLoadFailed: true,
+            LabelConsistencyLoadFailed: true);
+
+        // Act
+        var markdown = _sut.GenerateSummaryMarkdown(request);
+
+        // Assert
+        Assert.Contains("Workflow health could not be loaded for this export.", markdown);
+        Assert.Contains("Label consistency could not be loaded for this export.", markdown);
+        Assert.DoesNotContain("No failing workflows — great!", markdown);
+        Assert.DoesNotContain("Labels match the SoloDevBoard taxonomy — great!", markdown);
+    }
+
+    [Fact]
     public void GenerateSummaryMarkdown_WhenRequestIsNull_ThrowsArgumentNullException()
     {
         // Act

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardServiceTests.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 using SoloDevBoard.Application.Identity;
 using SoloDevBoard.Application.Services.Audit;
 using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Application.Services.Labels;
 using SoloDevBoard.Domain.Entities.Labels;
 using SoloDevBoard.Domain.Entities.Repositories;
 using SoloDevBoard.Domain.Entities.Triage;
@@ -16,13 +17,14 @@ public sealed class AuditDashboardServiceTests
     private const string OpenItemState = "open";
 
     private readonly IGitHubService _gitHubService = Substitute.For<IGitHubService>();
+    private readonly ILabelRepository _labelRepository = Substitute.For<ILabelRepository>();
     private readonly ICurrentUserContext _currentUserContext = Substitute.For<ICurrentUserContext>();
     private readonly AuditDashboardService _sut;
 
     public AuditDashboardServiceTests()
     {
         _currentUserContext.OwnerLogin.Returns("owner");
-        _sut = new AuditDashboardService(_gitHubService, _currentUserContext, NullLogger<AuditDashboardService>.Instance);
+        _sut = new AuditDashboardService(_gitHubService, _labelRepository, _currentUserContext, NullLogger<AuditDashboardService>.Instance);
     }
 
     [Fact]
@@ -557,6 +559,71 @@ public sealed class AuditDashboardServiceTests
         var act = async () => await _sut.GetDashboardSnapshotAsync(repos, cancellationToken: cancellationToken);
 
         // Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public async Task GetLabelConsistencyWarningsAsync_WhenTaxonomyLabelsAreMissingOrDivergent_ReturnsWarnings()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var expectedColour = RecommendedLabelTaxonomyCatalog.SoloDevBoard
+            .Single(label => label.Name == "type/bug")
+            .Colour;
+
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-one", cancellationToken)
+            .Returns(
+            [
+                new Label { Name = "type/bug", Colour = "ffffff", Description = "A bug or unexpected behaviour" },
+                new Label { Name = "custom/extra", Colour = "000000", Description = "Repo-specific" },
+            ]);
+
+        var result = await _sut.GetLabelConsistencyWarningsAsync(["owner/repo-one"], cancellationToken);
+
+        Assert.Contains(result, warning => warning.Kind == LabelConsistencyWarningKind.Missing && warning.LabelName == "type/story");
+        var divergent = Assert.Single(result, warning => warning.LabelName == "type/bug");
+        Assert.Equal(LabelConsistencyWarningKind.Divergent, divergent.Kind);
+        Assert.Contains(expectedColour, divergent.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(result, warning => warning.LabelName == "custom/extra");
+    }
+
+    [Fact]
+    public async Task GetLabelConsistencyWarningsAsync_WhenLabelsMatchTaxonomy_ReturnsNoWarnings()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var matchingLabels = RecommendedLabelTaxonomyCatalog.SoloDevBoard
+            .Select(label => new Label { Name = label.Name, Colour = "#" + label.Colour, Description = label.Description })
+            .ToArray();
+
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-one", cancellationToken)
+            .Returns(matchingLabels);
+
+        var result = await _sut.GetLabelConsistencyWarningsAsync(["repo-one"], cancellationToken);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetLabelConsistencyWarningsAsync_WhenLabelsEndpointReturnsNotFound_SkipsRepository()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-one", cancellationToken)
+            .Returns<Task<IReadOnlyList<Label>>>(_ => throw new HttpRequestException("gone", null, HttpStatusCode.NotFound));
+
+        var result = await _sut.GetLabelConsistencyWarningsAsync(["owner/repo-one"], cancellationToken);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetLabelConsistencyWarningsAsync_ReposIsNull_ThrowsArgumentNullException()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        var act = async () => await _sut.GetLabelConsistencyWarningsAsync(null!, cancellationToken);
+
         await Assert.ThrowsAsync<ArgumentNullException>(act);
     }
 }

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/AuditDashboardServiceTests.cs
@@ -617,6 +617,21 @@ public sealed class AuditDashboardServiceTests
         Assert.Empty(result);
     }
 
+    [Theory]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.Gone)]
+    public async Task GetLabelConsistencyWarningsAsync_WhenLabelsEndpointReturnsSkippableStatus_SkipsRepository(HttpStatusCode statusCode)
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-one", cancellationToken)
+            .Returns<Task<IReadOnlyList<Label>>>(_ => throw new HttpRequestException("unavailable", null, statusCode));
+
+        var result = await _sut.GetLabelConsistencyWarningsAsync(["owner/repo-one"], cancellationToken);
+
+        Assert.Empty(result);
+    }
+
     [Fact]
     public async Task GetLabelConsistencyWarningsAsync_ReposIsNull_ThrowsArgumentNullException()
     {

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelConsistencyAnalyserTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelConsistencyAnalyserTests.cs
@@ -1,0 +1,85 @@
+using SoloDevBoard.Application.Services.Audit;
+using SoloDevBoard.Application.Services.Labels;
+using SoloDevBoard.Domain.Entities.Labels;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Unit tests for <see cref="LabelConsistencyAnalyser"/>.</summary>
+public sealed class LabelConsistencyAnalyserTests
+{
+    [Fact]
+    public void Analyse_WhenLabelIsMissing_ReturnsMissingWarning()
+    {
+        var taxonomy = new[]
+        {
+            new LabelDto("type/bug", "d73a4a", "A bug or unexpected behaviour", string.Empty),
+        };
+
+        var warnings = LabelConsistencyAnalyser.Analyse("owner/repo", [], taxonomy);
+
+        var warning = Assert.Single(warnings);
+        Assert.Equal("owner/repo", warning.RepositoryFullName);
+        Assert.Equal("type/bug", warning.LabelName);
+        Assert.Equal(LabelConsistencyWarningKind.Missing, warning.Kind);
+        Assert.Equal("Missing from the repository.", warning.Detail);
+    }
+
+    [Fact]
+    public void Analyse_WhenColourDiffersIgnoringHashPrefix_DoesNotWarnWhenValuesMatch()
+    {
+        var taxonomy = new[]
+        {
+            new LabelDto("type/bug", "d73a4a", "A bug or unexpected behaviour", string.Empty),
+        };
+        var existing = new[]
+        {
+            new Label { Name = "type/bug", Colour = "#D73A4A", Description = "A bug or unexpected behaviour" },
+        };
+
+        var warnings = LabelConsistencyAnalyser.Analyse("owner/repo", existing, taxonomy);
+
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void Analyse_WhenDescriptionDiffers_ReturnsDivergentWarning()
+    {
+        var taxonomy = new[]
+        {
+            new LabelDto("type/bug", "d73a4a", "A bug or unexpected behaviour", string.Empty),
+        };
+        var existing = new[]
+        {
+            new Label { Name = "type/bug", Colour = "d73a4a", Description = "Something else" },
+        };
+
+        var warnings = LabelConsistencyAnalyser.Analyse("owner/repo", existing, taxonomy);
+
+        var warning = Assert.Single(warnings);
+        Assert.Equal(LabelConsistencyWarningKind.Divergent, warning.Kind);
+        Assert.Equal("Description differs from the taxonomy.", warning.Detail);
+    }
+
+    [Fact]
+    public void Analyse_WhenExtraLabelsExist_IgnoresLabelsNotInTaxonomy()
+    {
+        var taxonomy = RecommendedLabelTaxonomyCatalog.GitHubDefault.Take(1).ToArray();
+        var existing = new[]
+        {
+            new Label { Name = taxonomy[0].Name, Colour = taxonomy[0].Colour, Description = taxonomy[0].Description },
+            new Label { Name = "custom/only-here", Colour = "000000", Description = "Extra" },
+        };
+
+        var warnings = LabelConsistencyAnalyser.Analyse("owner/repo", existing, taxonomy);
+
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void Analyse_WhenRepositoryFullNameIsMissing_ThrowsArgumentException()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => LabelConsistencyAnalyser.Analyse(" ", [], []));
+
+        Assert.Equal("repositoryFullName", exception.ParamName);
+    }
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelConsistencyAnalyserTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelConsistencyAnalyserTests.cs
@@ -42,6 +42,44 @@ public sealed class LabelConsistencyAnalyserTests
     }
 
     [Fact]
+    public void Analyse_WhenColourDiffers_ReturnsDivergentWarningWithColourDetail()
+    {
+        var taxonomy = new[]
+        {
+            new LabelDto("type/bug", "d73a4a", "A bug or unexpected behaviour", string.Empty),
+        };
+        var existing = new[]
+        {
+            new Label { Name = "type/bug", Colour = "ffffff", Description = "A bug or unexpected behaviour" },
+        };
+
+        var warnings = LabelConsistencyAnalyser.Analyse("owner/repo", existing, taxonomy);
+
+        var warning = Assert.Single(warnings);
+        Assert.Equal(LabelConsistencyWarningKind.Divergent, warning.Kind);
+        Assert.Equal("Colour differs (expected #d73a4a, found #ffffff).", warning.Detail);
+    }
+
+    [Fact]
+    public void Analyse_WhenColourAndDescriptionDiffer_ReturnsCombinedDivergentDetail()
+    {
+        var taxonomy = new[]
+        {
+            new LabelDto("type/bug", "d73a4a", "A bug or unexpected behaviour", string.Empty),
+        };
+        var existing = new[]
+        {
+            new Label { Name = "type/bug", Colour = "ffffff", Description = "Something else" },
+        };
+
+        var warnings = LabelConsistencyAnalyser.Analyse("owner/repo", existing, taxonomy);
+
+        var warning = Assert.Single(warnings);
+        Assert.Equal(LabelConsistencyWarningKind.Divergent, warning.Kind);
+        Assert.Equal("Colour and description differ (expected #d73a4a, found #ffffff).", warning.Detail);
+    }
+
+    [Fact]
     public void Analyse_WhenDescriptionDiffers_ReturnsDivergentWarning()
     {
         var taxonomy = new[]

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelValueComparerTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelValueComparerTests.cs
@@ -1,0 +1,35 @@
+using SoloDevBoard.Application.Services.Labels;
+using SoloDevBoard.Domain.Entities.Labels;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Unit tests for <see cref="LabelValueComparer"/>.</summary>
+public sealed class LabelValueComparerTests
+{
+    [Fact]
+    public void ColoursMatch_WhenHashPrefixDiffers_ReturnsTrue()
+    {
+        Assert.True(LabelValueComparer.ColoursMatch("d73a4a", "#D73A4A"));
+    }
+
+    [Fact]
+    public void ColoursMatch_WhenValuesDiffer_ReturnsFalse()
+    {
+        Assert.False(LabelValueComparer.ColoursMatch("d73a4a", "ffffff"));
+    }
+
+    [Fact]
+    public void HaveSameValues_WhenColourUsesHashPrefix_ReturnsTrue()
+    {
+        var left = new Label { Name = "type/bug", Colour = "d73a4a", Description = "A bug" };
+        var right = new Label { Name = "type/bug", Colour = "#D73A4A", Description = "A bug" };
+
+        Assert.True(LabelValueComparer.HaveSameValues(left, right));
+    }
+
+    [Fact]
+    public void DescriptionsMatch_WhenBothNull_ReturnsTrue()
+    {
+        Assert.True(LabelValueComparer.DescriptionsMatch(null, null));
+    }
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/RecommendedLabelTaxonomyCatalogTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/RecommendedLabelTaxonomyCatalogTests.cs
@@ -1,0 +1,34 @@
+using SoloDevBoard.Application.Services.Labels;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Unit tests for <see cref="RecommendedLabelTaxonomyCatalog"/>.</summary>
+public sealed class RecommendedLabelTaxonomyCatalogTests
+{
+    [Fact]
+    public void TryGetLabels_WhenStrategyIdIsSoloDevBoard_ReturnsCanonicalTaxonomy()
+    {
+        var resolved = RecommendedLabelTaxonomyCatalog.TryGetLabels("solodevboard", out var labels);
+
+        Assert.True(resolved);
+        Assert.Same(RecommendedLabelTaxonomyCatalog.SoloDevBoard, labels);
+    }
+
+    [Fact]
+    public void TryGetLabels_WhenStrategyIdUsesDifferentCasing_ReturnsCanonicalTaxonomy()
+    {
+        var resolved = RecommendedLabelTaxonomyCatalog.TryGetLabels("SoloDevBoard", out var labels);
+
+        Assert.True(resolved);
+        Assert.Same(RecommendedLabelTaxonomyCatalog.SoloDevBoard, labels);
+    }
+
+    [Fact]
+    public void TryGetLabels_WhenStrategyIdIsUnrecognised_ReturnsFalse()
+    {
+        var resolved = RecommendedLabelTaxonomyCatalog.TryGetLabels("unknown", out var labels);
+
+        Assert.False(resolved);
+        Assert.Empty(labels);
+    }
+}

--- a/tests/E2E/USER_DOCS_ALIGNMENT.md
+++ b/tests/E2E/USER_DOCS_ALIGNMENT.md
@@ -27,7 +27,7 @@ When you add or change an end-user feature, update the user guide, the relevant 
 |------------|--------------|----------------------|-------------------------|---------|-------|
 | [Product landing](../../website/content/_index.md) (Hugo `/` only) | — | — (Hugo `hugo-build.yml` route check) | — | — | Short product-and-project landing (Learn more → About; icon tiles not docs links); not the Blazor app. |
 | [In-app home dashboard](../../website/content/docs/) | `/` | `smoke.spec.ts`, `navigation.spec.ts`, `accessibility.spec.ts` | `dashboard/home.png` | Tier 1 | In-app home lists eight feature cards; About and Appearance are reached via the app bar. |
-| [Audit Dashboard](../../website/content/docs/audit-dashboard.md) | `/audit-dashboard`, `/audit` | `audit-dashboard.spec.ts`, `accessibility.spec.ts` | `audit-dashboard/overview.png` | Tier 2 | Guide describes KPI cards, health sections, auto-refresh, and export; CI asserts shell, feedback region, and `/audit` alias with load failure. |
+| [Audit Dashboard](../../website/content/docs/audit-dashboard.md) | `/audit-dashboard`, `/audit` | `audit-dashboard.spec.ts`, `accessibility.spec.ts` | `audit-dashboard/overview.png` | Tier 2 | Guide describes KPI cards, health sections (including label consistency), auto-refresh, and export; CI asserts shell, feedback region, and `/audit` alias with load failure. |
 | [Repositories](../../website/content/docs/repositories.md) | `/repositories` | `repositories.spec.ts`, `accessibility.spec.ts` | `repositories/overview.png` | Tier 2 | Guide describes command strip, search, and a phone-safe stacked grid; CI asserts refresh, search, error-state retry, and no horizontal overflow at 390px. |
 | [One-Click Migration](../../website/content/docs/one-click-migration.md) | `/migrate` | `migrate.spec.ts`, `accessibility.spec.ts` | `one-click-migration/overview.png` | Tier 2 | Guide describes preview/apply workflow and conflict strategies; CI asserts setup shell, disabled preview, and API failure feedback. |
 | [Label Manager](../../website/content/docs/label-manager.md) | `/labels` | `labels.spec.ts`, `accessibility.spec.ts` | `label-manager/overview.png` | Tier 2 | Guide describes three tabs and taxonomy workflows; CI asserts tab strip, disabled actions, and no-repositories message. |
@@ -57,7 +57,7 @@ Use this when extending specs so assertions track documented workflows.
 |---------------|--------------|-------------------------|
 | Accessing (`/audit-dashboard`, `/audit`) | `audit-dashboard.spec.ts` URL and title | `docs-capture` |
 | Repository selector and load failure | Feedback region, "Unable to load repositories" | `prepareAuditDashboardForCapture` |
-| KPI cards, health sections, auto-refresh, export | — | `docs-capture` + unit/component tests |
+| KPI cards, health sections (including label consistency), auto-refresh, export | — | `docs-capture` + unit/component tests |
 
 ### Label Manager
 

--- a/website/content/docs/audit-dashboard.md
+++ b/website/content/docs/audit-dashboard.md
@@ -3,13 +3,11 @@ weight: 30
 title: Audit Dashboard
 landing: true
 landingIcon: analytics
-landingSubtitle: "Consolidated view of issues, open PRs, and workflow health across selected repositories."
+landingSubtitle: "Consolidated view of issues, open PRs, workflow health, and label consistency across selected repositories."
 guideStatus: Available
 ---
 
 The Audit Dashboard summarises open issues, open pull requests, and repository health across the repositories you select.
-
-> **Scope note** — Label consistency warnings are not part of v1.0.0. They are tracked for v1.1.0 as [#290](https://github.com/markheydon/solo-dev-board/issues/290).
 
 ![Audit Dashboard showing KPI summary and health indicators for markheydon/solo-dev-board](/images/audit-dashboard/overview.png)
 
@@ -22,8 +20,8 @@ The Audit Dashboard summarises open issues, open pull requests, and repository h
 
 - Choose one or more active repositories with the repository selector before loading data.
 - Review a sortable summary grid with repository name (linked to GitHub), open issue count, and open pull request count.
-- KPI summary cards show total open issues, total open pull requests, unlabelled issues, and failing workflows for the selection.
-- Health sections cover unlabelled issues, stale pull requests, and failing workflows, each with a badge count and expandable detail.
+- KPI summary cards show total open issues, total open pull requests, unlabelled issues, failing workflows, and label consistency warnings for the selection.
+- Health sections cover unlabelled issues, stale pull requests, failing workflows, and label consistency, each with a badge count and expandable detail.
 - Loading, empty, error, and prompt states appear in a consistent feedback region.
 - Auto-refresh can be set to off, every 1 minute, every 5 minutes, or every 15 minutes (default: every 5 minutes).
 - **Export Markdown** copies the current audit summary to the clipboard, respecting the selected repository filter.
@@ -36,10 +34,19 @@ The Audit Dashboard summarises open issues, open pull requests, and repository h
 3. Use **Select all** to include every active repository, or **Clear** to reset the selection.
 4. Click **Load selected repositories** to fetch audit data.
 5. Review the summary grid and KPI cards.
-6. Expand health sections for unlabelled issues, stale pull requests, and failing workflows.
+6. Expand health sections for unlabelled issues, stale pull requests, failing workflows, and label consistency.
 7. Optionally set **Auto-refresh** to keep the summary up to date.
 8. Click **Export Markdown** to copy the current summary for planning notes.
 9. To change the repository set, adjust the selector and load again.
+
+## Label consistency
+
+Label consistency compares each selected repository against the SoloDevBoard canonical taxonomy used by Label Manager:
+
+- **Missing** — a taxonomy label is not present in the repository.
+- **Divergent** — the label exists but its colour or description differs from the taxonomy.
+
+Extra labels that exist only in the repository are not reported. Use **Label Manager** to apply the taxonomy.
 
 ## Empty states
 
@@ -48,3 +55,4 @@ When a health category has no items, the dashboard shows a positive empty-state 
 - "No unlabelled issues — great."
 - "No stale pull requests — great."
 - "No failing workflows — great."
+- "Labels match the SoloDevBoard taxonomy — great."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Adds label consistency warnings to the Audit Dashboard so selected repositories can be compared with the SoloDevBoard canonical taxonomy.

- Missing taxonomy labels and colour or description drift are reported as warnings.
- Extra repository-only labels are not reported (the same rule as Label Manager taxonomy apply).
- A KPI card, health section, Markdown export, and user guide cover the new signal.
- Recommended taxonomies are shared via `RecommendedLabelTaxonomyCatalog` so Label Manager and Audit Dashboard stay aligned.

### Code review follow-up

- Extracted `LabelValueComparer` so Label Manager and Audit Dashboard use the same colour and description comparison rules.
- Reconciled `type/epic` description with `LABEL_STRATEGY.md`.
- Disabled Markdown export and added unavailable export sections when workflow health or label consistency secondary loads fail.
- Expanded unit and bUnit coverage for divergence messages, skippable HTTP statuses, and load-failure paths.

## Related Issue(s)

Closes #290

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [x] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Loaded-state screenshots were not recaptured in this environment (placeholder GitHub auth). CI still asserts the Audit Dashboard shell. Unit and bUnit coverage exercise the new KPI card, health section, and Markdown export.

## Additional Notes

Issue #290 had no acceptance criteria in the body. This delivery infers behaviour from the user story, Label Manager taxonomy apply (create/update/skip, no deletes), and the existing Audit Dashboard health-indicator pattern.

The taxonomy used is the SoloDevBoard canonical set. GitHub 404/403/410 on the labels endpoint skips that repository rather than treating it as fully missing.

Test run: 789 tests passed locally (`dotnet test`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10f7a5a6-749c-4952-94ed-faf5e55dcae8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10f7a5a6-749c-4952-94ed-faf5e55dcae8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

