### PR TITLE
[Test] Scope PM Workflow Retry locators to error containers

### DIFF
--- a/tests/E2E/tests/pm-workflow.spec.ts
+++ b/tests/E2E/tests/pm-workflow.spec.ts
@@ -31,12 +31,12 @@ test.describe('PM Workflow', () => {
     });
 
     if (await chromeError.isVisible()) {
-      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(chromeError.getByRole('button', { name: 'Retry' })).toBeVisible();
       return;
     }
 
     if (await occupancyError.isVisible()) {
-      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(occupancyError.getByRole('button', { name: 'Retry' })).toBeVisible();
       await expect(occupancyError).toContainText('Unable to load board occupancy');
       return;
     }
@@ -73,7 +73,7 @@ test.describe('PM Workflow', () => {
     await expect(chromeError.or(thresholdsRegion).first()).toBeVisible({ timeout: 15_000 });
 
     if (await chromeError.isVisible()) {
-      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(chromeError.getByRole('button', { name: 'Retry' })).toBeVisible();
       return;
     }
 
@@ -113,12 +113,12 @@ test.describe('PM Workflow', () => {
     });
 
     if (await chromeError.isVisible()) {
-      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(chromeError.getByRole('button', { name: 'Retry' })).toBeVisible();
       return;
     }
 
     if (await loadError.isVisible()) {
-      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(loadError.getByRole('button', { name: 'Retry' })).toBeVisible();
       await expect(loadError).toContainText('Unable to load the backlog');
       return;
     }
@@ -169,12 +169,12 @@ test.describe('Daily Focus', () => {
     ).toBeVisible({ timeout: 15_000 });
 
     if (await chromeError.isVisible()) {
-      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(chromeError.getByRole('button', { name: 'Retry' })).toBeVisible();
       return;
     }
 
     if (await occupancyError.isVisible()) {
-      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(occupancyError.getByRole('button', { name: 'Retry' })).toBeVisible();
       await expect(occupancyError).toContainText('Unable to load board occupancy');
       return;
     }
@@ -219,7 +219,7 @@ test.describe('Repo Management', () => {
     await expect(chromeError.or(thresholdsRegion).first()).toBeVisible({ timeout: 15_000 });
 
     if (await chromeError.isVisible()) {
-      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(chromeError.getByRole('button', { name: 'Retry' })).toBeVisible();
       return;
     }
 
@@ -293,12 +293,12 @@ test.describe('Backlog Review', () => {
     ).toBeVisible({ timeout: 15_000 });
 
     if (await chromeError.isVisible()) {
-      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(chromeError.getByRole('button', { name: 'Retry' })).toBeVisible();
       return;
     }
 
     if (await loadError.isVisible()) {
-      await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+      await expect(loadError.getByRole('button', { name: 'Retry' })).toBeVisible();
       await expect(loadError).toContainText('Unable to load the backlog');
       return;
     }


### PR DESCRIPTION
## Summary of Changes

Scopes Playwright `Retry` button assertions in `pm-workflow.spec.ts` to their error container regions (`chromeError`, `occupancyError`, `loadError`) so strict-mode locators do not match multiple Retry controls on the same page.

This is a CI collateral fix after #420 merged; it does not change SoloDevBoard application behaviour or Roadmap Sync assignee rules.

## Related Issue(s)

References #420

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [ ] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [ ] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — test-only change.

## Additional Notes

Extracted from trimmed #421 scope. Equivalent to commit `0a1c9e5` on the former branch. Affects ten `getByRole('button', { name: 'Retry' })` assertions across PM Workflow, Daily Focus, Repo Management, and Backlog Review describe blocks.