### PR TITLE
[Story] Add optional strict-mode label delete to recommended taxonomy (#380)

### DIFF
--- a/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor
@@ -160,6 +160,14 @@
                             }
                         </MudSelect>
 
+                        <MudCheckBox T="bool"
+                                     Value="removeLabelsOutsideTaxonomy"
+                                     ValueChanged="OnRemoveLabelsOutsideTaxonomyChanged"
+                                     Label="Remove labels outside taxonomy"
+                                     Disabled="@(ShowLoadingState || !selectedRepositories.Any() || recommendedStrategies.Count == 0)"
+                                     data-testid="remove-labels-outside-taxonomy-checkbox" />
+                        <MudText Typo="Typo.caption">When enabled, deletes every label not in the selected strategy, including GitHub defaults and automation labels such as <code>dependencies</code>.</MudText>
+
                         <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1">
                             <MudButton Variant="Variant.Outlined"
                                        Color="Color.Secondary"
@@ -207,7 +215,7 @@
                                 {
                                     <MudPaper Class="pa-3" Outlined="true">
                                         <MudText Typo="Typo.subtitle1">@preview.RepositoryFullName</MudText>
-                                        <MudText Typo="Typo.body2">Create: @preview.ToCreate.Count, Update: @preview.ToUpdate.Count, Skip: @preview.Skipped.Count</MudText>
+                                        <MudText Typo="Typo.body2">Create: @preview.ToCreate.Count, Update: @preview.ToUpdate.Count, Delete: @preview.ToDelete.Count, Skip: @preview.Skipped.Count</MudText>
 
                                         @if (preview.ToCreate.Count > 0)
                                         {
@@ -217,6 +225,11 @@
                                         @if (preview.ToUpdate.Count > 0)
                                         {
                                             <LabelPreviewTable Heading="Labels to update" Labels="preview.ToUpdate" />
+                                        }
+
+                                        @if (preview.ToDelete.Count > 0)
+                                        {
+                                            <LabelPreviewTable Heading="Labels to delete" Labels="preview.ToDelete" />
                                         }
                                     </MudPaper>
                                 }
@@ -232,11 +245,24 @@
                                         <MudText Typo="Typo.subtitle1">@result.RepositoryFullName</MudText>
                                         @if (result.HasError)
                                         {
-                                            <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Outlined">@result.ErrorMessage</MudAlert>
+                                            @if (!string.IsNullOrWhiteSpace(result.ErrorMessage))
+                                            {
+                                                <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Outlined">@result.ErrorMessage</MudAlert>
+                                            }
+
+                                            @foreach (var deleteError in result.DeleteErrors)
+                                            {
+                                                <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Outlined">Failed to delete '@deleteError.LabelName': @deleteError.ErrorMessage</MudAlert>
+                                            }
+
+                                            @if (result.CreatedCount > 0 || result.UpdatedCount > 0 || result.DeletedCount > 0 || result.SkippedCount > 0)
+                                            {
+                                                <MudText Typo="Typo.body2">Created: @result.CreatedCount, Updated: @result.UpdatedCount, Deleted: @result.DeletedCount, Skipped: @result.SkippedCount</MudText>
+                                            }
                                         }
                                         else
                                         {
-                                            <MudText Typo="Typo.body2">Created: @result.CreatedCount, Updated: @result.UpdatedCount, Skipped: @result.SkippedCount</MudText>
+                                            <MudText Typo="Typo.body2">Created: @result.CreatedCount, Updated: @result.UpdatedCount, Deleted: @result.DeletedCount, Skipped: @result.SkippedCount</MudText>
                                         }
                                     </MudPaper>
                                 }

--- a/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Labels/Pages/Labels.razor.cs
@@ -52,6 +52,7 @@ public partial class Labels : ComponentBase
     private IReadOnlyList<RecommendedTaxonomyRepositoryPreviewDto> recommendedPreview = [];
     private IReadOnlyList<RecommendedTaxonomyRepositoryResultDto> recommendedApplyResults = [];
     private bool showRecommendedPreview;
+    private bool removeLabelsOutsideTaxonomy;
     private bool isPreviewingRecommendedTaxonomy;
     private bool isApplyingRecommendedTaxonomy;
     private string? taxonomyOperationMessage;
