### PR TITLE
[Enabler] Add Projects v2 Status structure GraphQL for migration (#414)

### DIFF
--- a/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor.cs
@@ -38,8 +38,8 @@ public partial class Migration : ComponentBase
     private bool migrateLabels = true;
     private bool migrateMilestones = true;
     private MigrationConflictStrategy conflictStrategy = MigrationConflictStrategy.Skip;
-    private MigrationPreviewDto previewResult = new(MigrationConflictStrategy.Skip, [], []);
-    private MigrationResultDto applyResult = new(MigrationConflictStrategy.Skip, [], []);
+    private MigrationPreviewDto previewResult = new(MigrationConflictStrategy.Skip, [], [], []);
+    private MigrationResultDto applyResult = new(MigrationConflictStrategy.Skip, [], [], []);
     private bool isLoadingRepositories = true;
     private bool isPreviewing;
     private bool isApplying;
@@ -189,7 +189,7 @@ public partial class Migration : ComponentBase
                 conflictStrategy);
 
             showPreview = true;
-            applyResult = new MigrationResultDto(conflictStrategy, [], []);
+            applyResult = new MigrationResultDto(conflictStrategy, [], [], []);
         }
         catch (Exception ex) when (ex is HostedAuthenticationRequiredException or GitHubPatConnectivityRequiredException)
         {
@@ -204,7 +204,7 @@ public partial class Migration : ComponentBase
             operationSeverity = Severity.Error;
             operationMessage = $"GitHub API request failed while previewing migration. {ex.Message}";
             showPreview = false;
-            previewResult = new MigrationPreviewDto(conflictStrategy, [], []);
+            previewResult = new MigrationPreviewDto(conflictStrategy, [], [], []);
         }
         catch (Exception ex)
         {
@@ -212,7 +212,7 @@ public partial class Migration : ComponentBase
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while previewing migration.";
             showPreview = false;
-            previewResult = new MigrationPreviewDto(conflictStrategy, [], []);
+            previewResult = new MigrationPreviewDto(conflictStrategy, [], [], []);
         }
         finally
         {
@@ -223,7 +223,7 @@ public partial class Migration : ComponentBase
     private void CancelPreview()
     {
         showPreview = false;
-        previewResult = new MigrationPreviewDto(conflictStrategy, [], []);
+        previewResult = new MigrationPreviewDto(conflictStrategy, [], [], []);
         operationSeverity = Severity.Info;
         operationMessage = "Migration preview was cancelled. No changes were applied.";
     }
@@ -248,7 +248,7 @@ public partial class Migration : ComponentBase
                 conflictStrategy);
 
             showPreview = false;
-            previewResult = new MigrationPreviewDto(conflictStrategy, [], []);
+            previewResult = new MigrationPreviewDto(conflictStrategy, [], [], []);
 
             var labelFailures = applyResult.LabelResults.Count(result => result.HasError);
             var milestoneFailures = applyResult.MilestoneResults.Count(result => result.HasError);
@@ -369,8 +369,8 @@ public partial class Migration : ComponentBase
     private void ResetPreviewAndResults()
     {
         showPreview = false;
-        previewResult = new MigrationPreviewDto(conflictStrategy, [], []);
-        applyResult = new MigrationResultDto(conflictStrategy, [], []);
+        previewResult = new MigrationPreviewDto(conflictStrategy, [], [], []);
+        applyResult = new MigrationResultDto(conflictStrategy, [], [], []);
         operationMessage = null;
     }
 

--- a/src/Application/SoloDevBoard.Application/Services/GitHub/IGitHubService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/GitHub/IGitHubService.cs
@@ -1,5 +1,6 @@
 using SoloDevBoard.Application.Services.BoardRules;
 using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Domain.Entities.Migration;
 using SoloDevBoard.Domain.Entities.Milestones;
 using SoloDevBoard.Domain.Entities.PmWorkflow;
 using SoloDevBoard.Domain.Entities.Repositories;
@@ -195,6 +196,46 @@ public interface IGitHubService
         string projectId,
         string projectItemId,
         string focusOrderFieldId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Discovers linked project boards with full Status field structure for migration.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>Supported boards with Status options and linked-project visibility metadata.</returns>
