### PR TITLE
[Story] Complete Backlog Review grouping panels (#280, #278, #282, #281, #279)

### DIFF
--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor
@@ -5,8 +5,7 @@
     <MudText Typo="Typo.h5">Backlog Review</MudText>
     <MudText Typo="Typo.body1">
         Open issues and pull requests from included repositories, grouped by urgency.
-        Adding items to Up Next happens on the Planning tab.
-        Awaiting triage, near-complete epics, and neglected repositories will appear in later stories.
+        Rows open GitHub in a new tab. Adding items to Up Next happens on the Planning tab.
     </MudText>
 
     @if (ChromeState is null)
@@ -109,7 +108,10 @@
             <MudExpansionPanels MultiExpansion="true" data-testid="pm-workflow-backlog-panels">
                 @RenderGroupPanel("Urgent", "pm-workflow-backlog-urgent", FilteredUrgent)
                 @RenderGroupPanel("Ready to start", "pm-workflow-backlog-ready", FilteredReady)
+                @RenderGroupPanel("Awaiting triage", "pm-workflow-backlog-awaiting-triage", FilteredAwaitingTriage)
                 @RenderGroupPanel("Blocked / deferred", "pm-workflow-backlog-blocked", FilteredBlocked)
+                @RenderEpicsPanel()
+                @RenderNeglectedPanel()
             </MudExpansionPanels>
         }
     }
