### PR TITLE
[Test] Add Repo Management PM Workflow coverage (#388)

### DIFF
--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowReposTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowReposTests.cs
@@ -28,6 +28,30 @@ public sealed class PmWorkflowReposTests
     }
 
     [Fact]
+    public async Task PmWorkflowRepos_OnFirstLoad_ShowsDefaultThresholdFields()
+    {
+        ConfigureDefaults();
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowRepos>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var capacityField = cut.FindComponents<MudNumericField<int>>()
+                .First(component => component.Markup.Contains("Capacity limit", StringComparison.Ordinal));
+#pragma warning disable MUD0012
+            Assert.Equal(PmSettingsDefaults.Capacity, capacityField.Instance.Value);
+            var stallDaysField = cut.FindComponents<MudNumericField<int>>()
+                .First(component => component.Markup.Contains("Stall days", StringComparison.Ordinal));
+            Assert.Equal(PmSettingsDefaults.StallDays, stallDaysField.Instance.Value);
+            var neglectDaysField = cut.FindComponents<MudNumericField<int>>()
+                .First(component => component.Markup.Contains("Neglect days", StringComparison.Ordinal));
+            Assert.Equal(PmSettingsDefaults.NeglectDays, neglectDaysField.Instance.Value);
+#pragma warning restore MUD0012
+        });
+    }
+
+    [Fact]
     public async Task PmWorkflowRepos_WhenNoBoardIsSelected_ShowsInstructionalAlert()
     {
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
@@ -88,6 +112,39 @@ public sealed class PmWorkflowReposTests
                 .First(component => component.Markup.Contains("Neglect days", StringComparison.Ordinal));
             Assert.Equal(30, neglectDaysField.Instance.Value);
 #pragma warning restore MUD0012
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowRepos_IncludeRepository_PersistsAfterReload()
+    {
+        ConfigureDefaults();
+        _settingsStorage.StoredJson = """{"excludedRepositories":["owner/repo-b"]}""";
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowRepos>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("owner/repo-b", cut.Markup);
+            Assert.Contains("Include again", cut.Markup);
+        });
+
+        cut.Find("[data-testid='pm-workflow-include-button']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("No repositories are excluded. All active repositories participate.", cut.Markup);
+            Assert.Contains("owner/repo-b", cut.Find("[data-testid='pm-workflow-included-table']").InnerHtml);
+        });
+
+        await using var reloadContext = CreateContext();
+        var reload = reloadContext.RenderPmWorkflowPage<PmWorkflowRepos>();
+
+        reload.WaitForAssertion(() =>
+        {
+            Assert.Contains("No repositories are excluded. All active repositories participate.", reload.Markup);
+            Assert.Contains("owner/repo-b", reload.Find("[data-testid='pm-workflow-included-table']").InnerHtml);
         });
     }
 

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/PmSettingsDefaultsTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/PmSettingsDefaultsTests.cs
@@ -16,21 +16,4 @@ public sealed class PmSettingsDefaultsTests
         Assert.Equal(3, settings.StallDays);
         Assert.Equal(14, settings.NeglectDays);
     }
-
-    [Theory]
-    [InlineData(nameof(PmSettingsDefaults.Capacity), 8)]
-    [InlineData(nameof(PmSettingsDefaults.StallDays), 3)]
-    [InlineData(nameof(PmSettingsDefaults.NeglectDays), 14)]
-    public void DefaultConstants_MatchWireframeThresholds(string constantName, int expectedValue)
-    {
-        var actualValue = constantName switch
-        {
-            nameof(PmSettingsDefaults.Capacity) => PmSettingsDefaults.Capacity,
-            nameof(PmSettingsDefaults.StallDays) => PmSettingsDefaults.StallDays,
-            nameof(PmSettingsDefaults.NeglectDays) => PmSettingsDefaults.NeglectDays,
-            _ => throw new ArgumentOutOfRangeException(nameof(constantName), constantName, "Unexpected PM settings default constant."),
-        };
-
-        Assert.Equal(expectedValue, actualValue);
-    }
 }

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/PmSettingsDefaultsTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/PmSettingsDefaultsTests.cs
@@ -1,0 +1,36 @@
+using SoloDevBoard.Application.Services.PmWorkflow;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="PmSettingsDefaults"/>.</summary>
+public sealed class PmSettingsDefaultsTests
+{
+    [Fact]
+    public void Create_ReturnsRepositoryDefaultThresholds()
+    {
+        var settings = PmSettingsDefaults.Create();
+
+        Assert.Null(settings.PlanningBoardNodeId);
+        Assert.Empty(settings.ExcludedRepositories);
+        Assert.Equal(8, settings.Capacity);
+        Assert.Equal(3, settings.StallDays);
+        Assert.Equal(14, settings.NeglectDays);
+    }
+
+    [Theory]
+    [InlineData(nameof(PmSettingsDefaults.Capacity), 8)]
+    [InlineData(nameof(PmSettingsDefaults.StallDays), 3)]
+    [InlineData(nameof(PmSettingsDefaults.NeglectDays), 14)]
+    public void DefaultConstants_MatchWireframeThresholds(string constantName, int expectedValue)
+    {
+        var actualValue = constantName switch
+        {
+            nameof(PmSettingsDefaults.Capacity) => PmSettingsDefaults.Capacity,
+            nameof(PmSettingsDefaults.StallDays) => PmSettingsDefaults.StallDays,
+            nameof(PmSettingsDefaults.NeglectDays) => PmSettingsDefaults.NeglectDays,
+            _ => throw new ArgumentOutOfRangeException(nameof(constantName), constantName, "Unexpected PM settings default constant."),
+        };
+
+        Assert.Equal(expectedValue, actualValue);
+    }
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/PmSettingsServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/PmSettingsServiceTests.cs
@@ -221,6 +221,32 @@ public sealed class PmSettingsServiceTests
         Assert.Equal(expected.NeglectDays, actual.NeglectDays);
     }
 