+    Task<ProjectBoardDiscovery> DiscoverProjectBoardStatusStructuresAsync(string owner, string repo, CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves the Status field structure for a project board.</summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The Status field structure for the project board.</returns>
+    Task<ProjectBoardStatusStructure> GetProjectBoardStatusStructureAsync(string projectId, CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves the GitHub node identifier for a repository.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The repository node identifier.</returns>
+    Task<string> GetRepositoryNodeIdAsync(string owner, string repo, CancellationToken cancellationToken = default);
+
+    /// <summary>Creates a repository-linked Projects v2 board.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="title">The title for the new project board.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The Status field structure for the newly created board.</returns>
+    Task<ProjectBoardStatusStructure> CreateRepositoryLinkedProjectAsync(string owner, string repo, string title, CancellationToken cancellationToken = default);
+
+    /// <summary>Replaces the Status field options on a project board.</summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="statusFieldId">The Status field node identifier.</param>
+    /// <param name="options">The complete Status option list to persist.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The updated Status field structure.</returns>
+    Task<ProjectBoardStatusStructure> UpdateProjectBoardStatusOptionsAsync(
+        string projectId,
+        string statusFieldId,
+        IReadOnlyList<ProjectBoardStatusStructureOption> options,
         CancellationToken cancellationToken = default);
 
     /// <summary>Closes a triage item as duplicate and records a duplicate reference comment.</summary>

--- a/src/Application/SoloDevBoard.Application/Services/Migration/IMigrationService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/IMigrationService.cs
@@ -8,13 +8,15 @@ public interface IMigrationService
     /// <param name="targetRepositoryFullNames">The target repositories in owner/repository format.</param>
     /// <param name="scope">The migration item types to include.</param>
     /// <param name="conflictStrategy">The conflict strategy applied to existing target items.</param>
+    /// <param name="boardSelection">The project board selections when <paramref name="scope"/> includes project board columns.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    /// <returns>A preview describing label and milestone changes for each target repository.</returns>
+    /// <returns>A preview describing label, milestone, and Status column changes for each target repository.</returns>
     Task<MigrationPreviewDto> PreviewMigrationAsync(
         string sourceRepositoryFullName,
         IReadOnlyList<string> targetRepositoryFullNames,
         MigrationScopeDto scope,
         MigrationConflictStrategy conflictStrategy,
+        MigrationBoardSelectionDto? boardSelection = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>Applies migration for one source repository to multiple target repositories.</summary>
@@ -22,12 +24,14 @@ public interface IMigrationService
     /// <param name="targetRepositoryFullNames">The target repositories in owner/repository format.</param>
     /// <param name="scope">The migration item types to include.</param>
     /// <param name="conflictStrategy">The conflict strategy applied to existing target items.</param>
+    /// <param name="boardSelection">The project board selections when <paramref name="scope"/> includes project board columns.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    /// <returns>Per-repository results for label and milestone migration.</returns>
+    /// <returns>Per-repository results for label, milestone, and Status column migration.</returns>
     Task<MigrationResultDto> ApplyMigrationAsync(
         string sourceRepositoryFullName,
         IReadOnlyList<string> targetRepositoryFullNames,
         MigrationScopeDto scope,
         MigrationConflictStrategy conflictStrategy,
+        MigrationBoardSelectionDto? boardSelection = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/Application/SoloDevBoard.Application/Services/Migration/IProjectBoardStructureRepository.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/IProjectBoardStructureRepository.cs
@@ -1,0 +1,46 @@
+using SoloDevBoard.Domain.Entities.Migration;
+
+namespace SoloDevBoard.Application.Services.Migration;
+
+/// <summary>Provides repository operations for Projects v2 Status field structure.</summary>
+public interface IProjectBoardStructureRepository
+{
+    /// <summary>Discovers linked project boards for a repository, including visibility metadata.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>Supported boards and linked-project visibility counts.</returns>
+    Task<ProjectBoardDiscovery> DiscoverBoardsAsync(string owner, string repo, CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves the Status field structure for a project board.</summary>
+    /// <param name="projectId">The GitHub node identifier for the project board.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The Status field structure for the project board.</returns>
+    Task<ProjectBoardStatusStructure> GetStatusStructureAsync(string projectId, CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves Status option identifiers that are currently assigned to board items.</summary>
+    /// <param name="projectId">The GitHub node identifier for the project board.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The set of Status option identifiers in use on the board.</returns>
+    Task<IReadOnlySet<string>> GetStatusOptionIdsInUseAsync(string projectId, CancellationToken cancellationToken = default);
+
+    /// <summary>Creates a repository-linked Projects v2 board.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="title">The title for the new project board.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The Status field structure for the newly created board.</returns>
+    Task<ProjectBoardStatusStructure> CreateLinkedProjectAsync(string owner, string repo, string title, CancellationToken cancellationToken = default);
+
+    /// <summary>Replaces the Status field options on a project board.</summary>
+    /// <param name="projectId">The GitHub node identifier for the project board.</param>
+    /// <param name="statusFieldId">The Status field node identifier.</param>
+    /// <param name="options">The complete Status option list to persist.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The updated Status field structure.</returns>
+    Task<ProjectBoardStatusStructure> UpdateStatusOptionsAsync(
+        string projectId,
+        string statusFieldId,
+        IReadOnlyList<ProjectBoardStatusStructureOption> options,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Application/SoloDevBoard.Application/Services/Migration/MigrationBoardSelectionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/MigrationBoardSelectionDto.cs
@@ -1,0 +1,8 @@
+namespace SoloDevBoard.Application.Services.Migration;
+
+/// <summary>Represents source and per-target project board selections for column migration.</summary>
+/// <param name="SourceProjectId">The source project board identifier.</param>
+/// <param name="TargetSelections">The per-target board selections.</param>
+public sealed record MigrationBoardSelectionDto(
+    string SourceProjectId,
+    IReadOnlyList<MigrationTargetBoardSelectionDto> TargetSelections);

--- a/src/Application/SoloDevBoard.Application/Services/Migration/MigrationPreviewDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/MigrationPreviewDto.cs
@@ -2,11 +2,13 @@ using SoloDevBoard.Application.Services.Labels;
 
 namespace SoloDevBoard.Application.Services.Migration;
 
-/// <summary>Represents the migration preview across labels and milestones.</summary>
+/// <summary>Represents the migration preview across labels, milestones, and project board columns.</summary>
 /// <param name="ConflictStrategy">The selected conflict strategy used to generate the preview.</param>
 /// <param name="LabelPreviews">Per-repository label previews.</param>
 /// <param name="MilestonePreviews">Per-repository milestone previews.</param>
+/// <param name="ProjectBoardStatusPreviews">Per-repository Projects v2 Status column previews.</param>
 public sealed record MigrationPreviewDto(
     MigrationConflictStrategy ConflictStrategy,
     IReadOnlyList<LabelSyncRepositoryPreviewDto> LabelPreviews,
-    IReadOnlyList<MilestoneSyncRepositoryPreviewDto> MilestonePreviews);
+    IReadOnlyList<MilestoneSyncRepositoryPreviewDto> MilestonePreviews,
+    IReadOnlyList<ProjectBoardStatusSyncRepositoryPreviewDto> ProjectBoardStatusPreviews);

--- a/src/Application/SoloDevBoard.Application/Services/Migration/MigrationResultDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/MigrationResultDto.cs
@@ -2,11 +2,13 @@ using SoloDevBoard.Application.Services.Labels;
 
 namespace SoloDevBoard.Application.Services.Migration;
 
-/// <summary>Represents the migration apply result across labels and milestones.</summary>
+/// <summary>Represents the migration apply result across labels, milestones, and project board columns.</summary>
 /// <param name="ConflictStrategy">The selected conflict strategy used to apply migration.</param>
 /// <param name="LabelResults">Per-repository label apply results.</param>
 /// <param name="MilestoneResults">Per-repository milestone apply results.</param>
+/// <param name="ProjectBoardStatusResults">Per-repository Projects v2 Status column apply results.</param>
 public sealed record MigrationResultDto(
     MigrationConflictStrategy ConflictStrategy,
     IReadOnlyList<LabelSyncRepositoryResultDto> LabelResults,
-    IReadOnlyList<MilestoneSyncRepositoryResultDto> MilestoneResults);
+    IReadOnlyList<MilestoneSyncRepositoryResultDto> MilestoneResults,
+    IReadOnlyList<ProjectBoardStatusSyncRepositoryResultDto> ProjectBoardStatusResults);

--- a/src/Application/SoloDevBoard.Application/Services/Migration/MigrationScopeDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/MigrationScopeDto.cs
@@ -3,4 +3,8 @@ namespace SoloDevBoard.Application.Services.Migration;
 /// <summary>Represents which migration item types should be included.</summary>
 /// <param name="IncludeLabels">A value indicating whether labels are included.</param>
 /// <param name="IncludeMilestones">A value indicating whether milestones are included.</param>
-public sealed record MigrationScopeDto(bool IncludeLabels, bool IncludeMilestones);
+/// <param name="IncludeProjectBoardColumns">A value indicating whether Projects v2 Status columns are included.</param>
+public sealed record MigrationScopeDto(
+    bool IncludeLabels,
+    bool IncludeMilestones,
+    bool IncludeProjectBoardColumns = false);

--- a/src/Application/SoloDevBoard.Application/Services/Migration/MigrationService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/MigrationService.cs
@@ -225,21 +225,34 @@ public sealed class MigrationService : IMigrationService
                 var finalOptions = BuildFinalStatusOptionsForApply(
                     sourceStatusStructure.Options,
                     createdBoard.Options,
-                    MigrationConflictStrategy.Merge,
+                    conflictStrategy,
                     EmptyOptionIdSet);
 
                 await _projectBoardStructureRepository
                     .UpdateStatusOptionsAsync(createdBoard.ProjectId, createdBoard.StatusFieldId, finalOptions, cancellationToken)
                     .ConfigureAwait(false);
 
+                var discovery = await _projectBoardStructureRepository
+                    .DiscoverBoardsAsync(targetOwner, targetRepo, cancellationToken)
+                    .ConfigureAwait(false);
+                var accuratePreview = BuildStatusPreview(
+                    targetRepositoryFullName,
+                    sourceStatusStructure,
+                    createdBoard,
+                    new MigrationTargetBoardSelectionDto(targetRepositoryFullName, createdBoard.ProjectId, targetSelection.NewBoardTitle),
+                    discovery.TotalLinkedProjectCount,
+                    discovery.InaccessibleLinkedProjectCount,
+                    EmptyOptionIdSet,
+                    conflictStrategy);
+
                 return new ProjectBoardStatusSyncRepositoryResultDto(
                     targetRepositoryFullName,
-                    preview.ToCreate.Count,
-                    preview.ToUpdate.Count,
-                    preview.ToDelete.Count,
-                    preview.Skipped.Count,
+                    accuratePreview.ToCreate.Count,
+                    accuratePreview.ToUpdate.Count,
+                    accuratePreview.ToDelete.Count,
+                    accuratePreview.Skipped.Count,
                     createdBoard.ProjectId,
-                    preview.Warnings,
+                    accuratePreview.Warnings,
                     null);
             }
 
@@ -348,16 +361,19 @@ public sealed class MigrationService : IMigrationService
                 .Select(MapToStatusOptionDto)
                 .OrderBy(option => option.Order)
                 .ToArray();
+            var createNewBoardWarnings = createNewBoard
+                ? BuildCreateNewBoardPreviewWarnings(conflictStrategy)
+                : [];
 
             return new ProjectBoardStatusSyncRepositoryPreviewDto(
                 targetRepositoryFullName,
                 targetSelection.TargetProjectId,
-                true,
+                createNewBoard,
                 createOptions,
                 [],
                 [],
                 [],
-                [],
+                createNewBoardWarnings,
                 totalLinkedProjectCount,
                 inaccessibleLinkedProjectCount);
         }
@@ -711,6 +727,16 @@ public sealed class MigrationService : IMigrationService
             && string.Equals(left.Colour, right.Colour, StringComparison.OrdinalIgnoreCase)
             && string.Equals(left.Description, right.Description, StringComparison.Ordinal)
             && left.Order == right.Order;
+
+    private static IReadOnlyList<string> BuildCreateNewBoardPreviewWarnings(MigrationConflictStrategy conflictStrategy)
+    {
+        if (conflictStrategy == MigrationConflictStrategy.Overwrite)
+        {
+            return ["A new linked board will be created. GitHub default Status options that are not in the source will be removed after the board is created."];
+        }
+
+        return ["A new linked board will be created. GitHub default Status options whose names do not match the source may remain on the board."];
+    }
 
     private static LabelDto MapToLabelDto(Label label, string repositoryFullName)
         => new(label.Name, label.Colour, label.Description, repositoryFullName);

--- a/src/Application/SoloDevBoard.Application/Services/Migration/MigrationService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/MigrationService.cs
@@ -1,5 +1,6 @@
 using SoloDevBoard.Application.Services.Labels;
 using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Domain.Entities.Migration;
 using SoloDevBoard.Domain.Entities.Milestones;
 
 namespace SoloDevBoard.Application.Services.Migration;
@@ -9,17 +10,24 @@ public sealed class MigrationService : IMigrationService
 {
     private readonly ILabelRepository _labelRepository;
     private readonly IMilestoneRepository _milestoneRepository;
+    private readonly IProjectBoardStructureRepository _projectBoardStructureRepository;
 
     /// <summary>Initialises a new instance of the <see cref="MigrationService"/> class.</summary>
     /// <param name="labelRepository">The label repository used for migration operations.</param>
     /// <param name="milestoneRepository">The milestone repository used for migration operations.</param>
-    public MigrationService(ILabelRepository labelRepository, IMilestoneRepository milestoneRepository)
+    /// <param name="projectBoardStructureRepository">The project board structure repository used for Status column migration.</param>
+    public MigrationService(
+        ILabelRepository labelRepository,
+        IMilestoneRepository milestoneRepository,
+        IProjectBoardStructureRepository projectBoardStructureRepository)
     {
         ArgumentNullException.ThrowIfNull(labelRepository);
         ArgumentNullException.ThrowIfNull(milestoneRepository);
+        ArgumentNullException.ThrowIfNull(projectBoardStructureRepository);
 
         _labelRepository = labelRepository;
         _milestoneRepository = milestoneRepository;
+        _projectBoardStructureRepository = projectBoardStructureRepository;
     }
 
     /// <inheritdoc/>
@@ -28,11 +36,13 @@ public sealed class MigrationService : IMigrationService
         IReadOnlyList<string> targetRepositoryFullNames,
         MigrationScopeDto scope,
         MigrationConflictStrategy conflictStrategy,
+        MigrationBoardSelectionDto? boardSelection = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(sourceRepositoryFullName);
         ArgumentNullException.ThrowIfNull(scope);
         EnsureAtLeastOneScopeSelected(scope);
+        EnsureBoardSelectionWhenRequired(scope, boardSelection);
 
         var source = SplitRepositoryFullName(sourceRepositoryFullName);
         var normalisedTargets = NormaliseTargetRepositories(targetRepositoryFullNames, sourceRepositoryFullName);
@@ -44,8 +54,17 @@ public sealed class MigrationService : IMigrationService
             ? await _milestoneRepository.GetMilestonesAsync(source.Owner, source.Name, cancellationToken).ConfigureAwait(false)
             : [];
 
+        ProjectBoardStatusStructure? sourceStatusStructure = null;
+        if (scope.IncludeProjectBoardColumns)
+        {
+            sourceStatusStructure = await _projectBoardStructureRepository
+                .GetStatusStructureAsync(boardSelection!.SourceProjectId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         var labelPreviews = new List<LabelSyncRepositoryPreviewDto>();
         var milestonePreviews = new List<MilestoneSyncRepositoryPreviewDto>();
+        var statusPreviews = new List<ProjectBoardStatusSyncRepositoryPreviewDto>();
 
         foreach (var targetRepositoryFullName in normalisedTargets)
         {
@@ -55,22 +74,51 @@ public sealed class MigrationService : IMigrationService
             if (scope.IncludeLabels)
             {
                 var targetLabels = await _labelRepository.GetLabelsAsync(target.Owner, target.Name, cancellationToken).ConfigureAwait(false);
-                var labelPreview = BuildLabelPreview(targetRepositoryFullName, sourceLabels, targetLabels, conflictStrategy);
-                labelPreviews.Add(labelPreview);
+                labelPreviews.Add(BuildLabelPreview(targetRepositoryFullName, sourceLabels, targetLabels, conflictStrategy));
             }
 
             if (scope.IncludeMilestones)
             {
                 var targetMilestones = await _milestoneRepository.GetMilestonesAsync(target.Owner, target.Name, cancellationToken).ConfigureAwait(false);
-                var milestonePreview = BuildMilestonePreview(targetRepositoryFullName, sourceMilestones, targetMilestones, conflictStrategy);
-                milestonePreviews.Add(milestonePreview);
+                milestonePreviews.Add(BuildMilestonePreview(targetRepositoryFullName, sourceMilestones, targetMilestones, conflictStrategy));
+            }
+
+            if (scope.IncludeProjectBoardColumns)
+            {
+                var targetSelection = ResolveTargetBoardSelection(boardSelection!, targetRepositoryFullName);
+                var discovery = await _projectBoardStructureRepository
+                    .DiscoverBoardsAsync(target.Owner, target.Name, cancellationToken)
+                    .ConfigureAwait(false);
+
+                IReadOnlySet<string> optionIdsInUse = EmptyOptionIdSet;
+                ProjectBoardStatusStructure? targetStatusStructure = null;
+                if (!string.IsNullOrWhiteSpace(targetSelection.TargetProjectId))
+                {
+                    targetStatusStructure = await _projectBoardStructureRepository
+                        .GetStatusStructureAsync(targetSelection.TargetProjectId, cancellationToken)
+                        .ConfigureAwait(false);
+                    optionIdsInUse = await _projectBoardStructureRepository
+                        .GetStatusOptionIdsInUseAsync(targetSelection.TargetProjectId, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                statusPreviews.Add(BuildStatusPreview(
+                    targetRepositoryFullName,
+                    sourceStatusStructure!,
+                    targetStatusStructure,
+                    targetSelection,
+                    discovery.TotalLinkedProjectCount,
+                    discovery.InaccessibleLinkedProjectCount,
+                    optionIdsInUse,
+                    conflictStrategy));
             }
         }
 
         return new MigrationPreviewDto(
             conflictStrategy,
             labelPreviews.OrderBy(preview => preview.RepositoryFullName, StringComparer.OrdinalIgnoreCase).ToArray(),
-            milestonePreviews.OrderBy(preview => preview.RepositoryFullName, StringComparer.OrdinalIgnoreCase).ToArray());
+            milestonePreviews.OrderBy(preview => preview.RepositoryFullName, StringComparer.OrdinalIgnoreCase).ToArray(),
+            statusPreviews.OrderBy(preview => preview.RepositoryFullName, StringComparer.OrdinalIgnoreCase).ToArray());
     }
 
     /// <inheritdoc/>
@@ -79,11 +127,13 @@ public sealed class MigrationService : IMigrationService
         IReadOnlyList<string> targetRepositoryFullNames,
         MigrationScopeDto scope,
         MigrationConflictStrategy conflictStrategy,
+        MigrationBoardSelectionDto? boardSelection = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(sourceRepositoryFullName);
         ArgumentNullException.ThrowIfNull(scope);
         EnsureAtLeastOneScopeSelected(scope);
+        EnsureBoardSelectionWhenRequired(scope, boardSelection);
 
         var source = SplitRepositoryFullName(sourceRepositoryFullName);
         var normalisedTargets = NormaliseTargetRepositories(targetRepositoryFullNames, sourceRepositoryFullName);
@@ -95,8 +145,17 @@ public sealed class MigrationService : IMigrationService
             ? await _milestoneRepository.GetMilestonesAsync(source.Owner, source.Name, cancellationToken).ConfigureAwait(false)
             : [];
 
+        ProjectBoardStatusStructure? sourceStatusStructure = null;
+        if (scope.IncludeProjectBoardColumns)
+        {
+            sourceStatusStructure = await _projectBoardStructureRepository
+                .GetStatusStructureAsync(boardSelection!.SourceProjectId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         var labelResults = new List<LabelSyncRepositoryResultDto>();
         var milestoneResults = new List<MilestoneSyncRepositoryResultDto>();
+        var statusResults = new List<ProjectBoardStatusSyncRepositoryResultDto>();
 
         foreach (var targetRepositoryFullName in normalisedTargets)
         {
@@ -112,12 +171,319 @@ public sealed class MigrationService : IMigrationService
             {
                 milestoneResults.Add(await ApplyMilestoneMigrationAsync(targetRepositoryFullName, target.Owner, target.Name, sourceMilestones, conflictStrategy, cancellationToken).ConfigureAwait(false));
             }
+
+            if (scope.IncludeProjectBoardColumns)
+            {
+                var targetSelection = ResolveTargetBoardSelection(boardSelection!, targetRepositoryFullName);
+                statusResults.Add(await ApplyStatusMigrationAsync(
+                    targetRepositoryFullName,
+                    target.Owner,
+                    target.Name,
+                    sourceStatusStructure!,
+                    targetSelection,
+                    conflictStrategy,
+                    cancellationToken).ConfigureAwait(false));
+            }
         }
 
         return new MigrationResultDto(
             conflictStrategy,
             labelResults.OrderBy(result => result.RepositoryFullName, StringComparer.OrdinalIgnoreCase).ToArray(),
-            milestoneResults.OrderBy(result => result.RepositoryFullName, StringComparer.OrdinalIgnoreCase).ToArray());
+            milestoneResults.OrderBy(result => result.RepositoryFullName, StringComparer.OrdinalIgnoreCase).ToArray(),
+            statusResults.OrderBy(result => result.RepositoryFullName, StringComparer.OrdinalIgnoreCase).ToArray());
+    }
+
+    private async Task<ProjectBoardStatusSyncRepositoryResultDto> ApplyStatusMigrationAsync(
+        string targetRepositoryFullName,
+        string targetOwner,
+        string targetRepo,
+        ProjectBoardStatusStructure sourceStatusStructure,
+        MigrationTargetBoardSelectionDto targetSelection,
+        MigrationConflictStrategy conflictStrategy,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var preview = await BuildStatusPreviewForApplyAsync(
+                targetRepositoryFullName,
+                targetOwner,
+                targetRepo,
+                sourceStatusStructure,
+                targetSelection,
+                conflictStrategy,
+                cancellationToken).ConfigureAwait(false);
+
+            if (preview.CreateNewBoard)
+            {
+                var title = string.IsNullOrWhiteSpace(targetSelection.NewBoardTitle)
+                    ? $"{targetRepo} board"
+                    : targetSelection.NewBoardTitle.Trim();
+                var createdBoard = await _projectBoardStructureRepository
+                    .CreateLinkedProjectAsync(targetOwner, targetRepo, title, cancellationToken)
+                    .ConfigureAwait(false);
+
+                var finalOptions = BuildFinalStatusOptionsForApply(
+                    sourceStatusStructure.Options,
+                    createdBoard.Options,
+                    MigrationConflictStrategy.Merge,
+                    EmptyOptionIdSet);
+
+                await _projectBoardStructureRepository
+                    .UpdateStatusOptionsAsync(createdBoard.ProjectId, createdBoard.StatusFieldId, finalOptions, cancellationToken)
+                    .ConfigureAwait(false);
+
+                return new ProjectBoardStatusSyncRepositoryResultDto(
+                    targetRepositoryFullName,
+                    preview.ToCreate.Count,
+                    preview.ToUpdate.Count,
+                    preview.ToDelete.Count,
+                    preview.Skipped.Count,
+                    createdBoard.ProjectId,
+                    preview.Warnings,
+                    null);
+            }
+
+            var targetProjectId = targetSelection.TargetProjectId
+                ?? throw new InvalidOperationException("A target project board must be selected before applying Status column migration.");
+
+            var targetStatusStructure = await _projectBoardStructureRepository
+                .GetStatusStructureAsync(targetProjectId, cancellationToken)
+                .ConfigureAwait(false);
+            var optionIdsInUse = await _projectBoardStructureRepository
+                .GetStatusOptionIdsInUseAsync(targetProjectId, cancellationToken)
+                .ConfigureAwait(false);
+
+            var optionsToPersist = BuildFinalStatusOptionsForApply(
+                sourceStatusStructure.Options,
+                targetStatusStructure.Options,
+                conflictStrategy,
+                optionIdsInUse);
+
+            await _projectBoardStructureRepository
+                .UpdateStatusOptionsAsync(targetProjectId, targetStatusStructure.StatusFieldId, optionsToPersist, cancellationToken)
+                .ConfigureAwait(false);
+
+            return new ProjectBoardStatusSyncRepositoryResultDto(
+                targetRepositoryFullName,
+                preview.ToCreate.Count,
+                preview.ToUpdate.Count,
+                preview.ToDelete.Count,
+                preview.Skipped.Count,
+                null,
+                preview.Warnings,
+                null);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or KeyNotFoundException or ArgumentException or InvalidOperationException)
+        {
+            return new ProjectBoardStatusSyncRepositoryResultDto(
+                targetRepositoryFullName,
+                0,
+                0,
+                0,
+                0,
+                null,
+                [],
+                ex.Message);
+        }
+    }
+
+    private async Task<ProjectBoardStatusSyncRepositoryPreviewDto> BuildStatusPreviewForApplyAsync(
+        string targetRepositoryFullName,
+        string targetOwner,
+        string targetRepo,
+        ProjectBoardStatusStructure sourceStatusStructure,
+        MigrationTargetBoardSelectionDto targetSelection,
+        MigrationConflictStrategy conflictStrategy,
+        CancellationToken cancellationToken)
+    {
+        var discovery = await _projectBoardStructureRepository
+            .DiscoverBoardsAsync(targetOwner, targetRepo, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (targetSelection.TargetProjectId is null)
+        {
+            return BuildStatusPreview(
+                targetRepositoryFullName,
+                sourceStatusStructure,
+                null,
+                targetSelection,
+                discovery.TotalLinkedProjectCount,
+                discovery.InaccessibleLinkedProjectCount,
+                EmptyOptionIdSet,
+                conflictStrategy);
+        }
+
+        var targetStatusStructure = await _projectBoardStructureRepository
+            .GetStatusStructureAsync(targetSelection.TargetProjectId, cancellationToken)
+            .ConfigureAwait(false);
+        var optionIdsInUse = await _projectBoardStructureRepository
+            .GetStatusOptionIdsInUseAsync(targetSelection.TargetProjectId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return BuildStatusPreview(
+            targetRepositoryFullName,
+            sourceStatusStructure,
+            targetStatusStructure,
+            targetSelection,
+            discovery.TotalLinkedProjectCount,
+            discovery.InaccessibleLinkedProjectCount,
+            optionIdsInUse,
+            conflictStrategy);
+    }
+
+    private static ProjectBoardStatusSyncRepositoryPreviewDto BuildStatusPreview(
+        string targetRepositoryFullName,
+        ProjectBoardStatusStructure sourceStatusStructure,
+        ProjectBoardStatusStructure? targetStatusStructure,
+        MigrationTargetBoardSelectionDto targetSelection,
+        int totalLinkedProjectCount,
+        int inaccessibleLinkedProjectCount,
+        IReadOnlySet<string> optionIdsInUse,
+        MigrationConflictStrategy conflictStrategy)
+    {
+        var createNewBoard = string.IsNullOrWhiteSpace(targetSelection.TargetProjectId);
+        if (createNewBoard || targetStatusStructure is null)
+        {
+            var createOptions = sourceStatusStructure.Options
+                .Select(MapToStatusOptionDto)
+                .OrderBy(option => option.Order)
+                .ToArray();
+
+            return new ProjectBoardStatusSyncRepositoryPreviewDto(
+                targetRepositoryFullName,
+                targetSelection.TargetProjectId,
+                true,
+                createOptions,
+                [],
+                [],
+                [],
+                [],
+                totalLinkedProjectCount,
+                inaccessibleLinkedProjectCount);
+        }
+
+        var sourceByName = sourceStatusStructure.Options.ToDictionary(option => option.Name, StringComparer.OrdinalIgnoreCase);
+        var targetByName = targetStatusStructure.Options.ToDictionary(option => option.Name, StringComparer.OrdinalIgnoreCase);
+
+        var toCreate = sourceStatusStructure.Options
+            .Where(source => !targetByName.ContainsKey(source.Name))
+            .Select(MapToStatusOptionDto)
+            .OrderBy(option => option.Order)
+            .ToArray();
+
+        var toUpdate = conflictStrategy switch
+        {
+            MigrationConflictStrategy.Skip => Array.Empty<ProjectBoardStatusOptionDto>(),
+            _ => sourceStatusStructure.Options
+                .Where(source => targetByName.TryGetValue(source.Name, out var target) && !HasSameStatusValues(source, target))
+                .Select(source =>
+                {
+                    var targetOption = targetByName[source.Name];
+                    return MapToStatusOptionDto(source with { Id = targetOption.Id });
+                })
+                .OrderBy(option => option.Name, StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
+        };
+
+        var warnings = new List<string>();
+        var toDelete = new List<ProjectBoardStatusOptionDto>();
+        if (conflictStrategy == MigrationConflictStrategy.Overwrite)
+        {
+            foreach (var target in targetStatusStructure.Options.Where(target => !sourceByName.ContainsKey(target.Name)))
+            {
+                if (optionIdsInUse.Contains(target.Id))
+                {
+                    warnings.Add($"Status option '{target.Name}' was not removed because board items still use it.");
+                    continue;
+                }
+
+                toDelete.Add(MapToStatusOptionDto(target));
+            }
+        }
+
+        var skipped = BuildSkippedStatusItems(sourceStatusStructure.Options, targetByName, conflictStrategy);
+
+        return new ProjectBoardStatusSyncRepositoryPreviewDto(
+            targetRepositoryFullName,
+            targetSelection.TargetProjectId,
+            false,
+            toCreate,
+            toUpdate,
+            toDelete.OrderBy(option => option.Name, StringComparer.OrdinalIgnoreCase).ToArray(),
+            skipped,
+            warnings,
+            totalLinkedProjectCount,
+            inaccessibleLinkedProjectCount);
+    }
+
+    private static IReadOnlyList<ProjectBoardStatusOptionDto> BuildSkippedStatusItems(
+        IReadOnlyList<ProjectBoardStatusStructureOption> sourceOptions,
+        IReadOnlyDictionary<string, ProjectBoardStatusStructureOption> targetByName,
+        MigrationConflictStrategy conflictStrategy)
+    {
+        return sourceOptions
+            .Where(source => targetByName.TryGetValue(source.Name, out var target)
+                && (conflictStrategy == MigrationConflictStrategy.Skip || HasSameStatusValues(source, target)))
+            .Select(source =>
+            {
+                var targetOption = targetByName[source.Name];
+                return MapToStatusOptionDto(targetOption);
+            })
+            .OrderBy(option => option.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<ProjectBoardStatusStructureOption> BuildFinalStatusOptionsForApply(
+        IReadOnlyList<ProjectBoardStatusStructureOption> sourceOptions,
+        IReadOnlyList<ProjectBoardStatusStructureOption> targetOptions,
+        MigrationConflictStrategy conflictStrategy,
+        IReadOnlySet<string> optionIdsInUse)
+    {
+        var targetByName = targetOptions.ToDictionary(option => option.Name, StringComparer.OrdinalIgnoreCase);
+        var sourceByName = sourceOptions.ToDictionary(option => option.Name, StringComparer.OrdinalIgnoreCase);
+        var result = new List<ProjectBoardStatusStructureOption>();
+
+        foreach (var source in sourceOptions.OrderBy(option => option.Order))
+        {
+            if (targetByName.TryGetValue(source.Name, out var target))
+            {
+                if (conflictStrategy == MigrationConflictStrategy.Skip)
+                {
+                    result.Add(target with { Order = result.Count });
+                }
+                else
+                {
+                    result.Add(source with { Id = target.Id, Order = result.Count });
+                }
+            }
+            else
+            {
+                result.Add(source with { Id = string.Empty, Order = result.Count });
+            }
+        }
+
+        if (conflictStrategy != MigrationConflictStrategy.Overwrite)
+        {
+            foreach (var target in targetOptions.OrderBy(option => option.Order))
+            {
+                if (!sourceByName.ContainsKey(target.Name))
+                {
+                    result.Add(target with { Order = result.Count });
+                }
+            }
+
+            return result;
+        }
+
+        foreach (var target in targetOptions.OrderBy(option => option.Order))
+        {
+            if (!sourceByName.ContainsKey(target.Name) && optionIdsInUse.Contains(target.Id))
+            {
+                result.Add(target with { Order = result.Count });
+            }
+        }
+
+        return result;
     }
 
     private async Task<LabelSyncRepositoryResultDto> ApplyLabelMigrationAsync(
@@ -320,6 +686,32 @@ public sealed class MigrationService : IMigrationService
             .ToArray();
     }
 
+    private static MigrationTargetBoardSelectionDto ResolveTargetBoardSelection(
+        MigrationBoardSelectionDto boardSelection,
+        string targetRepositoryFullName)
+    {
+        var selection = boardSelection.TargetSelections
+            .FirstOrDefault(target => target.RepositoryFullName.Equals(targetRepositoryFullName, StringComparison.OrdinalIgnoreCase));
+
+        if (selection is null)
+        {
+            throw new ArgumentException(
+                $"Board selection is missing for target repository '{targetRepositoryFullName}'.",
+                nameof(boardSelection));
+        }
+
+        return selection;
+    }
+
+    private static ProjectBoardStatusOptionDto MapToStatusOptionDto(ProjectBoardStatusStructureOption option)
+        => new(option.Id, option.Name, option.Colour, option.Description, option.Order);
+
+    private static bool HasSameStatusValues(ProjectBoardStatusStructureOption left, ProjectBoardStatusStructureOption right)
+        => string.Equals(left.Name, right.Name, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(left.Colour, right.Colour, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(left.Description, right.Description, StringComparison.Ordinal)
+            && left.Order == right.Order;
+
     private static LabelDto MapToLabelDto(Label label, string repositoryFullName)
         => new(label.Name, label.Colour, label.Description, repositoryFullName);
 
@@ -405,11 +797,33 @@ public sealed class MigrationService : IMigrationService
 
     private static void EnsureAtLeastOneScopeSelected(MigrationScopeDto scope)
     {
-        if (!scope.IncludeLabels && !scope.IncludeMilestones)
+        if (!scope.IncludeLabels && !scope.IncludeMilestones && !scope.IncludeProjectBoardColumns)
         {
             throw new ArgumentException("At least one migration item type must be selected.", nameof(scope));
         }
     }
+
+    private static void EnsureBoardSelectionWhenRequired(MigrationScopeDto scope, MigrationBoardSelectionDto? boardSelection)
+    {
+        if (!scope.IncludeProjectBoardColumns)
+        {
+            return;
+        }
+
+        ArgumentNullException.ThrowIfNull(boardSelection);
+
+        if (string.IsNullOrWhiteSpace(boardSelection.SourceProjectId))
+        {
+            throw new ArgumentException("A source project board must be selected when project board columns are included.", nameof(boardSelection));
+        }
+
+        if (boardSelection.TargetSelections.Count == 0)
+        {
+            throw new ArgumentException("At least one target board selection must be provided.", nameof(boardSelection));
+        }
+    }
+
+    private static readonly IReadOnlySet<string> EmptyOptionIdSet = new HashSet<string>(StringComparer.Ordinal);
 
     private sealed record RepositoryCoordinates(string Owner, string Name);
 }

--- a/src/Application/SoloDevBoard.Application/Services/Migration/MigrationTargetBoardSelectionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/MigrationTargetBoardSelectionDto.cs
@@ -1,0 +1,10 @@
+namespace SoloDevBoard.Application.Services.Migration;
+
+/// <summary>Represents the board selection for a single target repository.</summary>
+/// <param name="RepositoryFullName">The target repository in owner/repository format.</param>
+/// <param name="TargetProjectId">The selected target project board identifier, or <see langword="null"/> when creating a new board.</param>
+/// <param name="NewBoardTitle">The title for a newly created board when <paramref name="TargetProjectId"/> is <see langword="null"/>.</param>
+public sealed record MigrationTargetBoardSelectionDto(
+    string RepositoryFullName,
+    string? TargetProjectId,
+    string? NewBoardTitle);

--- a/src/Application/SoloDevBoard.Application/Services/Migration/ProjectBoardStatusOptionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/ProjectBoardStatusOptionDto.cs
@@ -1,0 +1,14 @@
+namespace SoloDevBoard.Application.Services.Migration;
+
+/// <summary>Represents a Projects v2 Status option in migration preview and apply results.</summary>
+/// <param name="Id">The GitHub node identifier for the option, when known.</param>
+/// <param name="Name">The display name of the option.</param>
+/// <param name="Colour">The GitHub single-select colour enum value.</param>
+/// <param name="Description">The plain-text description of the option.</param>
+/// <param name="Order">The zero-based display order of the option.</param>
+public sealed record ProjectBoardStatusOptionDto(
+    string Id,
+    string Name,
+    string Colour,
+    string Description,
+    int Order);

--- a/src/Application/SoloDevBoard.Application/Services/Migration/ProjectBoardStatusSyncRepositoryPreviewDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/ProjectBoardStatusSyncRepositoryPreviewDto.cs
@@ -1,0 +1,24 @@
+namespace SoloDevBoard.Application.Services.Migration;
+
+/// <summary>Represents a Projects v2 Status column synchronisation preview for a target repository.</summary>
+/// <param name="RepositoryFullName">The target repository in owner/repository format.</param>
+/// <param name="TargetProjectId">The selected target project board identifier, or <see langword="null"/> when creating a new board.</param>
+/// <param name="CreateNewBoard">A value indicating whether a new linked board will be created.</param>
+/// <param name="ToCreate">The Status options to create on the target board.</param>
+/// <param name="ToUpdate">The Status options to update on the target board.</param>
+/// <param name="ToDelete">The Status options to remove from the target board.</param>
+/// <param name="Skipped">The Status options skipped by conflict strategy rules.</param>
+/// <param name="Warnings">Warning messages for operations that cannot be completed safely.</param>
+/// <param name="TotalLinkedProjectCount">The total number of linked project boards reported by GitHub.</param>
+/// <param name="InaccessibleLinkedProjectCount">The number of linked project boards that are inaccessible to the current credentials.</param>
+public sealed record ProjectBoardStatusSyncRepositoryPreviewDto(
+    string RepositoryFullName,
+    string? TargetProjectId,
+    bool CreateNewBoard,
+    IReadOnlyList<ProjectBoardStatusOptionDto> ToCreate,
+    IReadOnlyList<ProjectBoardStatusOptionDto> ToUpdate,
+    IReadOnlyList<ProjectBoardStatusOptionDto> ToDelete,
+    IReadOnlyList<ProjectBoardStatusOptionDto> Skipped,
+    IReadOnlyList<string> Warnings,
+    int TotalLinkedProjectCount,
+    int InaccessibleLinkedProjectCount);

--- a/src/Application/SoloDevBoard.Application/Services/Migration/ProjectBoardStatusSyncRepositoryResultDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/ProjectBoardStatusSyncRepositoryResultDto.cs
@@ -1,0 +1,20 @@
+namespace SoloDevBoard.Application.Services.Migration;
+
+/// <summary>Represents a Projects v2 Status column synchronisation apply result for a target repository.</summary>
+/// <param name="RepositoryFullName">The target repository in owner/repository format.</param>
+/// <param name="CreatedCount">The number of Status options created.</param>
+/// <param name="UpdatedCount">The number of Status options updated.</param>
+/// <param name="DeletedCount">The number of Status options removed.</param>
+/// <param name="SkippedCount">The number of Status options skipped.</param>
+/// <param name="CreatedProjectId">The identifier of a newly created project board, when applicable.</param>
+/// <param name="Warnings">Warning messages for operations that could not be completed safely.</param>
+/// <param name="ErrorMessage">An error message when apply failed for this repository.</param>
+public sealed record ProjectBoardStatusSyncRepositoryResultDto(
+    string RepositoryFullName,
+    int CreatedCount,
+    int UpdatedCount,
+    int DeletedCount,
+    int SkippedCount,
+    string? CreatedProjectId,
+    IReadOnlyList<string> Warnings,
+    string? ErrorMessage);

--- a/src/Application/SoloDevBoard.Application/Services/Migration/ProjectBoardStatusSyncRepositoryResultDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/ProjectBoardStatusSyncRepositoryResultDto.cs
@@ -17,4 +17,8 @@ public sealed record ProjectBoardStatusSyncRepositoryResultDto(
     int SkippedCount,
     string? CreatedProjectId,
     IReadOnlyList<string> Warnings,
-    string? ErrorMessage);
+    string? ErrorMessage)
+{
+    /// <summary>Gets a value indicating whether the synchronisation failed for this repository.</summary>
+    public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/Migration/ProjectBoardDiscovery.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Migration/ProjectBoardDiscovery.cs
@@ -1,0 +1,14 @@
+namespace SoloDevBoard.Domain.Entities.Migration;
+
+/// <summary>Represents Projects v2 board discovery for a repository, including visibility metadata.</summary>
+public sealed record ProjectBoardDiscovery
+{
+    /// <summary>Gets supported project boards that expose a Status field with options.</summary>
+    public IReadOnlyList<ProjectBoardStatusStructure> SupportedBoards { get; init; } = [];
+
+    /// <summary>Gets the total number of linked project boards reported by GitHub.</summary>
+    public int TotalLinkedProjectCount { get; init; }
+
+    /// <summary>Gets the number of linked project boards that are inaccessible to the current credentials.</summary>
+    public int InaccessibleLinkedProjectCount { get; init; }
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/Migration/ProjectBoardStatusStructure.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Migration/ProjectBoardStatusStructure.cs
@@ -1,0 +1,17 @@
+namespace SoloDevBoard.Domain.Entities.Migration;
+
+/// <summary>Represents the Status field structure for a Projects v2 board.</summary>
+public sealed record ProjectBoardStatusStructure
+{
+    /// <summary>Gets the GitHub node identifier for the project board.</summary>
+    public string ProjectId { get; init; } = string.Empty;
+
+    /// <summary>Gets the project board title.</summary>
+    public string ProjectTitle { get; init; } = string.Empty;
+
+    /// <summary>Gets the Status field node identifier for the board.</summary>
+    public string StatusFieldId { get; init; } = string.Empty;
+
+    /// <summary>Gets the Status field options in board-defined order.</summary>
+    public IReadOnlyList<ProjectBoardStatusStructureOption> Options { get; init; } = [];
+}

--- a/src/Domain/SoloDevBoard.Domain/Entities/Migration/ProjectBoardStatusStructureOption.cs
+++ b/src/Domain/SoloDevBoard.Domain/Entities/Migration/ProjectBoardStatusStructureOption.cs
@@ -1,0 +1,20 @@
+namespace SoloDevBoard.Domain.Entities.Migration;
+
+/// <summary>Represents a Projects v2 Status single-select option within a board structure.</summary>
+public sealed record ProjectBoardStatusStructureOption
+{
+    /// <summary>Gets the GitHub node identifier for the status option.</summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Gets the display name of the status option.</summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Gets the GitHub single-select colour enum value (for example, GRAY or BLUE).</summary>
+    public string Colour { get; init; } = "GRAY";
+
+    /// <summary>Gets the plain-text description of the status option.</summary>
+    public string Description { get; init; } = string.Empty;
+
+    /// <summary>Gets the zero-based display order of the option on the board.</summary>
+    public int Order { get; init; }
+}

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/Common/InfrastructureServiceExtensions.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/Common/InfrastructureServiceExtensions.cs
@@ -10,6 +10,7 @@ using SoloDevBoard.Application.Services.Workflows;
 using SoloDevBoard.Infrastructure.GitHub;
 using SoloDevBoard.Infrastructure.Identity;
 using SoloDevBoard.Infrastructure.Labels;
+using SoloDevBoard.Infrastructure.Migration;
 using SoloDevBoard.Infrastructure.Milestones;
 using SoloDevBoard.Infrastructure.Workflows;
 
@@ -114,6 +115,7 @@ public static class InfrastructureServiceExtensions
         services.AddScoped<IGitHubService, GitHubService>();
         services.AddScoped<ILabelRepository, GitHubLabelRepository>();
         services.AddScoped<IMilestoneRepository, GitHubMilestoneRepository>();
+        services.AddScoped<IProjectBoardStructureRepository, GitHubProjectBoardStructureRepository>();
         services.AddScoped<IWorkflowFileRepository, GitHubWorkflowFileRepository>();
 
         return services;

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
@@ -424,53 +424,15 @@ public sealed class GitHubService : IGitHubService
     /// <inheritdoc/>
     public async Task<RepositoryProjectBoardDiscoveryResult> GetProjectBoardsForRepositoryAsync(string owner, string repo, CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
-        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        var discovery = await DiscoverRepositoryLinkedProjectBoardNodesAsync(owner, repo, cancellationToken).ConfigureAwait(false);
 
-        const string query = "query TriageProjectBoards($owner: String!, $repo: String!) { repository(owner: $owner, name: $repo) { projectsV2(first: 50) { nodes { id title public owner { ... on User { login } ... on Organization { login } } fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } } }";
-
-        var client = CreateAuthenticatedClient();
-        var requestBody = new GraphQlRequestDto(
-            query,
-            new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["owner"] = owner,
-                ["repo"] = repo,
-            });
-
-        using var response = await client.PostAsJsonAsync("/graphql", requestBody, JsonOptions, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
-
-        var payload = await response.Content.ReadFromJsonAsync<GetProjectBoardsResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
-            ?? throw CreateInvalidResponseException("GraphQL response body was empty.", "/graphql");
-
-        var rawNodes = payload.Data?.Repository?.ProjectsV2?.Nodes ?? [];
-        var accessibleNodes = rawNodes
-            .Where(static node => node is not null)
-            .Select(static node => node!)
-            .ToArray();
-
-        if (_docsCaptureOptions.Enabled)
+        if (discovery.Errors.Count > 0 && discovery.AccessibleNodes.Count == 0)
         {
-            accessibleNodes = accessibleNodes
-                .Where(static node => node.IsPublic)
-                .ToArray();
-        }
-
-        var totalLinkedProjectCount = _docsCaptureOptions.Enabled
-            ? accessibleNodes.Length
-            : rawNodes.Count;
-        var inaccessibleLinkedProjectCount = _docsCaptureOptions.Enabled
-            ? 0
-            : rawNodes.Count - accessibleNodes.Length;
-
-        if (payload.Errors.Count > 0 && accessibleNodes.Length == 0)
-        {
-            var combinedErrors = string.Join("; ", payload.Errors.Select(static error => error.Message));
+            var combinedErrors = string.Join("; ", discovery.Errors.Select(static error => error.Message));
             throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
         }
 
-        var supportedProjectBoards = accessibleNodes
+        var supportedProjectBoards = discovery.AccessibleNodes
             .Select(ToProjectBoardDomain)
             .Where(static projectBoard => projectBoard is not null)
             .Select(static projectBoard => projectBoard!)
@@ -479,8 +441,8 @@ public sealed class GitHubService : IGitHubService
 
         return new RepositoryProjectBoardDiscoveryResult(
             supportedProjectBoards,
-            totalLinkedProjectCount,
-            inaccessibleLinkedProjectCount);
+            discovery.TotalLinkedProjectCount,
+            discovery.InaccessibleLinkedProjectCount);
     }
 
     /// <inheritdoc/>
@@ -743,48 +705,15 @@ public sealed class GitHubService : IGitHubService
     /// <inheritdoc/>
     public async Task<ProjectBoardDiscovery> DiscoverProjectBoardStatusStructuresAsync(string owner, string repo, CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
-        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        var discovery = await DiscoverRepositoryLinkedProjectBoardNodesAsync(owner, repo, cancellationToken).ConfigureAwait(false);
 
-        const string query = "query MigrationProjectBoardDiscovery($owner: String!, $repo: String!) { repository(owner: $owner, name: $repo) { projectsV2(first: 50) { nodes { id title public owner { ... on User { login } ... on Organization { login } } fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name color description } } } } } } } }";
-
-        var client = CreateAuthenticatedClient();
-        var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
+        if (discovery.Errors.Count > 0 && discovery.AccessibleNodes.Count == 0)
         {
-            ["owner"] = owner,
-            ["repo"] = repo,
-        };
-
-        var payload = await PostGraphQlAsync<GetProjectBoardsResponseDto>(client, query, variables, cancellationToken)
-            .ConfigureAwait(false);
-
-        var rawNodes = payload.Data?.Repository?.ProjectsV2?.Nodes ?? [];
-        var accessibleNodes = rawNodes
-            .Where(static node => node is not null)
-            .Select(static node => node!)
-            .ToArray();
-
-        if (_docsCaptureOptions.Enabled)
-        {
-            accessibleNodes = accessibleNodes
-                .Where(static node => node.IsPublic)
-                .ToArray();
-        }
-
-        var totalLinkedProjectCount = _docsCaptureOptions.Enabled
-            ? accessibleNodes.Length
-            : rawNodes.Count;
-        var inaccessibleLinkedProjectCount = _docsCaptureOptions.Enabled
-            ? 0
-            : rawNodes.Count - accessibleNodes.Length;
-
-        if (payload.Errors.Count > 0 && accessibleNodes.Length == 0)
-        {
-            var combinedErrors = string.Join("; ", payload.Errors.Select(static error => error.Message));
+            var combinedErrors = string.Join("; ", discovery.Errors.Select(static error => error.Message));
             throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
         }
 
-        var supportedBoards = accessibleNodes
+        var supportedBoards = discovery.AccessibleNodes
             .Select(ToProjectBoardStatusStructureDomain)
             .Where(static structure => structure is not null)
             .Select(static structure => structure!)
@@ -794,8 +723,8 @@ public sealed class GitHubService : IGitHubService
         return new ProjectBoardDiscovery
         {
             SupportedBoards = supportedBoards,
-            TotalLinkedProjectCount = totalLinkedProjectCount,
-            InaccessibleLinkedProjectCount = inaccessibleLinkedProjectCount,
+            TotalLinkedProjectCount = discovery.TotalLinkedProjectCount,
+            InaccessibleLinkedProjectCount = discovery.InaccessibleLinkedProjectCount,
         };
     }
 
@@ -1277,6 +1206,72 @@ public sealed class GitHubService : IGitHubService
             $"GitHub API request failed with status code {(int)response.StatusCode} ({response.StatusCode}). Response body: {responseBody}",
             null,
             response.StatusCode);
+    }
+
+    private const string RepositoryLinkedProjectBoardDiscoveryQuery =
+        "query RepositoryLinkedProjectBoardDiscovery($owner: String!, $repo: String!) { repository(owner: $owner, name: $repo) { projectsV2(first: 50) { nodes { id title public owner { ... on User { login } ... on Organization { login } } fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name color description } } } } } } } }";
+
+    private sealed record RepositoryLinkedProjectBoardNodesDiscovery(
+        IReadOnlyList<ProjectBoardNodeDto> AccessibleNodes,
+        int TotalLinkedProjectCount,
+        int InaccessibleLinkedProjectCount,
+        IReadOnlyList<GraphQlErrorDto> Errors);
+
+    private async Task<RepositoryLinkedProjectBoardNodesDiscovery> DiscoverRepositoryLinkedProjectBoardNodesAsync(
+        string owner,
+        string repo,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var client = CreateAuthenticatedClient();
+        var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["owner"] = owner,
+            ["repo"] = repo,
+        };
+
+        var requestBody = new GraphQlObjectVariablesRequestDto(RepositoryLinkedProjectBoardDiscoveryQuery, variables);
+        using var response = await client.PostAsJsonAsync("/graphql", requestBody, JsonOptions, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStatusCodeAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var payload = await response.Content.ReadFromJsonAsync<GetProjectBoardsResponseDto>(JsonOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw CreateInvalidResponseException("GraphQL response body was empty.", "/graphql");
+
+        return ResolveRepositoryLinkedProjectBoardNodesDiscovery(
+            payload.Data?.Repository?.ProjectsV2?.Nodes ?? [],
+            payload.Errors);
+    }
+
+    private RepositoryLinkedProjectBoardNodesDiscovery ResolveRepositoryLinkedProjectBoardNodesDiscovery(
+        IReadOnlyList<ProjectBoardNodeDto> rawNodes,
+        IReadOnlyList<GraphQlErrorDto> errors)
+    {
+        var accessibleNodes = rawNodes
+            .Where(static node => node is not null)
+            .Select(static node => node!)
+            .ToArray();
+
+        if (_docsCaptureOptions.Enabled)
+        {
+            accessibleNodes = accessibleNodes
+                .Where(static node => node.IsPublic)
+                .ToArray();
+        }
+
+        var totalLinkedProjectCount = _docsCaptureOptions.Enabled
+            ? accessibleNodes.Length
+            : rawNodes.Count;
+        var inaccessibleLinkedProjectCount = _docsCaptureOptions.Enabled
+            ? 0
+            : rawNodes.Count - accessibleNodes.Length;
+
+        return new RepositoryLinkedProjectBoardNodesDiscovery(
+            accessibleNodes,
+            totalLinkedProjectCount,
+            inaccessibleLinkedProjectCount,
+            errors);
     }
 
     private static TriageProjectBoard? ToProjectBoardDomain(ProjectBoardNodeDto? node)

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/GitHub/GitHubService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using SoloDevBoard.Application.Services.BoardRules;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Domain.Entities.Migration;
 using SoloDevBoard.Domain.Entities.Milestones;
 using SoloDevBoard.Domain.Entities.PmWorkflow;
 using SoloDevBoard.Domain.Entities.Repositories;
@@ -740,6 +741,233 @@ public sealed class GitHubService : IGitHubService
     }
 
     /// <inheritdoc/>
+    public async Task<ProjectBoardDiscovery> DiscoverProjectBoardStatusStructuresAsync(string owner, string repo, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        const string query = "query MigrationProjectBoardDiscovery($owner: String!, $repo: String!) { repository(owner: $owner, name: $repo) { projectsV2(first: 50) { nodes { id title public owner { ... on User { login } ... on Organization { login } } fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name color description } } } } } } } }";
+
+        var client = CreateAuthenticatedClient();
+        var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["owner"] = owner,
+            ["repo"] = repo,
+        };
+
+        var payload = await PostGraphQlAsync<GetProjectBoardsResponseDto>(client, query, variables, cancellationToken)
+            .ConfigureAwait(false);
+
+        var rawNodes = payload.Data?.Repository?.ProjectsV2?.Nodes ?? [];
+        var accessibleNodes = rawNodes
+            .Where(static node => node is not null)
+            .Select(static node => node!)
+            .ToArray();
+
+        if (_docsCaptureOptions.Enabled)
+        {
+            accessibleNodes = accessibleNodes
+                .Where(static node => node.IsPublic)
+                .ToArray();
+        }
+
+        var totalLinkedProjectCount = _docsCaptureOptions.Enabled
+            ? accessibleNodes.Length
+            : rawNodes.Count;
+        var inaccessibleLinkedProjectCount = _docsCaptureOptions.Enabled
+            ? 0
+            : rawNodes.Count - accessibleNodes.Length;
+
+        if (payload.Errors.Count > 0 && accessibleNodes.Length == 0)
+        {
+            var combinedErrors = string.Join("; ", payload.Errors.Select(static error => error.Message));
+            throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
+        }
+
+        var supportedBoards = accessibleNodes
+            .Select(ToProjectBoardStatusStructureDomain)
+            .Where(static structure => structure is not null)
+            .Select(static structure => structure!)
+            .OrderBy(structure => structure.ProjectTitle, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return new ProjectBoardDiscovery
+        {
+            SupportedBoards = supportedBoards,
+            TotalLinkedProjectCount = totalLinkedProjectCount,
+            InaccessibleLinkedProjectCount = inaccessibleLinkedProjectCount,
+        };
+    }
+
+    /// <inheritdoc/>
+    public async Task<ProjectBoardStatusStructure> GetProjectBoardStatusStructureAsync(string projectId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+
+        const string query = "query ProjectBoardStatusStructure($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { id title fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name color description } } } } } } }";
+
+        var client = CreateAuthenticatedClient();
+        var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["projectId"] = projectId,
+        };
+
+        var payload = await PostGraphQlAsync<GetProjectBoardStatusStructureResponseDto>(client, query, variables, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (payload.Errors.Count > 0)
+        {
+            var combinedErrors = string.Join("; ", payload.Errors.Select(static error => error.Message));
+            throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
+        }
+
+        var structure = ToProjectBoardStatusStructureDomain(payload.Data?.Node);
+        if (structure is null)
+        {
+            throw CreateInvalidResponseException("GraphQL response did not contain a supported Status field structure.", "/graphql");
+        }
+
+        return structure;
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> GetRepositoryNodeIdAsync(string owner, string repo, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        const string query = "query RepositoryNodeId($owner: String!, $repo: String!) { repository(owner: $owner, name: $repo) { id } }";
+
+        var client = CreateAuthenticatedClient();
+        var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["owner"] = owner,
+            ["repo"] = repo,
+        };
+
+        var payload = await PostGraphQlAsync<GetRepositoryNodeIdResponseDto>(client, query, variables, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (payload.Errors.Count > 0)
+        {
+            var combinedErrors = string.Join("; ", payload.Errors.Select(static error => error.Message));
+            throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
+        }
+
+        var repositoryId = payload.Data?.Repository?.Id;
+        if (string.IsNullOrWhiteSpace(repositoryId))
+        {
+            throw CreateInvalidResponseException("GraphQL response did not contain the repository node identifier.", "/graphql");
+        }
+
+        return repositoryId;
+    }
+
+    /// <inheritdoc/>
+    public async Task<ProjectBoardStatusStructure> CreateRepositoryLinkedProjectAsync(string owner, string repo, string title, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+
+        var repositoryId = await GetRepositoryNodeIdAsync(owner, repo, cancellationToken).ConfigureAwait(false);
+
+        const string mutation = "mutation CreateRepositoryLinkedProject($title: String!, $repositoryId: ID!) { createProjectV2(input: { title: $title, repositoryId: $repositoryId }) { projectV2 { id title fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name color description } } } } } } }";
+
+        var client = CreateAuthenticatedClient();
+        var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["title"] = title,
+            ["repositoryId"] = repositoryId,
+        };
+
+        var payload = await PostGraphQlAsync<CreateRepositoryLinkedProjectResponseDto>(client, mutation, variables, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (payload.Errors.Count > 0)
+        {
+            var combinedErrors = string.Join("; ", payload.Errors.Select(static error => error.Message));
+            throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
+        }
+
+        var structure = ToProjectBoardStatusStructureDomain(payload.Data?.CreateProjectV2?.ProjectV2);
+        if (structure is null)
+        {
+            throw CreateInvalidResponseException("GraphQL response did not contain a supported Status field structure.", "/graphql");
+        }
+
+        return structure;
+    }
+
+    /// <inheritdoc/>
+    public async Task<ProjectBoardStatusStructure> UpdateProjectBoardStatusOptionsAsync(
+        string projectId,
+        string statusFieldId,
+        IReadOnlyList<ProjectBoardStatusStructureOption> options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(statusFieldId);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.Count == 0)
+        {
+            throw new ArgumentException("At least one Status option must be provided.", nameof(options));
+        }
+
+        const string mutation = "mutation UpdateProjectBoardStatusField($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) { updateProjectV2Field(input: { fieldId: $fieldId, singleSelectOptions: $options }) { projectV2Field { ... on ProjectV2SingleSelectField { id name options { id name color description } } } } }";
+
+        var optionInputs = options
+            .Select(option =>
+            {
+                var input = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["name"] = option.Name,
+                    ["color"] = option.Colour,
+                    ["description"] = option.Description ?? string.Empty,
+                };
+
+                if (!string.IsNullOrWhiteSpace(option.Id))
+                {
+                    input["id"] = option.Id;
+                }
+
+                return input;
+            })
+            .ToArray();
+
+        var client = CreateAuthenticatedClient();
+        var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["fieldId"] = statusFieldId,
+            ["options"] = optionInputs,
+        };
+
+        var payload = await PostGraphQlAsync<UpdateProjectBoardStatusFieldResponseDto>(client, mutation, variables, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (payload.Errors.Count > 0)
+        {
+            var combinedErrors = string.Join("; ", payload.Errors.Select(static error => error.Message));
+            throw new HttpRequestException($"GitHub GraphQL request failed. Errors: {combinedErrors}");
+        }
+
+        var updatedField = payload.Data?.UpdateProjectV2Field?.ProjectV2Field;
+        if (updatedField is null || string.IsNullOrWhiteSpace(updatedField.Id))
+        {
+            throw CreateInvalidResponseException("GraphQL response did not contain the updated Status field.", "/graphql");
+        }
+
+        return new ProjectBoardStatusStructure
+        {
+            ProjectId = projectId,
+            ProjectTitle = string.Empty,
+            StatusFieldId = updatedField.Id,
+            Options = MapStatusStructureOptions(updatedField.Options),
+        };
+    }
+
+    /// <inheritdoc/>
     public async Task CloseTriageItemAsDuplicateAsync(string owner, string repo, GitHubTriageItemType itemType, int itemNumber, string duplicateReference, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
@@ -1090,6 +1318,64 @@ public sealed class GitHubService : IGitHubService
             StatusFieldId = statusField.Id,
             StatusOptions = statusOptions,
         };
+    }
+
+    private static ProjectBoardStatusStructure? ToProjectBoardStatusStructureDomain(ProjectBoardNodeDto? node)
+    {
+        if (node is null || string.IsNullOrWhiteSpace(node.Id) || string.IsNullOrWhiteSpace(node.Title))
+        {
+            return null;
+        }
+
+        var statusField = node.Fields?.Nodes
+            .FirstOrDefault(field =>
+                !string.IsNullOrWhiteSpace(field.Id)
+                && field.Name.Equals("Status", StringComparison.OrdinalIgnoreCase));
+
+        if (statusField is null || string.IsNullOrWhiteSpace(statusField.Id))
+        {
+            return null;
+        }
+
+        var options = MapStatusStructureOptions(statusField.Options);
+        if (options.Count == 0)
+        {
+            return null;
+        }
+
+        return new ProjectBoardStatusStructure
+        {
+            ProjectId = node.Id,
+            ProjectTitle = node.Title,
+            StatusFieldId = statusField.Id,
+            Options = options,
+        };
+    }
+
+    private static IReadOnlyList<ProjectBoardStatusStructureOption> MapStatusStructureOptions(
+        IReadOnlyList<ProjectBoardSingleSelectOptionDto> options)
+    {
+        var mapped = new List<ProjectBoardStatusStructureOption>();
+        var order = 0;
+
+        foreach (var option in options)
+        {
+            if (string.IsNullOrWhiteSpace(option.Name))
+            {
+                continue;
+            }
+
+            mapped.Add(new ProjectBoardStatusStructureOption
+            {
+                Id = option.Id,
+                Name = option.Name,
+                Colour = string.IsNullOrWhiteSpace(option.Color) ? "GRAY" : option.Color,
+                Description = option.Description ?? string.Empty,
+                Order = order++,
+            });
+        }
+
+        return mapped;
     }
 
     private static ProjectBoardFieldIds ToProjectBoardFieldIds(IReadOnlyList<ProjectBoardCatalogueFieldDto> fields)
@@ -2147,9 +2433,104 @@ public sealed class GitHubService : IGitHubService
 
         [JsonPropertyName("name")]
         public string Name { get; init; } = string.Empty;
+
+        [JsonPropertyName("color")]
+        public string Color { get; init; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string? Description { get; init; }
     }
 
-    /// <summary>DTO wrapper for GraphQL update-project-item-focus-order responses.</summary>
+    /// <summary>DTO wrapper for GraphQL project-board status-structure responses.</summary>
+    private sealed record GetProjectBoardStatusStructureResponseDto
+    {
+        [JsonPropertyName("data")]
+        public GetProjectBoardStatusStructureDataDto? Data { get; init; }
+
+        [JsonPropertyName("errors")]
+        public IReadOnlyList<GraphQlErrorDto> Errors { get; init; } = [];
+    }
+
+    /// <summary>DTO for project-board status-structure GraphQL data payload.</summary>
+    private sealed record GetProjectBoardStatusStructureDataDto
+    {
+        [JsonPropertyName("node")]
+        public ProjectBoardNodeDto? Node { get; init; }
+    }
+
+    /// <summary>DTO wrapper for GraphQL repository node-id responses.</summary>
+    private sealed record GetRepositoryNodeIdResponseDto
+    {
+        [JsonPropertyName("data")]
+        public GetRepositoryNodeIdDataDto? Data { get; init; }
+
+        [JsonPropertyName("errors")]
+        public IReadOnlyList<GraphQlErrorDto> Errors { get; init; } = [];
+    }
+
+    /// <summary>DTO for repository node-id GraphQL data payload.</summary>
+    private sealed record GetRepositoryNodeIdDataDto
+    {
+        [JsonPropertyName("repository")]
+        public RepositoryNodeIdDto? Repository { get; init; }
+    }
+
+    /// <summary>DTO for repository node identifiers.</summary>
+    private sealed record RepositoryNodeIdDto
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = string.Empty;
+    }
+
+    /// <summary>DTO wrapper for GraphQL create-project responses.</summary>
+    private sealed record CreateRepositoryLinkedProjectResponseDto
+    {
+        [JsonPropertyName("data")]
+        public CreateRepositoryLinkedProjectDataDto? Data { get; init; }
+
+        [JsonPropertyName("errors")]
+        public IReadOnlyList<GraphQlErrorDto> Errors { get; init; } = [];
+    }
+
+    /// <summary>DTO for create-project GraphQL data payload.</summary>
+    private sealed record CreateRepositoryLinkedProjectDataDto
+    {
+        [JsonPropertyName("createProjectV2")]
+        public CreateRepositoryLinkedProjectPayloadDto? CreateProjectV2 { get; init; }
+    }
+
+    /// <summary>DTO for create-project GraphQL payload.</summary>
+    private sealed record CreateRepositoryLinkedProjectPayloadDto
+    {
+        [JsonPropertyName("projectV2")]
+        public ProjectBoardNodeDto? ProjectV2 { get; init; }
+    }
+
+    /// <summary>DTO wrapper for GraphQL update-status-field responses.</summary>
+    private sealed record UpdateProjectBoardStatusFieldResponseDto
+    {
+        [JsonPropertyName("data")]
+        public UpdateProjectBoardStatusFieldDataDto? Data { get; init; }
+
+        [JsonPropertyName("errors")]
+        public IReadOnlyList<GraphQlErrorDto> Errors { get; init; } = [];
+    }
+
+    /// <summary>DTO for update-status-field GraphQL data payload.</summary>
+    private sealed record UpdateProjectBoardStatusFieldDataDto
+    {
+        [JsonPropertyName("updateProjectV2Field")]
+        public UpdateProjectBoardStatusFieldPayloadDto? UpdateProjectV2Field { get; init; }
+    }
+
+    /// <summary>DTO for update-status-field GraphQL payload.</summary>
+    private sealed record UpdateProjectBoardStatusFieldPayloadDto
+    {
+        [JsonPropertyName("projectV2Field")]
+        public ProjectBoardSingleSelectFieldDto? ProjectV2Field { get; init; }
+    }
+
+    /// <summary>DTO for update-project-item-focus-order GraphQL responses.</summary>
     private sealed record UpdateProjectBoardItemFocusOrderResponseDto
     {
         [JsonPropertyName("data")]

--- a/src/Infrastructure/SoloDevBoard.Infrastructure/Migration/GitHubProjectBoardStructureRepository.cs
+++ b/src/Infrastructure/SoloDevBoard.Infrastructure/Migration/GitHubProjectBoardStructureRepository.cs
@@ -1,0 +1,51 @@
+using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Application.Services.Migration;
+using SoloDevBoard.Domain.Entities.Migration;
+
+namespace SoloDevBoard.Infrastructure.Migration;
+
+/// <summary>GitHub GraphQL implementation of <see cref="IProjectBoardStructureRepository"/>.</summary>
+public sealed class GitHubProjectBoardStructureRepository : IProjectBoardStructureRepository
+{
+    private readonly IGitHubService _gitHubService;
+
+    /// <summary>Initialises a new instance of the <see cref="GitHubProjectBoardStructureRepository"/> class.</summary>
+    /// <param name="gitHubService">The GitHub service used for Projects v2 GraphQL operations.</param>
+    public GitHubProjectBoardStructureRepository(IGitHubService gitHubService)
+    {
+        ArgumentNullException.ThrowIfNull(gitHubService);
+        _gitHubService = gitHubService;
+    }
+
+    /// <inheritdoc/>
+    public Task<ProjectBoardDiscovery> DiscoverBoardsAsync(string owner, string repo, CancellationToken cancellationToken = default)
+        => _gitHubService.DiscoverProjectBoardStatusStructuresAsync(owner, repo, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<ProjectBoardStatusStructure> GetStatusStructureAsync(string projectId, CancellationToken cancellationToken = default)
+        => _gitHubService.GetProjectBoardStatusStructureAsync(projectId, cancellationToken);
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlySet<string>> GetStatusOptionIdsInUseAsync(string projectId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+
+        var catalogue = await _gitHubService.GetProjectBoardItemsAsync(projectId, cancellationToken).ConfigureAwait(false);
+        return catalogue.Items
+            .Where(item => item.Status is not null && !string.IsNullOrWhiteSpace(item.Status.OptionId))
+            .Select(item => item.Status!.OptionId)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    /// <inheritdoc/>
+    public Task<ProjectBoardStatusStructure> CreateLinkedProjectAsync(string owner, string repo, string title, CancellationToken cancellationToken = default)
+        => _gitHubService.CreateRepositoryLinkedProjectAsync(owner, repo, title, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<ProjectBoardStatusStructure> UpdateStatusOptionsAsync(
+        string projectId,
+        string statusFieldId,
+        IReadOnlyList<ProjectBoardStatusStructureOption> options,
+        CancellationToken cancellationToken = default)
+        => _gitHubService.UpdateProjectBoardStatusOptionsAsync(projectId, statusFieldId, options, cancellationToken);
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
@@ -74,10 +74,11 @@ public sealed class MigrationTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Is<MigrationScopeDto>(scope => scope!.IncludeLabels && scope.IncludeMilestones), MigrationConflictStrategy.Overwrite, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Is<MigrationScopeDto>(scope => scope!.IncludeLabels && scope.IncludeMilestones), MigrationConflictStrategy.Overwrite, Arg.Any<MigrationBoardSelectionDto?>(), Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Overwrite,
                 [new LabelSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])],
-                [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])]));
+                [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])],
+                []));
 
         await using var ctx = CreateContext();
 
@@ -99,7 +100,7 @@ public sealed class MigrationTests
         // Assert
         cut.WaitForAssertion(() => Assert.Contains("Migration preview (Overwrite)", cut.Markup));
 
-        await _migrationService.Received(1).PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Is<MigrationScopeDto>(scope => scope!.IncludeLabels && scope.IncludeMilestones), MigrationConflictStrategy.Overwrite, Arg.Any<CancellationToken>());
+        await _migrationService.Received(1).PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Is<MigrationScopeDto>(scope => scope!.IncludeLabels && scope.IncludeMilestones), MigrationConflictStrategy.Overwrite, Arg.Any<MigrationBoardSelectionDto?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -111,7 +112,7 @@ public sealed class MigrationTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<MigrationBoardSelectionDto?>(), Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Skip,
                 [new LabelSyncRepositoryPreviewDto(
                     "owner/repo-b",
@@ -119,7 +120,8 @@ public sealed class MigrationTests
                     [],
                     [],
                     [new LabelDto("type/story", "1d76db", "Story", "owner/repo-b")])],
-                [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])]));
+                [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])],
+                []));
 
         await using var ctx = CreateContext();
 