@@ -145,7 +147,16 @@
                             @foreach (var item in items)
                             {
                                 <tr data-testid="@($"{testId}-row")">
-                                    <td>@FormatItemKind(item.ItemType)</td>
+                                    <td>
+                                        <MudChip T="string"
+                                                 Value="@FormatItemKindChip(item.ItemType)"
+                                                 Variant="Variant.Outlined"
+                                                 Color="Color.Default"
+                                                 Size="Size.Small"
+                                                 data-testid="pm-workflow-backlog-kind-chip">
+                                            @FormatItemKindChip(item.ItemType)
+                                        </MudChip>
+                                    </td>
                                     <td>
                                         <MudLink Href="@item.HtmlUrl"
                                                  Target="_blank"
@@ -156,6 +167,105 @@
                                     </td>
                                     <td>@item.Title</td>
                                     <td>@FormatPriority(item.PriorityLabel)</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </MudSimpleTable>
+                }
+            </ChildContent>
+        </MudExpansionPanel>
+    };
+
+    private RenderFragment RenderEpicsPanel() => __builder =>
+    {
+        <MudExpansionPanel Expanded="true" data-testid="pm-workflow-backlog-epics">
+            <TitleContent>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    <MudText Typo="Typo.subtitle1">Epics near completion</MudText>
+                    <MudBadge Color="Color.Primary" Content="@FilteredEpicsNearComplete.Count" Overlap="false" />
+                </MudStack>
+            </TitleContent>
+            <ChildContent>
+                @if (snapshot?.SubIssueCountsUnavailable == true)
+                {
+                    <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="pm-workflow-backlog-epics-unavailable">
+                        Open epics or features were found, but GitHub did not return sub-issue counts. Near-completion parents cannot be listed without that data.
+                    </MudAlert>
+                }
+                else if (FilteredEpicsNearComplete.Count == 0)
+                {
+                    <MudText Typo="Typo.body2" data-testid="pm-workflow-backlog-epics-empty">No near-complete epics or features.</MudText>
+                }
+                else
+                {
+                    <MudSimpleTable Hover="true" Dense="true" data-testid="pm-workflow-backlog-epics-table">
+                        <thead>
+                            <tr>
+                                <th>Item</th>
+                                <th>Title</th>
+                                <th>Type</th>
+                                <th>Sub-issues</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var epic in FilteredEpicsNearComplete)
+                            {
+                                <tr data-testid="pm-workflow-backlog-epics-row">
+                                    <td>
+                                        <MudLink Href="@epic.HtmlUrl"
+                                                 Target="_blank"
+                                                 rel="noopener noreferrer"
+                                                 data-testid="pm-workflow-backlog-epic-link">
+                                            @($"{epic.RepositoryFullName}#{epic.Number}")
+                                        </MudLink>
+                                    </td>
+                                    <td>@epic.Title</td>
+                                    <td>@epic.TypeLabel</td>
+                                    <td>@($"{epic.SubIssueCompleted}/{epic.SubIssueTotal}")</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </MudSimpleTable>
+                }
+            </ChildContent>
+        </MudExpansionPanel>
+    };
+
+    private RenderFragment RenderNeglectedPanel() => __builder =>
+    {
+        <MudExpansionPanel Expanded="true" data-testid="pm-workflow-backlog-neglected">
+            <TitleContent>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    <MudText Typo="Typo.subtitle1">Neglected repositories</MudText>
+                    <MudBadge Color="Color.Primary" Content="@FilteredNeglectedRepositories.Count" Overlap="false" />
+                </MudStack>
+            </TitleContent>
+            <ChildContent>
+                @if (FilteredNeglectedRepositories.Count == 0)
+                {
+                    <MudText Typo="Typo.body2" data-testid="pm-workflow-backlog-neglected-empty">
+                        No included repositories have been inactive for @NeglectDaysThreshold or more days.
+                    </MudText>
+                }
+                else
+                {
+                    <MudSimpleTable Hover="true" Dense="true" data-testid="pm-workflow-backlog-neglected-table">
+                        <thead>
+                            <tr>
+                                <th>Repository</th>
+                                <th>Last activity</th>
+                                <th>Open issues</th>
+                                <th>Open PRs</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var repository in FilteredNeglectedRepositories)
+                            {
+                                <tr data-testid="pm-workflow-backlog-neglected-row">
+                                    <td>@repository.FullName</td>
+                                    <td>@FormatLastActivity(repository.LastActivityAt)</td>
+                                    <td>@repository.OpenIssueCount</td>
+                                    <td>@repository.OpenPullRequestCount</td>
                                 </tr>
                             }
                         </tbody>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor
@@ -150,7 +150,7 @@
                                     <td>
                                         <MudChip T="string"
                                                  Value="@FormatItemKindChip(item.ItemType)"
-                                                 Variant="Variant.Outlined"
+                                                 Variant="@FormatItemKindChipVariant(item.ItemType)"
                                                  Color="@FormatItemKindChipColor(item.ItemType)"
                                                  Size="Size.Small"
                                                  data-testid="pm-workflow-backlog-kind-chip">

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor
@@ -122,7 +122,7 @@
     {
         <MudExpansionPanel Expanded="true" data-testid="@testId">
             <TitleContent>
-                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                     <MudText Typo="Typo.subtitle1">@title</MudText>
                     <MudBadge Color="Color.Primary" Content="@items.Count" Overlap="false" />
                 </MudStack>
@@ -151,7 +151,7 @@
                                         <MudChip T="string"
                                                  Value="@FormatItemKindChip(item.ItemType)"
                                                  Variant="Variant.Outlined"
-                                                 Color="Color.Default"
+                                                 Color="@FormatItemKindChipColor(item.ItemType)"
                                                  Size="Size.Small"
                                                  data-testid="pm-workflow-backlog-kind-chip">
                                             @FormatItemKindChip(item.ItemType)
@@ -180,7 +180,7 @@
     {
         <MudExpansionPanel Expanded="true" data-testid="pm-workflow-backlog-epics">
             <TitleContent>
-                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                     <MudText Typo="Typo.subtitle1">Epics near completion</MudText>
                     <MudBadge Color="Color.Primary" Content="@FilteredEpicsNearComplete.Count" Overlap="false" />
                 </MudStack>
@@ -235,7 +235,7 @@
     {
         <MudExpansionPanel Expanded="true" data-testid="pm-workflow-backlog-neglected">
             <TitleContent>
-                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                     <MudText Typo="Typo.subtitle1">Neglected repositories</MudText>
                     <MudBadge Color="Color.Primary" Content="@FilteredNeglectedRepositories.Count" Overlap="false" />
                 </MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor
@@ -150,7 +150,7 @@
                                     <td>
                                         <MudChip T="string"
                                                  Value="@FormatItemKindChip(item.ItemType)"
-                                                 Variant="@FormatItemKindChipVariant(item.ItemType)"
+                                                 Variant="Variant.Filled"
                                                  Color="@FormatItemKindChipColor(item.ItemType)"
                                                  Size="Size.Small"
                                                  data-testid="pm-workflow-backlog-kind-chip">

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor.cs
@@ -322,7 +322,10 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
         => itemType == PmWorkItemTypeDto.PullRequest ? "Pull request" : "Issue";
 
     private static Color FormatItemKindChipColor(PmWorkItemTypeDto itemType)
-        => itemType == PmWorkItemTypeDto.PullRequest ? Color.Secondary : Color.Info;
+        => itemType == PmWorkItemTypeDto.PullRequest ? Color.Warning : Color.Info;
+
+    private static Variant FormatItemKindChipVariant(PmWorkItemTypeDto itemType)
+        => itemType == PmWorkItemTypeDto.PullRequest ? Variant.Outlined : Variant.Filled;
 
     private static string FormatPriority(string? priorityLabel)
         => string.IsNullOrWhiteSpace(priorityLabel) ? "Unlabelled" : priorityLabel;

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor.cs
@@ -324,9 +324,6 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
     private static Color FormatItemKindChipColor(PmWorkItemTypeDto itemType)
         => itemType == PmWorkItemTypeDto.PullRequest ? Color.Warning : Color.Info;
 
-    private static Variant FormatItemKindChipVariant(PmWorkItemTypeDto itemType)
-        => itemType == PmWorkItemTypeDto.PullRequest ? Variant.Outlined : Variant.Filled;
-
     private static string FormatPriority(string? priorityLabel)
         => string.IsNullOrWhiteSpace(priorityLabel) ? "Unlabelled" : priorityLabel;
 

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor.cs
@@ -36,6 +36,11 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
     private int loadGeneration;
     private int loadedRevision = -1;
 
+    private int NeglectDaysThreshold
+        => ChromeState?.Settings.NeglectDays > 0
+            ? ChromeState.Settings.NeglectDays
+            : PmSettingsDefaults.NeglectDays;
+
     /// <inheritdoc/>
     protected override Task OnParametersSetAsync()
     {
@@ -68,6 +73,7 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
             ? []
             : snapshot.Urgent
                 .Concat(snapshot.ReadyToStart)
+                .Concat(snapshot.AwaitingTriage)
                 .Concat(snapshot.BlockedOrDeferred)
                 .Select(static item => item.RepositoryFullName)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -78,19 +84,33 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
 
     private IReadOnlyList<BacklogReviewItemDto> FilteredReady => Filter(snapshot?.ReadyToStart);
 
+    private IReadOnlyList<BacklogReviewItemDto> FilteredAwaitingTriage => Filter(snapshot?.AwaitingTriage);
+
     private IReadOnlyList<BacklogReviewItemDto> FilteredBlocked => Filter(snapshot?.BlockedOrDeferred);
+
+    private IReadOnlyList<BacklogEpicNearCompleteItemDto> FilteredEpicsNearComplete
+        => FilterEpics(snapshot?.EpicsNearComplete);
+
+    private IReadOnlyList<BacklogNeglectedRepositoryDto> FilteredNeglectedRepositories
+        => FilterNeglected(snapshot?.NeglectedRepositories);
 
     private bool IsCatalogueEmpty
         => snapshot is not null
             && snapshot.Urgent.Count == 0
             && snapshot.ReadyToStart.Count == 0
-            && snapshot.BlockedOrDeferred.Count == 0;
+            && snapshot.AwaitingTriage.Count == 0
+            && snapshot.BlockedOrDeferred.Count == 0
+            && snapshot.EpicsNearComplete.Count == 0
+            && snapshot.NeglectedRepositories.Count == 0;
 
     private bool HasNoFilteredItems
         => !IsCatalogueEmpty
             && FilteredUrgent.Count == 0
             && FilteredReady.Count == 0
-            && FilteredBlocked.Count == 0;
+            && FilteredAwaitingTriage.Count == 0
+            && FilteredBlocked.Count == 0
+            && FilteredEpicsNearComplete.Count == 0
+            && FilteredNeglectedRepositories.Count == 0;
 
     private bool TryApplyCachedResult(string boardId)
     {
@@ -214,6 +234,43 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
         return items.Where(MatchesFilters).ToArray();
     }
 
+    private IReadOnlyList<BacklogEpicNearCompleteItemDto> FilterEpics(
+        IReadOnlyList<BacklogEpicNearCompleteItemDto>? items)
+    {
+        if (items is null || items.Count == 0)
+        {
+            return [];
+        }
+
+        return items.Where(MatchesEpicFilters).ToArray();
+    }
+
+    private IReadOnlyList<BacklogNeglectedRepositoryDto> FilterNeglected(
+        IReadOnlyList<BacklogNeglectedRepositoryDto>? items)
+    {
+        if (items is null || items.Count == 0)
+        {
+            return [];
+        }
+
+        if (!string.IsNullOrWhiteSpace(selectedRepositoryFilter)
+            && !items.Any(repository =>
+                repository.FullName.Equals(selectedRepositoryFilter, StringComparison.OrdinalIgnoreCase)))
+        {
+            return [];
+        }
+
+        if (string.IsNullOrWhiteSpace(searchText))
+        {
+            return items.ToArray();
+        }
+
+        var query = searchText.Trim();
+        return items
+            .Where(repository => repository.FullName.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+    }
+
     private bool MatchesFilters(BacklogReviewItemDto item)
     {
         if (selectedTypeFilter == IssueTypeFilter && item.ItemType != PmWorkItemTypeDto.Issue)
@@ -244,11 +301,41 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
             || $"{item.RepositoryFullName}#{item.Number}".Contains(query, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string FormatItemKind(PmWorkItemTypeDto itemType)
+    private bool MatchesEpicFilters(BacklogEpicNearCompleteItemDto epic)
+    {
+        if (!string.IsNullOrWhiteSpace(selectedRepositoryFilter)
+            && !epic.RepositoryFullName.Equals(selectedRepositoryFilter, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(searchText))
+        {
+            return true;
+        }
+
+        var query = searchText.Trim();
+        return epic.Title.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || epic.RepositoryFullName.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || epic.Number.ToString().Contains(query, StringComparison.OrdinalIgnoreCase)
+            || $"{epic.RepositoryFullName}#{epic.Number}".Contains(query, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string FormatItemKindChip(PmWorkItemTypeDto itemType)
         => itemType == PmWorkItemTypeDto.PullRequest ? "Pull request" : "Issue";
 
     private static string FormatPriority(string? priorityLabel)
         => string.IsNullOrWhiteSpace(priorityLabel) ? "Unlabelled" : priorityLabel;
+
+    private static string FormatLastActivity(DateTimeOffset? lastActivityAt)
+    {
+        if (lastActivityAt is null || lastActivityAt == default)
+        {
+            return "Never";
+        }
+
+        return lastActivityAt.Value.ToString("d MMM yyyy");
+    }
 
     private static string? FormatPartialFailureWarning(IReadOnlyList<PmRepositoryCatalogueFailureDto> failures)
     {

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowBacklogPanel.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using MudBlazor;
 using SoloDevBoard.Application.Services.PmWorkflow;
 
 namespace SoloDevBoard.App.Components.Features.PmWorkflow;
@@ -34,7 +35,6 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
     private string selectedRepositoryFilter = AllRepositoriesFilter;
     private string searchText = string.Empty;
     private int loadGeneration;
-    private int loadedRevision = -1;
 
     private int NeglectDaysThreshold
         => ChromeState?.Settings.NeglectDays > 0
@@ -54,12 +54,11 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
             snapshot = null;
             loadErrorMessage = null;
             warningMessage = null;
-            loadedRevision = -1;
             return Task.CompletedTask;
         }
 
         var boardId = ChromeState.Settings.PlanningBoardNodeId!;
-        if (loadedRevision == DataRevision && TryApplyCachedResult(boardId))
+        if (TryApplyCachedResult(boardId))
         {
             return Task.CompletedTask;
         }
@@ -136,14 +135,13 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
             return Task.CompletedTask;
         }
 
-        loadedRevision = -1;
         ChromeCoordinator.ClearBacklogReview();
         return LoadAsync(ChromeState.Settings.PlanningBoardNodeId);
     }
 
     private async Task LoadAsync(string boardId)
     {
-        if (loadedRevision == DataRevision && TryApplyCachedResult(boardId))
+        if (TryApplyCachedResult(boardId))
         {
             return;
         }
@@ -165,7 +163,6 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
 
             snapshot = result;
             warningMessage = FormatPartialFailureWarning(result.Failures);
-            loadedRevision = DataRevision;
             ChromeCoordinator.SetBacklogReview(boardId, result, null, isLoading: false, warningMessage);
         }
         catch (Exception exception)
@@ -323,6 +320,9 @@ public partial class PmWorkflowBacklogPanel : ComponentBase
 
     private static string FormatItemKindChip(PmWorkItemTypeDto itemType)
         => itemType == PmWorkItemTypeDto.PullRequest ? "Pull request" : "Issue";
+
+    private static Color FormatItemKindChipColor(PmWorkItemTypeDto itemType)
+        => itemType == PmWorkItemTypeDto.PullRequest ? Color.Secondary : Color.Info;
 
     private static string FormatPriority(string? priorityLabel)
         => string.IsNullOrWhiteSpace(priorityLabel) ? "Unlabelled" : priorityLabel;

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogEpicNearCompleteItemDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogEpicNearCompleteItemDto.cs
@@ -1,0 +1,18 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>An open epic or feature whose tracked sub-issues are all closed.</summary>
+/// <param name="RepositoryFullName">The repository in <c>owner/name</c> form.</param>
+/// <param name="Number">The repository-scoped issue number.</param>
+/// <param name="Title">The item title.</param>
+/// <param name="HtmlUrl">The browser URL for the item on GitHub.</param>
+/// <param name="TypeLabel">The <c>type/epic</c> or <c>type/feature</c> label name.</param>
+/// <param name="SubIssueTotal">The tracked sub-issue total from GitHub.</param>
+/// <param name="SubIssueCompleted">The completed tracked sub-issue count from GitHub.</param>
+public sealed record BacklogEpicNearCompleteItemDto(
+    string RepositoryFullName,
+    int Number,
+    string Title,
+    string HtmlUrl,
+    string TypeLabel,
+    int SubIssueTotal,
+    int SubIssueCompleted);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogNeglectedRepositoryDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogNeglectedRepositoryDto.cs
@@ -1,0 +1,12 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>A repository with no recent issue or pull request activity in Backlog Review.</summary>
+/// <param name="FullName">The repository in <c>owner/name</c> form.</param>
+/// <param name="LastActivityAt">The latest catalogue item update, or <see langword="null"/> when no activity was recorded.</param>
+/// <param name="OpenIssueCount">The number of open issues in the catalogue for this repository.</param>
+/// <param name="OpenPullRequestCount">The number of open pull requests in the catalogue for this repository.</param>
+public sealed record BacklogNeglectedRepositoryDto(
+    string FullName,
+    DateTimeOffset? LastActivityAt,
+    int OpenIssueCount,
+    int OpenPullRequestCount);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewGrouping.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewGrouping.cs
@@ -4,20 +4,27 @@ namespace SoloDevBoard.Application.Services.PmWorkflow;
 public static class BacklogReviewGrouping
 {
     /// <summary>
-    /// Groups work items into urgent, ready-to-start, and blocked or deferred lists.
-    /// An item may appear in more than one group.
+    /// Groups work items into urgent, ready-to-start, awaiting-triage, blocked or deferred, near-complete epics,
+    /// and neglected repositories.
     /// </summary>
     /// <param name="workItems">Open issues and pull requests from included repositories.</param>
     /// <param name="boardItems">Items currently on the selected planning board.</param>
+    /// <param name="repositorySummaries">Per-repository open-work summaries from the catalogue.</param>
     /// <param name="failures">Per-repository catalogue failures to carry through to the result.</param>
+    /// <param name="neglectDays">Inclusive days without issue or pull request activity before a repository is neglected.</param>
+    /// <param name="referenceTimeUtc">The UTC instant used for neglect-day comparisons.</param>
     /// <returns>The grouped Backlog Review snapshot.</returns>
     public static BacklogReviewResultDto Group(
         IReadOnlyList<PmWorkItemDto> workItems,
         IReadOnlyList<ProjectBoardItemDto> boardItems,
-        IReadOnlyList<PmRepositoryCatalogueFailureDto> failures)
+        IReadOnlyList<PmRepositorySummaryDto> repositorySummaries,
+        IReadOnlyList<PmRepositoryCatalogueFailureDto> failures,
+        int neglectDays,
+        DateTimeOffset referenceTimeUtc)
     {
         ArgumentNullException.ThrowIfNull(workItems);
         ArgumentNullException.ThrowIfNull(boardItems);
+        ArgumentNullException.ThrowIfNull(repositorySummaries);
         ArgumentNullException.ThrowIfNull(failures);
 
         var boardStatusByKey = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -35,7 +42,9 @@ public static class BacklogReviewGrouping
 
         var urgent = new List<BacklogReviewItemDto>();
         var ready = new List<BacklogReviewItemDto>();
+        var awaitingTriage = new List<BacklogReviewItemDto>();
         var blocked = new List<BacklogReviewItemDto>();
+        var epicsNearComplete = new List<BacklogEpicNearCompleteItemDto>();
 
         foreach (var workItem in workItems)
         {
@@ -47,7 +56,11 @@ public static class BacklogReviewGrouping
                 urgent.Add(row);
             }
 
-            if (IsReadyToStart(workItem, boardStatusName))
+            if (IsAwaitingTriage(workItem))
+            {
+                awaitingTriage.Add(row);
+            }
+            else if (IsReadyToStart(workItem, boardStatusName))
             {
                 ready.Add(row);
             }
@@ -56,12 +69,24 @@ public static class BacklogReviewGrouping
             {
                 blocked.Add(row);
             }
+
+            if (TryMapEpicNearComplete(workItem, out var epicNearComplete))
+            {
+                epicsNearComplete.Add(epicNearComplete);
+            }
         }
+
+        var neglectedRepositories = BuildNeglectedRepositories(repositorySummaries, neglectDays, referenceTimeUtc);
+        var subIssueCountsUnavailable = HasOpenEpicsWithoutSubIssueCounts(workItems);
 
         return new BacklogReviewResultDto(
             Sort(urgent),
             Sort(ready),
+            Sort(awaitingTriage),
             Sort(blocked),
+            SortEpics(epicsNearComplete),
+            neglectedRepositories,
+            subIssueCountsUnavailable,
             failures);
     }
 
@@ -74,9 +99,18 @@ public static class BacklogReviewGrouping
         return PmLabelHelpers.IsUrgent(item.Labels);
     }
 
+    /// <summary>Returns whether the item is missing a core <c>type/</c> or <c>priority/</c> label.</summary>
+    /// <param name="item">The catalogue work item.</param>
+    /// <returns><see langword="true"/> when either core label prefix is absent.</returns>
+    public static bool IsAwaitingTriage(PmWorkItemDto item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        return PmLabelHelpers.IsAwaitingTriage(item.Labels);
+    }
+
     /// <summary>
-    /// Returns whether the item is ready to start: unblocked by labels and board Status,
-    /// and not already Up Next or In Progress.
+    /// Returns whether the item is ready to start: fully labelled, unblocked by labels and board Status,
+    /// not urgent, and not already Up Next or In Progress.
     /// </summary>
     /// <param name="item">The catalogue work item.</param>
     /// <param name="boardStatusName">The joined planning-board Status name, or <see langword="null"/> when unset.</param>
@@ -84,6 +118,11 @@ public static class BacklogReviewGrouping
     public static bool IsReadyToStart(PmWorkItemDto item, string? boardStatusName)
     {
         ArgumentNullException.ThrowIfNull(item);
+
+        if (IsAwaitingTriage(item) || IsUrgent(item))
+        {
+            return false;
+        }
 
         if (!PmLabelHelpers.IsUnblocked(item.Labels))
         {
@@ -103,6 +142,34 @@ public static class BacklogReviewGrouping
     {
         ArgumentNullException.ThrowIfNull(item);
         return PmLabelHelpers.IsBlockedOrDeferred(item.Labels) || IsParkedBoardStatus(boardStatusName);
+    }
+
+    /// <summary>
+    /// Returns whether a repository has had no issue or pull request activity within the neglect threshold.
+    /// </summary>
+    /// <param name="summary">The repository summary from the work-item catalogue.</param>
+    /// <param name="neglectDays">The inclusive neglect threshold in days.</param>
+    /// <param name="referenceTimeUtc">The UTC instant used for the comparison.</param>
+    /// <returns><see langword="true"/> when the repository is neglected; otherwise, <see langword="false"/>.</returns>
+    public static bool IsNeglected(
+        PmRepositorySummaryDto summary,
+        int neglectDays,
+        DateTimeOffset referenceTimeUtc)
+    {
+        ArgumentNullException.ThrowIfNull(summary);
+
+        if (neglectDays <= 0)
+        {
+            return false;
+        }
+
+        if (summary.LastActivityAt == default)
+        {
+            return true;
+        }
+
+        var daysSinceActivity = (referenceTimeUtc - summary.LastActivityAt).TotalDays;
+        return daysSinceActivity >= neglectDays;
     }
 
     /// <summary>Returns whether a board Status name is Blocked or Ice Box.</summary>
@@ -134,6 +201,59 @@ public static class BacklogReviewGrouping
         return DailyFocusBoardStateMapper.IsActiveLoadStatus(statusName) || IsParkedBoardStatus(statusName);
     }
 
+    private static bool TryMapEpicNearComplete(
+        PmWorkItemDto item,
+        out BacklogEpicNearCompleteItemDto epicNearComplete)
+    {
+        epicNearComplete = null!;
+
+        if (!PmLabelHelpers.IsEpicNearComplete(item.Labels, item.SubIssueTotal, item.SubIssueCompleted))
+        {
+            return false;
+        }
+
+        var typeLabel = PmLabelHelpers.ParseTypeLabel(item.Labels)!;
+        epicNearComplete = new BacklogEpicNearCompleteItemDto(
+            item.RepositoryFullName,
+            item.Number,
+            item.Title,
+            item.HtmlUrl,
+            typeLabel,
+            item.SubIssueTotal!.Value,
+            item.SubIssueCompleted!.Value);
+        return true;
+    }
+
+    private static bool HasOpenEpicsWithoutSubIssueCounts(IReadOnlyList<PmWorkItemDto> workItems)
+    {
+        var openEpicsOrFeatures = workItems
+            .Where(static item => item.ItemType == PmWorkItemTypeDto.Issue)
+            .Select(static item => (Item: item, TypeLabel: PmLabelHelpers.ParseTypeLabel(item.Labels)))
+            .Where(static pair => pair.TypeLabel is PmLabelHelpers.EpicTypeLabel or PmLabelHelpers.FeatureTypeLabel)
+            .ToArray();
+
+        if (openEpicsOrFeatures.Length == 0)
+        {
+            return false;
+        }
+
+        return openEpicsOrFeatures.All(static pair => pair.Item.SubIssueTotal is null);
+    }
+
+    private static IReadOnlyList<BacklogNeglectedRepositoryDto> BuildNeglectedRepositories(
+        IReadOnlyList<PmRepositorySummaryDto> repositorySummaries,
+        int neglectDays,
+        DateTimeOffset referenceTimeUtc)
+        => repositorySummaries
+            .Where(summary => summary.IsIncluded && IsNeglected(summary, neglectDays, referenceTimeUtc))
+            .Select(static summary => new BacklogNeglectedRepositoryDto(
+                summary.FullName,
+                summary.LastActivityAt == default ? null : summary.LastActivityAt,
+                summary.OpenIssueCount,
+                summary.OpenPullRequestCount))
+            .OrderBy(static repository => repository.FullName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
     private static BacklogReviewItemDto Map(PmWorkItemDto item, string? boardStatusName)
         => new(
             item.ItemType,
@@ -149,6 +269,13 @@ public static class BacklogReviewGrouping
         => items
             .OrderBy(static item => PmPriorityRanker.GetRank(item.PriorityLabel))
             .ThenBy(static item => item.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static item => item.Number)
+            .ToArray();
+
+    private static IReadOnlyList<BacklogEpicNearCompleteItemDto> SortEpics(
+        IReadOnlyList<BacklogEpicNearCompleteItemDto> items)
+        => items
+            .OrderBy(static item => item.RepositoryFullName, StringComparer.OrdinalIgnoreCase)
             .ThenBy(static item => item.Number)
             .ToArray();
 }

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewResultDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewResultDto.cs
@@ -2,8 +2,14 @@ namespace SoloDevBoard.Application.Services.PmWorkflow;
 
 /// <summary>Grouped Backlog Review items plus any partial catalogue failures.</summary>
 /// <param name="Urgent">Items labelled <c>priority/high</c> or <c>priority/critical</c>.</param>
-/// <param name="ReadyToStart">Unblocked items that are not already Up Next or In Progress.</param>
+/// <param name="ReadyToStart">Unblocked, fully labelled items that are not urgent and not already Up Next or In Progress.</param>
+/// <param name="AwaitingTriage">Items missing a core <c>type/</c> or <c>priority/</c> label.</param>
 /// <param name="BlockedOrDeferred">Items parked by <c>status/blocked</c>, <c>status/ice-box</c>, or matching board Status.</param>
+/// <param name="EpicsNearComplete">Open epics or features whose tracked sub-issues are all closed.</param>
+/// <param name="NeglectedRepositories">Included repositories with no issue or pull request activity within the neglect threshold.</param>
+/// <param name="SubIssueCountsUnavailable">
+/// <see langword="true"/> when open epics or features exist but GitHub did not return sub-issue counts for any of them.
+/// </param>
 /// <param name="Failures">
 /// Per-repository catalogue failures. Grouping still proceeds when this list is non-empty and
 /// the remaining items produced groups.
@@ -11,5 +17,9 @@ namespace SoloDevBoard.Application.Services.PmWorkflow;
 public sealed record BacklogReviewResultDto(
     IReadOnlyList<BacklogReviewItemDto> Urgent,
     IReadOnlyList<BacklogReviewItemDto> ReadyToStart,
+    IReadOnlyList<BacklogReviewItemDto> AwaitingTriage,
     IReadOnlyList<BacklogReviewItemDto> BlockedOrDeferred,
+    IReadOnlyList<BacklogEpicNearCompleteItemDto> EpicsNearComplete,
+    IReadOnlyList<BacklogNeglectedRepositoryDto> NeglectedRepositories,
+    bool SubIssueCountsUnavailable,
     IReadOnlyList<PmRepositoryCatalogueFailureDto> Failures);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/BacklogReviewService.cs
@@ -5,19 +5,24 @@ public sealed class BacklogReviewService : IBacklogReviewService
 {
     private readonly IPmWorkItemCatalogueService _workItemCatalogueService;
     private readonly IProjectItemCatalogueService _projectItemCatalogueService;
+    private readonly IPmSettingsService _pmSettingsService;
 
     /// <summary>Initialises a new instance of the <see cref="BacklogReviewService"/> class.</summary>
     /// <param name="workItemCatalogueService">The cross-repository work-item catalogue.</param>
     /// <param name="projectItemCatalogueService">The project board item catalogue.</param>
+    /// <param name="pmSettingsService">The PM settings service.</param>
     public BacklogReviewService(
         IPmWorkItemCatalogueService workItemCatalogueService,
-        IProjectItemCatalogueService projectItemCatalogueService)
+        IProjectItemCatalogueService projectItemCatalogueService,
+        IPmSettingsService pmSettingsService)
     {
         ArgumentNullException.ThrowIfNull(workItemCatalogueService);
         ArgumentNullException.ThrowIfNull(projectItemCatalogueService);
+        ArgumentNullException.ThrowIfNull(pmSettingsService);
 
         _workItemCatalogueService = workItemCatalogueService;
         _projectItemCatalogueService = projectItemCatalogueService;
+        _pmSettingsService = pmSettingsService;
     }
 
     /// <inheritdoc/>
@@ -34,6 +39,9 @@ public sealed class BacklogReviewService : IBacklogReviewService
         cancellationToken.ThrowIfCancellationRequested();
         ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
 
+        var settings = await _pmSettingsService.GetSettingsAsync().ConfigureAwait(false);
+        var neglectDays = settings.NeglectDays > 0 ? settings.NeglectDays : PmSettingsDefaults.NeglectDays;
+
         var workItemsTask = _workItemCatalogueService.GetCatalogueAsync(cancellationToken);
         var boardCatalogueTask = _projectItemCatalogueService.GetCatalogueAsync(projectId, cancellationToken);
         await Task.WhenAll(workItemsTask, boardCatalogueTask).ConfigureAwait(false);
@@ -46,7 +54,13 @@ public sealed class BacklogReviewService : IBacklogReviewService
             throw CreateCatalogueFailureException(workItems.Failures);
         }
 
-        return BacklogReviewGrouping.Group(workItems.Items, boardCatalogue.Items, workItems.Failures);
+        return BacklogReviewGrouping.Group(
+            workItems.Items,
+            boardCatalogue.Items,
+            workItems.RepositorySummaries,
+            workItems.Failures,
+            neglectDays,
+            DateTimeOffset.UtcNow);
     }
 
     private static InvalidOperationException CreateCatalogueFailureException(

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
@@ -121,9 +121,9 @@ public sealed class PmWorkflowBacklogTests
             Assert.Equal(Color.Info, issueChip.Instance.Color);
             Assert.Equal(Variant.Filled, issueChip.Instance.Variant);
             Assert.Equal(Color.Warning, pullRequestChip.Instance.Color);
-            Assert.Equal(Variant.Outlined, pullRequestChip.Instance.Variant);
+            Assert.Equal(Variant.Filled, pullRequestChip.Instance.Variant);
             Assert.NotEqual(issueChip.Instance.Color, pullRequestChip.Instance.Color);
-            Assert.NotEqual(issueChip.Instance.Variant, pullRequestChip.Instance.Variant);
+            Assert.Equal(issueChip.Instance.Variant, pullRequestChip.Instance.Variant);
 #pragma warning restore MUD0012
         });
     }

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
@@ -115,11 +115,15 @@ public sealed class PmWorkflowBacklogTests
 #pragma warning disable MUD0012
             var issueChip = cut.FindComponents<MudChip<string>>()
                 .First(component => component.Markup.Contains("Issue", StringComparison.Ordinal));
-            Assert.Equal(Color.Info, issueChip.Instance.Color);
-
             var pullRequestChip = cut.FindComponents<MudChip<string>>()
                 .First(component => component.Markup.Contains("Pull request", StringComparison.Ordinal));
-            Assert.Equal(Color.Secondary, pullRequestChip.Instance.Color);
+
+            Assert.Equal(Color.Info, issueChip.Instance.Color);
+            Assert.Equal(Variant.Filled, issueChip.Instance.Variant);
+            Assert.Equal(Color.Warning, pullRequestChip.Instance.Color);
+            Assert.Equal(Variant.Outlined, pullRequestChip.Instance.Variant);
+            Assert.NotEqual(issueChip.Instance.Color, pullRequestChip.Instance.Color);
+            Assert.NotEqual(issueChip.Instance.Variant, pullRequestChip.Instance.Variant);
 #pragma warning restore MUD0012
         });
     }

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
@@ -22,12 +22,15 @@ public sealed class PmWorkflowBacklogTests
     private readonly IPmProjectBoardDiscoveryService _projectBoardDiscoveryService =
         Substitute.For<IPmProjectBoardDiscoveryService>();
     private readonly IBacklogReviewService _backlogReviewService = Substitute.For<IBacklogReviewService>();
+    private readonly IPmWorkItemCatalogueService _workItemCatalogueService = Substitute.For<IPmWorkItemCatalogueService>();
     private readonly FakePmSettingsStorage _settingsStorage = new();
 
     public PmWorkflowBacklogTests()
     {
         _backlogReviewService.GetBacklogAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(EmptyBacklogResult());
+        _workItemCatalogueService.GetCatalogueAsync(Arg.Any<CancellationToken>())
+            .Returns(new PmWorkItemCatalogueResultDto([], [], []));
     }
 
     [Fact]
@@ -60,6 +63,64 @@ public sealed class PmWorkflowBacklogTests
         {
             Assert.Contains("Backlog Review", cut.Markup);
             Assert.Contains("Select a planning board in the dropdown above to load Backlog Review groups.", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowTabSwitch_WhenReturningToBacklog_DoesNotReloadGroups()
+    {
+        ConfigureDefaults();
+        _backlogReviewService.GetBacklogAsync("PVT_board", Arg.Any<CancellationToken>())
+            .Returns(new BacklogReviewResultDto(
+                [CreateItem(PmWorkItemTypeDto.Issue, "owner/repo-a", 10, "Fix auth", ["priority/high"])],
+                [],
+                [],
+                [],
+                [],
+                [],
+                false,
+                []));
+
+        await using var ctx = CreateContext();
+        var backlog = ctx.RenderPmWorkflowPage<PmWorkflowBacklog>();
+
+        backlog.WaitForAssertion(() => Assert.Contains("Fix auth", backlog.Markup));
+
+        ctx.RenderPmWorkflowPage<PmWorkflowRepos>();
+        ctx.RenderPmWorkflowPage<PmWorkflowBacklog>();
+
+        await _backlogReviewService.Received(1).GetBacklogAsync("PVT_board", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PmWorkflowBacklog_WhenGroupsHaveItems_ShowsDistinctKindChipColours()
+    {
+        ConfigureDefaults();
+        _backlogReviewService.GetBacklogAsync("PVT_board", Arg.Any<CancellationToken>())
+            .Returns(new BacklogReviewResultDto(
+                [CreateItem(PmWorkItemTypeDto.Issue, "owner/repo-a", 10, "Fix auth", ["priority/high"])],
+                [],
+                [],
+                [CreateItem(PmWorkItemTypeDto.PullRequest, "owner/repo-b", 12, "Parked PR", ["status/blocked"])],
+                [],
+                [],
+                false,
+                []));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowBacklog>();
+
+        cut.WaitForAssertion(() =>
+        {
+#pragma warning disable MUD0012
+            var issueChip = cut.FindComponents<MudChip<string>>()
+                .First(component => component.Markup.Contains("Issue", StringComparison.Ordinal));
+            Assert.Equal(Color.Info, issueChip.Instance.Color);
+
+            var pullRequestChip = cut.FindComponents<MudChip<string>>()
+                .First(component => component.Markup.Contains("Pull request", StringComparison.Ordinal));
+            Assert.Equal(Color.Secondary, pullRequestChip.Instance.Color);
+#pragma warning restore MUD0012
         });
     }
 
@@ -292,6 +353,7 @@ public sealed class PmWorkflowBacklogTests
         ctx.Services.AddScoped(_ => _repositoryService);
         ctx.Services.AddScoped(_ => _projectBoardDiscoveryService);
         ctx.Services.AddScoped(_ => _backlogReviewService);
+        ctx.Services.AddScoped(_ => _workItemCatalogueService);
         ctx.Services.AddScoped<PmWorkflowChromeCoordinator>();
         ctx.Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
@@ -27,7 +27,7 @@ public sealed class PmWorkflowBacklogTests
     public PmWorkflowBacklogTests()
     {
         _backlogReviewService.GetBacklogAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new BacklogReviewResultDto([], [], [], []));
+            .Returns(EmptyBacklogResult());
     }
 
     [Fact]
@@ -64,14 +64,18 @@ public sealed class PmWorkflowBacklogTests
     }
 
     [Fact]
-    public async Task PmWorkflowBacklog_WhenGroupsHaveItems_ShowsPanelsAndFilters()
+    public async Task PmWorkflowBacklog_WhenGroupsHaveItems_ShowsPanelsFiltersAndKindChips()
     {
         ConfigureDefaults();
         _backlogReviewService.GetBacklogAsync("PVT_board", Arg.Any<CancellationToken>())
             .Returns(new BacklogReviewResultDto(
                 [CreateItem(PmWorkItemTypeDto.Issue, "owner/repo-a", 10, "Fix auth", ["priority/high"])],
                 [CreateItem(PmWorkItemTypeDto.Issue, "owner/repo-a", 11, "Ready story", ["priority/medium"])],
+                [CreateItem(PmWorkItemTypeDto.Issue, "owner/repo-c", 13, "Needs labels", ["type/story"])],
                 [CreateItem(PmWorkItemTypeDto.PullRequest, "owner/repo-b", 12, "Parked PR", ["status/blocked"])],
+                [],
+                [],
+                false,
                 []));
 
         await using var ctx = CreateContext();
@@ -82,12 +86,18 @@ public sealed class PmWorkflowBacklogTests
             Assert.Contains("data-testid=\"pm-workflow-backlog-filters\"", cut.Markup);
             Assert.Contains("Urgent", cut.Markup);
             Assert.Contains("Ready to start", cut.Markup);
+            Assert.Contains("Awaiting triage", cut.Markup);
             Assert.Contains("Blocked / deferred", cut.Markup);
+            Assert.Contains("Epics near completion", cut.Markup);
+            Assert.Contains("Neglected repositories", cut.Markup);
             Assert.Contains("owner/repo-a#10", cut.Markup);
             Assert.Contains("Fix auth", cut.Markup);
             Assert.Contains("owner/repo-a#11", cut.Markup);
             Assert.Contains("owner/repo-b#12", cut.Markup);
+            Assert.Contains("Needs labels", cut.Markup);
+            Assert.Contains("data-testid=\"pm-workflow-backlog-kind-chip\"", cut.Markup);
             Assert.Contains("Pull request", cut.Markup);
+            Assert.Contains("Issue", cut.Markup);
         });
     }
 
@@ -134,6 +144,10 @@ public sealed class PmWorkflowBacklogTests
                     [CreateItem(PmWorkItemTypeDto.Issue, "owner/repo-a", 40, "Recovered", ["priority/high"])],
                     [],
                     [],
+                    [],
+                    [],
+                    [],
+                    false,
                     []));
 
         await using var ctx = CreateContext();
