### PR TITLE
[Story] Add cross-repository Backlog Review urgency groups (#277)

### DIFF
--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowBacklog.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/Pages/PmWorkflowBacklog.razor
@@ -4,10 +4,4 @@
 
 <PageTitle>PM Workflow — Backlog</PageTitle>
 
-<MudStack Spacing="2" data-testid="pm-workflow-backlog-page">
-    <MudText Typo="Typo.h5">Backlog Review</MudText>
-    <MudText Typo="Typo.body1">
-        Cross-repository backlog grouping will appear here once stories #277–#282 ship.
-        Configure repositories and planning thresholds on the Repos tab meanwhile.
-    </MudText>
-</MudStack>
+<PmWorkflowBacklogPanel />

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor
@@ -1,0 +1,167 @@
+@using SoloDevBoard.App.Components.Features.PmWorkflow
+@using SoloDevBoard.Application.Services.PmWorkflow
+
+<MudStack Spacing="3" data-testid="pm-workflow-backlog-page">
+    <MudText Typo="Typo.h5">Backlog Review</MudText>
+    <MudText Typo="Typo.body1">
+        Open issues and pull requests from included repositories, grouped by urgency.
+        Adding items to Up Next happens on the Planning tab.
+        Awaiting triage, near-complete epics, and neglected repositories will appear in later stories.
+    </MudText>
+
+    @if (ChromeState is null)
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">PM Workflow chrome is unavailable.</MudAlert>
+    }
+    else if (!ChromeState.IsLoading && !string.IsNullOrWhiteSpace(ChromeState.LoadErrorMessage))
+    {
+        @* Chrome already shows the error and retry. *@
+    }
+    else if (ChromeState.IsLoading)
+    {
+        <MudText Typo="Typo.body2" data-testid="pm-workflow-backlog-loading-chrome">
+            Loading planning boards before Backlog Review.
+        </MudText>
+    }
+    else if (!ChromeState.HasPlanningBoardSelected)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="pm-workflow-backlog-no-board">
+            Select a planning board in the dropdown above to load Backlog Review groups.
+        </MudAlert>
+    }
+    else
+    {
+        @if (isLoading)
+        {
+            <MudProgressLinear Indeterminate="true" Color="Color.Primary" aria-label="Loading Backlog Review" />
+        }
+
+        @if (!string.IsNullOrWhiteSpace(loadErrorMessage))
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" data-testid="pm-workflow-backlog-error">
+                @loadErrorMessage
+                <MudButton Variant="Variant.Text"
+                           OnClick="RetryLoadAsync"
+                           data-testid="pm-workflow-backlog-retry">Retry</MudButton>
+            </MudAlert>
+        }
+        else if (!isLoading && snapshot is not null)
+        {
+            @if (!string.IsNullOrWhiteSpace(warningMessage))
+            {
+                <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" data-testid="pm-workflow-backlog-warning">
+                    @warningMessage
+                    <MudButton Variant="Variant.Text"
+                               OnClick="RetryLoadAsync"
+                               data-testid="pm-workflow-backlog-retry">Retry</MudButton>
+                </MudAlert>
+            }
+
+            <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2" AlignItems="AlignItems.End" data-testid="pm-workflow-backlog-filters">
+                <MudSelect T="string"
+                           Label="Type"
+                           Variant="Variant.Outlined"
+                           Dense="true"
+                           Value="selectedTypeFilter"
+                           ValueChanged="OnTypeFilterChanged"
+                           data-testid="pm-workflow-backlog-type-filter">
+                    <MudSelectItem T="string" Value="@AllTypesFilter">All types</MudSelectItem>
+                    <MudSelectItem T="string" Value="@IssueTypeFilter">Issues</MudSelectItem>
+                    <MudSelectItem T="string" Value="@PullRequestTypeFilter">Pull requests</MudSelectItem>
+                </MudSelect>
+                <MudSelect T="string"
+                           Label="Repository"
+                           Variant="Variant.Outlined"
+                           Dense="true"
+                           Value="selectedRepositoryFilter"
+                           ValueChanged="OnRepositoryFilterChanged"
+                           data-testid="pm-workflow-backlog-repo-filter">
+                    <MudSelectItem T="string" Value="@AllRepositoriesFilter">All repositories</MudSelectItem>
+                    @foreach (var repository in RepositoryOptions)
+                    {
+                        <MudSelectItem T="string" Value="@repository">@repository</MudSelectItem>
+                    }
+                </MudSelect>
+                <MudTextField T="string"
+                              Label="Search"
+                              Variant="Variant.Outlined"
+                              Immediate="true"
+                              DebounceInterval="200"
+                              Value="searchText"
+                              ValueChanged="OnSearchChanged"
+                              Clearable="true"
+                              data-testid="pm-workflow-backlog-search" />
+            </MudStack>
+
+            @if (IsCatalogueEmpty)
+            {
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="pm-workflow-backlog-empty">
+                    No open issues or pull requests in included repositories.
+                </MudAlert>
+            }
+            else if (HasNoFilteredItems)
+            {
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="pm-workflow-backlog-filter-empty">
+                    No items match the current filters.
+                </MudAlert>
+            }
+
+            <MudExpansionPanels MultiExpansion="true" data-testid="pm-workflow-backlog-panels">
+                @RenderGroupPanel("Urgent", "pm-workflow-backlog-urgent", FilteredUrgent)
+                @RenderGroupPanel("Ready to start", "pm-workflow-backlog-ready", FilteredReady)
+                @RenderGroupPanel("Blocked / deferred", "pm-workflow-backlog-blocked", FilteredBlocked)
+            </MudExpansionPanels>
+        }
+    }
+</MudStack>
+
+@code {
+    private RenderFragment RenderGroupPanel(string title, string testId, IReadOnlyList<BacklogReviewItemDto> items) => __builder =>
+    {
+        <MudExpansionPanel Expanded="true" data-testid="@testId">
+            <TitleContent>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    <MudText Typo="Typo.subtitle1">@title</MudText>
+                    <MudBadge Color="Color.Primary" Content="@items.Count" Overlap="false" />
+                </MudStack>
+            </TitleContent>
+            <ChildContent>
+                @if (items.Count == 0)
+                {
+                    <MudText Typo="Typo.body2" data-testid="@($"{testId}-empty")">No items in this group.</MudText>
+                }
+                else
+                {
+                    <MudSimpleTable Hover="true" Dense="true" data-testid="@($"{testId}-table")">
+                        <thead>
+                            <tr>
+                                <th>Kind</th>
+                                <th>Item</th>
+                                <th>Title</th>
+                                <th>Priority</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var item in items)
+                            {
+                                <tr data-testid="@($"{testId}-row")">
+                                    <td>@FormatItemKind(item.ItemType)</td>
+                                    <td>
+                                        <MudLink Href="@item.HtmlUrl"
+                                                 Target="_blank"
+                                                 rel="noopener noreferrer"
+                                                 data-testid="pm-workflow-backlog-item-link">
+                                            @($"{item.RepositoryFullName}#{item.Number}")
+                                        </MudLink>
+                                    </td>
+                                    <td>@item.Title</td>
+                                    <td>@FormatPriority(item.PriorityLabel)</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </MudSimpleTable>
+                }
+            </ChildContent>
+        </MudExpansionPanel>
+    };
+}

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor.cs
@@ -34,6 +34,7 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
     private string selectedRepositoryFilter = AllRepositoriesFilter;
     private string searchText = string.Empty;
     private int loadGeneration;
+    private int loadedRevision = -1;
 
     /// <inheritdoc/>
     protected override Task OnParametersSetAsync()
@@ -48,11 +49,12 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
             snapshot = null;
             loadErrorMessage = null;
             warningMessage = null;
+            loadedRevision = -1;
             return Task.CompletedTask;
         }
 
         var boardId = ChromeState.Settings.PlanningBoardNodeId!;
-        if (TryApplyCachedResult(boardId))
+        if (loadedRevision == DataRevision && TryApplyCachedResult(boardId))
         {
             return Task.CompletedTask;
         }
@@ -114,13 +116,14 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
             return Task.CompletedTask;
         }
 
