### PR TITLE
[Test] Add Daily Focus PM Workflow coverage (#385)

### DIFF
--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowDailyFocusTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowDailyFocusTests.cs
@@ -51,6 +51,30 @@ public sealed class PmWorkflowDailyFocusTests
     }
 
     [Fact]
+    public async Task PmWorkflowDailyFocus_RouteShell_ExposesPageTestIdAndHeading()
+    {
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
+            CreateRepository("owner", "repo-a"),
+        ]);
+        _projectBoardDiscoveryService.GetPlanningBoardOptionsForRepositoriesAsync(
+            Arg.Any<IReadOnlyList<RepositoryDto>>(),
+            Arg.Any<CancellationToken>()).Returns(
+            new PmProjectBoardDiscoveryDto([], 0, 0));
+
+        await using var ctx = CreateContext();
+        ctx.Services.GetRequiredService<NavigationManager>().NavigateTo("/pm-workflow/daily-focus");
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowDailyFocus>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("data-testid=\"pm-workflow-daily-focus-page\"", cut.Markup);
+            Assert.Contains("Daily Focus", cut.Markup);
+            Assert.Contains("data-testid=\"pm-workflow-shell\"", cut.Markup);
+            Assert.Contains("data-testid=\"pm-workflow-tab-strip\"", cut.Markup);
+        });
+    }
+
+    [Fact]
     public async Task PmWorkflowDailyFocus_WhenNoBoardIsSelected_ShowsInstructionalAlert()
     {
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([

--- a/tests/E2E/USER_DOCS_ALIGNMENT.md
+++ b/tests/E2E/USER_DOCS_ALIGNMENT.md
@@ -108,6 +108,20 @@ Use this when extending specs so assertions track documented workflows.
 | Backlog Review filters, urgency panels, empty copy, warning, or catalogue error | `pm-workflow-backlog-filters` / `pm-workflow-backlog-panels` / empty or error copy, or chrome error | `docs-capture` (pending) |
 | Planning | — | Not shipped |
 
+### Daily Focus automated coverage ([#385](https://github.com/markheydon/solo-dev-board/issues/385))
+
+Issue [#385](https://github.com/markheydon/solo-dev-board/issues/385) closes the Daily Focus test slice for stories [#273](https://github.com/markheydon/solo-dev-board/issues/273)–[#276](https://github.com/markheydon/solo-dev-board/issues/276). When `website/content/docs/pm-workflow.md` is published, keep this mapping alongside the PM Workflow rows above.
+
+| Behaviour | Unit / component | Playwright (CI placeholder auth) |
+|-----------|------------------|----------------------------------|
+| Column counts and active load (Up Next + In Progress) | `DailyFocusBoardStateMapperTests`, `DailyFocusBoardStateServiceTests` | `pm-workflow.spec.ts` `Daily Focus` describe — occupancy region or empty/error copy |
+| Inclusive 3-day Up Next stall | `DailyFocusBoardStateMapperTests` | `pm-workflow.spec.ts` `PM Workflow` describe — `pm-workflow-daily-focus-stalled` when occupancy loads |
+| Top-three priority ranking | `DailyFocusRecommendationMapperTests`, `DailyFocusRecommendationServiceTests` | `pm-workflow.spec.ts` `PM Workflow` describe — recommendations region or error/warning |
+| Stalled review pull requests | `DailyFocusStalledReviewDetectorTests`, `DailyFocusStalledReviewServiceTests` | `pm-workflow.spec.ts` `PM Workflow` describe — `pm-workflow-daily-focus-stalled-reviews` or error |
+| Route shell, loading, empty board, GitHub retry, inaccessible-board warning | `PmWorkflowDailyFocusTests` | `pm-workflow.spec.ts` `Daily Focus` describe — route shell and no-board/empty/error copy |
+
+Defer full user-guide publish and docs-capture screenshots until the PM Workflow guide leaves `draft: true`.
+
 ## Screenshot hygiene
 
 - Use **light theme** at **1400×900** viewport with kebab-case PNG filenames under `website/static/images/<feature-slug>/`.

--- a/tests/E2E/tests/pm-workflow.spec.ts
+++ b/tests/E2E/tests/pm-workflow.spec.ts
@@ -132,3 +132,54 @@ test.describe('PM Workflow', () => {
     }
   });
 });
+
+test.describe('Daily Focus', () => {
+  test('direct navigation opens the Daily Focus route shell', async ({ page }) => {
+    await page.goto('/pm-workflow/daily-focus');
+
+    await expect(page).toHaveURL(/\/pm-workflow\/daily-focus$/);
+    await expect(page).toHaveTitle(/PM Workflow — Daily Focus/);
+    await expect(page.getByTestId('pm-workflow-shell')).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-tab-strip')).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Daily Focus' })).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-daily-focus-page')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Daily Focus' })).toBeVisible();
+  });
+
+  test('shows no-board instructional copy, empty board, or occupancy error', async ({ page }) => {
+    await page.goto('/pm-workflow/daily-focus');
+
+    await expect(page.getByTestId('pm-workflow-shell')).toBeVisible();
+
+    const chromeError = page.getByTestId('pm-workflow-chrome-error');
+    const noBoardAlert = page.getByTestId('pm-workflow-daily-focus-no-board');
+    const emptyBoardAlert = page.getByTestId('pm-workflow-daily-focus-empty');
+    const emptyBoardPaper = page.getByTestId('pm-workflow-daily-focus-empty-board');
+    const occupancyError = page.getByTestId('pm-workflow-daily-focus-error');
+
+    await expect(
+      chromeError.or(noBoardAlert).or(emptyBoardAlert).or(emptyBoardPaper).or(occupancyError).first(),
+    ).toBeVisible({ timeout: 15_000 });
+
+    if (await chromeError.isVisible()) {
+      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      return;
+    }
+
+    if (await occupancyError.isVisible()) {
+      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(occupancyError).toContainText('Unable to load board occupancy');
+      return;
+    }
+
+    if (await noBoardAlert.isVisible()) {
+      await expect(noBoardAlert).toContainText(
+        'Select a planning board in the dropdown above to load Daily Focus occupancy and recommendations.',
+      );
+      return;
+    }
+
+    await expect(emptyBoardAlert.or(emptyBoardPaper).first()).toBeVisible();
+    await expect(page.getByText('This planning board has no items.')).toBeVisible();
+  });
+});