@@ -110,6 +111,16 @@ public partial class Labels : ComponentBase
     private Task OnStrategySelectedAsync(string strategyId)
     {
         selectedStrategyId = strategyId;
+        recommendedPreview = [];
+        showRecommendedPreview = false;
+        recommendedApplyResults = [];
+        taxonomyOperationMessage = null;
+        return Task.CompletedTask;
+    }
+
+    private Task OnRemoveLabelsOutsideTaxonomyChanged(bool value)
+    {
+        removeLabelsOutsideTaxonomy = value;
         recommendedPreview = [];
         showRecommendedPreview = false;
         recommendedApplyResults = [];
@@ -242,7 +253,7 @@ public partial class Labels : ComponentBase
         {
             taxonomyOperationMessage = null;
             recommendedApplyResults = [];
-            recommendedPreview = await LabelManagerService.PreviewRecommendedTaxonomyAsync(selectedStrategyId, selectedFullNames);
+            recommendedPreview = await LabelManagerService.PreviewRecommendedTaxonomyAsync(selectedStrategyId, selectedFullNames, removeLabelsOutsideTaxonomy);
             showRecommendedPreview = true;
         }
         catch (Exception ex) when (ex is HostedAuthenticationRequiredException or GitHubPatConnectivityRequiredException)
@@ -299,24 +310,25 @@ public partial class Labels : ComponentBase
         isApplyingRecommendedTaxonomy = true;
         try
         {
-            recommendedApplyResults = await LabelManagerService.ApplyRecommendedTaxonomyAsync(selectedStrategyId, selectedFullNames);
+            recommendedApplyResults = await LabelManagerService.ApplyRecommendedTaxonomyAsync(selectedStrategyId, selectedFullNames, removeLabelsOutsideTaxonomy);
             showRecommendedPreview = false;
             recommendedPreview = [];
 
             var failedCount = recommendedApplyResults.Count(result => result.HasError);
             var createdCount = recommendedApplyResults.Sum(result => result.CreatedCount);
             var updatedCount = recommendedApplyResults.Sum(result => result.UpdatedCount);
+            var deletedCount = recommendedApplyResults.Sum(result => result.DeletedCount);
             var skippedCount = recommendedApplyResults.Sum(result => result.SkippedCount);
 
             if (failedCount == 0)
             {
                 taxonomyOperationSeverity = Severity.Success;
-                taxonomyOperationMessage = $"Applied taxonomy successfully. Created {createdCount}, updated {updatedCount}, skipped {skippedCount}.";
+                taxonomyOperationMessage = $"Applied taxonomy successfully. Created {createdCount}, updated {updatedCount}, deleted {deletedCount}, skipped {skippedCount}.";
             }
             else
             {
                 taxonomyOperationSeverity = Severity.Warning;
-                taxonomyOperationMessage = $"Applied taxonomy with {failedCount} repository errors. Created {createdCount}, updated {updatedCount}, skipped {skippedCount}.";
+                taxonomyOperationMessage = $"Applied taxonomy with {failedCount} repository errors. Created {createdCount}, updated {updatedCount}, deleted {deletedCount}, skipped {skippedCount}.";
             }
 
             await LoadLabelsForSelectionAsync();

--- a/src/Application/SoloDevBoard.Application/Services/Labels/ILabelManagerService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Labels/ILabelManagerService.cs
@@ -79,14 +79,16 @@ public interface ILabelManagerService
     /// <summary>Builds a preview for applying a recommended taxonomy to repositories.</summary>
     /// <param name="strategyId">The recommended strategy identifier.</param>
     /// <param name="repositories">The target repositories in owner/repository format.</param>
+    /// <param name="removeLabelsOutsideTaxonomy">When <see langword="true" />, includes labels to delete that are not in the strategy set.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    /// <returns>A read-only list of repository previews showing create, update, and skip actions.</returns>
-    Task<IReadOnlyList<RecommendedTaxonomyRepositoryPreviewDto>> PreviewRecommendedTaxonomyAsync(string strategyId, IReadOnlyList<string> repositories, CancellationToken cancellationToken = default);
+    /// <returns>A read-only list of repository previews showing create, update, delete, and skip actions.</returns>
+    Task<IReadOnlyList<RecommendedTaxonomyRepositoryPreviewDto>> PreviewRecommendedTaxonomyAsync(string strategyId, IReadOnlyList<string> repositories, bool removeLabelsOutsideTaxonomy = false, CancellationToken cancellationToken = default);
 
     /// <summary>Applies a recommended taxonomy to repositories and returns per-repository summaries.</summary>
     /// <param name="strategyId">The recommended strategy identifier.</param>
     /// <param name="repositories">The target repositories in owner/repository format.</param>
+    /// <param name="removeLabelsOutsideTaxonomy">When <see langword="true" />, deletes labels not in the strategy set after create and update.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>A read-only list of per-repository results.</returns>
-    Task<IReadOnlyList<RecommendedTaxonomyRepositoryResultDto>> ApplyRecommendedTaxonomyAsync(string strategyId, IReadOnlyList<string> repositories, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<RecommendedTaxonomyRepositoryResultDto>> ApplyRecommendedTaxonomyAsync(string strategyId, IReadOnlyList<string> repositories, bool removeLabelsOutsideTaxonomy = false, CancellationToken cancellationToken = default);
 }

--- a/src/Application/SoloDevBoard.Application/Services/Labels/LabelService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Labels/LabelService.cs
@@ -232,7 +232,7 @@ public sealed class LabelService : ILabelManagerService
     }
 
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<RecommendedTaxonomyRepositoryPreviewDto>> PreviewRecommendedTaxonomyAsync(string strategyId, IReadOnlyList<string> repositories, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<RecommendedTaxonomyRepositoryPreviewDto>> PreviewRecommendedTaxonomyAsync(string strategyId, IReadOnlyList<string> repositories, bool removeLabelsOutsideTaxonomy = false, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(strategyId);
         var normalisedRepositories = NormaliseRepositories(repositories);
@@ -245,7 +245,7 @@ public sealed class LabelService : ILabelManagerService
             cancellationToken.ThrowIfCancellationRequested();
             var repository = SplitRepositoryFullName(repositoryFullName);
             var existing = await _labelRepository.GetLabelsAsync(repository.Owner, repository.Name, cancellationToken).ConfigureAwait(false);
-            previews.Add(BuildRepositoryPreview(repositoryFullName, strategyLabels, existing));
+            previews.Add(BuildRepositoryPreview(repositoryFullName, strategyLabels, existing, removeLabelsOutsideTaxonomy));
         }
 
         return previews
@@ -254,7 +254,7 @@ public sealed class LabelService : ILabelManagerService
     }
 
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<RecommendedTaxonomyRepositoryResultDto>> ApplyRecommendedTaxonomyAsync(string strategyId, IReadOnlyList<string> repositories, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<RecommendedTaxonomyRepositoryResultDto>> ApplyRecommendedTaxonomyAsync(string strategyId, IReadOnlyList<string> repositories, bool removeLabelsOutsideTaxonomy = false, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(strategyId);
         var normalisedRepositories = NormaliseRepositories(repositories);
@@ -266,11 +266,16 @@ public sealed class LabelService : ILabelManagerService
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            var createdCount = 0;
+            var updatedCount = 0;
+            var deletedCount = 0;
+            var deleteErrors = new List<RecommendedTaxonomyLabelDeleteErrorDto>();
+
             try
             {
                 var repository = SplitRepositoryFullName(repositoryFullName);
                 var existing = await _labelRepository.GetLabelsAsync(repository.Owner, repository.Name, cancellationToken).ConfigureAwait(false);
-                var preview = BuildRepositoryPreview(repositoryFullName, strategyLabels, existing);
+                var preview = BuildRepositoryPreview(repositoryFullName, strategyLabels, existing, removeLabelsOutsideTaxonomy);
 
                 foreach (var labelToCreate in preview.ToCreate)
                 {
@@ -278,6 +283,7 @@ public sealed class LabelService : ILabelManagerService
                     await _labelRepository
                         .CreateLabelAsync(repository.Owner, repository.Name, MapToDomain(labelToCreate, repository.Name), cancellationToken)
                         .ConfigureAwait(false);
+                    createdCount++;
                 }
 
                 foreach (var labelToUpdate in preview.ToUpdate)
@@ -286,22 +292,44 @@ public sealed class LabelService : ILabelManagerService
                     await _labelRepository
                         .UpdateLabelAsync(repository.Owner, repository.Name, labelToUpdate.Name, MapToDomain(labelToUpdate, repository.Name), cancellationToken)
                         .ConfigureAwait(false);
+                    updatedCount++;
+                }
+
+                foreach (var labelToDelete in preview.ToDelete)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    try
+                    {
+                        await _labelRepository
+                            .DeleteLabelAsync(repository.Owner, repository.Name, labelToDelete.Name, cancellationToken)
+                            .ConfigureAwait(false);
+                        deletedCount++;
+                    }
+                    catch (Exception ex) when (ex is HttpRequestException or KeyNotFoundException or ArgumentException)
+                    {
+                        deleteErrors.Add(new RecommendedTaxonomyLabelDeleteErrorDto(labelToDelete.Name, ex.Message));
+                    }
                 }
 
                 results.Add(new RecommendedTaxonomyRepositoryResultDto(
                     repositoryFullName,
-                    preview.ToCreate.Count,
-                    preview.ToUpdate.Count,
+                    createdCount,
+                    updatedCount,
+                    deletedCount,
                     preview.Skipped.Count,
+                    deleteErrors,
                     null));
             }
             catch (Exception ex) when (ex is HttpRequestException or KeyNotFoundException or ArgumentException)
             {
                 results.Add(new RecommendedTaxonomyRepositoryResultDto(
                     repositoryFullName,
+                    createdCount,
+                    updatedCount,
+                    deletedCount,
                     0,
-                    0,
-                    0,
+                    deleteErrors,
                     ex.Message));
             }
         }