@@ -154,7 +156,7 @@ public sealed class MigrationTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<MigrationBoardSelectionDto?>(), Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Skip,
                 [new LabelSyncRepositoryPreviewDto(
                     "owner/repo-b",
@@ -162,7 +164,8 @@ public sealed class MigrationTests
                     [],
                     [],
                     [])],
-                [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])]));
+                [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])],
+                []));
 
         await using var ctx = CreateContext();
 
@@ -195,7 +198,7 @@ public sealed class MigrationTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<MigrationBoardSelectionDto?>(), Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Merge,
                 [new LabelSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])],
                 [new MilestoneSyncRepositoryPreviewDto(
@@ -203,7 +206,8 @@ public sealed class MigrationTests
                     [new MilestoneDto(1, 1, "Sprint 12", "Delivery sprint", "open", DateTimeOffset.Parse("2026-04-30T00:00:00Z"), 0, 0)],
                     [],
                     [],
-                    [])]));
+                    [])],
+                []));
 
         await using var ctx = CreateContext();
 
@@ -263,7 +267,7 @@ public sealed class MigrationTests
 
         // Assert
         Assert.Empty(cut.FindAll("[data-testid='migration-preview-card']"));
-        await _migrationService.DidNotReceive().PreviewMigrationAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<MigrationScopeDto>(), Arg.Any<MigrationConflictStrategy>(), Arg.Any<CancellationToken>());
+        await _migrationService.DidNotReceive().PreviewMigrationAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<MigrationScopeDto>(), Arg.Any<MigrationConflictStrategy>(), Arg.Any<MigrationBoardSelectionDto?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -276,7 +280,7 @@ public sealed class MigrationTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<MigrationBoardSelectionDto?>(), Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Skip,
                 [new LabelSyncRepositoryPreviewDto(
                     "owner/repo-b",
@@ -284,9 +288,10 @@ public sealed class MigrationTests
                     [],
                     [],
                     [])],
