### PR TITLE
[Test] Add Backlog Review PM Workflow coverage and docs alignment (#386)

### DIFF
--- a/tests/E2E/CRITICAL_JOURNEYS.md
+++ b/tests/E2E/CRITICAL_JOURNEYS.md
@@ -43,7 +43,7 @@ For data-driven journeys against a real GitHub account, run the PAT suite locall
 | Label Manager taxonomy tabs and empty repository state | `labels.spec.ts` | Tab strip, disabled actions, and no-repositories message. |
 | Workflow template browse, filter, and select | `workflows.spec.ts` | Built-in templates load; repository selector shows error. |
 | Triage not-started region without repositories | `triage.spec.ts` | Shell heading and no-repositories alert. |
-| PM Workflow Daily Focus, Backlog Review, and Repo Management shells | `pm-workflow.spec.ts` | Shared chrome, Daily Focus occupancy, recommendations, stalled Up Next, and stalled-review regions or empty/error/warning copy, Backlog Review filters and urgency panels or empty/error/warning copy, Repos tab thresholds, exclusions, and per-repository summary or chrome error with retry. |
+| PM Workflow Daily Focus, Backlog Review, and Repo Management shells | `pm-workflow.spec.ts` | Shared chrome, Daily Focus occupancy, recommendations, stalled Up Next, and stalled-review regions or empty/error/warning copy, Backlog Review filters and all grouping panels (urgent, ready, awaiting triage, blocked, epics near completion, neglected repositories) or empty/error/warning copy, Repos tab thresholds, exclusions, and per-repository summary or chrome error with retry. Dedicated `Daily Focus`, `Backlog Review`, and `Repo Management` describe blocks assert route shells and tab-specific no-board/empty/error states. |
 
 ### Tier 3 — Out of CI scope (manual or future)
 

--- a/tests/E2E/USER_DOCS_ALIGNMENT.md
+++ b/tests/E2E/USER_DOCS_ALIGNMENT.md
@@ -106,7 +106,7 @@ Use this when extending specs so assertions track documented workflows.
 | Excluded repositories and quick exclude | `pm-workflow-exclusions-region`, exclude autocomplete | `docs-capture` (pending) |
 | Per-repository summary table, empty state, load error, or partial failure | `pm-workflow-repository-summary-table` / `pm-workflow-repository-summary-empty` / `pm-workflow-repository-summary-error` / `pm-workflow-repository-summary-partial-failure` | `docs-capture` (pending) |
 | Backlog Review filters, urgency panels, empty copy, warning, or catalogue error | `pm-workflow.spec.ts` `PM Workflow` describe — `pm-workflow-backlog-filters` / `pm-workflow-backlog-panels` / empty or error copy, or chrome error | `docs-capture` (pending) |
-| Awaiting triage, epics near completion, neglected repositories, and issue/PR kind chips | `pm-workflow.spec.ts` `Backlog Review` describe — `pm-workflow-backlog-awaiting-triage`, `pm-workflow-backlog-epics`, `pm-workflow-backlog-neglected`, and `pm-workflow-backlog-kind-chip` when panels load | `docs-capture` (pending) |
+| Awaiting triage, epics near completion, and neglected repositories | `pm-workflow.spec.ts` `Backlog Review` describe — `pm-workflow-backlog-awaiting-triage`, `pm-workflow-backlog-epics`, and `pm-workflow-backlog-neglected` when panels load | `docs-capture` (pending) |
 | Planning | — | Not shipped |
 
 ### Daily Focus automated coverage ([#385](https://github.com/markheydon/solo-dev-board/issues/385))
@@ -134,16 +134,16 @@ Issue [#388](https://github.com/markheydon/solo-dev-board/issues/388) closes the
 | Per-repository summary table, empty state, load error, or partial failure | `PmWorkflowReposTests` | `pm-workflow.spec.ts` `Repo Management` and `PM Workflow` describes — summary region or error/empty/loading |
 | Route shell and no-board instructional copy | `PmWorkflowReposTests` | `pm-workflow.spec.ts` `Repo Management` describe — route shell and board selector alert |
 
-### Backlog Review automated coverage ([#419](https://github.com/markheydon/solo-dev-board/pull/419), issues [#280](https://github.com/markheydon/solo-dev-board/issues/280)–[#279](https://github.com/markheydon/solo-dev-board/issues/279))
+### Backlog Review automated coverage ([#386](https://github.com/markheydon/solo-dev-board/issues/386))
 
-PR [#419](https://github.com/markheydon/solo-dev-board/pull/419) shipped the Backlog Review grouping stack. Issue [#277](https://github.com/markheydon/solo-dev-board/issues/277) remains the parent feature; child stories [#280](https://github.com/markheydon/solo-dev-board/issues/280) (issue/PR chips), [#278](https://github.com/markheydon/solo-dev-board/issues/278) (awaiting triage), [#282](https://github.com/markheydon/solo-dev-board/issues/282) (urgent deduplication), [#281](https://github.com/markheydon/solo-dev-board/issues/281) (neglected repositories), and [#279](https://github.com/markheydon/solo-dev-board/issues/279) (epics near completion) are covered by this delivery.
+Issue [#386](https://github.com/markheydon/solo-dev-board/issues/386) closes the Backlog Review test slice for stories [#280](https://github.com/markheydon/solo-dev-board/issues/280)–[#279](https://github.com/markheydon/solo-dev-board/issues/279) (parent feature [#277](https://github.com/markheydon/solo-dev-board/issues/277), delivered in PR [#419](https://github.com/markheydon/solo-dev-board/pull/419)). When `website/content/docs/pm-workflow.md` is published, keep this mapping alongside the PM Workflow rows above.
 
 | Behaviour | Unit / component | Playwright (CI placeholder auth) |
 |-----------|------------------|----------------------------------|
 | Urgent, Ready to start, and Blocked/deferred panels | `BacklogReviewGroupingTests`, `BacklogReviewServiceTests` | `pm-workflow.spec.ts` `PM Workflow` and `Backlog Review` describes — urgency panel `data-testid`s |
 | Awaiting triage (missing `type/` or `priority/`) | `BacklogReviewGroupingTests` | `pm-workflow.spec.ts` `Backlog Review` describe — `pm-workflow-backlog-awaiting-triage` |
 | Urgent items deduplicated from Ready to start | `BacklogReviewGroupingTests` | Unit/component only (row membership) |
-| Issue versus pull request kind chips | `PmWorkflowBacklogTests` | `pm-workflow.spec.ts` `Backlog Review` describe — `pm-workflow-backlog-kind-chip` when table rows render |
+| Issue versus pull request kind chips | `PmWorkflowBacklogTests` | Unit/component only (row chips); `docs-capture` when table rows render |
 | Epics near completion | `BacklogReviewGroupingTests`, `PmWorkflowBacklogTests` | `pm-workflow.spec.ts` `Backlog Review` describe — `pm-workflow-backlog-epics` panel or empty/unavailable copy |
 | Neglected repositories | `BacklogReviewGroupingTests`, `PmWorkflowBacklogTests` | `pm-workflow.spec.ts` `Backlog Review` describe — `pm-workflow-backlog-neglected` panel or empty copy |
 | Route shell, no-board copy, catalogue empty, filter empty, GitHub retry | `PmWorkflowBacklogTests` | `pm-workflow.spec.ts` `Backlog Review` describe — route shell and no-board/empty/error copy |

--- a/tests/E2E/USER_DOCS_ALIGNMENT.md
+++ b/tests/E2E/USER_DOCS_ALIGNMENT.md
@@ -146,7 +146,7 @@ Issue [#386](https://github.com/markheydon/solo-dev-board/issues/386) closes the
 | Issue versus pull request kind chips | `PmWorkflowBacklogTests` | Unit/component only (row chips); `docs-capture` when table rows render |
 | Epics near completion | `BacklogReviewGroupingTests`, `PmWorkflowBacklogTests` | `pm-workflow.spec.ts` `Backlog Review` describe — `pm-workflow-backlog-epics` panel or empty/unavailable copy |
 | Neglected repositories | `BacklogReviewGroupingTests`, `PmWorkflowBacklogTests` | `pm-workflow.spec.ts` `Backlog Review` describe — `pm-workflow-backlog-neglected` panel or empty copy |
-| Route shell, no-board copy, catalogue empty, filter empty, GitHub retry | `PmWorkflowBacklogTests` | `pm-workflow.spec.ts` `Backlog Review` describe — route shell and no-board/empty/error copy |
+| Route shell, no-board copy, catalogue empty, filter empty, partial-failure warning, GitHub retry | `PmWorkflowBacklogTests` | `pm-workflow.spec.ts` `Backlog Review` describe — route shell and no-board/empty/error/warning copy |
 
 See [CRITICAL_JOURNEYS.md](CRITICAL_JOURNEYS.md) Tier 2 — PM Workflow row — for the journey-level summary.
 

--- a/tests/E2E/USER_DOCS_ALIGNMENT.md
+++ b/tests/E2E/USER_DOCS_ALIGNMENT.md
@@ -36,7 +36,7 @@ When you add or change an end-user feature, update the user guide, the relevant 
 | [Workflow Templates](../../website/content/docs/workflow-templates.md) | `/workflows` | `workflows.spec.ts`, `accessibility.spec.ts` | `workflow-templates/overview.png` | Tier 2 | Guide describes browse, parameterise, apply, and drift; CI asserts built-in template browse/filter/select and repository error state. |
 | [Appearance](../../website/content/docs/appearance.md) | App bar (all shell pages) | `appearance.spec.ts`, `accessibility.spec.ts` | `appearance/theme-toggle.png` | Tier 1 | Guide describes Automatic → Light → Dark cycling and persistence; not a drawer route. |
 | [About (in-app)](../../website/content/docs/about.md) | `/about` | `about.spec.ts`, `accessibility.spec.ts` | `about/overview.png` | Tier 1 | Guide describes More options menu access (User Guide external link and About route) and metadata fields. Not the Hugo `/about/` narrative section. |
-| Cross-Repo PM Workflow (`draft: true`, partial) | `/pm-workflow`, `/pm-workflow/daily-focus`, `/pm-workflow/backlog`, `/pm-workflow/repos` | `pm-workflow.spec.ts`, `accessibility.spec.ts` | `pm-workflow/daily-focus.png` and `pm-workflow/repos.png` (pending) | Tier 2 | Draft guide documents Daily Focus occupancy, recommendations, stalled Up Next alerts, stalled review pull requests, Backlog Review grouping ([#277](https://github.com/markheydon/solo-dev-board/issues/277)), and Repo Management ([#273](https://github.com/markheydon/solo-dev-board/issues/273), [#274](https://github.com/markheydon/solo-dev-board/issues/274), [#275](https://github.com/markheydon/solo-dev-board/issues/275), [#276](https://github.com/markheydon/solo-dev-board/issues/276), [#287](https://github.com/markheydon/solo-dev-board/issues/287), [#288](https://github.com/markheydon/solo-dev-board/issues/288)); Planning remains a placeholder. CI asserts shell, tab strip, Daily Focus occupancy, recommendation, stalled Up Next, and stalled-review regions or empty/error/warning copy, Backlog filters and urgency panels or empty/error/warning copy, and Repos regions (including per-repository summary) or chrome error. |
+| Cross-Repo PM Workflow (`draft: true`, partial) | `/pm-workflow`, `/pm-workflow/daily-focus`, `/pm-workflow/backlog`, `/pm-workflow/repos` | `pm-workflow.spec.ts`, `accessibility.spec.ts` | `pm-workflow/daily-focus.png` and `pm-workflow/repos.png` (pending) | Tier 2 | Draft guide documents Daily Focus occupancy, recommendations, stalled Up Next alerts, stalled review pull requests, Backlog Review grouping ([#277](https://github.com/markheydon/solo-dev-board/issues/277), [#280](https://github.com/markheydon/solo-dev-board/issues/280)–[#279](https://github.com/markheydon/solo-dev-board/issues/279)), and Repo Management ([#273](https://github.com/markheydon/solo-dev-board/issues/273), [#274](https://github.com/markheydon/solo-dev-board/issues/274), [#275](https://github.com/markheydon/solo-dev-board/issues/275), [#276](https://github.com/markheydon/solo-dev-board/issues/276), [#287](https://github.com/markheydon/solo-dev-board/issues/287), [#288](https://github.com/markheydon/solo-dev-board/issues/288)); Planning remains a placeholder. CI asserts shell, tab strip, Daily Focus occupancy, recommendation, stalled Up Next, and stalled-review regions or empty/error/warning copy, Backlog filters and all grouping panels (including awaiting triage, epics near completion, and neglected repositories) or empty/error/warning copy, and Repos regions (including per-repository summary) or chrome error. |
 
 ### Auth and entry journeys (operator docs, not user guide)
 
@@ -105,7 +105,8 @@ Use this when extending specs so assertions track documented workflows.
 | Included repositories table or empty state | `pm-workflow-included-table` / `pm-workflow-no-included-text` | `docs-capture` (pending) |
 | Excluded repositories and quick exclude | `pm-workflow-exclusions-region`, exclude autocomplete | `docs-capture` (pending) |
 | Per-repository summary table, empty state, load error, or partial failure | `pm-workflow-repository-summary-table` / `pm-workflow-repository-summary-empty` / `pm-workflow-repository-summary-error` / `pm-workflow-repository-summary-partial-failure` | `docs-capture` (pending) |
-| Backlog Review filters, urgency panels, empty copy, warning, or catalogue error | `pm-workflow-backlog-filters` / `pm-workflow-backlog-panels` / empty or error copy, or chrome error | `docs-capture` (pending) |
+| Backlog Review filters, urgency panels, empty copy, warning, or catalogue error | `pm-workflow.spec.ts` `PM Workflow` describe — `pm-workflow-backlog-filters` / `pm-workflow-backlog-panels` / empty or error copy, or chrome error | `docs-capture` (pending) |
+| Awaiting triage, epics near completion, neglected repositories, and issue/PR kind chips | `pm-workflow.spec.ts` `Backlog Review` describe — `pm-workflow-backlog-awaiting-triage`, `pm-workflow-backlog-epics`, `pm-workflow-backlog-neglected`, and `pm-workflow-backlog-kind-chip` when panels load | `docs-capture` (pending) |
 | Planning | — | Not shipped |
 
 ### Daily Focus automated coverage ([#385](https://github.com/markheydon/solo-dev-board/issues/385))
@@ -121,6 +122,33 @@ Issue [#385](https://github.com/markheydon/solo-dev-board/issues/385) closes the
 | Route shell, loading, empty board, GitHub retry, inaccessible-board warning | `PmWorkflowDailyFocusTests` | `pm-workflow.spec.ts` `Daily Focus` describe — route shell and no-board/empty/error copy |
 
 Defer full user-guide publish and docs-capture screenshots until the PM Workflow guide leaves `draft: true`.
+
+### Repo Management automated coverage ([#388](https://github.com/markheydon/solo-dev-board/issues/388))
+
+Issue [#388](https://github.com/markheydon/solo-dev-board/issues/388) closes the Repo Management test slice for stories [#287](https://github.com/markheydon/solo-dev-board/issues/287) and [#288](https://github.com/markheydon/solo-dev-board/issues/288). When `website/content/docs/pm-workflow.md` is published, keep this mapping alongside the PM Workflow rows above.
+
+| Behaviour | Unit / component | Playwright (CI placeholder auth) |
+|-----------|------------------|----------------------------------|
+| Planning thresholds (capacity, stall days, neglect days) | `PmSettingsDefaultsTests`, `PmSettingsServiceTests` | `pm-workflow.spec.ts` `Repo Management` describe — threshold fields and regions |
+| Repository participation and exclusions | `PmWorkflowReposTests` | `pm-workflow.spec.ts` `Repo Management` describe — participation summary, included table, exclusions |
+| Per-repository summary table, empty state, load error, or partial failure | `PmWorkflowReposTests` | `pm-workflow.spec.ts` `Repo Management` and `PM Workflow` describes — summary region or error/empty/loading |
+| Route shell and no-board instructional copy | `PmWorkflowReposTests` | `pm-workflow.spec.ts` `Repo Management` describe — route shell and board selector alert |
+
+### Backlog Review automated coverage ([#419](https://github.com/markheydon/solo-dev-board/pull/419), issues [#280](https://github.com/markheydon/solo-dev-board/issues/280)–[#279](https://github.com/markheydon/solo-dev-board/issues/279))
+
+PR [#419](https://github.com/markheydon/solo-dev-board/pull/419) shipped the Backlog Review grouping stack. Issue [#277](https://github.com/markheydon/solo-dev-board/issues/277) remains the parent feature; child stories [#280](https://github.com/markheydon/solo-dev-board/issues/280) (issue/PR chips), [#278](https://github.com/markheydon/solo-dev-board/issues/278) (awaiting triage), [#282](https://github.com/markheydon/solo-dev-board/issues/282) (urgent deduplication), [#281](https://github.com/markheydon/solo-dev-board/issues/281) (neglected repositories), and [#279](https://github.com/markheydon/solo-dev-board/issues/279) (epics near completion) are covered by this delivery.
+
+| Behaviour | Unit / component | Playwright (CI placeholder auth) |
+|-----------|------------------|----------------------------------|
+| Urgent, Ready to start, and Blocked/deferred panels | `BacklogReviewGroupingTests`, `BacklogReviewServiceTests` | `pm-workflow.spec.ts` `PM Workflow` and `Backlog Review` describes — urgency panel `data-testid`s |
+| Awaiting triage (missing `type/` or `priority/`) | `BacklogReviewGroupingTests` | `pm-workflow.spec.ts` `Backlog Review` describe — `pm-workflow-backlog-awaiting-triage` |
+| Urgent items deduplicated from Ready to start | `BacklogReviewGroupingTests` | Unit/component only (row membership) |
+| Issue versus pull request kind chips | `PmWorkflowBacklogTests` | `pm-workflow.spec.ts` `Backlog Review` describe — `pm-workflow-backlog-kind-chip` when table rows render |
+| Epics near completion | `BacklogReviewGroupingTests`, `PmWorkflowBacklogTests` | `pm-workflow.spec.ts` `Backlog Review` describe — `pm-workflow-backlog-epics` panel or empty/unavailable copy |
+| Neglected repositories | `BacklogReviewGroupingTests`, `PmWorkflowBacklogTests` | `pm-workflow.spec.ts` `Backlog Review` describe — `pm-workflow-backlog-neglected` panel or empty copy |
+| Route shell, no-board copy, catalogue empty, filter empty, GitHub retry | `PmWorkflowBacklogTests` | `pm-workflow.spec.ts` `Backlog Review` describe — route shell and no-board/empty/error copy |
+
+See [CRITICAL_JOURNEYS.md](CRITICAL_JOURNEYS.md) Tier 2 — PM Workflow row — for the journey-level summary.
 
 ## Screenshot hygiene
 

--- a/tests/E2E/tests/pm-workflow.spec.ts
+++ b/tests/E2E/tests/pm-workflow.spec.ts
@@ -246,3 +246,84 @@ test.describe('Repo Management', () => {
     await expect(noBoardAlert.or(page.getByTestId('pm-workflow-board-select')).first()).toBeVisible();
   });
 });
+
+test.describe('Backlog Review', () => {
+  test('direct navigation opens the Backlog Review route shell', async ({ page }) => {
+    await page.goto('/pm-workflow/backlog');
+
+    await expect(page).toHaveURL(/\/pm-workflow\/backlog$/);
+    await expect(page).toHaveTitle(/PM Workflow — Backlog/);
+    await expect(page.getByTestId('pm-workflow-shell')).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-tab-strip')).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Backlog' })).toBeVisible();
+    await expect(page.getByTestId('pm-workflow-backlog-page')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Backlog Review' })).toBeVisible();
+  });
+
+  test('shows no-board instructional copy, grouping panels, empty catalogue, or load error', async ({ page }) => {
+    await page.goto('/pm-workflow/backlog');
+
+    await expect(page.getByTestId('pm-workflow-shell')).toBeVisible();
+
+    const chromeError = page.getByTestId('pm-workflow-chrome-error');
+    const noBoardAlert = page.getByTestId('pm-workflow-backlog-no-board');
+    const filters = page.getByTestId('pm-workflow-backlog-filters');
+    const panels = page.getByTestId('pm-workflow-backlog-panels');
+    const catalogueEmpty = page.getByTestId('pm-workflow-backlog-empty');
+    const filterEmpty = page.getByTestId('pm-workflow-backlog-filter-empty');
+    const loadError = page.getByTestId('pm-workflow-backlog-error');
+    const warning = page.getByTestId('pm-workflow-backlog-warning');
+
+    await expect(
+      chromeError
+        .or(noBoardAlert)
+        .or(filters)
+        .or(catalogueEmpty)
+        .or(filterEmpty)
+        .or(loadError)
+        .or(warning)
+        .first(),
+    ).toBeVisible({ timeout: 15_000 });
+
+    if (await chromeError.isVisible()) {
+      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      return;
+    }
+
+    if (await loadError.isVisible()) {
+      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(loadError).toContainText('Unable to load the backlog');
+      return;
+    }
+
+    if (await noBoardAlert.isVisible()) {
+      await expect(noBoardAlert).toContainText(
+        'Select a planning board in the dropdown above to load Backlog Review groups.',
+      );
+      return;
+    }
+
+    if (await catalogueEmpty.isVisible()) {
+      await expect(catalogueEmpty).toContainText('No open issues or pull requests in included repositories.');
+      return;
+    }
+
+    if (await filterEmpty.isVisible()) {
+      await expect(filterEmpty).toContainText('No items match the current filters.');
+      return;
+    }
+
+    if (await filters.isVisible()) {
+      await expect(panels).toBeVisible();
+      await expect(page.getByTestId('pm-workflow-backlog-urgent')).toBeVisible();
+      await expect(page.getByTestId('pm-workflow-backlog-ready')).toBeVisible();
+      await expect(page.getByTestId('pm-workflow-backlog-awaiting-triage')).toBeVisible();
+      await expect(page.getByTestId('pm-workflow-backlog-blocked')).toBeVisible();
+      await expect(page.getByTestId('pm-workflow-backlog-epics')).toBeVisible();
+      await expect(page.getByTestId('pm-workflow-backlog-neglected')).toBeVisible();
+      await expect(page.getByTestId('pm-workflow-backlog-search')).toBeVisible();
+      await expect(page.getByTestId('pm-workflow-backlog-type-filter')).toBeVisible();
+      await expect(page.getByTestId('pm-workflow-backlog-repo-filter')).toBeVisible();
+    }
+  });
+});

--- a/tests/E2E/tests/pm-workflow.spec.ts
+++ b/tests/E2E/tests/pm-workflow.spec.ts
@@ -297,8 +297,8 @@ test.describe('Backlog Review', () => {
     }
 
     if (await warning.isVisible()) {
-      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
       await expect(warning).toContainText('failed to load');
+      await expect(page.getByTestId('pm-workflow-backlog-retry')).toBeVisible();
     }
 
     if (await noBoardAlert.isVisible()) {

--- a/tests/E2E/tests/pm-workflow.spec.ts
+++ b/tests/E2E/tests/pm-workflow.spec.ts
@@ -296,6 +296,11 @@ test.describe('Backlog Review', () => {
       return;
     }
 
+    if (await warning.isVisible()) {
+      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(warning).toContainText('failed to load');
+    }
+
     if (await noBoardAlert.isVisible()) {
       await expect(noBoardAlert).toContainText(
         'Select a planning board in the dropdown above to load Backlog Review groups.',

--- a/tests/E2E/tests/pm-workflow.spec.ts
+++ b/tests/E2E/tests/pm-workflow.spec.ts
@@ -243,7 +243,14 @@ test.describe('Repo Management', () => {
         .or(page.getByTestId('pm-workflow-repository-summary-partial-failure'))
         .or(page.getByTestId('pm-workflow-repository-summary-loading')),
     ).toBeVisible();
-    await expect(noBoardAlert.or(page.getByTestId('pm-workflow-board-select')).first()).toBeVisible();
+
+    if (await noBoardAlert.isVisible()) {
+      await expect(noBoardAlert).toContainText('Select a planning board');
+    } else if (await page.getByText(/Board:/).isVisible()) {
+      await expect(page.getByTestId('pm-workflow-shared-chrome')).toContainText('Board:');
+    } else {
+      await expect(page.getByRole('combobox', { name: 'Planning board' })).toBeAttached();
+    }
   });
 });
 

--- a/website/content/docs/pm-workflow.md
+++ b/website/content/docs/pm-workflow.md
@@ -5,7 +5,7 @@ weight: 110
 guideStatus: Partially Available
 ---
 
-> ⚠️ **Partial delivery** — Daily Focus, Backlog Review grouping, and Repo Management are available in the app under **PM Workflow**. Iteration Planning, awaiting-triage and neglected-repo backlog panels, and issue versus pull request chips are not shipped yet. This guide remains a draft until all four tabs match the wireframe; only the sections below describe current behaviour.
+> ⚠️ **Partial delivery** — Daily Focus, Backlog Review grouping, and Repo Management are available in the app under **PM Workflow**. Iteration Planning remains a placeholder. This guide remains a draft until all four tabs match the wireframe; only the sections below describe current behaviour.
 
 ---
 
@@ -23,7 +23,7 @@ The system is built around two modes of operation:
 | Tab | Route | Status |
 |-----|-------|--------|
 | **Daily Focus** | `/pm-workflow/daily-focus` | **Partial** — Status occupancy chips, active load, stalled Up Next, top-three recommendations, and pull requests awaiting review for the configured Stall days threshold. |
-| **Backlog** | `/pm-workflow/backlog` | **Partial** — search, type and repository filters, plus Urgent, Ready to start, and Blocked/deferred panels. Awaiting triage, near-complete epics, and neglected repositories are still planned. |
+| **Backlog** | `/pm-workflow/backlog` | **Partial** — search, type and repository filters, Urgent, Ready to start, Awaiting triage, Blocked/deferred, Epics near completion, and Neglected repositories panels. Issue and pull request kind chips appear on grouped rows. Urgent items are omitted from Ready to start. |
 | Planning | `/pm-workflow/planning` | Placeholder — story [#283](https://github.com/markheydon/solo-dev-board/issues/283). |
 | **Repos** | `/pm-workflow/repos` | **Available** — planning board selection, thresholds, repository exclusions, and per-repository open-work counts. |
 
@@ -123,14 +123,19 @@ Filters apply in the browser after the catalogue loads. They do not reload GitHu
 After a board is selected, expansion panels list:
 
 1. **Urgent** — items labelled `priority/high` or `priority/critical`.
-2. **Ready to start** — unblocked items (`status/blocked` and `status/ice-box` absent, board Status not Blocked or Ice Box) that are not already **Up Next** or **In Progress**.
-3. **Blocked / deferred** — items labelled `status/blocked` or `status/ice-box`, or whose joined board Status is **Blocked** or **Ice Box**.
+2. **Ready to start** — unblocked items (`status/blocked` and `status/ice-box` absent, board Status not Blocked or Ice Box) that are not already **Up Next** or **In Progress**. Items already listed under **Urgent** are omitted here.
+3. **Awaiting triage** — open issues or pull requests missing a `type/` or `priority/` label.
+4. **Blocked / deferred** — items labelled `status/blocked` or `status/ice-box`, or whose joined board Status is **Blocked** or **Ice Box**.
+5. **Epics near completion** — open epics or features whose sub-issues are all closed (requires GitHub sub-issue counts).
+6. **Neglected repositories** — included repositories with no open issue or pull request activity within the persisted **Neglect days** threshold (default 14).
+
+Each grouped row shows an **Issue** or **PR** chip, a `owner/name#number` link that opens GitHub in a new tab, the title, and the priority label when present.
 
 An item can appear in more than one panel (for example an urgent item that is also blocked). Each panel header includes a count. Empty panels say there are no items in that group.
 
-If there are no open issues or pull requests in included repositories, an informational alert says so. If the current filters hide every row, a separate alert says no items match. If every included repository fails to load, an error alert includes **Retry**. If some repositories fail but others succeed, grouping still proceeds and a warning lists the failed repositories with **Retry**.
+If there are no open issues or pull requests in included repositories, an informational alert says so. If the current filters hide every row, a separate alert says no items match. If every included repository fails to load, an error alert includes **Retry**. If some repositories fail but others succeed, grouping still proceeds and a warning lists the failed repositories with **Retry**. When GitHub does not return sub-issue counts, **Epics near completion** explains that near-complete parents cannot be listed.
 
-> **Scope note** — Awaiting triage (missing `type/` or `priority/`), near-complete epics, neglected repositories, and issue versus pull request chips are tracked on later stories and are not shown yet.
+> **Scope note** — Iteration Planning (adding items to **Up Next**) remains on story [#283](https://github.com/markheydon/solo-dev-board/issues/283).
 
 ---
 
@@ -227,10 +232,7 @@ A quick morning summary that will also answer stalled-work questions:
 
 The grouped view is shipped as described above. Still planned:
 
-- Neglected repositories (no issue or PR activity within the neglect threshold).
-- Items awaiting triage (missing `type/` or `priority/` labels).
-- Near-complete epics.
-- Issue versus pull request chips on every row.
+- Adding selected items to **Up Next** from Backlog Review (Iteration Planning tab).
 
 ### Iteration Planning
 


### PR DESCRIPTION
## Summary of Changes

Deferred follow-up from PM Workflow delivery PRs #417–#419. Adds a dedicated `Backlog Review` Playwright describe block for backlog tab navigation and empty/error/shell states under CI placeholder auth, updates the draft PM Workflow user guide with scope notes for panels shipped in #419 (issue/PR chips, awaiting triage, urgent deduplication, neglected repositories, epics near completion), and completes the `USER_DOCS_ALIGNMENT.md` inventory for Daily Focus (#385), Repo Management (#388), and Backlog Review (#386).

## Related Issue(s)

References #272, #277, #280, #278, #282, #281, #279, #385, #386, #388

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — E2E and documentation alignment only.

## Additional Notes

- `dotnet clean SoloDevBoard.slnx && dotnet test SoloDevBoard.slnx` — all tests passed locally.
- Existing `PM Workflow`, `Daily Focus`, and `Repo Management` describe blocks are unchanged.
- `website/content/_index.md` did not require updates (PM Workflow guide remains `draft: true`).
- Issues #280, #278, #282, #281, #279, #385, and #388 were auto-closed by squash merges of #419, #418, and #417.