@@ -336,10 +364,16 @@ public sealed class LabelService : ILabelManagerService
     /// <param name="repositoryFullName">The owner/repository full name.</param>
     /// <param name="strategyLabels">The strategy labels to compare against.</param>
     /// <param name="existingLabels">The labels currently present in the repository.</param>
-    /// <returns>A repository preview showing create, update, and skip actions.</returns>
-    private static RecommendedTaxonomyRepositoryPreviewDto BuildRepositoryPreview(string repositoryFullName, IReadOnlyList<LabelDto> strategyLabels, IReadOnlyList<Label> existingLabels)
+    /// <param name="removeLabelsOutsideTaxonomy">When <see langword="true" />, includes labels to delete that are not in the strategy set.</param>
+    /// <returns>A repository preview showing create, update, delete, and skip actions.</returns>
+    private static RecommendedTaxonomyRepositoryPreviewDto BuildRepositoryPreview(
+        string repositoryFullName,
+        IReadOnlyList<LabelDto> strategyLabels,
+        IReadOnlyList<Label> existingLabels,
+        bool removeLabelsOutsideTaxonomy)
     {
         var existingByName = existingLabels.ToDictionary(label => label.Name, StringComparer.OrdinalIgnoreCase);
+        var strategyByName = strategyLabels.ToDictionary(label => label.Name, StringComparer.OrdinalIgnoreCase);
 
         var toCreate = strategyLabels
             .Where(label => !existingByName.ContainsKey(label.Name))
@@ -361,7 +395,15 @@ public sealed class LabelService : ILabelManagerService
             .OrderBy(label => label.Name, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-        return new RecommendedTaxonomyRepositoryPreviewDto(repositoryFullName, toCreate, toUpdate, skipped);
+        var toDelete = removeLabelsOutsideTaxonomy
+            ? existingLabels
+                .Where(label => !strategyByName.ContainsKey(label.Name))
+                .Select(label => MapToDto(label, repositoryFullName))
+                .OrderBy(label => label.Name, StringComparer.OrdinalIgnoreCase)
+                .ToArray()
+            : [];
+
+        return new RecommendedTaxonomyRepositoryPreviewDto(repositoryFullName, toCreate, toUpdate, toDelete, skipped);
     }
 
     /// <summary>Maps an application label DTO to a domain label record.</summary>

--- a/src/Application/SoloDevBoard.Application/Services/Labels/RecommendedTaxonomyLabelDeleteErrorDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Labels/RecommendedTaxonomyLabelDeleteErrorDto.cs
@@ -1,0 +1,6 @@
+namespace SoloDevBoard.Application.Services.Labels;
+
+/// <summary>Represents a failed label delete during recommended taxonomy apply.</summary>
+/// <param name="LabelName">The label name that could not be deleted.</param>
+/// <param name="ErrorMessage">The error message returned for this label.</param>
+public sealed record RecommendedTaxonomyLabelDeleteErrorDto(string LabelName, string ErrorMessage);

--- a/src/Application/SoloDevBoard.Application/Services/Labels/RecommendedTaxonomyRepositoryPreviewDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Labels/RecommendedTaxonomyRepositoryPreviewDto.cs
@@ -4,9 +4,11 @@ namespace SoloDevBoard.Application.Services.Labels;
 /// <param name="RepositoryFullName">The owner/repository full name.</param>
 /// <param name="ToCreate">Labels that would be created.</param>
 /// <param name="ToUpdate">Labels that would be updated.</param>
+/// <param name="ToDelete">Labels that would be deleted when strict mode is enabled.</param>
 /// <param name="Skipped">Labels already matching the strategy exactly.</param>
 public sealed record RecommendedTaxonomyRepositoryPreviewDto(
     string RepositoryFullName,
     IReadOnlyList<LabelDto> ToCreate,
     IReadOnlyList<LabelDto> ToUpdate,
+    IReadOnlyList<LabelDto> ToDelete,
     IReadOnlyList<LabelDto> Skipped);

--- a/src/Application/SoloDevBoard.Application/Services/Labels/RecommendedTaxonomyRepositoryResultDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Labels/RecommendedTaxonomyRepositoryResultDto.cs
@@ -4,15 +4,19 @@ namespace SoloDevBoard.Application.Services.Labels;
 /// <param name="RepositoryFullName">The owner/repository full name.</param>
 /// <param name="CreatedCount">The number of labels created.</param>
 /// <param name="UpdatedCount">The number of labels updated.</param>
+/// <param name="DeletedCount">The number of labels deleted.</param>
 /// <param name="SkippedCount">The number of labels skipped because they already matched.</param>
+/// <param name="DeleteErrors">Per-label delete failures when strict mode is enabled.</param>
 /// <param name="ErrorMessage">The repository-specific error message when apply fails.</param>
 public sealed record RecommendedTaxonomyRepositoryResultDto(
     string RepositoryFullName,
     int CreatedCount,
     int UpdatedCount,
+    int DeletedCount,
     int SkippedCount,
+    IReadOnlyList<RecommendedTaxonomyLabelDeleteErrorDto> DeleteErrors,
     string? ErrorMessage)
 {
     /// <summary>Gets a value indicating whether the apply operation failed for this repository.</summary>
-    public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
+    public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage) || DeleteErrors.Count > 0;
 }