--- a/tests/E2E/tests/pm-workflow.spec.ts
+++ b/tests/E2E/tests/pm-workflow.spec.ts
@@ -153,12 +153,19 @@ test.describe('Daily Focus', () => {
 
     const chromeError = page.getByTestId('pm-workflow-chrome-error');
     const noBoardAlert = page.getByTestId('pm-workflow-daily-focus-no-board');
+    const occupancyRegion = page.getByTestId('pm-workflow-daily-focus-board-state');
     const emptyBoardAlert = page.getByTestId('pm-workflow-daily-focus-empty');
     const emptyBoardPaper = page.getByTestId('pm-workflow-daily-focus-empty-board');
     const occupancyError = page.getByTestId('pm-workflow-daily-focus-error');
 
     await expect(
-      chromeError.or(noBoardAlert).or(emptyBoardAlert).or(emptyBoardPaper).or(occupancyError).first(),
+      chromeError
+        .or(noBoardAlert)
+        .or(occupancyRegion)
+        .or(emptyBoardAlert)
+        .or(emptyBoardPaper)
+        .or(occupancyError)
+        .first(),
     ).toBeVisible({ timeout: 15_000 });
 
     if (await chromeError.isVisible()) {
@@ -179,7 +186,18 @@ test.describe('Daily Focus', () => {
       return;
     }
 
+    if (await occupancyRegion.isVisible()) {
+      const hasEmptyBoardState = await emptyBoardAlert.or(emptyBoardPaper).first().isVisible();
+      if (!hasEmptyBoardState) {
+        return;
+      }
+    }
+
     await expect(emptyBoardAlert.or(emptyBoardPaper).first()).toBeVisible();
-    await expect(page.getByText('This planning board has no items.')).toBeVisible();
+    await expect(
+      page
+        .getByText('This planning board has no items.')
+        .or(page.getByText('This planning board has no Status options and no items yet.')),
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary of Changes

Closes the Daily Focus test slice for [#385](https://github.com/markheydon/solo-dev-board/issues/385) by documenting existing unit and component coverage (delivered with stories [#273](https://github.com/markheydon/solo-dev-board/issues/273)–[#276](https://github.com/markheydon/solo-dev-board/issues/276)) and adding the remaining Playwright and alignment artefacts:

- Append a dedicated `Daily Focus` `test.describe` block in `pm-workflow.spec.ts` for direct route navigation and no-board/empty/error copy (CI placeholder auth).
- Add a bUnit route-shell assertion for `pm-workflow-daily-focus-page` and shared chrome `data-testid`s.
- Add a Daily Focus coverage mapping table to `tests/E2E/USER_DOCS_ALIGNMENT.md` for when `pm-workflow.md` is published.

## Related Issue(s)

Closes #385

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — test-only change.

## Additional Notes

**Verify gate:** `dotnet clean SoloDevBoard.slnx && dotnet test SoloDevBoard.slnx` — 821 passed, 0 failed.

**Tests added in this PR:** 1 bUnit (`PmWorkflowDailyFocus_RouteShell_ExposesPageTestIdAndHeading`), 2 Playwright (`Daily Focus` describe).

**Existing Daily Focus coverage (on `main` from stories #273–#276):**

| Layer | Files |
|-------|-------|
| Unit | `DailyFocusBoardStateMapperTests`, `DailyFocusBoardStateServiceTests`, `DailyFocusRecommendationMapperTests`, `DailyFocusRecommendationServiceTests`, `DailyFocusStalledReviewDetectorTests`, `DailyFocusStalledReviewServiceTests` |
| bUnit | `PmWorkflowDailyFocusTests` (24 scenarios including loading, empty board, GitHub retry, inaccessible-board warning) |

**Deferred:** `website/content/docs/pm-workflow.md` publish and docs-capture screenshots remain deferred until the guide leaves `draft: true`.