+        loadedRevision = -1;
         ChromeCoordinator.ClearBacklogReview();
         return LoadAsync(ChromeState.Settings.PlanningBoardNodeId);
     }
 
     private async Task LoadAsync(string boardId)
     {
-        if (TryApplyCachedResult(boardId))
+        if (loadedRevision == DataRevision && TryApplyCachedResult(boardId))
         {
             return;
         }
@@ -142,6 +145,7 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
 
             snapshot = result;
             warningMessage = FormatPartialFailureWarning(result.Failures);
+            loadedRevision = DataRevision;
             ChromeCoordinator.SetBacklogReview(boardId, result, null, isLoading: false, warningMessage);
         }
         catch (Exception exception)

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor.cs
@@ -1,0 +1,260 @@
+using Microsoft.AspNetCore.Components;
+using SoloDevBoard.Application.Services.PmWorkflow;
+
+namespace SoloDevBoard.App.Components.Features.PmWorkflow;
+
+/// <summary>Backlog Review grouping panel rendered inside <see cref="PmWorkflowShell"/>.</summary>
+public partial class PmWorkflowBacklogPanel : ComponentBase
+{
+    internal const string AllTypesFilter = "";
+    internal const string IssueTypeFilter = "issue";
+    internal const string PullRequestTypeFilter = "pr";
+    internal const string AllRepositoriesFilter = "";
+
+    [CascadingParameter]
+    public PmWorkflowChromeState? ChromeState { get; set; }
+
+    [CascadingParameter(Name = "PmWorkflowDataRevision")]
+    public int DataRevision { get; set; }
+
+    [Inject]
+    public PmWorkflowChromeCoordinator ChromeCoordinator { get; set; } = default!;
+
+    [Inject]
+    public IBacklogReviewService BacklogReviewService { get; set; } = default!;
+
+    [Inject]
+    public ILogger<PmWorkflowBacklogPanel> Logger { get; set; } = default!;
+
+    private BacklogReviewResultDto? snapshot;
+    private bool isLoading;
+    private string? loadErrorMessage;
+    private string? warningMessage;
+    private string selectedTypeFilter = AllTypesFilter;
+    private string selectedRepositoryFilter = AllRepositoriesFilter;
+    private string searchText = string.Empty;
+    private int loadGeneration;
+
+    /// <inheritdoc/>
+    protected override Task OnParametersSetAsync()
+    {
+        if (ChromeState is null || ChromeState.IsLoading)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (!ChromeState.HasPlanningBoardSelected)
+        {
+            snapshot = null;
+            loadErrorMessage = null;
+            warningMessage = null;
+            return Task.CompletedTask;
+        }
+
+        var boardId = ChromeState.Settings.PlanningBoardNodeId!;
+        if (TryApplyCachedResult(boardId))
+        {
+            return Task.CompletedTask;
+        }
+
+        _ = LoadAsync(boardId);
+        return Task.CompletedTask;
+    }
+
+    private IReadOnlyList<string> RepositoryOptions
+        => snapshot is null
+            ? []
+            : snapshot.Urgent
+                .Concat(snapshot.ReadyToStart)
+                .Concat(snapshot.BlockedOrDeferred)
+                .Select(static item => item.RepositoryFullName)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+    private IReadOnlyList<BacklogReviewItemDto> FilteredUrgent => Filter(snapshot?.Urgent);
+
+    private IReadOnlyList<BacklogReviewItemDto> FilteredReady => Filter(snapshot?.ReadyToStart);
+
+    private IReadOnlyList<BacklogReviewItemDto> FilteredBlocked => Filter(snapshot?.BlockedOrDeferred);
+
+    private bool IsCatalogueEmpty
+        => snapshot is not null
+            && snapshot.Urgent.Count == 0
+            && snapshot.ReadyToStart.Count == 0
+            && snapshot.BlockedOrDeferred.Count == 0;
+
+    private bool HasNoFilteredItems
+        => !IsCatalogueEmpty
+            && FilteredUrgent.Count == 0
+            && FilteredReady.Count == 0
+            && FilteredBlocked.Count == 0;
+
+    private bool TryApplyCachedResult(string boardId)
+    {
+        var cached = ChromeCoordinator.BacklogReview;
+        if (cached is null || !cached.BoardId.Equals(boardId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        isLoading = cached.IsLoading;
+        snapshot = cached.Result;
+        loadErrorMessage = cached.ErrorMessage;
+        warningMessage = cached.WarningMessage;
+        return cached.IsLoading
+            || cached.Result is not null
+            || !string.IsNullOrWhiteSpace(cached.ErrorMessage);
+    }
+
+    private Task RetryLoadAsync()
+    {
+        if (ChromeState is null || string.IsNullOrWhiteSpace(ChromeState.Settings.PlanningBoardNodeId))
+        {
+            return Task.CompletedTask;
+        }
+
+        ChromeCoordinator.ClearBacklogReview();
+        return LoadAsync(ChromeState.Settings.PlanningBoardNodeId);
+    }
+
+    private async Task LoadAsync(string boardId)
+    {
+        if (TryApplyCachedResult(boardId))
+        {
+            return;
+        }
+
+        var generation = Interlocked.Increment(ref loadGeneration);
+        isLoading = true;
+        loadErrorMessage = null;
+        warningMessage = null;
+        snapshot = null;
+        ChromeCoordinator.SetBacklogReview(boardId, null, null, isLoading: true);
+
+        try
+        {
+            var result = await BacklogReviewService.GetBacklogAsync(boardId).ConfigureAwait(false);
+            if (!ShouldApplyResult(generation, boardId))
+            {
+                return;
+            }
+
+            snapshot = result;
+            warningMessage = FormatPartialFailureWarning(result.Failures);
+            ChromeCoordinator.SetBacklogReview(boardId, result, null, isLoading: false, warningMessage);
+        }
+        catch (Exception exception)
+        {
+            Logger.LogError(exception, "Failed to load Backlog Review groups.");
+            if (!ShouldApplyResult(generation, boardId))
+            {
+                return;
+            }
+
+            snapshot = null;
+            warningMessage = null;
+            loadErrorMessage = "Unable to load the backlog. Check your GitHub connection and try again.";
+            ChromeCoordinator.SetBacklogReview(boardId, null, loadErrorMessage, isLoading: false);
+        }
+        finally
+        {
+            if (generation == loadGeneration)
+            {
+                isLoading = false;
+                await InvokeAsync(StateHasChanged).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private bool ShouldApplyResult(int generation, string boardId)
+    {
+        if (generation != loadGeneration)
+        {
+            return false;
+        }
+
+        var currentBoardId = ChromeState?.Settings.PlanningBoardNodeId;
+        return !string.IsNullOrWhiteSpace(currentBoardId)
+            && currentBoardId.Equals(boardId, StringComparison.Ordinal);
+    }
+
+    internal Task OnTypeFilterChanged(string value)
+    {
+        selectedTypeFilter = value ?? AllTypesFilter;
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    internal Task OnRepositoryFilterChanged(string value)
+    {
+        selectedRepositoryFilter = value ?? AllRepositoriesFilter;
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    internal Task OnSearchChanged(string value)
+    {
+        searchText = value ?? string.Empty;
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    private IReadOnlyList<BacklogReviewItemDto> Filter(IReadOnlyList<BacklogReviewItemDto>? items)
+    {
+        if (items is null || items.Count == 0)
+        {
+            return [];
+        }
+
+        return items.Where(MatchesFilters).ToArray();
+    }
+
+    private bool MatchesFilters(BacklogReviewItemDto item)
+    {
+        if (selectedTypeFilter == IssueTypeFilter && item.ItemType != PmWorkItemTypeDto.Issue)
+        {
+            return false;
+        }
+
+        if (selectedTypeFilter == PullRequestTypeFilter && item.ItemType != PmWorkItemTypeDto.PullRequest)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(selectedRepositoryFilter)
+            && !item.RepositoryFullName.Equals(selectedRepositoryFilter, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(searchText))
+        {
+            return true;
+        }
+
+        var query = searchText.Trim();
+        return item.Title.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || item.RepositoryFullName.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || item.Number.ToString().Contains(query, StringComparison.OrdinalIgnoreCase)
+            || $"{item.RepositoryFullName}#{item.Number}".Contains(query, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string FormatItemKind(PmWorkItemTypeDto itemType)
+        => itemType == PmWorkItemTypeDto.PullRequest ? "Pull request" : "Issue";
+
+    private static string FormatPriority(string? priorityLabel)
+        => string.IsNullOrWhiteSpace(priorityLabel) ? "Unlabelled" : priorityLabel;
+
+    private static string? FormatPartialFailureWarning(IReadOnlyList<PmRepositoryCatalogueFailureDto> failures)
+    {
+        if (failures.Count == 0)
+        {
+            return null;
+        }
+
+        var repositories = string.Join(", ", failures.Select(static failure => failure.RepositoryFullName));
+        var noun = failures.Count == 1 ? "repository" : "repositories";
+        return $"The backlog was grouped without {failures.Count} {noun} that failed to load: {repositories}.";
+    }
+}

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowChromeCoordinator.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowChromeCoordinator.cs
@@ -53,6 +53,9 @@ public sealed class PmWorkflowChromeCoordinator
     /// <summary>Gets the cached Daily Focus recommendations for the current circuit, if any.</summary>
     public DailyFocusRecommendationsCacheEntry? DailyFocusRecommendations { get; private set; }
 
+    /// <summary>Gets the cached Backlog Review grouping for the current circuit, if any.</summary>
+    public BacklogReviewCacheEntry? BacklogReview { get; private set; }
+
     /// <summary>Loads chrome data when it has not been loaded yet for this circuit.</summary>
     /// <returns>A task that completes when the load attempt finishes or is skipped.</returns>
     public Task EnsureLoadedAsync() =>
@@ -75,6 +78,7 @@ public sealed class PmWorkflowChromeCoordinator
             ClearDailyFocusBoardState();
             ClearDailyFocusStalledReviews();
             ClearDailyFocusRecommendations();
+            ClearBacklogReview();
         }
 
         CancelPendingLoad();
@@ -93,6 +97,7 @@ public sealed class PmWorkflowChromeCoordinator
         State.Settings = await _pmSettingsService.GetSettingsAsync().ConfigureAwait(false);
         ClearDailyFocusStalledReviews();
         ClearDailyFocusRecommendations();
+        ClearBacklogReview();
         State.MarkDataChanged();
     }
 
@@ -176,6 +181,32 @@ public sealed class PmWorkflowChromeCoordinator
 
     /// <summary>Clears cached Daily Focus recommendations.</summary>
     public void ClearDailyFocusRecommendations() => DailyFocusRecommendations = null;
+
+    /// <summary>Stores Backlog Review grouping in the circuit cache.</summary>
+    /// <param name="boardId">The planning board node identifier.</param>
+    /// <param name="result">The grouped backlog, when successful.</param>
+    /// <param name="errorMessage">The load error message, when unsuccessful.</param>
+    /// <param name="isLoading"><see langword="true"/> when a load is currently in flight; otherwise, <see langword="false"/>.</param>
+    /// <param name="warningMessage">A partial-catalogue warning, when grouping proceeded without every repository.</param>
+    public void SetBacklogReview(
+        string boardId,
+        BacklogReviewResultDto? result,
+        string? errorMessage,
+        bool isLoading,
+        string? warningMessage = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(boardId);
+
+        BacklogReview = new BacklogReviewCacheEntry(
+            boardId,
+            result,
+            errorMessage,
+            isLoading,
+            warningMessage);
+    }
+
+    /// <summary>Clears cached Backlog Review grouping.</summary>
+    public void ClearBacklogReview() => BacklogReview = null;
 
     /// <summary>Cancels any in-flight chrome load, for example when leaving PM Workflow.</summary>
     public void CancelPendingLoad()
@@ -301,6 +332,19 @@ public sealed record DailyFocusStalledReviewsCacheEntry(
 public sealed record DailyFocusRecommendationsCacheEntry(
     string BoardId,
     IReadOnlyList<DailyFocusRecommendationDto>? Recommendations,
+    string? ErrorMessage,
+    bool IsLoading,
+    string? WarningMessage = null);
+
+/// <summary>Cached Backlog Review grouping for a planning board within the current circuit.</summary>
+/// <param name="BoardId">The planning board node identifier.</param>
+/// <param name="Result">The grouped backlog, when successful.</param>
+/// <param name="ErrorMessage">The load error message, when unsuccessful.</param>
+/// <param name="IsLoading">Whether a load is currently in flight.</param>
+/// <param name="WarningMessage">A partial-catalogue warning, when grouping proceeded without every repository.</param>
+public sealed record BacklogReviewCacheEntry(
+    string BoardId,
+    BacklogReviewResultDto? Result,
     string? ErrorMessage,
     bool IsLoading,
     string? WarningMessage = null);

--- a/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/ApplicationServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ public static class ApplicationServiceCollectionExtensions
         services.TryAddSingleton(TimeProvider.System);
         services.AddScoped<IDailyFocusStalledReviewService, DailyFocusStalledReviewService>();
         services.AddScoped<IDailyFocusRecommendationService, DailyFocusRecommendationService>();
+        services.AddScoped<IBacklogReviewService, BacklogReviewService>();
 
         return services;
     }

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewGrouping.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewGrouping.cs
@@ -1,0 +1,153 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Classifies catalogue work items into Backlog Review urgency groups.</summary>
+public static class BacklogReviewGrouping
+{
+    /// <summary>
+    /// Groups work items into urgent, ready-to-start, and blocked or deferred lists.
+    /// An item may appear in more than one group.
+    /// </summary>
+    /// <param name="workItems">Open issues and pull requests from included repositories.</param>
+    /// <param name="boardItems">Items currently on the selected planning board.</param>
+    /// <param name="failures">Per-repository catalogue failures to carry through to the result.</param>
+    /// <returns>The grouped Backlog Review snapshot.</returns>
+    public static BacklogReviewResultDto Group(
+        IReadOnlyList<PmWorkItemDto> workItems,
+        IReadOnlyList<ProjectBoardItemDto> boardItems,
+        IReadOnlyList<PmRepositoryCatalogueFailureDto> failures)
+    {
+        ArgumentNullException.ThrowIfNull(workItems);
+        ArgumentNullException.ThrowIfNull(boardItems);
+        ArgumentNullException.ThrowIfNull(failures);
+
+        var boardStatusByKey = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var boardItem in boardItems)
+        {
+            var statusName = boardItem.Status?.Name;
+            if (string.IsNullOrWhiteSpace(statusName))
+            {
+                continue;
+            }
+
+            boardStatusByKey[PmWorkItemJoinKey.For(boardItem)] = statusName;
+        }
+
+        var urgent = new List<BacklogReviewItemDto>();
+        var ready = new List<BacklogReviewItemDto>();
+        var blocked = new List<BacklogReviewItemDto>();
+
+        foreach (var workItem in workItems)
+        {
+            boardStatusByKey.TryGetValue(PmWorkItemJoinKey.For(workItem), out var boardStatusName);
+            var row = Map(workItem, boardStatusName);
+
+            if (IsUrgent(workItem))
+            {
+                urgent.Add(row);
+            }
+
+            if (IsReadyToStart(workItem, boardStatusName))
+            {
+                ready.Add(row);
+            }
+
+            if (IsBlockedOrDeferred(workItem, boardStatusName))
+            {
+                blocked.Add(row);
+            }
+        }
+
+        return new BacklogReviewResultDto(
+            Sort(urgent),
+            Sort(ready),
+            Sort(blocked),
+            failures);
+    }
+
+    /// <summary>Returns whether the item belongs in the urgent group.</summary>
+    /// <param name="item">The catalogue work item.</param>
+    /// <returns><see langword="true" /> when a critical or high priority label is present.</returns>
+    public static bool IsUrgent(PmWorkItemDto item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        return PmLabelHelpers.IsUrgent(item.Labels);
+    }
+
+    /// <summary>
+    /// Returns whether the item is ready to start: unblocked by labels and board Status,
+    /// and not already Up Next or In Progress.
+    /// </summary>
+    /// <param name="item">The catalogue work item.</param>
+    /// <param name="boardStatusName">The joined planning-board Status name, or <see langword="null"/> when unset.</param>
+    /// <returns><see langword="true" /> when the item can be started; otherwise, <see langword="false" />.</returns>
+    public static bool IsReadyToStart(PmWorkItemDto item, string? boardStatusName)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        if (!PmLabelHelpers.IsUnblocked(item.Labels))
+        {
+            return false;
+        }
+
+        return !IsCommittedOrParkedBoardStatus(boardStatusName);
+    }
+
+    /// <summary>
+    /// Returns whether the item is blocked or deferred via status labels or parked board Status.
+    /// </summary>
+    /// <param name="item">The catalogue work item.</param>
+    /// <param name="boardStatusName">The joined planning-board Status name, or <see langword="null"/> when unset.</param>
+    /// <returns><see langword="true" /> when the item is parked; otherwise, <see langword="false" />.</returns>
+    public static bool IsBlockedOrDeferred(PmWorkItemDto item, string? boardStatusName)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        return PmLabelHelpers.IsBlockedOrDeferred(item.Labels) || IsParkedBoardStatus(boardStatusName);
+    }
+
+    /// <summary>Returns whether a board Status name is Blocked or Ice Box.</summary>
+    /// <param name="statusName">The Status option display name, or <see langword="null"/> when unset.</param>
+    /// <returns><see langword="true" /> when the name is Blocked or Ice Box; otherwise, <see langword="false" />.</returns>
+    public static bool IsParkedBoardStatus(string? statusName)
+    {
+        if (string.IsNullOrWhiteSpace(statusName))
+        {
+            return false;
+        }
+
+        return statusName.Equals(DailyFocusRecommendationMapper.BlockedStatusName, StringComparison.OrdinalIgnoreCase)
+            || statusName.Equals(DailyFocusRecommendationMapper.IceBoxStatusName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Returns whether a board Status name is Up Next, In Progress, Blocked, or Ice Box.</summary>
+    /// <param name="statusName">The Status option display name, or <see langword="null"/> when unset.</param>
+    /// <returns>
+    /// <see langword="true" /> when the name is a committed or parked Status; otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool IsCommittedOrParkedBoardStatus(string? statusName)
+    {
+        if (string.IsNullOrWhiteSpace(statusName))
+        {
+            return false;
+        }
+
+        return DailyFocusBoardStateMapper.IsActiveLoadStatus(statusName) || IsParkedBoardStatus(statusName);
+    }
+
+    private static BacklogReviewItemDto Map(PmWorkItemDto item, string? boardStatusName)
+        => new(
+            item.ItemType,
+            item.RepositoryFullName,
+            item.Number,
+            item.Title,
+            item.HtmlUrl,
+            item.Labels,
+            PmLabelHelpers.ParsePriorityLabel(item.Labels),
+            boardStatusName);
+
+    private static IReadOnlyList<BacklogReviewItemDto> Sort(IReadOnlyList<BacklogReviewItemDto> items)
+        => items
+            .OrderBy(static item => PmPriorityRanker.GetRank(item.PriorityLabel))
+            .ThenBy(static item => item.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static item => item.Number)
+            .ToArray();
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewGrouping.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewGrouping.cs
@@ -29,7 +29,8 @@ public static class BacklogReviewGrouping
                 continue;
             }
 
-            boardStatusByKey[PmWorkItemJoinKey.For(boardItem)] = statusName;
+            // Duplicate join keys are unlikely; keep the first board status encountered.
+            boardStatusByKey.TryAdd(PmWorkItemJoinKey.For(boardItem), statusName);
         }
 
         var urgent = new List<BacklogReviewItemDto>();

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewItemDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewItemDto.cs
@@ -1,0 +1,20 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>A Backlog Review row at the Application→App boundary.</summary>
+/// <param name="ItemType">Whether the item is an issue or pull request.</param>
+/// <param name="RepositoryFullName">The repository in <c>owner/name</c> form.</param>
+/// <param name="Number">The repository-scoped issue or pull request number.</param>
+/// <param name="Title">The item title.</param>
+/// <param name="HtmlUrl">The browser URL for the item on GitHub.</param>
+/// <param name="Labels">Label names currently applied to the item.</param>
+/// <param name="PriorityLabel">The <c>priority/</c> label name, or <see langword="null"/> when unlabelled.</param>
+/// <param name="BoardStatusName">The joined planning-board Status name, or <see langword="null"/> when the item is not on the board.</param>
+public sealed record BacklogReviewItemDto(
+    PmWorkItemTypeDto ItemType,
+    string RepositoryFullName,
+    int Number,
+    string Title,
+    string HtmlUrl,
+    IReadOnlyList<string> Labels,
+    string? PriorityLabel,
+    string? BoardStatusName);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewResultDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewResultDto.cs
@@ -1,0 +1,15 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Grouped Backlog Review items plus any partial catalogue failures.</summary>
+/// <param name="Urgent">Items labelled <c>priority/high</c> or <c>priority/critical</c>.</param>
+/// <param name="ReadyToStart">Unblocked items that are not already Up Next or In Progress.</param>
+/// <param name="BlockedOrDeferred">Items parked by <c>status/blocked</c>, <c>status/ice-box</c>, or matching board Status.</param>
+/// <param name="Failures">
+/// Per-repository catalogue failures. Grouping still proceeds when this list is non-empty and
+/// the remaining items produced groups.
+/// </param>
+public sealed record BacklogReviewResultDto(
+    IReadOnlyList<BacklogReviewItemDto> Urgent,
+    IReadOnlyList<BacklogReviewItemDto> ReadyToStart,
+    IReadOnlyList<BacklogReviewItemDto> BlockedOrDeferred,
+    IReadOnlyList<PmRepositoryCatalogueFailureDto> Failures);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewService.cs
@@ -1,0 +1,60 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Default implementation of <see cref="IBacklogReviewService"/>.</summary>
+public sealed class BacklogReviewService : IBacklogReviewService
+{
+    private readonly IPmWorkItemCatalogueService _workItemCatalogueService;
+    private readonly IProjectItemCatalogueService _projectItemCatalogueService;
+
+    /// <summary>Initialises a new instance of the <see cref="BacklogReviewService"/> class.</summary>
+    /// <param name="workItemCatalogueService">The cross-repository work-item catalogue.</param>
+    /// <param name="projectItemCatalogueService">The project board item catalogue.</param>
+    public BacklogReviewService(
+        IPmWorkItemCatalogueService workItemCatalogueService,
+        IProjectItemCatalogueService projectItemCatalogueService)
+    {
+        ArgumentNullException.ThrowIfNull(workItemCatalogueService);
+        ArgumentNullException.ThrowIfNull(projectItemCatalogueService);
+
+        _workItemCatalogueService = workItemCatalogueService;
+        _projectItemCatalogueService = projectItemCatalogueService;
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Repository exclusions are applied by <see cref="IPmWorkItemCatalogueService"/>.
+    /// Board Status joins use the selected planning board catalogue.
+    /// Partial catalogue failures still group the remaining items; a total failure (no items and at least
+    /// one repository error) throws so the App can show Retry instead of a false empty list.
+    /// </remarks>
+    public async Task<BacklogReviewResultDto> GetBacklogAsync(
+        string projectId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+
+        var workItemsTask = _workItemCatalogueService.GetCatalogueAsync(cancellationToken);
+        var boardCatalogueTask = _projectItemCatalogueService.GetCatalogueAsync(projectId, cancellationToken);
+        await Task.WhenAll(workItemsTask, boardCatalogueTask).ConfigureAwait(false);
+
+        var workItems = await workItemsTask.ConfigureAwait(false);
+        var boardCatalogue = await boardCatalogueTask.ConfigureAwait(false);
+
+        if (workItems.Items.Count == 0 && workItems.Failures.Count > 0)
+        {
+            throw CreateCatalogueFailureException(workItems.Failures);
+        }
+
+        return BacklogReviewGrouping.Group(workItems.Items, boardCatalogue.Items, workItems.Failures);
+    }
+
+    private static InvalidOperationException CreateCatalogueFailureException(
+        IReadOnlyList<PmRepositoryCatalogueFailureDto> failures)
+    {
+        var repositories = string.Join(", ", failures.Select(static failure => failure.RepositoryFullName));
+        var noun = failures.Count == 1 ? "repository" : "repositories";
+        return new InvalidOperationException(
+            $"Unable to load the backlog because {failures.Count} {noun} failed to load: {repositories}.");
+    }
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/DailyFocusRecommendationMapper.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/DailyFocusRecommendationMapper.cs
@@ -34,13 +34,13 @@ public static class DailyFocusRecommendationMapper
         {
             if (IsExcludedBoardStatus(boardItem.Status?.Name))
             {
-                excludedKeys.Add(BuildContentKey(boardItem));
+                excludedKeys.Add(PmWorkItemJoinKey.For(boardItem));
             }
         }
 
         return workItems
             .Where(item => PmLabelHelpers.IsUnblocked(item.Labels)
-                && !excludedKeys.Contains(BuildContentKey(item)))
+                && !excludedKeys.Contains(PmWorkItemJoinKey.For(item)))
             .OrderBy(static item => PmPriorityRanker.GetRank(PmLabelHelpers.ParsePriorityLabel(item.Labels)))
             .ThenByDescending(static item => item.UpdatedAt)
             .ThenBy(static item => item.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
@@ -77,20 +77,4 @@ public static class DailyFocusRecommendationMapper
             item.Title,
             item.HtmlUrl,
             PmLabelHelpers.ParsePriorityLabel(item.Labels));
-
-    private static string BuildContentKey(PmWorkItemDto item)
-        => BuildContentKey(item.ItemType == PmWorkItemTypeDto.PullRequest, item.RepositoryFullName, item.Number);
-
-    private static string BuildContentKey(ProjectBoardItemDto item)
-    {
-        var repositoryFullName = $"{item.Content.RepositoryOwner}/{item.Content.RepositoryName}";
-        var isPullRequest = item.Content.ContentType == ProjectBoardItemContentTypeDto.PullRequest;
-        return BuildContentKey(isPullRequest, repositoryFullName, item.Content.Number);
-    }
-
-    private static string BuildContentKey(bool isPullRequest, string repositoryFullName, int number)
-    {
-        var kind = isPullRequest ? "pr" : "issue";
-        return $"{kind}:{repositoryFullName}#{number}";
-    }
 }

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IBacklogReviewService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IBacklogReviewService.cs
@@ -1,0 +1,20 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Groups open work from included repositories into Backlog Review urgency panels.</summary>
+public interface IBacklogReviewService
+{
+    /// <summary>
+    /// Loads open issues and pull requests from included repositories and groups them for Backlog Review.
+    /// </summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier for the selected planning board.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>
+    /// Grouped items and any per-repository catalogue failures that did not prevent grouping.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// The work-item catalogue reported repository failures and returned no items to group.
+    /// </exception>
+    Task<BacklogReviewResultDto> GetBacklogAsync(
+        string projectId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmWorkItemJoinKey.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PmWorkItemJoinKey.cs
@@ -1,0 +1,37 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Builds stable join keys for matching catalogue work items to planning-board cards.</summary>
+public static class PmWorkItemJoinKey
+{
+    /// <summary>Builds a join key for a catalogue work item.</summary>
+    /// <param name="item">The catalogue work item.</param>
+    /// <returns>A key that distinguishes issues from pull requests that share a number.</returns>
+    public static string For(PmWorkItemDto item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        return For(item.ItemType == PmWorkItemTypeDto.PullRequest, item.RepositoryFullName, item.Number);
+    }
+
+    /// <summary>Builds a join key for a planning-board item.</summary>
+    /// <param name="item">The planning-board item.</param>
+    /// <returns>A key that distinguishes issues from pull requests that share a number.</returns>
+    public static string For(ProjectBoardItemDto item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        var repositoryFullName = $"{item.Content.RepositoryOwner}/{item.Content.RepositoryName}";
+        var isPullRequest = item.Content.ContentType == ProjectBoardItemContentTypeDto.PullRequest;
+        return For(isPullRequest, repositoryFullName, item.Content.Number);
+    }
+
+    /// <summary>Builds a join key from the item kind, repository, and number.</summary>
+    /// <param name="isPullRequest"><see langword="true" /> when the item is a pull request; otherwise, <see langword="false" />.</param>
+    /// <param name="repositoryFullName">The repository in <c>owner/name</c> form.</param>
+    /// <param name="number">The repository-scoped issue or pull request number.</param>
+    /// <returns>A key in the form <c>issue:owner/name#n</c> or <c>pr:owner/name#n</c>.</returns>
+    public static string For(bool isPullRequest, string repositoryFullName, int number)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryFullName);
+        var kind = isPullRequest ? "pr" : "issue";
+        return $"{kind}:{repositoryFullName}#{number}";
+    }
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
@@ -1,0 +1,267 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MudBlazor;
+using MudBlazor.Services;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using SoloDevBoard.App.Components.Features.PmWorkflow;
+using SoloDevBoard.App.Components.Features.PmWorkflow.Pages;
+using SoloDevBoard.App.Components.Shell.Layout;
+using SoloDevBoard.Application.Services.PmWorkflow;
+using SoloDevBoard.Application.Services.Repositories;
+
+namespace SoloDevBoard.App.Tests;
+
+/// <summary>Component tests for Backlog Review on <see cref="PmWorkflowBacklog"/>.</summary>
+public sealed class PmWorkflowBacklogTests
+{
+    private readonly IRepositoryService _repositoryService = Substitute.For<IRepositoryService>();
+    private readonly IPmProjectBoardDiscoveryService _projectBoardDiscoveryService =
+        Substitute.For<IPmProjectBoardDiscoveryService>();
+    private readonly IBacklogReviewService _backlogReviewService = Substitute.For<IBacklogReviewService>();
+    private readonly FakePmSettingsStorage _settingsStorage = new();
+
+    public PmWorkflowBacklogTests()
+    {
+        _backlogReviewService.GetBacklogAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new BacklogReviewResultDto([], [], [], []));
+    }
+
+    [Fact]
+    public void PmWorkflowLayout_UsesMainLayoutAsParent()
+    {
+        var layoutAttribute = typeof(PmWorkflowLayout)
+            .GetCustomAttributes(typeof(LayoutAttribute), inherit: true)
+            .Cast<LayoutAttribute>()
+            .FirstOrDefault();
+
+        Assert.NotNull(layoutAttribute);
+        Assert.Equal(typeof(MainLayout), layoutAttribute.LayoutType);
+    }
+
+    [Fact]
+    public async Task PmWorkflowBacklog_WhenNoBoardIsSelected_ShowsInstructionalAlert()
+    {
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
+            CreateRepository("owner", "repo-a"),
+        ]);
+        _projectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
+            Arg.Any<IReadOnlyList<RepositoryDto>>(),
+            Arg.Any<CancellationToken>()).Returns(
+            new PmProjectBoardDiscoveryDto([], 0, 0));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowBacklog>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Backlog Review", cut.Markup);
+            Assert.Contains("Select a planning board in the dropdown above to load Backlog Review groups.", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowBacklog_WhenGroupsHaveItems_ShowsPanelsAndFilters()
+    {
+        ConfigureDefaults();
+        _backlogReviewService.GetBacklogAsync("PVT_board", Arg.Any<CancellationToken>())
+            .Returns(new BacklogReviewResultDto(
+                [CreateItem(PmWorkItemTypeDto.Issue, "owner/repo-a", 10, "Fix auth", ["priority/high"])],
+                [CreateItem(PmWorkItemTypeDto.Issue, "owner/repo-a", 11, "Ready story", ["priority/medium"])],
+                [CreateItem(PmWorkItemTypeDto.PullRequest, "owner/repo-b", 12, "Parked PR", ["status/blocked"])],
+                []));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowBacklog>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("data-testid=\"pm-workflow-backlog-filters\"", cut.Markup);
+            Assert.Contains("Urgent", cut.Markup);
+            Assert.Contains("Ready to start", cut.Markup);
+            Assert.Contains("Blocked / deferred", cut.Markup);
+            Assert.Contains("owner/repo-a#10", cut.Markup);
+            Assert.Contains("Fix auth", cut.Markup);
+            Assert.Contains("owner/repo-a#11", cut.Markup);
+            Assert.Contains("owner/repo-b#12", cut.Markup);
+            Assert.Contains("Pull request", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowBacklog_WhenCatalogueIsEmpty_ShowsEmptyAlert()
+    {
+        ConfigureDefaults();
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowBacklog>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("No open issues or pull requests in included repositories.", cut.Markup);
+            Assert.Contains("No items in this group.", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowBacklog_WhenLoadFails_ShowsErrorWithRetry()
+    {
+        ConfigureDefaults();
+        _backlogReviewService.GetBacklogAsync("PVT_board", Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("GitHub unavailable"));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowBacklog>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Unable to load the backlog.", cut.Markup);
+            Assert.Contains("Retry", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowBacklog_WhenRetryClickedAfterFailure_ReloadsGroups()
+    {
+        ConfigureDefaults();
+        _backlogReviewService.GetBacklogAsync("PVT_board", Arg.Any<CancellationToken>())
+            .Returns(
+                _ => throw new InvalidOperationException("GitHub unavailable"),
+                _ => new BacklogReviewResultDto(
+                    [CreateItem(PmWorkItemTypeDto.Issue, "owner/repo-a", 40, "Recovered", ["priority/high"])],
+                    [],
+                    [],
+                    []));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowBacklog>();
+
+        cut.WaitForAssertion(() => Assert.Contains("Unable to load the backlog.", cut.Markup));
+
+        await cut.InvokeAsync(() => cut.Find("[data-testid='pm-workflow-backlog-retry']").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("owner/repo-a#40", cut.Markup);
+            Assert.Contains("Recovered", cut.Markup);
+        });
+
+        await _backlogReviewService.Received(2).GetBacklogAsync("PVT_board", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PmWorkflowBacklog_WhenCatalogueHasPartialFailures_ShowsWarningAndRows()
+    {
+        ConfigureDefaults();
+        _backlogReviewService.GetBacklogAsync("PVT_board", Arg.Any<CancellationToken>())
+            .Returns(new BacklogReviewResultDto(
+                [CreateItem(PmWorkItemTypeDto.Issue, "owner/repo-a", 40, "Ship backlog", ["priority/high"])],
+                [],
+                [],
+                [new PmRepositoryCatalogueFailureDto("owner/failed-repo", "Not found", 404)]));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowBacklog>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("owner/repo-a#40", cut.Markup);
+            Assert.Contains("owner/failed-repo", cut.Markup);
+            Assert.Contains("grouped without 1 repository that failed to load", cut.Markup);
+            Assert.DoesNotContain("Unable to load the backlog.", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowBacklog_WhenSearchExcludesAllRows_ShowsFilterEmptyAlert()
+    {
+        ConfigureDefaults();
+        _backlogReviewService.GetBacklogAsync("PVT_board", Arg.Any<CancellationToken>())
+            .Returns(new BacklogReviewResultDto(
+                [CreateItem(PmWorkItemTypeDto.Issue, "owner/repo-a", 10, "Fix auth", ["priority/high"])],
+                [],
+                [],
+                []));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowBacklog>();
+
+        cut.WaitForAssertion(() => Assert.Contains("Fix auth", cut.Markup));
+
+        var panel = cut.FindComponent<PmWorkflowBacklogPanel>();
+        await cut.InvokeAsync(() => panel.Instance.OnSearchChanged("nomatch"));
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains("No items match the current filters.", cut.Markup));
+    }
+
+    private void ConfigureDefaults()
+    {
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
+            CreateRepository("owner", "repo-a"),
+        ]);
+        _projectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
+            Arg.Any<IReadOnlyList<RepositoryDto>>(),
+            Arg.Any<CancellationToken>()).Returns(
+            new PmProjectBoardDiscoveryDto(
+                [new PmPlanningBoardOptionDto("PVT_board", "Roadmap", "owner", "status-field")],
+                1,
+                0));
+    }
+
+    private BunitContext CreateContext()
+    {
+        var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddMudServices();
+        ctx.Services.AddTestGitHubAuthenticationRecovery();
+        ctx.Services.AddSingleton<IPmSettingsStorage>(_settingsStorage);
+        ctx.Services.AddScoped<IPmSettingsService, PmSettingsService>();
+        ctx.Services.AddScoped(_ => _repositoryService);
+        ctx.Services.AddScoped(_ => _projectBoardDiscoveryService);
+        ctx.Services.AddScoped(_ => _backlogReviewService);
+        ctx.Services.AddScoped<PmWorkflowChromeCoordinator>();
+        ctx.Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+
+        ctx.Render<MudPopoverProvider>();
+        ctx.Render<MudDialogProvider>();
+        ctx.Render<MudSnackbarProvider>();
+
+        return ctx;
+    }
+
+    private static BacklogReviewItemDto CreateItem(
+        PmWorkItemTypeDto itemType,
+        string repositoryFullName,
+        int number,
+        string title,
+        IReadOnlyList<string> labels)
+        => new(
+            itemType,
+            repositoryFullName,
+            number,
+            title,
+            $"https://github.com/{repositoryFullName}/issues/{number}",
+            labels,
+            PmLabelHelpers.ParsePriorityLabel(labels),
+            BoardStatusName: null);
+
+    private static RepositoryDto CreateRepository(string owner, string name) =>
+        new(1, name, $"{owner}/{name}", string.Empty, $"https://github.com/{owner}/{name}", false, false, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+    private sealed class FakePmSettingsStorage : IPmSettingsStorage
+    {
+        public string? StoredJson { get; set; }
+
+        public Task<string?> GetStoredJsonAsync() => Task.FromResult(StoredJson);
+
+        public Task SetStoredJsonAsync(string json)
+        {
+            StoredJson = json;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowChromeCoordinatorTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowChromeCoordinatorTests.cs
@@ -87,12 +87,14 @@ public sealed class PmWorkflowChromeCoordinatorTests
             new DailyFocusStalledReviewSnapshotDto([], UsedInReviewColumn: false),
             null,
             isLoading: false);
+        coordinator.SetBacklogReview("PVT_board", new BacklogReviewResultDto([], [], [], []), null, isLoading: false);
 
         await coordinator.RefreshAsync(forceReload: true);
 
         Assert.Null(coordinator.DailyFocusBoardState);
         Assert.Null(coordinator.DailyFocusRecommendations);
         Assert.Null(coordinator.DailyFocusStalledReviews);
+        Assert.Null(coordinator.BacklogReview);
     }
 
     [Fact]
@@ -110,11 +112,13 @@ public sealed class PmWorkflowChromeCoordinatorTests
             new DailyFocusStalledReviewSnapshotDto([], UsedInReviewColumn: false),
             null,
             isLoading: false);
+        coordinator.SetBacklogReview("PVT_board", new BacklogReviewResultDto([], [], [], []), null, isLoading: false);
 
         await coordinator.SaveSettingsAsync(PmSettingsDefaults.Create());
 
         Assert.Null(coordinator.DailyFocusRecommendations);
         Assert.Null(coordinator.DailyFocusStalledReviews);
+        Assert.Null(coordinator.BacklogReview);
     }
 
     [Fact]

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowLayoutTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowLayoutTests.cs
@@ -7,6 +7,7 @@ public sealed class PmWorkflowLayoutTests
 {
     [Theory]
     [InlineData("https://localhost/pm-workflow/daily-focus", true)]
+    [InlineData("https://localhost/pm-workflow/backlog", true)]
     [InlineData("https://localhost/pm-workflow/repos", true)]
     [InlineData("https://localhost/pm-workflow", true)]
     [InlineData("https://localhost/", false)]

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
@@ -53,6 +53,7 @@ public sealed class ApplicationServiceCollectionExtensionsTests
         AssertServiceRegistration<IDailyFocusBoardStateService, DailyFocusBoardStateService>(services, ServiceLifetime.Scoped);
         AssertServiceRegistration<IDailyFocusStalledReviewService, DailyFocusStalledReviewService>(services, ServiceLifetime.Scoped);
         AssertServiceRegistration<IDailyFocusRecommendationService, DailyFocusRecommendationService>(services, ServiceLifetime.Scoped);
+        AssertServiceRegistration<IBacklogReviewService, BacklogReviewService>(services, ServiceLifetime.Scoped);
         var timeProvider = Assert.Single(services, d => d.ServiceType == typeof(TimeProvider));
         Assert.Equal(ServiceLifetime.Singleton, timeProvider.Lifetime);
         Assert.Same(TimeProvider.System, timeProvider.ImplementationInstance);

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/BacklogReviewGroupingTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/BacklogReviewGroupingTests.cs
@@ -1,0 +1,212 @@
+using SoloDevBoard.Application.Services.PmWorkflow;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="BacklogReviewGrouping"/> membership predicates.</summary>
+public sealed class BacklogReviewGroupingTests
+{
+    [Fact]
+    public void Group_NullArguments_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            BacklogReviewGrouping.Group(null!, [], []));
+        Assert.Throws<ArgumentNullException>(() =>
+            BacklogReviewGrouping.Group([], null!, []));
+        Assert.Throws<ArgumentNullException>(() =>
+            BacklogReviewGrouping.Group([], [], null!));
+    }
+
+    [Fact]
+    public void IsUrgent_HighAndCritical_ReturnsTrue()
+    {
+        var high = CreateWorkItem(1, "Urgent high", ["priority/high"]);
+        var critical = CreateWorkItem(2, "Urgent critical", ["priority/critical"]);
+        var medium = CreateWorkItem(3, "Medium", ["priority/medium"]);
+
+        Assert.True(BacklogReviewGrouping.IsUrgent(high));
+        Assert.True(BacklogReviewGrouping.IsUrgent(critical));
+        Assert.False(BacklogReviewGrouping.IsUrgent(medium));
+    }
+
+    [Fact]
+    public void IsReadyToStart_UnblockedAndNotCommitted_ReturnsTrue()
+    {
+        var item = CreateWorkItem(10, "Ready story", ["type/story", "priority/medium"]);
+
+        Assert.True(BacklogReviewGrouping.IsReadyToStart(item, boardStatusName: null));
+        Assert.True(BacklogReviewGrouping.IsReadyToStart(item, "Todo"));
+    }
+
+    [Theory]
+    [InlineData("Up Next")]
+    [InlineData("In Progress")]
+    [InlineData("Blocked")]
+    [InlineData("Ice Box")]
+    public void IsReadyToStart_CommittedOrParkedBoardStatus_ReturnsFalse(string boardStatus)
+    {
+        var item = CreateWorkItem(11, "Not ready", ["type/story", "priority/high"]);
+
+        Assert.False(BacklogReviewGrouping.IsReadyToStart(item, boardStatus));
+    }
+
+    [Fact]
+    public void IsReadyToStart_BlockedLabel_ReturnsFalse()
+    {
+        var item = CreateWorkItem(12, "Blocked", ["type/story", "priority/medium", "status/blocked"]);
+
+        Assert.False(BacklogReviewGrouping.IsReadyToStart(item, boardStatusName: null));
+    }
+
+    [Fact]
+    public void IsBlockedOrDeferred_StatusLabelsAndParkedBoard_ReturnsTrue()
+    {
+        var blocked = CreateWorkItem(20, "Label blocked", ["status/blocked"]);
+        var iceBoxed = CreateWorkItem(21, "Label ice box", ["status/ice-box"]);
+        var unlabelled = CreateWorkItem(22, "Board parked", ["priority/low"]);
+
+        Assert.True(BacklogReviewGrouping.IsBlockedOrDeferred(blocked, boardStatusName: null));
+        Assert.True(BacklogReviewGrouping.IsBlockedOrDeferred(iceBoxed, boardStatusName: null));
+        Assert.True(BacklogReviewGrouping.IsBlockedOrDeferred(unlabelled, "Blocked"));
+        Assert.True(BacklogReviewGrouping.IsBlockedOrDeferred(unlabelled, "Ice Box"));
+        Assert.False(BacklogReviewGrouping.IsBlockedOrDeferred(unlabelled, "Todo"));
+    }
+
+    [Fact]
+    public void Group_OverlappingUrgentAndReady_PlacesItemInBothLists()
+    {
+        var item = CreateWorkItem(30, "Urgent ready", ["priority/critical", "type/bug"]);
+
+        var result = BacklogReviewGrouping.Group([item], [], []);
+
+        Assert.Equal(30, Assert.Single(result.Urgent).Number);
+        Assert.Equal(30, Assert.Single(result.ReadyToStart).Number);
+        Assert.Empty(result.BlockedOrDeferred);
+    }
+
+    [Fact]
+    public void Group_UrgentOnUpNext_IsUrgentButNotReady()
+    {
+        var item = CreateWorkItem(31, "Queued urgent", ["priority/high", "type/story"]);
+        var boardItems = new[]
+        {
+            CreateBoardItem(31, "Up Next", ProjectBoardItemContentTypeDto.Issue),
+        };
+
+        var result = BacklogReviewGrouping.Group([item], boardItems, []);
+
+        Assert.Equal(31, Assert.Single(result.Urgent).Number);
+        Assert.Empty(result.ReadyToStart);
+        Assert.Empty(result.BlockedOrDeferred);
+    }
+
+    [Fact]
+    public void Group_BoardIceBoxWithoutLabel_IsBlockedNotReady()
+    {
+        var item = CreateWorkItem(32, "Parked", ["priority/medium", "type/story"]);
+        var boardItems = new[]
+        {
+            CreateBoardItem(32, "Ice Box", ProjectBoardItemContentTypeDto.Issue),
+        };
+
+        var result = BacklogReviewGrouping.Group([item], boardItems, []);
+
+        Assert.Empty(result.Urgent);
+        Assert.Empty(result.ReadyToStart);
+        var blocked = Assert.Single(result.BlockedOrDeferred);
+        Assert.Equal(32, blocked.Number);
+        Assert.Equal("Ice Box", blocked.BoardStatusName);
+    }
+
+    [Fact]
+    public void Group_IssueAndPullRequestShareNumber_JoinsOnlyMatchingType()
+    {
+        var issue = CreateWorkItem(8, "Issue still open", ["priority/medium", "type/story"]);
+        var pullRequest = CreateWorkItem(
+            8,
+            "PR parked",
+            ["priority/high"],
+            PmWorkItemTypeDto.PullRequest);
+        var boardItems = new[]
+        {
+            CreateBoardItem(8, "Blocked", ProjectBoardItemContentTypeDto.PullRequest),
+        };
+
+        var result = BacklogReviewGrouping.Group([issue, pullRequest], boardItems, []);
+
+        Assert.Equal(8, Assert.Single(result.Urgent).Number);
+        Assert.Equal("PR parked", result.Urgent[0].Title);
+        Assert.Equal("Issue still open", Assert.Single(result.ReadyToStart).Title);
+        Assert.Equal("PR parked", Assert.Single(result.BlockedOrDeferred).Title);
+    }
+
+    [Fact]
+    public void Group_SortsByPriorityThenRepositoryThenNumber()
+    {
+        var items = new[]
+        {
+            CreateWorkItem(2, "Second medium", ["priority/medium"], repositoryFullName: "owner/b"),
+            CreateWorkItem(1, "First medium", ["priority/medium"], repositoryFullName: "owner/a"),
+            CreateWorkItem(9, "Critical", ["priority/critical"], repositoryFullName: "owner/z"),
+        };
+
+        var result = BacklogReviewGrouping.Group(items, [], []);
+
+        Assert.Equal([9, 1, 2], result.ReadyToStart.Select(item => item.Number).ToArray());
+    }
+
+    [Fact]
+    public void Group_CarriesFailuresThrough()
+    {
+        var failures = new[]
+        {
+            new PmRepositoryCatalogueFailureDto("owner/failed", "Not found", 404),
+        };
+
+        var result = BacklogReviewGrouping.Group([], [], failures);
+
+        Assert.Same(failures, result.Failures);
+    }
+
+    private static PmWorkItemDto CreateWorkItem(
+        int number,
+        string title,
+        IReadOnlyList<string> labels,
+        PmWorkItemTypeDto itemType = PmWorkItemTypeDto.Issue,
+        string repositoryFullName = "owner/a")
+    {
+        var path = itemType == PmWorkItemTypeDto.PullRequest ? "pull" : "issues";
+        return new PmWorkItemDto(
+            itemType,
+            number,
+            title,
+            $"https://github.com/{repositoryFullName}/{path}/{number}",
+            repositoryFullName,
+            labels,
+            MilestoneNumber: null,
+            MilestoneTitle: null,
+            CreatedAt: DateTimeOffset.Parse("2026-08-18T00:00:00Z"),
+            UpdatedAt: DateTimeOffset.Parse("2026-08-18T00:00:00Z"),
+            IsDraft: itemType == PmWorkItemTypeDto.PullRequest ? false : null,
+            HasReviewPending: itemType == PmWorkItemTypeDto.PullRequest ? false : null,
+            SubIssueTotal: null,
+            SubIssueCompleted: null);
+    }
+
+    private static ProjectBoardItemDto CreateBoardItem(
+        int number,
+        string statusName,
+        ProjectBoardItemContentTypeDto contentType)
+        => new(
+            $"PVTI_{number}",
+            new ProjectBoardItemStatusDto($"opt-{number}", statusName),
+            FocusOrder: null,
+            new ProjectBoardItemContentDto(
+                contentType,
+                number,
+                "owner",
+                "a",
+                "Board title",
+                "https://github.com/owner/a/issues/1"),
+            DateTimeOffset.UnixEpoch,
+            false);
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/BacklogReviewGroupingTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/BacklogReviewGroupingTests.cs
@@ -155,6 +155,22 @@ public sealed class BacklogReviewGroupingTests
     }
 
     [Fact]
+    public void Group_DuplicateBoardJoinKeys_KeepsFirstStatus()
+    {
+        var item = CreateWorkItem(50, "Duplicate key item", ["priority/medium", "type/story"]);
+        var boardItems = new[]
+        {
+            CreateBoardItem(50, "Todo", ProjectBoardItemContentTypeDto.Issue),
+            CreateBoardItem(50, "Blocked", ProjectBoardItemContentTypeDto.Issue),
+        };
+
+        var result = BacklogReviewGrouping.Group([item], boardItems, []);
+
+        Assert.Equal(50, Assert.Single(result.ReadyToStart).Number);
+        Assert.Empty(result.BlockedOrDeferred);
+    }
+
+    [Fact]
     public void Group_CarriesFailuresThrough()
     {
         var failures = new[]

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/BacklogReviewServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/BacklogReviewServiceTests.cs
@@ -1,0 +1,162 @@
+using NSubstitute;
+using SoloDevBoard.Application.Services.PmWorkflow;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="BacklogReviewService"/>.</summary>
+public sealed class BacklogReviewServiceTests
+{
+    private readonly IPmWorkItemCatalogueService _workItemCatalogueService =
+        Substitute.For<IPmWorkItemCatalogueService>();
+    private readonly IProjectItemCatalogueService _projectItemCatalogueService =
+        Substitute.For<IProjectItemCatalogueService>();
+
+    [Fact]
+    public void Constructor_WorkItemCatalogueIsNull_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _ = new BacklogReviewService(null!, _projectItemCatalogueService));
+    }
+
+    [Fact]
+    public void Constructor_ProjectCatalogueIsNull_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _ = new BacklogReviewService(_workItemCatalogueService, null!));
+    }
+
+    [Fact]
+    public async Task GetBacklogAsync_ProjectIdIsBlank_ThrowsArgumentException()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var sut = new BacklogReviewService(_workItemCatalogueService, _projectItemCatalogueService);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            sut.GetBacklogAsync(" ", cancellationToken));
+    }
+
+    [Fact]
+    public async Task GetBacklogAsync_CataloguesReturned_GroupsItems()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var updated = DateTimeOffset.Parse("2026-08-18T00:00:00Z");
+        var workItems = new[]
+        {
+            new PmWorkItemDto(
+                PmWorkItemTypeDto.Issue,
+                40,
+                "Do this",
+                "https://github.com/owner/repo/issues/40",
+                "owner/repo",
+                ["priority/high", "type/story"],
+                null,
+                null,
+                updated,
+                updated,
+                null,
+                null,
+                null,
+                null),
+            new PmWorkItemDto(
+                PmWorkItemTypeDto.Issue,
+                41,
+                "Parked",
+                "https://github.com/owner/repo/issues/41",
+                "owner/repo",
+                ["priority/medium", "status/blocked"],
+                null,
+                null,
+                updated,
+                updated,
+                null,
+                null,
+                null,
+                null),
+        };
+
+        _workItemCatalogueService.GetCatalogueAsync(cancellationToken)
+            .Returns(new PmWorkItemCatalogueResultDto(workItems, [], []));
+        _projectItemCatalogueService.GetCatalogueAsync("PVT_board", cancellationToken)
+            .Returns(new ProjectBoardItemCatalogueDto(
+                new ProjectBoardFieldIdsDto("PVTF_status", null),
+                [],
+                []));
+
+        var sut = new BacklogReviewService(_workItemCatalogueService, _projectItemCatalogueService);
+
+        var result = await sut.GetBacklogAsync("PVT_board", cancellationToken);
+
+        Assert.Equal(40, Assert.Single(result.Urgent).Number);
+        Assert.Equal(40, Assert.Single(result.ReadyToStart).Number);
+        Assert.Equal(41, Assert.Single(result.BlockedOrDeferred).Number);
+        Assert.Empty(result.Failures);
+    }
+
+    [Fact]
+    public async Task GetBacklogAsync_CatalogueHasFailuresAndNoItems_ThrowsInvalidOperationException()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        _workItemCatalogueService.GetCatalogueAsync(cancellationToken)
+            .Returns(new PmWorkItemCatalogueResultDto(
+                [],
+                [new PmRepositoryCatalogueFailureDto("owner/repo-a", "GitHub unavailable", 500)],
+                []));
+        _projectItemCatalogueService.GetCatalogueAsync("PVT_board", cancellationToken)
+            .Returns(new ProjectBoardItemCatalogueDto(
+                new ProjectBoardFieldIdsDto("PVTF_status", null),
+                [],
+                []));
+
+        var sut = new BacklogReviewService(_workItemCatalogueService, _projectItemCatalogueService);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.GetBacklogAsync("PVT_board", cancellationToken));
+
+        Assert.Contains("owner/repo-a", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("1 repository failed", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetBacklogAsync_CatalogueHasPartialFailures_GroupsRemainingItemsAndReturnsFailures()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var updated = DateTimeOffset.Parse("2026-08-18T00:00:00Z");
+        var workItems = new[]
+        {
+            new PmWorkItemDto(
+                PmWorkItemTypeDto.Issue,
+                40,
+                "Do this",
+                "https://github.com/owner/repo/issues/40",
+                "owner/repo",
+                ["priority/medium", "type/story"],
+                null,
+                null,
+                updated,
+                updated,
+                null,
+                null,
+                null,
+                null),
+        };
+
+        _workItemCatalogueService.GetCatalogueAsync(cancellationToken)
+            .Returns(new PmWorkItemCatalogueResultDto(
+                workItems,
+                [new PmRepositoryCatalogueFailureDto("owner/repo-b", "Not found", 404)],
+                []));
+        _projectItemCatalogueService.GetCatalogueAsync("PVT_board", cancellationToken)
+            .Returns(new ProjectBoardItemCatalogueDto(
+                new ProjectBoardFieldIdsDto("PVTF_status", null),
+                [],
+                []));
+
+        var sut = new BacklogReviewService(_workItemCatalogueService, _projectItemCatalogueService);
+
+        var result = await sut.GetBacklogAsync("PVT_board", cancellationToken);
+
+        Assert.Equal(40, Assert.Single(result.ReadyToStart).Number);
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal("owner/repo-b", failure.RepositoryFullName);
+    }
+}

--- a/tests/E2E/CRITICAL_JOURNEYS.md
+++ b/tests/E2E/CRITICAL_JOURNEYS.md
@@ -43,7 +43,7 @@ For data-driven journeys against a real GitHub account, run the PAT suite locall
 | Label Manager taxonomy tabs and empty repository state | `labels.spec.ts` | Tab strip, disabled actions, and no-repositories message. |
 | Workflow template browse, filter, and select | `workflows.spec.ts` | Built-in templates load; repository selector shows error. |
 | Triage not-started region without repositories | `triage.spec.ts` | Shell heading and no-repositories alert. |
-| PM Workflow Daily Focus and Repo Management shells | `pm-workflow.spec.ts` | Shared chrome, Daily Focus occupancy, recommendations, stalled Up Next, and stalled-review regions or empty/error/warning copy, Repos tab thresholds, exclusions, and per-repository summary or chrome error with retry. |
+| PM Workflow Daily Focus, Backlog Review, and Repo Management shells | `pm-workflow.spec.ts` | Shared chrome, Daily Focus occupancy, recommendations, stalled Up Next, and stalled-review regions or empty/error/warning copy, Backlog Review filters and urgency panels or empty/error/warning copy, Repos tab thresholds, exclusions, and per-repository summary or chrome error with retry. |
 
 ### Tier 3 — Out of CI scope (manual or future)
 

--- a/tests/E2E/README.md
+++ b/tests/E2E/README.md
@@ -23,7 +23,7 @@ Published user guides must stay aligned with these tests like-for-like. See [USE
 | `labels.spec.ts` | Label Manager shell, tabs, and empty-repository state |
 | `workflows.spec.ts` | Built-in template browse/filter/select and repository error state |
 | `triage.spec.ts` | Triage shell and no-repositories alert without a live GitHub connection |
-| `pm-workflow.spec.ts` | PM Workflow Daily Focus occupancy, recommendations, stalled Up Next, and stalled-review shell and Repos tab threshold, exclusion, and summary regions or chrome error |
+| `pm-workflow.spec.ts` | PM Workflow Daily Focus occupancy, recommendations, stalled Up Next, stalled-review, and Backlog Review shells, plus Repos tab threshold, exclusion, and summary regions or chrome error |
 | `accessibility.spec.ts` | WCAG 2.1 AA axe-core scan of Tier 1–2 journeys in light and dark mode; labelled shell controls; isolated snackbar contrast scan |
 
 Tests are designed to pass in CI with placeholder auth. The PAT job uses `GitHubAuth__PersonalAccessToken=ci-e2e-placeholder`. The hosted job uses placeholder GitHub App credentials and asserts the login gate without live OAuth. Repository-dependent features assert empty or error states rather than live GitHub data.

--- a/tests/E2E/USER_DOCS_ALIGNMENT.md
+++ b/tests/E2E/USER_DOCS_ALIGNMENT.md
@@ -36,7 +36,7 @@ When you add or change an end-user feature, update the user guide, the relevant 
 | [Workflow Templates](../../website/content/docs/workflow-templates.md) | `/workflows` | `workflows.spec.ts`, `accessibility.spec.ts` | `workflow-templates/overview.png` | Tier 2 | Guide describes browse, parameterise, apply, and drift; CI asserts built-in template browse/filter/select and repository error state. |
 | [Appearance](../../website/content/docs/appearance.md) | App bar (all shell pages) | `appearance.spec.ts`, `accessibility.spec.ts` | `appearance/theme-toggle.png` | Tier 1 | Guide describes Automatic → Light → Dark cycling and persistence; not a drawer route. |
 | [About (in-app)](../../website/content/docs/about.md) | `/about` | `about.spec.ts`, `accessibility.spec.ts` | `about/overview.png` | Tier 1 | Guide describes More options menu access (User Guide external link and About route) and metadata fields. Not the Hugo `/about/` narrative section. |
-| Cross-Repo PM Workflow (`draft: true`, partial) | `/pm-workflow`, `/pm-workflow/daily-focus`, `/pm-workflow/repos` | `pm-workflow.spec.ts`, `accessibility.spec.ts` | `pm-workflow/daily-focus.png` and `pm-workflow/repos.png` (pending) | Tier 2 | Draft guide documents Daily Focus occupancy, recommendations, stalled Up Next alerts, stalled review pull requests, and Repo Management ([#273](https://github.com/markheydon/solo-dev-board/issues/273), [#274](https://github.com/markheydon/solo-dev-board/issues/274), [#275](https://github.com/markheydon/solo-dev-board/issues/275), [#276](https://github.com/markheydon/solo-dev-board/issues/276), [#287](https://github.com/markheydon/solo-dev-board/issues/287), [#288](https://github.com/markheydon/solo-dev-board/issues/288)); Backlog and Planning remain placeholders. CI asserts shell, tab strip, Daily Focus occupancy, recommendation, stalled Up Next, and stalled-review regions or empty/error/warning copy, and Repos regions (including per-repository summary) or chrome error. |
+| Cross-Repo PM Workflow (`draft: true`, partial) | `/pm-workflow`, `/pm-workflow/daily-focus`, `/pm-workflow/backlog`, `/pm-workflow/repos` | `pm-workflow.spec.ts`, `accessibility.spec.ts` | `pm-workflow/daily-focus.png` and `pm-workflow/repos.png` (pending) | Tier 2 | Draft guide documents Daily Focus occupancy, recommendations, stalled Up Next alerts, stalled review pull requests, Backlog Review grouping ([#277](https://github.com/markheydon/solo-dev-board/issues/277)), and Repo Management ([#273](https://github.com/markheydon/solo-dev-board/issues/273), [#274](https://github.com/markheydon/solo-dev-board/issues/274), [#275](https://github.com/markheydon/solo-dev-board/issues/275), [#276](https://github.com/markheydon/solo-dev-board/issues/276), [#287](https://github.com/markheydon/solo-dev-board/issues/287), [#288](https://github.com/markheydon/solo-dev-board/issues/288)); Planning remains a placeholder. CI asserts shell, tab strip, Daily Focus occupancy, recommendation, stalled Up Next, and stalled-review regions or empty/error/warning copy, Backlog filters and urgency panels or empty/error/warning copy, and Repos regions (including per-repository summary) or chrome error. |
 
 ### Auth and entry journeys (operator docs, not user guide)
 
@@ -90,7 +90,7 @@ Use this when extending specs so assertions track documented workflows.
 | More options → About | `about.spec.ts` navigation |
 | Version, build, .NET, auth mode, login, repository link | `about.spec.ts` `data-testid` fields |
 
-### Cross-Repo PM Workflow (partial — Daily Focus occupancy, recommendations, stalled Up Next, stalled review PRs, and Repo Management)
+### Cross-Repo PM Workflow (partial — Daily Focus occupancy, recommendations, stalled Up Next, stalled review PRs, Backlog Review grouping, and Repo Management)
 
 | Guide section | CI assertion | Loaded-state validation |
 |---------------|--------------|-------------------------|
@@ -105,7 +105,8 @@ Use this when extending specs so assertions track documented workflows.
 | Included repositories table or empty state | `pm-workflow-included-table` / `pm-workflow-no-included-text` | `docs-capture` (pending) |
 | Excluded repositories and quick exclude | `pm-workflow-exclusions-region`, exclude autocomplete | `docs-capture` (pending) |
 | Per-repository summary table, empty state, load error, or partial failure | `pm-workflow-repository-summary-table` / `pm-workflow-repository-summary-empty` / `pm-workflow-repository-summary-error` / `pm-workflow-repository-summary-partial-failure` | `docs-capture` (pending) |
-| Backlog, Planning | — | Not shipped |
+| Backlog Review filters, urgency panels, empty copy, warning, or catalogue error | `pm-workflow-backlog-filters` / `pm-workflow-backlog-panels` / empty or error copy, or chrome error | `docs-capture` (pending) |
+| Planning | — | Not shipped |
 
 ## Screenshot hygiene
 

--- a/tests/E2E/fixtures/accessibility.ts
+++ b/tests/E2E/fixtures/accessibility.ts
@@ -16,6 +16,7 @@ export const accessibilityRoutes = [
   { path: '/triage', name: 'Triage' },
   { path: '/workflows', name: 'Workflow Templates' },
   { path: '/pm-workflow/daily-focus', name: 'PM Workflow Daily Focus' },
+  { path: '/pm-workflow/backlog', name: 'PM Workflow Backlog Review' },
 ] as const;
 
 const wcagTags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] as const;
@@ -107,7 +108,7 @@ export async function waitForAccessibilityScanReady(page: Page, path: string): P
     await expect(page.getByTestId('repositories-refresh-button')).toBeEnabled({ timeout: 15_000 });
   }
 
-  if (routePath === '/pm-workflow/daily-focus' || routePath === '/pm-workflow/repos') {
+  if (routePath === '/pm-workflow/daily-focus' || routePath === '/pm-workflow/backlog' || routePath === '/pm-workflow/repos') {
     await expect(page.getByTestId('pm-workflow-shell')).toBeVisible();
     await expect(page.locator('[aria-label="Loading PM Workflow"]')).toBeHidden({ timeout: 15_000 });
   }

--- a/tests/E2E/tests/pm-workflow.spec.ts
+++ b/tests/E2E/tests/pm-workflow.spec.ts
@@ -96,4 +96,39 @@ test.describe('PM Workflow', () => {
         .or(page.getByTestId('pm-workflow-repository-summary-loading')),
     ).toBeVisible();
   });
+
+  test('backlog tab shows filters and urgency panels, empty copy, or a load error', async ({ page }) => {
+    await page.goto('/pm-workflow/backlog');
+
+    await expect(page.getByTestId('pm-workflow-shell')).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Backlog' })).toBeVisible();
+
+    const chromeError = page.getByTestId('pm-workflow-chrome-error');
+    const noBoardAlert = page.getByTestId('pm-workflow-backlog-no-board');
+    const filters = page.getByTestId('pm-workflow-backlog-filters');
+    const loadError = page.getByTestId('pm-workflow-backlog-error');
+
+    await expect(chromeError.or(noBoardAlert).or(filters).or(loadError).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    if (await chromeError.isVisible()) {
+      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      return;
+    }
+
+    if (await loadError.isVisible()) {
+      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(loadError).toContainText('Unable to load the backlog');
+      return;
+    }
+
+    if (await filters.isVisible()) {
+      await expect(page.getByTestId('pm-workflow-backlog-panels')).toBeVisible();
+      await expect(page.getByTestId('pm-workflow-backlog-urgent')).toBeVisible();
+      await expect(page.getByTestId('pm-workflow-backlog-ready')).toBeVisible();
+      await expect(page.getByTestId('pm-workflow-backlog-blocked')).toBeVisible();
+      await expect(page.getByTestId('pm-workflow-backlog-search')).toBeVisible();
+    }
+  });
 });

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -12,7 +12,7 @@ Guides for using SoloDevBoard in the app. Developer and operator material (local
 
 ## Coming later
 
-- Cross-Repo PM Workflow — Daily Focus occupancy, recommendations, stalled Up Next alerts, stalled review pull requests, and Repo Management (including per-repository counts) are in the app; the user guide remains `draft: true` until Backlog and Planning ship.
+- Cross-Repo PM Workflow — Daily Focus occupancy, recommendations, stalled Up Next alerts, stalled review pull requests, Backlog Review grouping, and Repo Management (including per-repository counts) are in the app; the user guide remains `draft: true` until Planning ships.
 
 ## Related repository docs
 

--- a/website/content/docs/pm-workflow.md
+++ b/website/content/docs/pm-workflow.md
@@ -5,7 +5,7 @@ weight: 110
 guideStatus: Partially Available
 ---
 
-> ⚠️ **Partial delivery** — Daily Focus board occupancy, top-three recommendations, stalled Up Next alerts, stalled review pull requests, and Repo Management are available in the app under **PM Workflow**. Backlog Review and Iteration Planning are not shipped yet. This guide remains a draft until all four tabs match the wireframe; only the sections below describe current behaviour.
+> ⚠️ **Partial delivery** — Daily Focus, Backlog Review grouping, and Repo Management are available in the app under **PM Workflow**. Iteration Planning, awaiting-triage and neglected-repo backlog panels, and issue versus pull request chips are not shipped yet. This guide remains a draft until all four tabs match the wireframe; only the sections below describe current behaviour.
 
 ---
 
@@ -23,7 +23,7 @@ The system is built around two modes of operation:
 | Tab | Route | Status |
 |-----|-------|--------|
 | **Daily Focus** | `/pm-workflow/daily-focus` | **Partial** — Status occupancy chips, active load, stalled Up Next, top-three recommendations, and pull requests awaiting review for the configured Stall days threshold. |
-| Backlog | `/pm-workflow/backlog` | Placeholder — story [#277](https://github.com/markheydon/solo-dev-board/issues/277). |
+| **Backlog** | `/pm-workflow/backlog` | **Partial** — search, type and repository filters, plus Urgent, Ready to start, and Blocked/deferred panels. Awaiting triage, near-complete epics, and neglected repositories are still planned. |
 | Planning | `/pm-workflow/planning` | Placeholder — story [#283](https://github.com/markheydon/solo-dev-board/issues/283). |
 | **Repos** | `/pm-workflow/repos` | **Available** — planning board selection, thresholds, repository exclusions, and per-repository open-work counts. |
 
@@ -49,7 +49,7 @@ Shared chrome on every PM Workflow tab includes:
 
 If GitHub reports linked project boards that cannot be read with your current sign-in (common for private user-owned boards under GitHub App sign-in), a warning appears at the top of the page. See [plan/GITHUB_PROJECTS_V2_ACCESS.md](https://github.com/markheydon/solo-dev-board/blob/main/plan/GITHUB_PROJECTS_V2_ACCESS.md) in the repository.
 
-Until a board is selected, an informational alert points at the **Planning board** dropdown. Occupancy, stalled Up Next items, and recommendations load as soon as you open Daily Focus when a board is already stored, or as soon as you choose one. Use the **Repos** tab to edit exclusions and thresholds.
+Until a board is selected, an informational alert points at the **Planning board** dropdown. Occupancy, stalled Up Next items, and recommendations load as soon as you open Daily Focus when a board is already stored, or as soon as you choose one. Backlog Review uses the same board selection. Use the **Repos** tab to edit exclusions and thresholds.
 
 A progress bar at the top of the page shows while planning boards are discovered. Switching tabs does not restart that load.
 
@@ -97,6 +97,43 @@ If no pull requests meet the threshold, an informational alert says so. If the l
 
 ---
 
+## Backlog Review (partial)
+
+Backlog Review is a read-only weekly PM pass across included repositories. It groups open issues and pull requests into urgency panels. Rows open GitHub in a new tab. Adding work to **Up Next** remains on the Planning tab.
+
+### Accessing
+
+1. Open **PM Workflow**.
+2. Select the **Backlog** tab (`/pm-workflow/backlog`).
+
+The same shared chrome described under Daily Focus appears on this tab. Until a board is selected, an informational alert points at the **Planning board** dropdown.
+
+### Filters
+
+Above the panels:
+
+- **Type** — All types, Issues, or Pull requests.
+- **Repository** — All repositories, or one `owner/name` value from the loaded catalogue.
+- **Search** — Matches title, repository name, or item number.
+
+Filters apply in the browser after the catalogue loads. They do not reload GitHub.
+
+### Groups
+
+After a board is selected, expansion panels list:
+
+1. **Urgent** — items labelled `priority/high` or `priority/critical`.
+2. **Ready to start** — unblocked items (`status/blocked` and `status/ice-box` absent, board Status not Blocked or Ice Box) that are not already **Up Next** or **In Progress**.
+3. **Blocked / deferred** — items labelled `status/blocked` or `status/ice-box`, or whose joined board Status is **Blocked** or **Ice Box**.
+
+An item can appear in more than one panel (for example an urgent item that is also blocked). Each panel header includes a count. Empty panels say there are no items in that group.
+
+If there are no open issues or pull requests in included repositories, an informational alert says so. If the current filters hide every row, a separate alert says no items match. If every included repository fails to load, an error alert includes **Retry**. If some repositories fail but others succeed, grouping still proceeds and a warning lists the failed repositories with **Retry**.
+
+> **Scope note** — Awaiting triage (missing `type/` or `priority/`), near-complete epics, neglected repositories, and issue versus pull request chips are tracked on later stories and are not shown yet.
+
+---
+
 ## Repo Management (available)
 
 Repo Management controls which repositories and which Projects v2 board participate in PM operations. Settings persist in your browser (see [Configuration](#configuration)).
@@ -116,7 +153,7 @@ The same shared chrome described under Daily Focus appears on this tab.
 
 Until a board is selected, an informational alert explains that other tabs need a board. You can still edit Repo Management settings below.
 
-Board occupancy on Daily Focus counts mapped Issue and Pull Request cards. Recommendations, stalled Up Next items, and stalled review pull requests honour repository exclusions. Backlog queries and planning candidates will also honour exclusions when those panels ship.
+Board occupancy on Daily Focus counts mapped Issue and Pull Request cards. Recommendations, stalled Up Next items, stalled review pull requests, and Backlog Review honour repository exclusions. Planning candidates will also honour exclusions when that panel ships.
 
 ### Set planning thresholds
 
@@ -135,7 +172,7 @@ Under **Planning thresholds**:
 
 The **Repository participation** section shows how many repositories are included and excluded. Every active repository participates in PM queries by default. Archived repositories are never offered.
 
-Excluded repositories are omitted from Daily Focus recommendations, stalled Up Next, and stalled review pull requests and, when they ship, Backlog Review and Planning candidates.
+Excluded repositories are omitted from Daily Focus recommendations, stalled Up Next, stalled review pull requests, and Backlog Review, and, when it ships, Planning candidates.
 
 **Included repositories** lists active `owner/name` values that currently participate:
 
@@ -186,15 +223,14 @@ A quick morning summary that will also answer stalled-work questions:
 - Stalled PR reviews: shipped on Daily Focus as described above.
 - Top three recommended work items: shipped on Daily Focus as described above.
 
-### Backlog Review
+### Backlog Review (remaining)
 
-A cross-repository prioritised view of all your open work:
+The grouped view is shipped as described above. Still planned:
 
-- Urgent items (high-priority issues and PRs surfaced at the top).
-- Items ready to start (unblocked stories and bugs across included repos).
-- Blocked and deferred items (parked in Blocked or Ice Box).
 - Neglected repositories (no issue or PR activity within the neglect threshold).
 - Items awaiting triage (missing `type/` or `priority/` labels).
+- Near-complete epics.
+- Issue versus pull request chips on every row.
 
 ### Iteration Planning
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Adds the Backlog Review page shell on `/pm-workflow/backlog`. Open issues and pull requests from included repositories are grouped into Urgent, Ready to start, and Blocked/deferred panels, with search plus optional type and repository filters. Loading, empty, and partial-failure alerts match Daily Focus.

## Related Issue(s)

Closes #277

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing application behaviour to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Not captured in this environment (placeholder GitHub auth). Playwright asserts the Backlog tab shell.

## Additional Notes

- Ready means unblocked by `status/blocked` / `status/ice-box` and not already Up Next, In Progress, Blocked, or Ice Box on the selected board.
- Blocked/deferred uses those status labels and matching board Status names (DEC-029 display-name matching).
- Awaiting triage, near-complete epics, neglected repositories, and issue versus pull request chips remain later stories on the same route.
- Later stories: #278, #279, #280, #281, #282. Test issue #386 remains open for remaining Backlog coverage.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e16109c-eb6e-4346-808d-047ad5af46ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e16109c-eb6e-4346-808d-047ad5af46ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