--- a/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/LabelsTests.cs
@@ -270,11 +270,12 @@ public sealed class LabelsTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
 
-        _labelManagerService.PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns([
+        _labelManagerService.PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns([
                 new RecommendedTaxonomyRepositoryPreviewDto(
                     "owner/repo-a",
                     [new LabelDto("type/story", "1d76db", "Story", "owner/repo-a")],
                     [new LabelDto("priority/high", "d93f0b", "High", "owner/repo-a")],
+                    [],
                     [new LabelDto("status/todo", "ffffff", "Ready", "owner/repo-a")]),
             ]);
 
@@ -307,16 +308,17 @@ public sealed class LabelsTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
 
-        _labelManagerService.PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns([
+        _labelManagerService.PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns([
                 new RecommendedTaxonomyRepositoryPreviewDto(
                     "owner/repo-a",
                     [new LabelDto("type/story", "1d76db", "Story", "owner/repo-a")],
                     [],
+                    [],
                     []),
             ]);
 
-        _labelManagerService.ApplyRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns([
-                new RecommendedTaxonomyRepositoryResultDto("owner/repo-a", 1, 0, 0, null),
+        _labelManagerService.ApplyRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns([
+                new RecommendedTaxonomyRepositoryResultDto("owner/repo-a", 1, 0, 0, 0, [], null),
             ]);
 
         _labelManagerService.GetLabelsForRepositoriesAsync("owner", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(Array.Empty<LabelDto>());
@@ -338,11 +340,11 @@ public sealed class LabelsTests
         cut.WaitForAssertion(() =>
         {
             Assert.Contains("Apply summary", cut.Markup);
-            Assert.Contains("Created: 1, Updated: 0, Skipped: 0", cut.Markup);
-            Assert.Contains("Applied taxonomy successfully", cut.Markup);
+            Assert.Contains("Created: 1, Updated: 0, Deleted: 0, Skipped: 0", cut.Markup);
+            Assert.Contains("Applied taxonomy successfully. Created 1, updated 0, deleted 0, skipped 0.", cut.Markup);
         });
 
-        await _labelManagerService.Received(1).ApplyRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+        await _labelManagerService.Received(1).ApplyRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), false, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -353,8 +355,8 @@ public sealed class LabelsTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
 
-        _labelManagerService.PreviewRecommendedTaxonomyAsync("solodevboard", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns([
-                new RecommendedTaxonomyRepositoryPreviewDto("owner/repo-a", [], [], []),
+        _labelManagerService.PreviewRecommendedTaxonomyAsync("solodevboard", Arg.Any<IReadOnlyList<string>>(), false, Arg.Any<CancellationToken>()).Returns([
+                new RecommendedTaxonomyRepositoryPreviewDto("owner/repo-a", [], [], [], []),
             ]);
 
         await using var ctx = CreateContext();
@@ -367,7 +369,7 @@ public sealed class LabelsTests
         cut.Find("[data-testid='preview-taxonomy-button']").Click();
 
         // Assert
-        await _labelManagerService.Received(1).PreviewRecommendedTaxonomyAsync("solodevboard", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+        await _labelManagerService.Received(1).PreviewRecommendedTaxonomyAsync("solodevboard", Arg.Any<IReadOnlyList<string>>(), false, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -379,7 +381,7 @@ public sealed class LabelsTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
 
-        _labelManagerService.PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(previewTask.Task);
+        _labelManagerService.PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(previewTask.Task);
 
         await using var ctx = CreateContext();
 
@@ -394,13 +396,100 @@ public sealed class LabelsTests
         previewButton.Click();
 
         await cut.InvokeAsync(() => previewTask.SetResult([
-            new RecommendedTaxonomyRepositoryPreviewDto("owner/repo-a", [], [], []),
+            new RecommendedTaxonomyRepositoryPreviewDto("owner/repo-a", [], [], [], []),
         ]));
 
         cut.WaitForAssertion(() => Assert.Contains("Taxonomy preview", cut.Markup));
 
         // Assert
-        await _labelManagerService.Received(1).PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+        await _labelManagerService.Received(1).PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Labels_RecommendedTaxonomy_RemoveOutsideTaxonomyCheckbox_IsUncheckedByDefault()
+    {
+        // Arrange
+        var repoA = CreateRepository("owner", "repo-a");
+
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Labels>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
+        await SelectRepositoriesAsync(cut, repoA);
+        await ActivateTabAsync(cut, "Recommended taxonomy");
+
+        // Assert
+        var checkbox = cut.Find("[data-testid='remove-labels-outside-taxonomy-checkbox']");
+        Assert.False(checkbox.HasAttribute("checked"));
+        Assert.Contains("Remove labels outside taxonomy", cut.Markup);
+    }
+
+    [Fact]
+    public async Task Labels_PreviewRecommendedTaxonomy_WhenRemoveOutsideTaxonomyEnabled_PassesStrictModeToService()
+    {
+        // Arrange
+        var repoA = CreateRepository("owner", "repo-a");
+
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
+
+        _labelManagerService.PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), true, Arg.Any<CancellationToken>()).Returns([
+                new RecommendedTaxonomyRepositoryPreviewDto(
+                    "owner/repo-a",
+                    [],
+                    [],
+                    [new LabelDto("dependencies", "0366d6", "Dependencies", "owner/repo-a")],
+                    []),
+            ]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Labels>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
+        await SelectRepositoriesAsync(cut, repoA);
+        await ActivateTabAsync(cut, "Recommended taxonomy");
+
+        var checkbox = cut.FindComponent<MudCheckBox<bool>>();
+        await cut.InvokeAsync(() => checkbox.Instance.ValueChanged.InvokeAsync(true));
+        cut.Find("[data-testid='preview-taxonomy-button']").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Delete: 1", cut.Markup);
+            Assert.Contains("Labels to delete", cut.Markup);
+            Assert.Contains("dependencies", cut.Markup);
+        });
+
+        await _labelManagerService.Received(1).PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), true, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Labels_PreviewRecommendedTaxonomy_WhenRemoveOutsideTaxonomyDisabled_PassesFalseToService()
+    {
+        // Arrange
+        var repoA = CreateRepository("owner", "repo-a");
+
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repoA]);
+
+        _labelManagerService.PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), false, Arg.Any<CancellationToken>()).Returns([
+                new RecommendedTaxonomyRepositoryPreviewDto("owner/repo-a", [], [], [], []),
+            ]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Labels>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='repository-autocomplete']"));
+        await SelectRepositoriesAsync(cut, repoA);
+        await ActivateTabAsync(cut, "Recommended taxonomy");
+        cut.Find("[data-testid='preview-taxonomy-button']").Click();
+
+        // Assert
+        await _labelManagerService.Received(1).PreviewRecommendedTaxonomyAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), false, Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/LabelServiceTests.cs
@@ -634,7 +634,7 @@ public sealed class LabelServiceTests
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.PreviewRecommendedTaxonomyAsync("github-default", ["owner/repo-a"], cancellationToken);
+        var result = await sut.PreviewRecommendedTaxonomyAsync("github-default", ["owner/repo-a"], cancellationToken: cancellationToken);
 
         // Assert
         var preview = Assert.Single(result);
@@ -642,6 +642,116 @@ public sealed class LabelServiceTests
         Assert.Contains(preview.ToCreate, label => label.Name == "enhancement");
         Assert.Contains(preview.ToUpdate, label => label.Name == "bug");
         Assert.Contains(preview.Skipped, label => label.Name == "documentation");
+        Assert.Empty(preview.ToDelete);
+    }
+
+    [Fact]
+    public async Task PreviewRecommendedTaxonomyAsync_WhenRemoveOutsideTaxonomyEnabled_ReturnsLabelsToDelete()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-a", cancellationToken)
+            .Returns([
+                new Label { Name = "bug", Colour = "d73a4a", Description = "Something is not working", RepositoryName = "repo-a" },
+                new Label { Name = "dependencies", Colour = "0366d6", Description = "Pull requests that update a dependency", RepositoryName = "repo-a" },
+                new Label { Name = "epic", Colour = "5319e7", Description = "Legacy epic label", RepositoryName = "repo-a" },
+            ]);
+
+        var sut = new LabelService(_labelRepository);
+
+        // Act
+        var result = await sut.PreviewRecommendedTaxonomyAsync("github-default", ["owner/repo-a"], removeLabelsOutsideTaxonomy: true, cancellationToken);
+
+        // Assert
+        var preview = Assert.Single(result);
+        Assert.Contains(preview.ToDelete, label => label.Name == "dependencies");
+        Assert.Contains(preview.ToDelete, label => label.Name == "epic");
+        Assert.DoesNotContain(preview.ToDelete, label => label.Name == "bug");
+    }
+
+    [Fact]
+    public async Task ApplyRecommendedTaxonomyAsync_WhenRemoveOutsideTaxonomyEnabled_DeletesExtraneousLabels()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-a", cancellationToken)
+            .Returns([
+                new Label { Name = "bug", Colour = "d73a4a", Description = "Something is not working", RepositoryName = "repo-a" },
+                new Label { Name = "dependencies", Colour = "0366d6", Description = "Pull requests that update a dependency", RepositoryName = "repo-a" },
+                new Label { Name = "documentation", Colour = "0075ca", Description = "Improvements or additions to documentation", RepositoryName = "repo-a" },
+                new Label { Name = "duplicate", Colour = "cfd3d7", Description = "This issue or pull request already exists", RepositoryName = "repo-a" },
+                new Label { Name = "enhancement", Colour = "a2eeef", Description = "New feature or request", RepositoryName = "repo-a" },
+                new Label { Name = "good first issue", Colour = "7057ff", Description = "Good for newcomers", RepositoryName = "repo-a" },
+                new Label { Name = "help wanted", Colour = "008672", Description = "Extra attention is needed", RepositoryName = "repo-a" },
+                new Label { Name = "invalid", Colour = "e4e669", Description = "This does not appear to be valid", RepositoryName = "repo-a" },
+                new Label { Name = "question", Colour = "d876e3", Description = "Further information is requested", RepositoryName = "repo-a" },
+                new Label { Name = "wontfix", Colour = "ffffff", Description = "This will not be worked on", RepositoryName = "repo-a" },
+                new Label { Name = "epic", Colour = "5319e7", Description = "Legacy epic label", RepositoryName = "repo-a" },
+            ]);
+
+        _labelRepository
+            .DeleteLabelAsync("owner", "repo-a", Arg.Any<string>(), cancellationToken)
+            .Returns(Task.CompletedTask);
+
+        var sut = new LabelService(_labelRepository);
+
+        // Act
+        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a"], removeLabelsOutsideTaxonomy: true, cancellationToken);
+
+        // Assert
+        var summary = Assert.Single(result);
+        Assert.Equal(2, summary.DeletedCount);
+        Assert.Empty(summary.DeleteErrors);
+        Assert.False(summary.HasError);
+        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-a", "dependencies", cancellationToken);
+        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-a", "epic", cancellationToken);
+        await _labelRepository.DidNotReceive().DeleteLabelAsync("owner", "repo-a", "bug", cancellationToken);
+    }
+
+    [Fact]
+    public async Task ApplyRecommendedTaxonomyAsync_WhenDeleteFails_RecordsPerLabelErrorAndContinues()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        // Arrange
+        _labelRepository
+            .GetLabelsAsync("owner", "repo-a", cancellationToken)
+            .Returns([
+                new Label { Name = "bug", Colour = "d73a4a", Description = "Something is not working", RepositoryName = "repo-a" },
+                new Label { Name = "documentation", Colour = "0075ca", Description = "Improvements or additions to documentation", RepositoryName = "repo-a" },
+                new Label { Name = "duplicate", Colour = "cfd3d7", Description = "This issue or pull request already exists", RepositoryName = "repo-a" },
+                new Label { Name = "enhancement", Colour = "a2eeef", Description = "New feature or request", RepositoryName = "repo-a" },
+                new Label { Name = "good first issue", Colour = "7057ff", Description = "Good for newcomers", RepositoryName = "repo-a" },
+                new Label { Name = "help wanted", Colour = "008672", Description = "Extra attention is needed", RepositoryName = "repo-a" },
+                new Label { Name = "invalid", Colour = "e4e669", Description = "This does not appear to be valid", RepositoryName = "repo-a" },
+                new Label { Name = "question", Colour = "d876e3", Description = "Further information is requested", RepositoryName = "repo-a" },
+                new Label { Name = "wontfix", Colour = "ffffff", Description = "This will not be worked on", RepositoryName = "repo-a" },
+                new Label { Name = "epic", Colour = "5319e7", Description = "Legacy epic label", RepositoryName = "repo-a" },
+                new Label { Name = "story", Colour = "1d76db", Description = "Legacy story label", RepositoryName = "repo-a" },
+            ]);
+
+        _labelRepository
+            .DeleteLabelAsync("owner", "repo-a", "epic", cancellationToken)
+            .Returns(Task.FromException(new HttpRequestException("Label is still in use")));
+
+        _labelRepository
+            .DeleteLabelAsync("owner", "repo-a", "story", cancellationToken)
+            .Returns(Task.CompletedTask);
+
+        var sut = new LabelService(_labelRepository);
+
+        // Act
+        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a"], removeLabelsOutsideTaxonomy: true, cancellationToken);
+
+        // Assert
+        var summary = Assert.Single(result);
+        Assert.Equal(1, summary.DeletedCount);
+        Assert.True(summary.HasError);
+        var deleteError = Assert.Single(summary.DeleteErrors);
+        Assert.Equal("epic", deleteError.LabelName);
+        Assert.Equal("Label is still in use", deleteError.ErrorMessage);
+        await _labelRepository.Received(1).DeleteLabelAsync("owner", "repo-a", "story", cancellationToken);
     }
 
     [Fact]