@@ -161,6 +175,10 @@ public sealed class PmWorkflowBacklogTests
                 [CreateItem(PmWorkItemTypeDto.Issue, "owner/repo-a", 40, "Ship backlog", ["priority/high"])],
                 [],
                 [],
+                [],
+                [],
+                [],
+                false,
                 [new PmRepositoryCatalogueFailureDto("owner/failed-repo", "Not found", 404)]));
 
         await using var ctx = CreateContext();
@@ -184,6 +202,10 @@ public sealed class PmWorkflowBacklogTests
                 [CreateItem(PmWorkItemTypeDto.Issue, "owner/repo-a", 10, "Fix auth", ["priority/high"])],
                 [],
                 [],
+                [],
+                [],
+                [],
+                false,
                 []));
 
         await using var ctx = CreateContext();
@@ -196,6 +218,53 @@ public sealed class PmWorkflowBacklogTests
 
         cut.WaitForAssertion(() =>
             Assert.Contains("No items match the current filters.", cut.Markup));
+    }
+
+    [Fact]
+    public async Task PmWorkflowBacklog_WhenNeglectedRepositoriesExist_ShowsRepositoryRows()
+    {
+        ConfigureDefaults();
+        _backlogReviewService.GetBacklogAsync("PVT_board", Arg.Any<CancellationToken>())
+            .Returns(new BacklogReviewResultDto(
+                [],
+                [],
+                [],
+                [],
+                [],
+                [new BacklogNeglectedRepositoryDto("owner/quiet", DateTimeOffset.Parse("2026-07-01T00:00:00Z"), 0, 0)],
+                false,
+                []));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowBacklog>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("owner/quiet", cut.Markup);
+            Assert.Contains("1 Jul 2026", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowBacklog_WhenSubIssueCountsUnavailable_ShowsExplanatoryAlert()
+    {
+        ConfigureDefaults();
+        _backlogReviewService.GetBacklogAsync("PVT_board", Arg.Any<CancellationToken>())
+            .Returns(new BacklogReviewResultDto(
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                true,
+                []));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowBacklog>();
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains("GitHub did not return sub-issue counts", cut.Markup));
     }
 
     private void ConfigureDefaults()
@@ -232,6 +301,9 @@ public sealed class PmWorkflowBacklogTests
 
         return ctx;
     }