+    [Fact]
+    public async Task SaveSettingsAsync_RemovingExcludedRepository_RoundTripsThroughStorage()
+    {
+        var storage = new FakePmSettingsStorage();
+        var service = CreateService(storage);
+
+        await service.SaveSettingsAsync(new PmSettingsDto(
+            "PVT_board123",
+            ["owner/dotfiles", "owner/personal-site"],
+            PmSettingsDefaults.Capacity,
+            PmSettingsDefaults.StallDays,
+            PmSettingsDefaults.NeglectDays));
+
+        await service.SaveSettingsAsync(new PmSettingsDto(
+            "PVT_board123",
+            ["owner/personal-site"],
+            PmSettingsDefaults.Capacity,
+            PmSettingsDefaults.StallDays,
+            PmSettingsDefaults.NeglectDays));
+
+        var settings = await service.GetSettingsAsync();
+
+        Assert.Equal(["owner/personal-site"], settings.ExcludedRepositories);
+        Assert.DoesNotContain("owner/dotfiles", settings.ExcludedRepositories);
+    }
+
     private static PmSettingsService CreateService(FakePmSettingsStorage storage) =>
         new(storage, NullLogger<PmSettingsService>.Instance);
 

--- a/tests/E2E/tests/pm-workflow.spec.ts
+++ b/tests/E2E/tests/pm-workflow.spec.ts
@@ -132,3 +132,48 @@ test.describe('PM Workflow', () => {
     }
   });
 });
+
+test.describe('Repo Management', () => {
+  test('repos tab shows planning thresholds, exclusions, and per-repository summary shell', async ({ page }) => {
+    await page.goto('/pm-workflow/repos');
+
+    await expect(page).toHaveTitle(/PM Workflow — Repos/);
+    await expect(page.getByTestId('pm-workflow-shell')).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-repos-page')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Repo Management' })).toBeVisible();
+
+    const chromeError = page.getByTestId('pm-workflow-chrome-error');
+    const thresholdsRegion = page.getByTestId('pm-workflow-thresholds-region');
+    const exclusionsRegion = page.getByTestId('pm-workflow-exclusions-region');
+    const noBoardAlert = page.getByTestId('pm-workflow-no-board-alert');
+
+    await expect(chromeError.or(thresholdsRegion).first()).toBeVisible({ timeout: 15_000 });
+
+    if (await chromeError.isVisible()) {
+      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      return;
+    }
+
+    await expect(thresholdsRegion).toBeVisible();
+    await expect(exclusionsRegion).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-participation-summary')).toBeVisible();
+    await expect(
+      page.getByTestId('pm-workflow-included-table').or(page.getByTestId('pm-workflow-no-included-text')),
+    ).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-capacity-field')).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-stall-days-field')).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-neglect-days-field')).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-exclude-autocomplete')).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-no-exclusions-text')).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-repository-summary-region')).toBeVisible();
+    await expect(
+      page
+        .getByTestId('pm-workflow-repository-summary-table')
+        .or(page.getByTestId('pm-workflow-repository-summary-empty'))
+        .or(page.getByTestId('pm-workflow-repository-summary-error'))
+        .or(page.getByTestId('pm-workflow-repository-summary-partial-failure'))
+        .or(page.getByTestId('pm-workflow-repository-summary-loading')),
+    ).toBeVisible();
+    await expect(noBoardAlert.or(page.getByTestId('pm-workflow-board-select'))).toBeVisible();
+  });
+});

--- a/tests/E2E/tests/pm-workflow.spec.ts
+++ b/tests/E2E/tests/pm-workflow.spec.ts
@@ -174,6 +174,6 @@ test.describe('Repo Management', () => {
         .or(page.getByTestId('pm-workflow-repository-summary-partial-failure'))
         .or(page.getByTestId('pm-workflow-repository-summary-loading')),
     ).toBeVisible();
-    await expect(noBoardAlert.or(page.getByTestId('pm-workflow-board-select'))).toBeVisible();
+    await expect(noBoardAlert.or(page.getByTestId('pm-workflow-board-select')).first()).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary of Changes

Adds dedicated Repo Management test coverage for issue #388: default threshold constants (capacity 8, stall 3, neglect 14), exclude/include persistence via fake storage, bUnit assertions for default fields and include-again behaviour, and a Playwright `Repo Management` describe block for the `/pm-workflow/repos` shell under CI placeholder auth.

## Related Issue(s)

Closes #388

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [ ] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — test-only change.

## Additional Notes

- **Tests added:** 7 xUnit/bUnit tests and 1 Playwright test (8 total).
- **Verify gate:** `dotnet clean SoloDevBoard.slnx && dotnet test SoloDevBoard.slnx` — 827 passed, 0 failed.
- **Deferred:** `website/content/docs/pm-workflow.md` unchanged; guide remains `draft: true` until Planning ships.
- Builds on existing coverage from #383, #287, and #288 feature PRs; this issue consolidates the Repo Management test deliverable.