-                [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])]));
+                [new MilestoneSyncRepositoryPreviewDto("owner/repo-b", [], [], [], [])],
+                []));
 
-        _migrationService.ApplyMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>()).Returns(applyTaskSource.Task);
+        _migrationService.ApplyMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<MigrationBoardSelectionDto?>(), Arg.Any<CancellationToken>()).Returns(applyTaskSource.Task);
 
         await using var ctx = CreateContext();
 
@@ -309,11 +314,12 @@ public sealed class MigrationTests
         await cut.InvokeAsync(() => applyTaskSource.SetResult(new MigrationResultDto(
             MigrationConflictStrategy.Skip,
             [new LabelSyncRepositoryResultDto("owner/repo-b", 1, 0, 0, 0, null)],
+            [],
             [])));
 
         // Assert
         cut.WaitForAssertion(() => Assert.Contains("Migration completed successfully", cut.Markup));
-        await _migrationService.Received(1).ApplyMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<CancellationToken>());
+        await _migrationService.Received(1).ApplyMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Skip, Arg.Any<MigrationBoardSelectionDto?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -325,7 +331,7 @@ public sealed class MigrationTests
 
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
 
-        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
+        _migrationService.PreviewMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<MigrationBoardSelectionDto?>(), Arg.Any<CancellationToken>()).Returns(new MigrationPreviewDto(
                 MigrationConflictStrategy.Merge,
                 [new LabelSyncRepositoryPreviewDto(
                     "owner/repo-b",
@@ -338,12 +344,14 @@ public sealed class MigrationTests
                     [new MilestoneDto(1, 2, "Sprint 2", "Delivery", "open", null, 0, 0)],
                     [],
                     [],
-                    [])]));
+                    [])],
+                []));
 