+
+    private static BacklogReviewResultDto EmptyBacklogResult()
+        => new([], [], [], [], [], [], false, []);
 
     private static BacklogReviewItemDto CreateItem(
         PmWorkItemTypeDto itemType,

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowChromeCoordinatorTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowChromeCoordinatorTests.cs
@@ -87,7 +87,7 @@ public sealed class PmWorkflowChromeCoordinatorTests
             new DailyFocusStalledReviewSnapshotDto([], UsedInReviewColumn: false),
             null,
             isLoading: false);
-        coordinator.SetBacklogReview("PVT_board", new BacklogReviewResultDto([], [], [], []), null, isLoading: false);
+        coordinator.SetBacklogReview("PVT_board", EmptyBacklogResult(), null, isLoading: false);
 
         await coordinator.RefreshAsync(forceReload: true);
 
@@ -112,7 +112,7 @@ public sealed class PmWorkflowChromeCoordinatorTests
             new DailyFocusStalledReviewSnapshotDto([], UsedInReviewColumn: false),
             null,
             isLoading: false);
-        coordinator.SetBacklogReview("PVT_board", new BacklogReviewResultDto([], [], [], []), null, isLoading: false);
+        coordinator.SetBacklogReview("PVT_board", EmptyBacklogResult(), null, isLoading: false);
 
         await coordinator.SaveSettingsAsync(PmSettingsDefaults.Create());
 