@@ -666,16 +776,19 @@ public sealed class LabelServiceTests
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a"], cancellationToken);
+        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a"], cancellationToken: cancellationToken);
 
         // Assert
         var summary = Assert.Single(result);
         Assert.Equal(0, summary.CreatedCount);
         Assert.Equal(0, summary.UpdatedCount);
+        Assert.Equal(0, summary.DeletedCount);
         Assert.Equal(9, summary.SkippedCount);
+        Assert.Empty(summary.DeleteErrors);
         Assert.False(summary.HasError);
         await _labelRepository.DidNotReceive().CreateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), cancellationToken);
         await _labelRepository.DidNotReceive().UpdateLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Label>(), cancellationToken);
+        await _labelRepository.DidNotReceive().DeleteLabelAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
     }
 
     [Fact]
@@ -703,7 +816,7 @@ public sealed class LabelServiceTests
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a", "owner/repo-b"], cancellationToken);
+        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a", "owner/repo-b"], cancellationToken: cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -732,7 +845,7 @@ public sealed class LabelServiceTests
         var sut = new LabelService(_labelRepository);
 
         // Act
-        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a", "invalid-format"], cancellationToken);
+        var result = await sut.ApplyRecommendedTaxonomyAsync("github-default", ["owner/repo-a", "invalid-format"], cancellationToken: cancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);


### PR DESCRIPTION
## Summary of Changes

Adds an optional **Remove labels outside taxonomy** control to the Label Manager Recommended taxonomy tab. When enabled, preview and apply include a **To delete** list for repository labels not in the selected strategy (case-insensitive), aligned with the synchronisation tab summary format. Apply reports deleted counts and surfaces per-label delete failures without aborting the rest of the batch. Strict mode removes all extraneous labels, including automation labels such as `dependencies`; this is documented in the UI caption.

## Related Issue(s)

Closes #380

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [ ] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — UI extends an existing tab with a checkbox and delete preview rows; no screenshots captured in this PR.

## Additional Notes

- Application: `BuildRepositoryPreview`, `PreviewRecommendedTaxonomyAsync`, and `ApplyRecommendedTaxonomyAsync` accept `removeLabelsOutsideTaxonomy` (default `false`).
- New DTO: `RecommendedTaxonomyLabelDeleteErrorDto` for per-label delete failures on apply.
- Tests: Application coverage for preview/apply delete paths and bUnit coverage for toggle off/on behaviour.
- End-user docs under `website/` intentionally unchanged per issue acceptance criteria.