-        _migrationService.ApplyMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<CancellationToken>()).Returns(new MigrationResultDto(
+        _migrationService.ApplyMigrationAsync("owner/repo-a", Arg.Is<IReadOnlyList<string>>(targets => targets!.SequenceEqual(new[] { "owner/repo-b" })), Arg.Any<MigrationScopeDto>(), MigrationConflictStrategy.Merge, Arg.Any<MigrationBoardSelectionDto?>(), Arg.Any<CancellationToken>()).Returns(new MigrationResultDto(
                 MigrationConflictStrategy.Merge,
                 [new LabelSyncRepositoryResultDto("owner/repo-b", 1, 0, 0, 0, "GitHub label API rate limit reached")],
-                [new MilestoneSyncRepositoryResultDto("owner/repo-b", 1, 0, 0, 0, null)]));
+                [new MilestoneSyncRepositoryResultDto("owner/repo-b", 1, 0, 0, 0, null)],
+                []));
 
         await using var ctx = CreateContext();
 

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
@@ -495,6 +495,8 @@ public sealed class MigrationServiceTests
         Assert.Equal(3, preview.ToCreate.Count);
         Assert.Empty(preview.ToUpdate);
         Assert.Empty(preview.ToDelete);
+        Assert.Single(preview.Warnings);
+        Assert.Contains("GitHub default Status options", preview.Warnings[0], StringComparison.Ordinal);
     }
 
     [Fact]