@@ -174,4 +174,7 @@ public sealed class PmWorkflowChromeCoordinatorTests
 
     private static RepositoryDto CreateRepository(string owner, string name) =>
         new(1, name, $"{owner}/{name}", string.Empty, $"https://github.com/{owner}/{name}", false, false, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+    private static BacklogReviewResultDto EmptyBacklogResult()
+        => new([], [], [], [], [], [], false, []);
 }

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/BacklogReviewGroupingTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/BacklogReviewGroupingTests.cs
@@ -5,15 +5,19 @@ namespace SoloDevBoard.Application.Tests;
 /// <summary>Tests for <see cref="BacklogReviewGrouping"/> membership predicates.</summary>
 public sealed class BacklogReviewGroupingTests
 {
+    private static readonly DateTimeOffset ReferenceTime = DateTimeOffset.Parse("2026-08-20T12:00:00Z");
+
     [Fact]
     public void Group_NullArguments_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            BacklogReviewGrouping.Group(null!, [], []));
+            BacklogReviewGrouping.Group(null!, [], [], [], 14, ReferenceTime));
         Assert.Throws<ArgumentNullException>(() =>
-            BacklogReviewGrouping.Group([], null!, []));
+            BacklogReviewGrouping.Group([], null!, [], [], 14, ReferenceTime));
         Assert.Throws<ArgumentNullException>(() =>
-            BacklogReviewGrouping.Group([], [], null!));
+            BacklogReviewGrouping.Group([], [], null!, [], 14, ReferenceTime));
+        Assert.Throws<ArgumentNullException>(() =>
+            BacklogReviewGrouping.Group([], [], [], null!, 14, ReferenceTime));
     }
 
     [Fact]
@@ -28,6 +32,17 @@ public sealed class BacklogReviewGroupingTests
         Assert.False(BacklogReviewGrouping.IsUrgent(medium));
     }
 
+    [Theory]
+    [InlineData(new[] { "type/story" }, true)]
+    [InlineData(new[] { "priority/high" }, true)]
+    [InlineData(new[] { "type/story", "priority/high" }, false)]
+    public void IsAwaitingTriage_VariousLabels_ReturnsExpected(string[] labels, bool expected)
+    {
+        var item = CreateWorkItem(4, "Triage candidate", labels);
+
+        Assert.Equal(expected, BacklogReviewGrouping.IsAwaitingTriage(item));
+    }
+
     [Fact]
     public void IsReadyToStart_UnblockedAndNotCommitted_ReturnsTrue()
     {
@@ -37,6 +52,22 @@ public sealed class BacklogReviewGroupingTests
         Assert.True(BacklogReviewGrouping.IsReadyToStart(item, "Todo"));
     }
 
+    [Fact]
+    public void IsReadyToStart_Urgent_ReturnsFalse()
+    {
+        var item = CreateWorkItem(11, "Urgent ready", ["priority/critical", "type/bug"]);
+
+        Assert.False(BacklogReviewGrouping.IsReadyToStart(item, boardStatusName: null));
+    }
+
+    [Fact]
+    public void IsReadyToStart_AwaitingTriage_ReturnsFalse()
+    {
+        var item = CreateWorkItem(12, "Missing priority", ["type/story"]);
+
+        Assert.False(BacklogReviewGrouping.IsReadyToStart(item, boardStatusName: null));
+    }
+
     [Theory]
     [InlineData("Up Next")]
     [InlineData("In Progress")]