@@ -600,6 +602,76 @@ public sealed class MigrationServiceTests
             "created-status-field",
             Arg.Any<IReadOnlyList<ProjectBoardStatusStructureOption>>(),
             cancellationToken);
+    }
+
+    [Fact]
+    public async Task ApplyMigrationAsync_CreateNewBoardOverwrite_RemovesDefaultOptionsNotInSource()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SetupStatusColumnData();
+        var sut = CreateSubject();
+        var boardSelection = new MigrationBoardSelectionDto(
+            "source-project",
+            [new MigrationTargetBoardSelectionDto("owner/target", null, "Imported board")]);
+
+        _projectBoardStructureRepository
+            .CreateLinkedProjectAsync("owner", "target", "Imported board", cancellationToken)
+            .Returns(new ProjectBoardStatusStructure
+            {
+                ProjectId = "created-project",
+                ProjectTitle = "Imported board",
+                StatusFieldId = "created-status-field",
+                Options =
+                [
+                    new ProjectBoardStatusStructureOption { Id = "default-todo", Name = "Todo", Colour = "GRAY", Description = string.Empty, Order = 0 },
+                    new ProjectBoardStatusStructureOption { Id = "default-done", Name = "Done", Colour = "GREEN", Description = string.Empty, Order = 1 },
+                ],
+            });
+
+        IReadOnlyList<ProjectBoardStatusStructureOption>? capturedOptions = null;
+        _projectBoardStructureRepository
+            .UpdateStatusOptionsAsync("created-project", "created-status-field", Arg.Any<IReadOnlyList<ProjectBoardStatusStructureOption>>(), cancellationToken)
+            .Returns(callInfo =>
+            {
+                capturedOptions = callInfo.ArgAt<IReadOnlyList<ProjectBoardStatusStructureOption>>(2);
+                return new ProjectBoardStatusStructure
+                {
+                    ProjectId = "created-project",
+                    StatusFieldId = "created-status-field",
+                    Options = capturedOptions!,
+                };
+            });
+
+        var result = await sut.ApplyMigrationAsync(
+            "owner/source",
+            ["owner/target"],
+            new MigrationScopeDto(false, false, true),
+            MigrationConflictStrategy.Overwrite,
+            boardSelection,
+            cancellationToken);
+
+        var statusResult = Assert.Single(result.ProjectBoardStatusResults);
+        Assert.Null(statusResult.ErrorMessage);
+        Assert.NotNull(capturedOptions);
+        Assert.DoesNotContain(capturedOptions!, option => option.Name.Equals("Todo", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(capturedOptions!, option => option.Name.Equals("Done", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(3, capturedOptions!.Count);
+    }
+
+    [Fact]
+    public void ProjectBoardStatusSyncRepositoryResultDto_ErrorMessagePresent_HasErrorIsTrue()
+    {
+        var result = new ProjectBoardStatusSyncRepositoryResultDto(
+            "owner/target",
+            0,
+            0,
+            0,
+            0,
+            null,
+            [],
+            "GitHub API failed");
+
+        Assert.True(result.HasError);
     }
 
     private static MigrationBoardSelectionDto CreateBoardSelection(

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
@@ -2,6 +2,7 @@ using NSubstitute;
 using SoloDevBoard.Application.Services.Labels;
 using SoloDevBoard.Application.Services.Migration;
 using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Domain.Entities.Migration;
 using SoloDevBoard.Domain.Entities.Milestones;
 
 namespace SoloDevBoard.Application.Tests;
@@ -11,6 +12,7 @@ public sealed class MigrationServiceTests
 {
     private readonly ILabelRepository _labelRepository = Substitute.For<ILabelRepository>();
     private readonly IMilestoneRepository _milestoneRepository = Substitute.For<IMilestoneRepository>();
+    private readonly IProjectBoardStructureRepository _projectBoardStructureRepository = Substitute.For<IProjectBoardStructureRepository>();
 
     [Fact]
     public async Task PreviewMigrationAsync_SkipStrategy_ReturnsCreateAndSkipOnly()
@@ -25,7 +27,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(true, true),
-            MigrationConflictStrategy.Skip, cancellationToken);
+            MigrationConflictStrategy.Skip, cancellationToken: cancellationToken);
 
         // Assert
         Assert.Equal(MigrationConflictStrategy.Skip, result.ConflictStrategy);
@@ -62,7 +64,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(true, true),
-            MigrationConflictStrategy.Overwrite, cancellationToken);
+            MigrationConflictStrategy.Overwrite, cancellationToken: cancellationToken);
 
         // Assert
         Assert.Equal(MigrationConflictStrategy.Overwrite, result.ConflictStrategy);
@@ -132,7 +134,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(true, true),
-            MigrationConflictStrategy.Overwrite, cancellationToken);
+            MigrationConflictStrategy.Overwrite, cancellationToken: cancellationToken);
 
         // Assert
         Assert.Equal(MigrationConflictStrategy.Overwrite, result.ConflictStrategy);