@@ -44,7 +75,7 @@ public sealed class BacklogReviewGroupingTests
     [InlineData("Ice Box")]
     public void IsReadyToStart_CommittedOrParkedBoardStatus_ReturnsFalse(string boardStatus)
     {
-        var item = CreateWorkItem(11, "Not ready", ["type/story", "priority/high"]);
+        var item = CreateWorkItem(13, "Not ready", ["type/story", "priority/medium"]);
 
         Assert.False(BacklogReviewGrouping.IsReadyToStart(item, boardStatus));
     }
@@ -52,7 +83,7 @@ public sealed class BacklogReviewGroupingTests
     [Fact]
     public void IsReadyToStart_BlockedLabel_ReturnsFalse()
     {
-        var item = CreateWorkItem(12, "Blocked", ["type/story", "priority/medium", "status/blocked"]);
+        var item = CreateWorkItem(14, "Blocked", ["type/story", "priority/medium", "status/blocked"]);
 
         Assert.False(BacklogReviewGrouping.IsReadyToStart(item, boardStatusName: null));
     }
@@ -62,7 +93,7 @@ public sealed class BacklogReviewGroupingTests
     {
         var blocked = CreateWorkItem(20, "Label blocked", ["status/blocked"]);
         var iceBoxed = CreateWorkItem(21, "Label ice box", ["status/ice-box"]);
-        var unlabelled = CreateWorkItem(22, "Board parked", ["priority/low"]);
+        var unlabelled = CreateWorkItem(22, "Board parked", ["priority/low", "type/story"]);
 
         Assert.True(BacklogReviewGrouping.IsBlockedOrDeferred(blocked, boardStatusName: null));
         Assert.True(BacklogReviewGrouping.IsBlockedOrDeferred(iceBoxed, boardStatusName: null));
@@ -72,14 +103,14 @@ public sealed class BacklogReviewGroupingTests
     }
 
     [Fact]
-    public void Group_OverlappingUrgentAndReady_PlacesItemInBothLists()
+    public void Group_UrgentReadyItem_IsUrgentOnlyNotReady()
     {
         var item = CreateWorkItem(30, "Urgent ready", ["priority/critical", "type/bug"]);
 
-        var result = BacklogReviewGrouping.Group([item], [], []);
+        var result = BacklogReviewGrouping.Group([item], [], [], [], 14, ReferenceTime);
 
         Assert.Equal(30, Assert.Single(result.Urgent).Number);
-        Assert.Equal(30, Assert.Single(result.ReadyToStart).Number);
+        Assert.Empty(result.ReadyToStart);
         Assert.Empty(result.BlockedOrDeferred);
     }
 
@@ -92,7 +123,7 @@ public sealed class BacklogReviewGroupingTests
             CreateBoardItem(31, "Up Next", ProjectBoardItemContentTypeDto.Issue),
         };
 
-        var result = BacklogReviewGrouping.Group([item], boardItems, []);
+        var result = BacklogReviewGrouping.Group([item], boardItems, [], [], 14, ReferenceTime);
 
         Assert.Equal(31, Assert.Single(result.Urgent).Number);
         Assert.Empty(result.ReadyToStart);
@@ -100,20 +131,31 @@ public sealed class BacklogReviewGroupingTests
     }
 
     [Fact]
+    public void Group_MissingCoreLabels_GoesToAwaitingTriageNotReady()
+    {
+        var item = CreateWorkItem(32, "Needs labels", ["type/story"]);
+
+        var result = BacklogReviewGrouping.Group([item], [], [], [], 14, ReferenceTime);
+
+        Assert.Equal(32, Assert.Single(result.AwaitingTriage).Number);
+        Assert.Empty(result.ReadyToStart);
+    }
+
+    [Fact]
     public void Group_BoardIceBoxWithoutLabel_IsBlockedNotReady()
     {
-        var item = CreateWorkItem(32, "Parked", ["priority/medium", "type/story"]);
+        var item = CreateWorkItem(33, "Parked", ["priority/medium", "type/story"]);
         var boardItems = new[]
         {
-            CreateBoardItem(32, "Ice Box", ProjectBoardItemContentTypeDto.Issue),
+            CreateBoardItem(33, "Ice Box", ProjectBoardItemContentTypeDto.Issue),
         };
 
-        var result = BacklogReviewGrouping.Group([item], boardItems, []);
+        var result = BacklogReviewGrouping.Group([item], boardItems, [], [], 14, ReferenceTime);
 
         Assert.Empty(result.Urgent);
         Assert.Empty(result.ReadyToStart);
         var blocked = Assert.Single(result.BlockedOrDeferred);
-        Assert.Equal(32, blocked.Number);
+        Assert.Equal(33, blocked.Number);
         Assert.Equal("Ice Box", blocked.BoardStatusName);
     }
 
@@ -131,7 +173,7 @@ public sealed class BacklogReviewGroupingTests
             CreateBoardItem(8, "Blocked", ProjectBoardItemContentTypeDto.PullRequest),
         };
 
-        var result = BacklogReviewGrouping.Group([issue, pullRequest], boardItems, []);
+        var result = BacklogReviewGrouping.Group([issue, pullRequest], boardItems, [], [], 14, ReferenceTime);
 
         Assert.Equal(8, Assert.Single(result.Urgent).Number);
         Assert.Equal("PR parked", result.Urgent[0].Title);
@@ -144,14 +186,15 @@ public sealed class BacklogReviewGroupingTests
     {
         var items = new[]
         {
-            CreateWorkItem(2, "Second medium", ["priority/medium"], repositoryFullName: "owner/b"),
-            CreateWorkItem(1, "First medium", ["priority/medium"], repositoryFullName: "owner/a"),
-            CreateWorkItem(9, "Critical", ["priority/critical"], repositoryFullName: "owner/z"),
+            CreateWorkItem(2, "Second medium", ["priority/medium", "type/story"], repositoryFullName: "owner/b"),
+            CreateWorkItem(1, "First medium", ["priority/medium", "type/story"], repositoryFullName: "owner/a"),
+            CreateWorkItem(9, "Critical", ["priority/critical", "type/story"], repositoryFullName: "owner/z"),
         };
 
-        var result = BacklogReviewGrouping.Group(items, [], []);
+        var result = BacklogReviewGrouping.Group(items, [], [], [], 14, ReferenceTime);
 
-        Assert.Equal([9, 1, 2], result.ReadyToStart.Select(item => item.Number).ToArray());
+        Assert.Equal([9], result.Urgent.Select(item => item.Number).ToArray());
+        Assert.Equal([1, 2], result.ReadyToStart.Select(item => item.Number).ToArray());
     }
 
     [Fact]
@@ -164,7 +207,7 @@ public sealed class BacklogReviewGroupingTests
             CreateBoardItem(50, "Blocked", ProjectBoardItemContentTypeDto.Issue),
         };
 
-        var result = BacklogReviewGrouping.Group([item], boardItems, []);
+        var result = BacklogReviewGrouping.Group([item], boardItems, [], [], 14, ReferenceTime);
 
         Assert.Equal(50, Assert.Single(result.ReadyToStart).Number);
         Assert.Empty(result.BlockedOrDeferred);
@@ -178,9 +221,97 @@ public sealed class BacklogReviewGroupingTests
             new PmRepositoryCatalogueFailureDto("owner/failed", "Not found", 404),
         };
 
-        var result = BacklogReviewGrouping.Group([], [], failures);
+        var result = BacklogReviewGrouping.Group([], [], [], failures, 14, ReferenceTime);
 
         Assert.Same(failures, result.Failures);
+    }
+
+    [Theory]
+    [InlineData(13, false)]
+    [InlineData(14, true)]
+    [InlineData(15, true)]
+    public void IsNeglected_BoundaryDays_ReturnsExpected(int daysSinceActivity, bool expected)
+    {
+        var summary = new PmRepositorySummaryDto(
+            "owner/quiet",
+            0,
+            0,
+            ReferenceTime.AddDays(-daysSinceActivity),
+            IsIncluded: true);
+
+        Assert.Equal(expected, BacklogReviewGrouping.IsNeglected(summary, neglectDays: 14, ReferenceTime));
+    }
+
+    [Fact]
+    public void IsNeglected_NoRecordedActivity_ReturnsTrue()
+    {
+        var summary = new PmRepositorySummaryDto("owner/empty", 0, 0, default, IsIncluded: true);
+
+        Assert.True(BacklogReviewGrouping.IsNeglected(summary, neglectDays: 14, ReferenceTime));
+    }
+
+    [Fact]
+    public void Group_NeglectedRepositories_ListsInactiveIncludedRepos()
+    {
+        var summaries = new[]
+        {
+            new PmRepositorySummaryDto(
+                "owner/active",
+                2,
+                1,
+                ReferenceTime.AddDays(-3),
+                IsIncluded: true),
+            new PmRepositorySummaryDto(
+                "owner/quiet",
+                0,
+                0,
+                ReferenceTime.AddDays(-20),
+                IsIncluded: true),
+            new PmRepositorySummaryDto(
+                "owner/excluded",
+                0,
+                0,
+                ReferenceTime.AddDays(-30),
+                IsIncluded: false),
+        };
+
+        var result = BacklogReviewGrouping.Group([], [], summaries, [], 14, ReferenceTime);
+
+        var neglected = Assert.Single(result.NeglectedRepositories);
+        Assert.Equal("owner/quiet", neglected.FullName);
+        Assert.Equal(0, neglected.OpenIssueCount);
+        Assert.Equal(0, neglected.OpenPullRequestCount);
+        Assert.Equal(ReferenceTime.AddDays(-20), neglected.LastActivityAt);
+    }
+
+    [Fact]
+    public void Group_EpicNearComplete_IncludesCompletedParent()
+    {
+        var epic = CreateWorkItem(
+            60,
+            "Done epic",
+            ["type/epic", "priority/high"],
+            subIssueTotal: 3,
+            subIssueCompleted: 3);
+
+        var result = BacklogReviewGrouping.Group([epic], [], [], [], 14, ReferenceTime);
+
+        var nearComplete = Assert.Single(result.EpicsNearComplete);
+        Assert.Equal(60, nearComplete.Number);
+        Assert.Equal("type/epic", nearComplete.TypeLabel);
+        Assert.Equal(3, nearComplete.SubIssueTotal);
+        Assert.False(result.SubIssueCountsUnavailable);
+    }
+
+    [Fact]
+    public void Group_OpenEpicWithoutSubIssueCounts_SetsUnavailableFlag()
+    {
+        var epic = CreateWorkItem(61, "Unknown progress", ["type/epic", "priority/medium"]);
+
+        var result = BacklogReviewGrouping.Group([epic], [], [], [], 14, ReferenceTime);
+
+        Assert.Empty(result.EpicsNearComplete);
+        Assert.True(result.SubIssueCountsUnavailable);
     }
 
     private static PmWorkItemDto CreateWorkItem(
@@ -188,7 +319,9 @@ public sealed class BacklogReviewGroupingTests
         string title,
         IReadOnlyList<string> labels,
         PmWorkItemTypeDto itemType = PmWorkItemTypeDto.Issue,
-        string repositoryFullName = "owner/a")
+        string repositoryFullName = "owner/a",
+        int? subIssueTotal = null,
+        int? subIssueCompleted = null)
     {
         var path = itemType == PmWorkItemTypeDto.PullRequest ? "pull" : "issues";
         return new PmWorkItemDto(
@@ -204,8 +337,8 @@ public sealed class BacklogReviewGroupingTests
             UpdatedAt: DateTimeOffset.Parse("2026-08-18T00:00:00Z"),
             IsDraft: itemType == PmWorkItemTypeDto.PullRequest ? false : null,
             HasReviewPending: itemType == PmWorkItemTypeDto.PullRequest ? false : null,
-            SubIssueTotal: null,
-            SubIssueCompleted: null);
+            subIssueTotal,
+            subIssueCompleted);
     }
 
     private static ProjectBoardItemDto CreateBoardItem(

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/BacklogReviewServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/BacklogReviewServiceTests.cs
@@ -10,26 +10,39 @@ public sealed class BacklogReviewServiceTests
         Substitute.For<IPmWorkItemCatalogueService>();
     private readonly IProjectItemCatalogueService _projectItemCatalogueService =
         Substitute.For<IProjectItemCatalogueService>();
+    private readonly IPmSettingsService _pmSettingsService = Substitute.For<IPmSettingsService>();
+
+    public BacklogReviewServiceTests()
+    {
+        _pmSettingsService.GetSettingsAsync().Returns(PmSettingsDefaults.Create());
+    }
 
     [Fact]
     public void Constructor_WorkItemCatalogueIsNull_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            _ = new BacklogReviewService(null!, _projectItemCatalogueService));
+            _ = new BacklogReviewService(null!, _projectItemCatalogueService, _pmSettingsService));
     }
 
     [Fact]
     public void Constructor_ProjectCatalogueIsNull_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            _ = new BacklogReviewService(_workItemCatalogueService, null!));
+            _ = new BacklogReviewService(_workItemCatalogueService, null!, _pmSettingsService));
+    }
+
+    [Fact]
+    public void Constructor_SettingsServiceIsNull_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _ = new BacklogReviewService(_workItemCatalogueService, _projectItemCatalogueService, null!));
     }
 
     [Fact]
     public async Task GetBacklogAsync_ProjectIdIsBlank_ThrowsArgumentException()
     {
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
-        var sut = new BacklogReviewService(_workItemCatalogueService, _projectItemCatalogueService);
+        var sut = new BacklogReviewService(_workItemCatalogueService, _projectItemCatalogueService, _pmSettingsService);
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
             sut.GetBacklogAsync(" ", cancellationToken));
@@ -82,12 +95,12 @@ public sealed class BacklogReviewServiceTests
                 [],
                 []));
 
-        var sut = new BacklogReviewService(_workItemCatalogueService, _projectItemCatalogueService);
+        var sut = new BacklogReviewService(_workItemCatalogueService, _projectItemCatalogueService, _pmSettingsService);
 
         var result = await sut.GetBacklogAsync("PVT_board", cancellationToken);
 
         Assert.Equal(40, Assert.Single(result.Urgent).Number);
-        Assert.Equal(40, Assert.Single(result.ReadyToStart).Number);
+        Assert.Empty(result.ReadyToStart);
         Assert.Equal(41, Assert.Single(result.BlockedOrDeferred).Number);
         Assert.Empty(result.Failures);
     }
@@ -107,7 +120,7 @@ public sealed class BacklogReviewServiceTests
                 [],
                 []));
 
-        var sut = new BacklogReviewService(_workItemCatalogueService, _projectItemCatalogueService);
+        var sut = new BacklogReviewService(_workItemCatalogueService, _projectItemCatalogueService, _pmSettingsService);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             sut.GetBacklogAsync("PVT_board", cancellationToken));
@@ -151,7 +164,7 @@ public sealed class BacklogReviewServiceTests
                 [],
                 []));
 
-        var sut = new BacklogReviewService(_workItemCatalogueService, _projectItemCatalogueService);
+        var sut = new BacklogReviewService(_workItemCatalogueService, _projectItemCatalogueService, _pmSettingsService);
 
         var result = await sut.GetBacklogAsync("PVT_board", cancellationToken);
 


### PR DESCRIPTION
## Summary of Changes

Completes the Backlog Review stack on a single branch: issue versus pull request chips on every row, an awaiting-triage panel for items missing core labels, urgent deduplication from Ready to start, neglected-repository surfacing using the configured neglect-days threshold, and epics near completion when GitHub returns sub-issue counts.

## Related Issue(s)

Closes #280
Closes #278
Closes #282
Closes #281
Closes #279

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [ ] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — UI follows the existing Backlog Review panel pattern.

## Additional Notes

- Verify gate: `dotnet clean SoloDevBoard.slnx && dotnet test SoloDevBoard.slnx` — 836 tests passed.
- **Deferred follow-up:** `website/content/docs/pm-workflow.md`, `tests/E2E/USER_DOCS_ALIGNMENT.md`, and a new `test.describe('Backlog Review', …)` block in `tests/E2E/tests/pm-workflow.spec.ts` were intentionally not updated in this PR to avoid the E2E/docs merge hotspot. Docs and Playwright alignment should land in a follow-up once the guide can drop partial-delivery scope notes for these panels.