@@ -183,7 +185,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(true, true),
-            MigrationConflictStrategy.Skip, cancellationToken);
+            MigrationConflictStrategy.Skip, cancellationToken: cancellationToken);
 
         // Assert
         Assert.Single(result.LabelResults);
@@ -205,7 +207,7 @@ public sealed class MigrationServiceTests
     }
 
     private MigrationService CreateSubject()
-        => new(_labelRepository, _milestoneRepository);
+        => new(_labelRepository, _milestoneRepository, _projectBoardStructureRepository);
 
     [Fact]
     public async Task PreviewMigrationAsync_LabelsOnly_DoesNotReturnMilestonePreviews()
@@ -220,7 +222,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(true, false),
-            MigrationConflictStrategy.Merge, cancellationToken);
+            MigrationConflictStrategy.Merge, cancellationToken: cancellationToken);
 
         // Assert
         Assert.Single(result.LabelPreviews);
@@ -245,7 +247,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(false, true),
-            MigrationConflictStrategy.Skip, cancellationToken);
+            MigrationConflictStrategy.Skip, cancellationToken: cancellationToken);
 
         // Assert
         Assert.Empty(result.LabelResults);
@@ -269,7 +271,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(false, false),
-            MigrationConflictStrategy.Skip, cancellationToken);
+            MigrationConflictStrategy.Skip, cancellationToken: cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -288,7 +290,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/source"],
             new MigrationScopeDto(true, true),
-            MigrationConflictStrategy.Skip, cancellationToken);
+            MigrationConflictStrategy.Skip, cancellationToken: cancellationToken);
 
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(action);
@@ -333,7 +335,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target", "owner/failing"],
             new MigrationScopeDto(true, true),
-            MigrationConflictStrategy.Skip, cancellationToken);
+            MigrationConflictStrategy.Skip, cancellationToken: cancellationToken);
 
         // Assert
         Assert.Equal(2, result.LabelResults.Count);
@@ -383,7 +385,7 @@ public sealed class MigrationServiceTests
             "owner/source",
             ["owner/target"],
             new MigrationScopeDto(true, false),
-            MigrationConflictStrategy.Overwrite, cancellationToken);
+            MigrationConflictStrategy.Overwrite, cancellationToken: cancellationToken);
 
         // Assert
         var labelResult = Assert.Single(result.LabelResults);
@@ -392,6 +394,277 @@ public sealed class MigrationServiceTests
         Assert.Equal(0, labelResult.UpdatedCount);
         Assert.Contains("update failed", labelResult.ErrorMessage, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public async Task PreviewMigrationAsync_StatusColumnsSkip_ReturnsCreateAndSkipOnly()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SetupStatusColumnData();
+        var sut = CreateSubject();
+        var boardSelection = CreateBoardSelection("source-project", "owner/target", "target-project");
+
+        var result = await sut.PreviewMigrationAsync(
+            "owner/source",
+            ["owner/target"],
+            new MigrationScopeDto(false, false, true),
+            MigrationConflictStrategy.Skip,
+            boardSelection,
+            cancellationToken);
+
+        var preview = Assert.Single(result.ProjectBoardStatusPreviews);
+        Assert.Equal(2, preview.ToCreate.Count);
+        Assert.Contains(preview.ToCreate, option => option.Name == "Backlog");
+        Assert.Contains(preview.ToCreate, option => option.Name == "Done");
+        Assert.Empty(preview.ToUpdate);
+        Assert.Empty(preview.ToDelete);
+        Assert.Single(preview.Skipped);
+        Assert.Equal("In Progress", preview.Skipped[0].Name);
+    }
+
+    [Fact]
+    public async Task PreviewMigrationAsync_StatusColumnsMerge_ReturnsCreateUpdateAndKeepsTargetOnlyOption()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SetupStatusColumnData();
+        var sut = CreateSubject();
+        var boardSelection = CreateBoardSelection("source-project", "owner/target", "target-project");
+
+        var result = await sut.PreviewMigrationAsync(
+            "owner/source",
+            ["owner/target"],
+            new MigrationScopeDto(false, false, true),
+            MigrationConflictStrategy.Merge,
+            boardSelection,
+            cancellationToken);
+
+        var preview = Assert.Single(result.ProjectBoardStatusPreviews);
+        Assert.Equal(2, preview.ToCreate.Count);
+        Assert.Single(preview.ToUpdate);
+        Assert.Empty(preview.ToDelete);
+        Assert.Equal("In Progress", preview.ToUpdate[0].Name);
+    }
+
+    [Fact]
+    public async Task PreviewMigrationAsync_StatusColumnsOverwrite_BlocksDeleteWhenOptionStillInUse()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SetupStatusColumnData();
+        _projectBoardStructureRepository
+            .GetStatusOptionIdsInUseAsync("target-project", cancellationToken)
+            .Returns(new HashSet<string>(StringComparer.Ordinal) { "option-blocked" });
+
+        var sut = CreateSubject();
+        var boardSelection = CreateBoardSelection("source-project", "owner/target", "target-project");
+
+        var result = await sut.PreviewMigrationAsync(
+            "owner/source",
+            ["owner/target"],
+            new MigrationScopeDto(false, false, true),
+            MigrationConflictStrategy.Overwrite,
+            boardSelection,
+            cancellationToken);
+
+        var preview = Assert.Single(result.ProjectBoardStatusPreviews);
+        Assert.Equal(2, preview.ToDelete.Count);
+        Assert.Contains(preview.ToDelete, option => option.Name == "Legacy");
+        Assert.Contains(preview.ToDelete, option => option.Name == "Todo");
+        Assert.Single(preview.Warnings);
+        Assert.Contains("Blocked", preview.Warnings[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PreviewMigrationAsync_CreateNewBoard_ReturnsAllSourceOptionsAsCreates()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SetupStatusColumnData();
+        var sut = CreateSubject();
+        var boardSelection = new MigrationBoardSelectionDto(
+            "source-project",
+            [new MigrationTargetBoardSelectionDto("owner/target", null, "Target board")]);
+
+        var result = await sut.PreviewMigrationAsync(
+            "owner/source",
+            ["owner/target"],
+            new MigrationScopeDto(false, false, true),
+            MigrationConflictStrategy.Merge,
+            boardSelection,
+            cancellationToken);
+
+        var preview = Assert.Single(result.ProjectBoardStatusPreviews);
+        Assert.True(preview.CreateNewBoard);
+        Assert.Equal(3, preview.ToCreate.Count);
+        Assert.Empty(preview.ToUpdate);
+        Assert.Empty(preview.ToDelete);
+    }
+
+    [Fact]
+    public async Task PreviewMigrationAsync_StatusColumnsInaccessibleBoards_PropagatesVisibilityCounts()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SetupStatusColumnData(inaccessibleCount: 2, totalLinkedCount: 3);
+        var sut = CreateSubject();
+        var boardSelection = CreateBoardSelection("source-project", "owner/target", "target-project");
+
+        var result = await sut.PreviewMigrationAsync(
+            "owner/source",
+            ["owner/target"],
+            new MigrationScopeDto(false, false, true),
+            MigrationConflictStrategy.Skip,
+            boardSelection,
+            cancellationToken);
+
+        var preview = Assert.Single(result.ProjectBoardStatusPreviews);
+        Assert.Equal(3, preview.TotalLinkedProjectCount);
+        Assert.Equal(2, preview.InaccessibleLinkedProjectCount);
+    }
+
+    [Fact]
+    public async Task ApplyMigrationAsync_StatusColumnsMerge_PreservesTargetOptionIdsInUpdatePayload()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SetupStatusColumnData();
+        var sut = CreateSubject();
+        var boardSelection = CreateBoardSelection("source-project", "owner/target", "target-project");
+
+        IReadOnlyList<ProjectBoardStatusStructureOption>? capturedOptions = null;
+        _projectBoardStructureRepository
+            .UpdateStatusOptionsAsync("target-project", "status-field", Arg.Any<IReadOnlyList<ProjectBoardStatusStructureOption>>(), cancellationToken)
+            .Returns(callInfo =>
+            {
+                capturedOptions = callInfo.ArgAt<IReadOnlyList<ProjectBoardStatusStructureOption>>(2);
+                return CreateTargetStructure();
+            });
+
+        var result = await sut.ApplyMigrationAsync(
+            "owner/source",
+            ["owner/target"],
+            new MigrationScopeDto(false, false, true),
+            MigrationConflictStrategy.Merge,
+            boardSelection,
+            cancellationToken);
+
+        var statusResult = Assert.Single(result.ProjectBoardStatusResults);
+        Assert.Null(statusResult.ErrorMessage);
+        Assert.NotNull(capturedOptions);
+        var inProgress = capturedOptions!.Single(option => option.Name.Equals("In Progress", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal("option-in-progress", inProgress.Id);
+        Assert.Equal("YELLOW", inProgress.Colour, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ApplyMigrationAsync_CreateNewBoard_CreatesLinkedProjectAndReshapesStatusOptions()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SetupStatusColumnData();
+        var sut = CreateSubject();
+        var boardSelection = new MigrationBoardSelectionDto(
+            "source-project",
+            [new MigrationTargetBoardSelectionDto("owner/target", null, "Imported board")]);
+
+        _projectBoardStructureRepository
+            .CreateLinkedProjectAsync("owner", "target", "Imported board", cancellationToken)
+            .Returns(new ProjectBoardStatusStructure
+            {
+                ProjectId = "created-project",
+                ProjectTitle = "Imported board",
+                StatusFieldId = "created-status-field",
+                Options =
+                [
+                    new ProjectBoardStatusStructureOption { Id = "default-todo", Name = "Todo", Colour = "GRAY", Description = string.Empty, Order = 0 },
+                    new ProjectBoardStatusStructureOption { Id = "default-done", Name = "Done", Colour = "GREEN", Description = string.Empty, Order = 1 },
+                ],
+            });
+
+        _projectBoardStructureRepository
+            .UpdateStatusOptionsAsync("created-project", "created-status-field", Arg.Any<IReadOnlyList<ProjectBoardStatusStructureOption>>(), cancellationToken)
+            .Returns(callInfo => new ProjectBoardStatusStructure
+            {
+                ProjectId = "created-project",
+                StatusFieldId = "created-status-field",
+                Options = callInfo.ArgAt<IReadOnlyList<ProjectBoardStatusStructureOption>>(2),
+            });
+
+        var result = await sut.ApplyMigrationAsync(
+            "owner/source",
+            ["owner/target"],
+            new MigrationScopeDto(false, false, true),
+            MigrationConflictStrategy.Merge,
+            boardSelection,
+            cancellationToken);
+
+        var statusResult = Assert.Single(result.ProjectBoardStatusResults);
+        Assert.Equal("created-project", statusResult.CreatedProjectId);
+        await _projectBoardStructureRepository.Received(1).CreateLinkedProjectAsync("owner", "target", "Imported board", cancellationToken);
+        await _projectBoardStructureRepository.Received(1).UpdateStatusOptionsAsync(
+            "created-project",
+            "created-status-field",
+            Arg.Any<IReadOnlyList<ProjectBoardStatusStructureOption>>(),
+            cancellationToken);
+    }
+
+    private static MigrationBoardSelectionDto CreateBoardSelection(
+        string sourceProjectId,
+        string targetRepositoryFullName,
+        string targetProjectId)
+        => new(
+            sourceProjectId,
+            [new MigrationTargetBoardSelectionDto(targetRepositoryFullName, targetProjectId, null)]);
+
+    private void SetupStatusColumnData(int inaccessibleCount = 0, int totalLinkedCount = 1)
+    {
+        var sourceStructure = CreateSourceStructure();
+        var targetStructure = CreateTargetStructure();
+
+        _projectBoardStructureRepository
+            .GetStatusStructureAsync("source-project", Arg.Any<CancellationToken>())
+            .Returns(sourceStructure);
+
+        _projectBoardStructureRepository
+            .GetStatusStructureAsync("target-project", Arg.Any<CancellationToken>())
+            .Returns(targetStructure);
+
+        _projectBoardStructureRepository
+            .DiscoverBoardsAsync("owner", "target", Arg.Any<CancellationToken>())
+            .Returns(new ProjectBoardDiscovery
+            {
+                SupportedBoards = [targetStructure],
+                TotalLinkedProjectCount = totalLinkedCount,
+                InaccessibleLinkedProjectCount = inaccessibleCount,
+            });
+
+        _projectBoardStructureRepository
+            .GetStatusOptionIdsInUseAsync("target-project", Arg.Any<CancellationToken>())
+            .Returns(new HashSet<string>(StringComparer.Ordinal));
+    }
+
+    private static ProjectBoardStatusStructure CreateSourceStructure()
+        => new()
+        {
+            ProjectId = "source-project",
+            ProjectTitle = "Source board",
+            StatusFieldId = "source-status-field",
+            Options =
+            [
+                new ProjectBoardStatusStructureOption { Id = "source-backlog", Name = "Backlog", Colour = "GRAY", Description = "Queued", Order = 0 },
+                new ProjectBoardStatusStructureOption { Id = "source-in-progress", Name = "In Progress", Colour = "YELLOW", Description = "Active", Order = 1 },
+                new ProjectBoardStatusStructureOption { Id = "source-done", Name = "Done", Colour = "GREEN", Description = "Complete", Order = 2 },
+            ],
+        };
+
+    private static ProjectBoardStatusStructure CreateTargetStructure()
+        => new()
+        {
+            ProjectId = "target-project",
+            ProjectTitle = "Target board",
+            StatusFieldId = "status-field",
+            Options =
+            [
+                new ProjectBoardStatusStructureOption { Id = "option-todo", Name = "Todo", Colour = "GRAY", Description = string.Empty, Order = 0 },
+                new ProjectBoardStatusStructureOption { Id = "option-in-progress", Name = "In Progress", Colour = "BLUE", Description = "Existing", Order = 1 },
+                new ProjectBoardStatusStructureOption { Id = "option-legacy", Name = "Legacy", Colour = "PURPLE", Description = string.Empty, Order = 2 },
+                new ProjectBoardStatusStructureOption { Id = "option-blocked", Name = "Blocked", Colour = "RED", Description = string.Empty, Order = 3 },
+            ],
+        };
 
     private void SetupSourceAndTargetData()
     {

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using NSubstitute;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Domain.Entities.Labels;
+using SoloDevBoard.Domain.Entities.Migration;
 using SoloDevBoard.Domain.Entities.Triage;
 using SoloDevBoard.Infrastructure.GitHub;
 
@@ -1465,6 +1466,152 @@ public sealed class GitHubServiceTests
         Assert.Empty(result.SupportedProjectBoards);
         Assert.Equal(1, result.TotalLinkedProjectCount);
         Assert.Equal(0, result.InaccessibleLinkedProjectCount);
+    }
+
+    [Fact]
+    public async Task DiscoverProjectBoardStatusStructuresAsync_StatusFieldPresent_ReturnsColourAndDescription()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "projectsV2": {
+                            "nodes": [
+                                {
+                                    "id": "PVT_kwHOAJefG84BQ6bh",
+                                    "title": "Roadmap",
+                                    "public": true,
+                                    "owner": { "login": "owner" },
+                                    "fields": {
+                                        "nodes": [
+                                            {
+                                                "id": "PVTF_status",
+                                                "name": "Status",
+                                                "options": [
+                                                    { "id": "option-one", "name": "In Progress", "color": "YELLOW", "description": "Active work" },
+                                                    { "id": "option-two", "name": "Done", "color": "GREEN", "description": "Complete" }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        var result = await sut.DiscoverProjectBoardStatusStructuresAsync("owner", "repo", cancellationToken);
+
+        Assert.Single(result.SupportedBoards);
+        Assert.Equal(2, result.SupportedBoards[0].Options.Count);
+        Assert.Equal("YELLOW", result.SupportedBoards[0].Options[0].Colour, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("Active work", result.SupportedBoards[0].Options[0].Description);
+    }
+
+    [Fact]
+    public async Task CreateRepositoryLinkedProjectAsync_ValidResponse_ReturnsDefaultStatusStructure()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "repository": {
+                        "id": "R_kgDOExample"
+                    }
+                },
+                "errors": []
+            }
+            """),
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "createProjectV2": {
+                        "projectV2": {
+                            "id": "PVT_created",
+                            "title": "Imported board",
+                            "fields": {
+                                "nodes": [
+                                    {
+                                        "id": "PVTF_created_status",
+                                        "name": "Status",
+                                        "options": [
+                                            { "id": "opt-todo", "name": "Todo", "color": "GRAY", "description": "" },
+                                            { "id": "opt-done", "name": "Done", "color": "GREEN", "description": "" }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        var result = await sut.CreateRepositoryLinkedProjectAsync("owner", "repo", "Imported board", cancellationToken);
+
+        Assert.Equal("PVT_created", result.ProjectId);
+        Assert.Equal("PVTF_created_status", result.StatusFieldId);
+        Assert.Equal(2, result.Options.Count);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task UpdateProjectBoardStatusOptionsAsync_NameMatchedOptionsIncludeExistingIds()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "updateProjectV2Field": {
+                        "projectV2Field": {
+                            "id": "PVTF_status",
+                            "name": "Status",
+                            "options": [
+                                { "id": "option-one", "name": "In Progress", "color": "YELLOW", "description": "Active" },
+                                { "id": "option-new", "name": "Done", "color": "GREEN", "description": "Complete" }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+        var options = new List<ProjectBoardStatusStructureOption>
+        {
+            new() { Id = "option-one", Name = "In Progress", Colour = "YELLOW", Description = "Active", Order = 0 },
+            new() { Id = string.Empty, Name = "Done", Colour = "GREEN", Description = "Complete", Order = 1 },
+        };
+
+        await sut.UpdateProjectBoardStatusOptionsAsync("project-id", "PVTF_status", options, cancellationToken);
+
+        Assert.Single(handler.Requests);
+        var payload = await handler.Requests[0].Content!.ReadAsStringAsync(cancellationToken);
+        using var document = JsonDocument.Parse(payload);
+        var optionInputs = document.RootElement.GetProperty("variables").GetProperty("options");
+        Assert.Equal(2, optionInputs.GetArrayLength());
+        Assert.Equal("option-one", optionInputs[0].GetProperty("id").GetString());
+        Assert.False(optionInputs[1].TryGetProperty("id", out _));
+        Assert.Equal("YELLOW", optionInputs[0].GetProperty("color").GetString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary of Changes

Adds Application and Infrastructure support for migrating Projects v2 Status field structure (board columns) through the existing one-click migration service. Introduces domain records, `IProjectBoardStructureRepository`, GraphQL discovery/create/update paths, extended migration DTOs, and Skip/Merge/Overwrite conflict mapping with option-id preservation and safe overwrite warnings.

## Related Issue(s)

Closes #414

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [ ] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — Application/Infrastructure enabler only; UI lands in #416.

## Additional Notes

- `updateProjectV2Field` replaces the full option list; apply paths preserve existing target option node ids for case-insensitive name matches.
- Overwrite skips deletion of Status options still referenced by board items and surfaces a warning instead.
- Infrastructure GraphQL fixtures cover discovery, `createProjectV2`, and Status option update payloads.
- User guide and Playwright coverage remain on story #416 and test issue #415.


Made with [Cursor](https://cursor.com)