### PR TITLE
[Story] Migrate project board Status columns in One-Click Migration (#416)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -48,7 +48,7 @@ Use this path when you want a **personal** SoloDevBoard instance on your own Azu
 ### What you need
 
 1. An Azure subscription and a resource group (step 1 under [One-time Azure setup](#one-time-azure-setup)).
-2. A GitHub PAT with scopes `repo`, `read:org`, `workflow`, and `read:project` (same as local development).
+2. A GitHub PAT with scopes `repo`, `read:org`, `workflow`, `read:project`, and `project` when applying One-Click Migration project board columns (same as local development).
 3. **Local `aspire deploy`** (no GitHub Actions OIDC required).
 
 ### Deploy locally with `aspire deploy` (recommended for personal instances)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,7 +49,8 @@ Create a PAT at [GitHub → Settings → Developer settings → Personal access 
 - `repo` (full control of private repositories)
 - `read:org` (read-only access to organisation data, if applicable)
 - `workflow` (to manage GitHub Actions workflows)
-- `read:project` (read-only access to GitHub Projects; required for the Triage UI project board feature)
+- `read:project` (read-only access to GitHub Projects; required for Triage and Migration board discovery)
+- `project` (write access to GitHub Projects; required when applying One-Click Migration **Project board columns** scope in PAT mode)
 
 **Quick local setup (Aspire):**
 
@@ -224,7 +225,7 @@ Your GitHub login is resolved automatically from the PAT when the app starts. Pa
 
 **`hosted-sign-in-enabled`** — Selects the authentication mode. When `false` (the default), SoloDevBoard runs in PAT mode: a single configured token is used for all GitHub API calls and your login is resolved automatically from that token. When `true`, SoloDevBoard uses GitHub App OAuth sign-in at `/auth/sign-in`; each user authenticates with their own GitHub identity and session.
 
-**`gh-pat`** — Your GitHub personal access token for PAT mode. Set to `-` for hosted sign-in. SoloDevBoard uses this for every GitHub API request on your behalf in PAT mode. Required scopes: `repo`, `read:org`, `workflow`, and `read:project`. Your login is resolved automatically from the token.
+**`gh-pat`** — Your GitHub personal access token for PAT mode. Set to `-` for hosted sign-in. SoloDevBoard uses this for every GitHub API request on your behalf in PAT mode. Required scopes: `repo`, `read:org`, `workflow`, `read:project`, and `project` when you apply One-Click Migration project board columns. Your login is resolved automatically from the token.
 
 **`gh-app-client-id`** — The OAuth Client ID from your GitHub App settings. Set to `-` for PAT mode. Required for hosted sign-in.
 

--- a/src/App/SoloDevBoard.App/Components/Features/Migration/Components/StatusPreviewTable.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Migration/Components/StatusPreviewTable.razor
@@ -1,0 +1,22 @@
+@using SoloDevBoard.Application.Services.Migration
+
+@if (StatusOptions.Count > 0)
+{
+    <MudStack Spacing="1">
+        <MudText Typo="Typo.subtitle2">@Heading</MudText>
+        <MudTable T="ProjectBoardStatusOptionDto" Items="StatusOptions" Dense="true" Hover="true" Class="sdb-responsive-grid">
+            <HeaderContent>
+                <MudTh>Name</MudTh>
+                <MudTh>Colour</MudTh>
+                <MudTh>Description</MudTh>
+                <MudTh>Order</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Name">@context.Name</MudTd>
+                <MudTd DataLabel="Colour">@context.Colour</MudTd>
+                <MudTd DataLabel="Description">@(string.IsNullOrWhiteSpace(context.Description) ? "No description" : context.Description)</MudTd>
+                <MudTd DataLabel="Order">@context.Order</MudTd>
+            </RowTemplate>
+        </MudTable>
+    </MudStack>
+}

--- a/src/App/SoloDevBoard.App/Components/Features/Migration/Components/StatusPreviewTable.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Migration/Components/StatusPreviewTable.razor.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Components;
+using SoloDevBoard.Application.Services.Migration;
+
+namespace SoloDevBoard.App.Components.Features.Migration.Components;
+
+/// <summary>Renders a preview table for Projects v2 Status column options.</summary>
+public partial class StatusPreviewTable : ComponentBase
+{
+    /// <summary>Gets or sets the table heading.</summary>
+    [Parameter]
+    public string Heading { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the Status options to display.</summary>
+    [Parameter]
+    public IReadOnlyList<ProjectBoardStatusOptionDto> StatusOptions { get; set; } = [];
+}

--- a/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor
@@ -193,28 +193,30 @@
                                                     <MudText Typo="Typo.body2">Loading target project boards...</MudText>
                                                 </MudStack>
                                             }
-
-                                            @foreach (var targetRepositoryFullName in orderedTargetRepositoryFullNames)
+                                            else
                                             {
-                                                <MudPaper Class="pa-2" Outlined="true" data-testid="migration-target-board-selector">
-                                                    <MudStack Spacing="1">
-                                                        <MudText Typo="Typo.subtitle2">@targetRepositoryFullName</MudText>
-                                                        <MudSelect T="string"
-                                                                   Label="Target project board"
-                                                                   Value="@GetTargetBoardSelection(targetRepositoryFullName)"
-                                                                   ValueChanged="value => OnTargetProjectBoardChangedAsync(targetRepositoryFullName, value)"
-                                                                   Variant="Variant.Outlined"
-                                                                   Disabled="IsBusy"
-                                                                   Required="true"
-                                                                   data-testid="migration-target-board-select">
-                                                            @foreach (var board in GetTargetBoardOptions(targetRepositoryFullName))
-                                                            {
-                                                                <MudSelectItem T="string" Value="@board.Id">@board.Title</MudSelectItem>
-                                                            }
-                                                            <MudSelectItem T="string" Value="@CreateNewBoardOptionValue">Create a new board</MudSelectItem>
-                                                        </MudSelect>
-                                                    </MudStack>
-                                                </MudPaper>
+                                                @foreach (var targetRepositoryFullName in orderedTargetRepositoryFullNames)
+                                                {
+                                                    <MudPaper Class="pa-2" Outlined="true" data-testid="migration-target-board-selector">
+                                                        <MudStack Spacing="1">
+                                                            <MudText Typo="Typo.subtitle2">@targetRepositoryFullName</MudText>
+                                                            <MudSelect T="string"
+                                                                       Label="Target project board"
+                                                                       Value="@GetTargetBoardSelection(targetRepositoryFullName)"
+                                                                       ValueChanged="value => OnTargetProjectBoardChangedAsync(targetRepositoryFullName, value)"
+                                                                       Variant="Variant.Outlined"
+                                                                       Disabled="IsBusy"
+                                                                       Required="true"
+                                                                       data-testid="migration-target-board-select">
+                                                                @foreach (var board in GetTargetBoardOptions(targetRepositoryFullName))
+                                                                {
+                                                                    <MudSelectItem T="string" Value="@board.Id">@board.Title</MudSelectItem>
+                                                                }
+                                                                <MudSelectItem T="string" Value="@CreateNewBoardOptionValue">Create a new board</MudSelectItem>
+                                                            </MudSelect>
+                                                        </MudStack>
+                                                    </MudPaper>
+                                                }
                                             }
                                         }
                                     </MudStack>

--- a/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor
@@ -1,11 +1,12 @@
 @page "/migrate"
+@using SoloDevBoard.App.Components.Features.Migration.Components
 
 <PageTitle>One-Click Migration</PageTitle>
 
 <MudStack Spacing="3">
     <MudText Typo="Typo.h4">One-Click Migration</MudText>
-    <MudText Typo="Typo.body1">Run labels and milestones migration from one source repository to one or more target repositories.</MudText>
-    <MudText Typo="Typo.body2">This workflow covers the current delivery slice for labels and milestones only.</MudText>
+    <MudText Typo="Typo.body1">Run labels, milestones, and project board Status columns migration from one source repository to one or more target repositories.</MudText>
+    <MudText Typo="Typo.body2">Choose the migration scope that matches your repository setup transfer.</MudText>
 
     <MudPaper Class="pa-4" Elevation="1" data-testid="migration-workflow-controls-card">
         <MudStack Spacing="2">
@@ -124,13 +125,106 @@
                                                Disabled="IsBusy"
                                                Color="Color.Primary"
                                                data-testid="migration-scope-milestones-switch" />
+                                    <MudSwitch T="bool"
+                                               Value="migrateProjectBoardColumns"
+                                               ValueChanged="OnMigrateProjectBoardColumnsChangedAsync"
+                                               Label="Project board columns"
+                                               Disabled="IsBusy"
+                                               Color="Color.Primary"
+                                               data-testid="migration-scope-columns-switch" />
                                 </MudStack>
                             </MudPaper>
+
+                            @if (migrateProjectBoardColumns)
+                            {
+                                <MudPaper Class="pa-3" Outlined="true" data-testid="migration-board-selection-card">
+                                    <MudStack Spacing="2">
+                                        <MudText Typo="Typo.subtitle2">Project board selection</MudText>
+                                        <MudText Typo="Typo.body2">Choose the source board whose Status columns are copied, then choose a target board or create a new board for each target repository.</MudText>
+
+                                        @if (HasInaccessibleProjectBoardsWarning)
+                                        {
+                                            <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined" data-testid="migration-inaccessible-project-boards-warning">
+                                                @inaccessibleProjectBoardsWarning
+                                            </MudAlert>
+                                        }
+
+                                        @if (string.IsNullOrWhiteSpace(sourceRepositoryFullName))
+                                        {
+                                            <MudText Typo="Typo.body2" data-testid="migration-board-selection-prompt">Select a source repository to load supported project boards.</MudText>
+                                        }
+                                        else if (isLoadingSourceBoards)
+                                        {
+                                            <MudStack AlignItems="AlignItems.Center" Spacing="1" aria-live="polite" role="status" data-testid="migration-source-boards-loading-state">
+                                                <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading source project boards" />
+                                                <MudText Typo="Typo.body2">Loading source project boards...</MudText>
+                                            </MudStack>
+                                        }
+                                        else
+                                        {
+                                            <MudSelect T="string"
+                                                       Label="Source project board"
+                                                       Value="sourceProjectBoardId"
+                                                       ValueChanged="OnSourceProjectBoardChangedAsync"
+                                                       Variant="Variant.Outlined"
+                                                       Disabled="@(IsBusy || GetSourceBoardOptions().Count == 0)"
+                                                       Required="true"
+                                                       data-testid="migration-source-board-select">
+                                                @foreach (var board in GetSourceBoardOptions())
+                                                {
+                                                    <MudSelectItem T="string" Value="@board.Id">@board.Title</MudSelectItem>
+                                                }
+                                            </MudSelect>
+
+                                            @if (GetSourceBoardOptions().Count == 0)
+                                            {
+                                                <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Outlined" data-testid="migration-source-boards-empty-state">
+                                                    No supported project boards with a Status field were found for the source repository.
+                                                </MudAlert>
+                                            }
+                                        }
+
+                                        @if (targetRepositoryFullNames.Count > 0)
+                                        {
+                                            @if (isLoadingTargetBoards)
+                                            {
+                                                <MudStack AlignItems="AlignItems.Center" Spacing="1" aria-live="polite" role="status" data-testid="migration-target-boards-loading-state">
+                                                    <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading target project boards" />
+                                                    <MudText Typo="Typo.body2">Loading target project boards...</MudText>
+                                                </MudStack>
+                                            }
+
+                                            @foreach (var targetRepositoryFullName in orderedTargetRepositoryFullNames)
+                                            {
+                                                <MudPaper Class="pa-2" Outlined="true" data-testid="migration-target-board-selector">
+                                                    <MudStack Spacing="1">
+                                                        <MudText Typo="Typo.subtitle2">@targetRepositoryFullName</MudText>
+                                                        <MudSelect T="string"
+                                                                   Label="Target project board"
+                                                                   Value="@GetTargetBoardSelection(targetRepositoryFullName)"
+                                                                   ValueChanged="value => OnTargetProjectBoardChangedAsync(targetRepositoryFullName, value)"
+                                                                   Variant="Variant.Outlined"
+                                                                   Disabled="IsBusy"
+                                                                   Required="true"
+                                                                   data-testid="migration-target-board-select">
+                                                            @foreach (var board in GetTargetBoardOptions(targetRepositoryFullName))
+                                                            {
+                                                                <MudSelectItem T="string" Value="@board.Id">@board.Title</MudSelectItem>
+                                                            }
+                                                            <MudSelectItem T="string" Value="@CreateNewBoardOptionValue">Create a new board</MudSelectItem>
+                                                        </MudSelect>
+                                                    </MudStack>
+                                                </MudPaper>
+                                            }
+                                        }
+                                    </MudStack>
+                                </MudPaper>
+                            }
 
                             @if (conflictStrategy == MigrationConflictStrategy.Overwrite)
                             {
                                 <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined" data-testid="migration-overwrite-warning">
-                                    Overwrite can remove target labels and milestones that do not exist in the source repository.
+                                    Overwrite can remove target labels, milestones, and unused Status options that do not exist in the source repository.
                                 </MudAlert>
                             }
                         </MudStack>
@@ -187,6 +281,7 @@
                 {
                     var labelPreview = GetLabelPreview(repository);
                     var milestonePreview = GetMilestonePreview(repository);
+                    var statusPreview = GetStatusPreview(repository);
 
                     <MudPaper Class="pa-3" Outlined="true" data-testid="migration-preview-repository-card">
                         <MudText Typo="Typo.subtitle1">@repository</MudText>
@@ -231,7 +326,41 @@
                             }
                         }
 
-                        @if (!HasActionableChanges(labelPreview, milestonePreview))
+                        @if (migrateProjectBoardColumns)
+                        {
+                            <MudText Typo="Typo.body2">Status columns - Create: @statusPreview.ToCreate.Count, Update: @statusPreview.ToUpdate.Count, Delete: @statusPreview.ToDelete.Count, Skip: @statusPreview.Skipped.Count</MudText>
+
+                            @if (statusPreview.CreateNewBoard)
+                            {
+                                <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Outlined" data-testid="migration-status-create-board-info">
+                                    A new linked project board will be created for this target repository.
+                                </MudAlert>
+                            }
+
+                            @foreach (var warning in statusPreview.Warnings)
+                            {
+                                <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined" data-testid="migration-status-preview-warning">
+                                    @warning
+                                </MudAlert>
+                            }
+
+                            @if (statusPreview.ToCreate.Count > 0)
+                            {
+                                <StatusPreviewTable Heading="Status columns to create" StatusOptions="statusPreview.ToCreate" />
+                            }
+
+                            @if (statusPreview.ToUpdate.Count > 0)
+                            {
+                                <StatusPreviewTable Heading="Status columns to update" StatusOptions="statusPreview.ToUpdate" />
+                            }
+
+                            @if (statusPreview.ToDelete.Count > 0)
+                            {
+                                <StatusPreviewTable Heading="Status columns to delete" StatusOptions="statusPreview.ToDelete" />
+                            }
+                        }
+
+                        @if (!HasActionableChanges(labelPreview, milestonePreview, statusPreview))
                         {
                             <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Outlined" data-testid="migration-no-action-info">
                                 No create, update, or delete actions are required for this repository.
@@ -246,12 +375,12 @@
     {
         <MudPaper Class="pa-4" Elevation="1" data-testid="migration-preview-empty-state">
             <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Outlined">
-                Select one source repository, one or more target repositories, and at least one migration scope to generate a preview.
+                @BoardSelectionRequirementsMessage
             </MudAlert>
         </MudPaper>
     }
 
-    @if (applyResult.LabelResults.Count > 0 || applyResult.MilestoneResults.Count > 0)
+    @if (applyResult.LabelResults.Count > 0 || applyResult.MilestoneResults.Count > 0 || applyResult.ProjectBoardStatusResults.Count > 0)
     {
         <MudPaper Class="pa-4" Elevation="1" data-testid="migration-summary-card">
             <MudStack Spacing="2">
@@ -261,13 +390,15 @@
                 {
                     var labelResult = GetLabelResult(repository);
                     var milestoneResult = GetMilestoneResult(repository);
+                    var statusResult = GetStatusResult(repository);
                     var showLabelSummary = migrateLabels && applyResult.LabelResults.Any(item => item.RepositoryFullName.Equals(repository, StringComparison.OrdinalIgnoreCase));
                     var showMilestoneSummary = migrateMilestones && applyResult.MilestoneResults.Any(item => item.RepositoryFullName.Equals(repository, StringComparison.OrdinalIgnoreCase));
+                    var showStatusSummary = migrateProjectBoardColumns && applyResult.ProjectBoardStatusResults.Any(item => item.RepositoryFullName.Equals(repository, StringComparison.OrdinalIgnoreCase));
 
                     <MudPaper Class="pa-3" Outlined="true">
                         <MudText Typo="Typo.subtitle1">@repository</MudText>
 
-                        @if ((showLabelSummary && labelResult.HasError) || (showMilestoneSummary && milestoneResult.HasError))
+                        @if ((showLabelSummary && labelResult.HasError) || (showMilestoneSummary && milestoneResult.HasError) || (showStatusSummary && statusResult.HasError))
                         {
                             @if (showLabelSummary && labelResult.HasError)
                             {
@@ -277,6 +408,11 @@
                             @if (showMilestoneSummary && milestoneResult.HasError)
                             {
                                 <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Outlined">Milestone migration failed. @milestoneResult.ErrorMessage</MudAlert>
+                            }
+
+                            @if (showStatusSummary && statusResult.HasError)
+                            {
+                                <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Outlined">Status column migration failed. @statusResult.ErrorMessage</MudAlert>
                             }
                         }
                         else
@@ -289,6 +425,18 @@
                             @if (showMilestoneSummary)
                             {
                                 <MudText Typo="Typo.body2">Milestones - Created: @milestoneResult.CreatedCount, Updated: @milestoneResult.UpdatedCount, Deleted: @milestoneResult.DeletedCount, Skipped: @milestoneResult.SkippedCount</MudText>
+                            }
+
+                            @if (showStatusSummary)
+                            {
+                                <MudText Typo="Typo.body2">Status columns - Created: @statusResult.CreatedCount, Updated: @statusResult.UpdatedCount, Deleted: @statusResult.DeletedCount, Skipped: @statusResult.SkippedCount</MudText>
+
+                                @foreach (var warning in statusResult.Warnings)
+                                {
+                                    <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined" data-testid="migration-status-result-warning">
+                                        @warning
+                                    </MudAlert>
+                                }
                             }
                         }
                     </MudPaper>
@@ -310,7 +458,7 @@
             else if (!CanPreview)
             {
                 <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Outlined" data-testid="migration-requirements-info">
-                    Select repositories and migration scope to unlock preview.
+                    @BoardSelectionRequirementsMessage
                 </MudAlert>
             }
             else if (showPreview && !HasActionablePreviewChanges)

--- a/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor.cs
@@ -2,15 +2,18 @@ using Microsoft.AspNetCore.Components;
 using MudBlazor;
 using SoloDevBoard.App.Authentication;
 using SoloDevBoard.Application.Identity;
+using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Application.Services.Labels;
 using SoloDevBoard.Application.Services.Migration;
 using SoloDevBoard.Application.Services.Repositories;
 
 namespace SoloDevBoard.App.Components.Features.Migration.Pages;
 
-/// <summary>Provides the One-Click Migration workflow for labels and milestones.</summary>
+/// <summary>Provides the One-Click Migration workflow for labels, milestones, and project board columns.</summary>
 public partial class Migration : ComponentBase
 {
+    private const string CreateNewBoardOptionValue = "__create_new__";
+
     /// <summary>Gets or sets the application service used to retrieve repositories.</summary>
     [Inject]
     public IRepositoryService RepositoryService { get; set; } = default!;
@@ -37,6 +40,13 @@ public partial class Migration : ComponentBase
     private HashSet<string> targetRepositoryFullNames = new(StringComparer.OrdinalIgnoreCase);
     private bool migrateLabels = true;
     private bool migrateMilestones = true;
+    private bool migrateProjectBoardColumns;
+    private string sourceProjectBoardId = string.Empty;
+    private Dictionary<string, string> targetProjectBoardSelections = new(StringComparer.OrdinalIgnoreCase);
+    private MigrationProjectBoardDiscoveryDto? sourceBoardDiscovery;
+    private Dictionary<string, MigrationProjectBoardDiscoveryDto> targetBoardDiscoveries = new(StringComparer.OrdinalIgnoreCase);
+    private bool isLoadingSourceBoards;
+    private bool isLoadingTargetBoards;
     private MigrationConflictStrategy conflictStrategy = MigrationConflictStrategy.Skip;
     private MigrationPreviewDto previewResult = new(MigrationConflictStrategy.Skip, [], [], []);
     private MigrationResultDto applyResult = new(MigrationConflictStrategy.Skip, [], [], []);
@@ -45,6 +55,7 @@ public partial class Migration : ComponentBase
     private bool isApplying;
     private bool showPreview;
     private string? operationMessage;
+    private string? inaccessibleProjectBoardsWarning;
     private Severity operationSeverity = Severity.Info;
 
     private static readonly IReadOnlyList<ConflictOption> conflictOptions =
@@ -98,7 +109,7 @@ public partial class Migration : ComponentBase
         }
     }
 
-    private Task OnSelectedRepositoriesChangedAsync(IReadOnlyList<string> repositoryFullNames)
+    private async Task OnSelectedRepositoriesChangedAsync(IReadOnlyList<string> repositoryFullNames)
     {
         ArgumentNullException.ThrowIfNull(repositoryFullNames);
 
@@ -112,22 +123,22 @@ public partial class Migration : ComponentBase
             .ToArray();
 
         EnsureSelectionState();
-        return Task.CompletedTask;
+        await LoadBoardOptionsAsync();
     }
 
-    private Task OnSourceRepositoryChangedAsync(string value)
+    private async Task OnSourceRepositoryChangedAsync(string value)
     {
         sourceRepositoryFullName = value ?? string.Empty;
         _ = targetRepositoryFullNames.Remove(sourceRepositoryFullName);
         ResetPreviewAndResults();
-        return Task.CompletedTask;
+        await LoadBoardOptionsAsync();
     }
 
-    private Task OnTargetRepositoryChangedAsync(string repositoryFullName, bool isSelected)
+    private async Task OnTargetRepositoryChangedAsync(string repositoryFullName, bool isSelected)
     {
         if (string.IsNullOrWhiteSpace(repositoryFullName) || repositoryFullName.Equals(sourceRepositoryFullName, StringComparison.OrdinalIgnoreCase))
         {
-            return Task.CompletedTask;
+            return;
         }
 
         if (isSelected)
@@ -137,10 +148,12 @@ public partial class Migration : ComponentBase
         else
         {
             _ = targetRepositoryFullNames.Remove(repositoryFullName);
+            _ = targetProjectBoardSelections.Remove(repositoryFullName);
+            _ = targetBoardDiscoveries.Remove(repositoryFullName);
         }
 
         ResetPreviewAndResults();
-        return Task.CompletedTask;
+        await LoadBoardOptionsAsync();
     }
 
     private Task OnConflictStrategyChangedAsync(MigrationConflictStrategy value)
@@ -150,18 +163,211 @@ public partial class Migration : ComponentBase
         return Task.CompletedTask;
     }
 
-    private Task OnMigrateLabelsChangedAsync(bool value)
+    private async Task OnMigrateLabelsChangedAsync(bool value)
     {
         migrateLabels = value;
         ResetPreviewAndResults();
-        return Task.CompletedTask;
+        await Task.CompletedTask;
     }
 
-    private Task OnMigrateMilestonesChangedAsync(bool value)
+    private async Task OnMigrateMilestonesChangedAsync(bool value)
     {
         migrateMilestones = value;
         ResetPreviewAndResults();
-        return Task.CompletedTask;
+        await Task.CompletedTask;
+    }
+
+    private async Task OnMigrateProjectBoardColumnsChangedAsync(bool value)
+    {
+        migrateProjectBoardColumns = value;
+        ResetPreviewAndResults();
+
+        if (migrateProjectBoardColumns)
+        {
+            await LoadBoardOptionsAsync();
+        }
+        else
+        {
+            ClearBoardSelectionState();
+        }
+    }
+
+    private async Task OnSourceProjectBoardChangedAsync(string value)
+    {
+        sourceProjectBoardId = value ?? string.Empty;
+        ResetPreviewAndResults();
+        await Task.CompletedTask;
+    }
+
+    private async Task OnTargetProjectBoardChangedAsync(string repositoryFullName, string value)
+    {
+        if (string.IsNullOrWhiteSpace(repositoryFullName))
+        {
+            return;
+        }
+
+        targetProjectBoardSelections[repositoryFullName] = value ?? string.Empty;
+        ResetPreviewAndResults();
+        await Task.CompletedTask;
+    }
+
+    private async Task LoadBoardOptionsAsync()
+    {
+        if (!migrateProjectBoardColumns)
+        {
+            return;
+        }
+
+        await LoadSourceBoardOptionsAsync();
+
+        var targetNames = targetRepositoryFullNames
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        isLoadingTargetBoards = targetNames.Length > 0;
+        try
+        {
+            foreach (var targetRepositoryFullName in targetNames)
+            {
+                await LoadTargetBoardOptionsAsync(targetRepositoryFullName);
+            }
+        }
+        finally
+        {
+            isLoadingTargetBoards = false;
+        }
+
+        UpdateInaccessibleProjectBoardsWarning();
+    }
+
+    private async Task LoadSourceBoardOptionsAsync()
+    {
+        if (!migrateProjectBoardColumns || string.IsNullOrWhiteSpace(sourceRepositoryFullName))
+        {
+            sourceBoardDiscovery = null;
+            sourceProjectBoardId = string.Empty;
+            return;
+        }
+
+        var coordinates = SplitRepositoryFullName(sourceRepositoryFullName);
+        isLoadingSourceBoards = true;
+
+        try
+        {
+            sourceBoardDiscovery = await MigrationService.GetProjectBoardOptionsAsync(
+                coordinates.Owner,
+                coordinates.Name);
+
+            if (sourceBoardDiscovery.Options.Count == 1)
+            {
+                sourceProjectBoardId = sourceBoardDiscovery.Options[0].Id;
+            }
+            else if (!sourceBoardDiscovery.Options.Any(option => option.Id.Equals(sourceProjectBoardId, StringComparison.Ordinal)))
+            {
+                sourceProjectBoardId = string.Empty;
+            }
+        }
+        catch (Exception ex) when (ex is HostedAuthenticationRequiredException or GitHubPatConnectivityRequiredException)
+        {
+            if (GitHubAuthRecovery.TryInitiateRecovery(ex))
+            {
+                return;
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while loading source project boards for {SourceRepository}.", sourceRepositoryFullName);
+            operationSeverity = Severity.Error;
+            operationMessage = $"GitHub API request failed while loading source project boards. {ex.Message}";
+            sourceBoardDiscovery = null;
+            sourceProjectBoardId = string.Empty;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load source project boards for {SourceRepository}.", sourceRepositoryFullName);
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while loading source project boards.";
+            sourceBoardDiscovery = null;
+            sourceProjectBoardId = string.Empty;
+        }
+        finally
+        {
+            isLoadingSourceBoards = false;
+        }
+    }
+
+    private async Task LoadTargetBoardOptionsAsync(string targetRepositoryFullName)
+    {
+        var coordinates = SplitRepositoryFullName(targetRepositoryFullName);
+
+        try
+        {
+            var discovery = await MigrationService.GetProjectBoardOptionsAsync(
+                coordinates.Owner,
+                coordinates.Name);
+
+            targetBoardDiscoveries[targetRepositoryFullName] = discovery;
+
+            if (discovery.Options.Count == 1)
+            {
+                targetProjectBoardSelections[targetRepositoryFullName] = discovery.Options[0].Id;
+            }
+            else if (discovery.Options.Count == 0)
+            {
+                targetProjectBoardSelections[targetRepositoryFullName] = CreateNewBoardOptionValue;
+            }
+            else if (!targetProjectBoardSelections.TryGetValue(targetRepositoryFullName, out var selectedId)
+                || (!selectedId.Equals(CreateNewBoardOptionValue, StringComparison.Ordinal)
+                    && !discovery.Options.Any(option => option.Id.Equals(selectedId, StringComparison.Ordinal))))
+            {
+                targetProjectBoardSelections[targetRepositoryFullName] = string.Empty;
+            }
+        }
+        catch (Exception ex) when (ex is HostedAuthenticationRequiredException or GitHubPatConnectivityRequiredException)
+        {
+            if (GitHubAuthRecovery.TryInitiateRecovery(ex))
+            {
+                return;
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while loading target project boards for {TargetRepository}.", targetRepositoryFullName);
+            operationSeverity = Severity.Error;
+            operationMessage = $"GitHub API request failed while loading target project boards. {ex.Message}";
+            _ = targetBoardDiscoveries.Remove(targetRepositoryFullName);
+            _ = targetProjectBoardSelections.Remove(targetRepositoryFullName);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load target project boards for {TargetRepository}.", targetRepositoryFullName);
+            operationSeverity = Severity.Error;
+            operationMessage = "An unexpected error occurred while loading target project boards.";
+            _ = targetBoardDiscoveries.Remove(targetRepositoryFullName);
+            _ = targetProjectBoardSelections.Remove(targetRepositoryFullName);
+        }
+    }
+
+    private void UpdateInaccessibleProjectBoardsWarning()
+    {
+        var discoveries = new List<MigrationProjectBoardDiscoveryDto>();
+        if (sourceBoardDiscovery is not null)
+        {
+            discoveries.Add(sourceBoardDiscovery);
+        }
+
+        discoveries.AddRange(targetBoardDiscoveries.Values);
+
+        var inaccessibleDiscovery = discoveries
+            .Where(discovery => discovery.InaccessibleLinkedProjectCount > 0)
+            .OrderByDescending(discovery => discovery.InaccessibleLinkedProjectCount)
+            .FirstOrDefault();
+
+        inaccessibleProjectBoardsWarning = inaccessibleDiscovery is null
+            ? null
+            : LinkedProjectBoardVisibility.BuildInaccessibleProjectsWarning(
+                inaccessibleDiscovery.TotalLinkedProjectCount,
+                inaccessibleDiscovery.InaccessibleLinkedProjectCount);
     }
 
     private async Task PreviewMigrationAsync()
@@ -173,7 +379,7 @@ public partial class Migration : ComponentBase
 
         if (!CanPreview)
         {
-            Snackbar.Add("Select one source repository, at least one target repository, and at least one migration item before previewing migration.", Severity.Warning);
+            Snackbar.Add(GetPreviewBlockedMessage(), Severity.Warning);
             return;
         }
 
@@ -186,7 +392,8 @@ public partial class Migration : ComponentBase
                 sourceRepositoryFullName,
                 targetRepositoryFullNames.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToArray(),
                 BuildScope(),
-                conflictStrategy);
+                conflictStrategy,
+                BuildBoardSelection());
 
             showPreview = true;
             applyResult = new MigrationResultDto(conflictStrategy, [], [], []);
@@ -245,19 +452,21 @@ public partial class Migration : ComponentBase
                 sourceRepositoryFullName,
                 targetRepositoryFullNames.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToArray(),
                 BuildScope(),
-                conflictStrategy);
+                conflictStrategy,
+                BuildBoardSelection());
 
             showPreview = false;
             previewResult = new MigrationPreviewDto(conflictStrategy, [], [], []);
 
             var labelFailures = applyResult.LabelResults.Count(result => result.HasError);
             var milestoneFailures = applyResult.MilestoneResults.Count(result => result.HasError);
-            var totalFailures = labelFailures + milestoneFailures;
+            var statusFailures = applyResult.ProjectBoardStatusResults.Count(result => result.HasError);
+            var totalFailures = labelFailures + milestoneFailures + statusFailures;
 
             if (totalFailures == 0)
             {
                 operationSeverity = Severity.Success;
-                operationMessage = "Migration completed successfully for labels and milestones.";
+                operationMessage = "Migration completed successfully.";
             }
             else
             {
@@ -277,13 +486,43 @@ public partial class Migration : ComponentBase
         }
     }
 
-    private bool IsBusy => isLoadingRepositories || isPreviewing || isApplying;
+    private bool IsBusy => isLoadingRepositories || isPreviewing || isApplying || isLoadingSourceBoards || isLoadingTargetBoards;
+
+    private bool HasValidScopeSelection => migrateLabels || migrateMilestones || migrateProjectBoardColumns;
+
+    private bool HasCompleteBoardSelections
+    {
+        get
+        {
+            if (!migrateProjectBoardColumns)
+            {
+                return true;
+            }
+
+            if (string.IsNullOrWhiteSpace(sourceProjectBoardId))
+            {
+                return false;
+            }
+
+            foreach (var targetRepositoryFullName in targetRepositoryFullNames)
+            {
+                if (!targetProjectBoardSelections.TryGetValue(targetRepositoryFullName, out var selection)
+                    || string.IsNullOrWhiteSpace(selection))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
 
     private bool CanPreview => !IsBusy
         && selectedRepositories.Count >= 2
         && !string.IsNullOrWhiteSpace(sourceRepositoryFullName)
         && targetRepositoryFullNames.Count > 0
-        && (migrateLabels || migrateMilestones);
+        && HasValidScopeSelection
+        && HasCompleteBoardSelections;
 
     private bool CanApply => showPreview
         && !IsBusy
@@ -295,9 +534,12 @@ public partial class Migration : ComponentBase
         {
             var labelActions = previewResult.LabelPreviews.Sum(preview => preview.ToCreate.Count + preview.ToUpdate.Count + preview.ToDelete.Count);
             var milestoneActions = previewResult.MilestonePreviews.Sum(preview => preview.ToCreate.Count + preview.ToUpdate.Count + preview.ToDelete.Count);
-            return labelActions + milestoneActions > 0;
+            var statusActions = previewResult.ProjectBoardStatusPreviews.Sum(preview => preview.ToCreate.Count + preview.ToUpdate.Count + preview.ToDelete.Count);
+            return labelActions + milestoneActions + statusActions > 0;
         }
     }
+
+    private bool HasInaccessibleProjectBoardsWarning => !string.IsNullOrWhiteSpace(inaccessibleProjectBoardsWarning);
 
     private string RepositorySelectorSummary
     {
@@ -309,6 +551,11 @@ public partial class Migration : ComponentBase
             return $"Showing {repositoryCount} active {repositoryNoun}. {selectedRepositories.Count} selected. Archived repositories are hidden by default.";
         }
     }
+
+    private string BoardSelectionRequirementsMessage
+        => migrateProjectBoardColumns && !HasCompleteBoardSelections
+            ? "Select a source project board and choose a target board (or create a new board) for each target repository to unlock preview."
+            : "Select repositories and migration scope to unlock preview.";
 
     private IReadOnlyList<string> availableRepositoryFullNames
         => availableRepositories
@@ -322,10 +569,16 @@ public partial class Migration : ComponentBase
             .OrderBy(fullName => fullName, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
+    private IReadOnlyList<string> orderedTargetRepositoryFullNames
+        => targetRepositoryFullNames
+            .OrderBy(fullName => fullName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
     private IReadOnlyList<string> orderedPreviewRepositories
         => previewResult.LabelPreviews
             .Select(preview => preview.RepositoryFullName)
             .Union(previewResult.MilestonePreviews.Select(preview => preview.RepositoryFullName), StringComparer.OrdinalIgnoreCase)
+            .Union(previewResult.ProjectBoardStatusPreviews.Select(preview => preview.RepositoryFullName), StringComparer.OrdinalIgnoreCase)
             .OrderBy(fullName => fullName, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
@@ -333,6 +586,7 @@ public partial class Migration : ComponentBase
         => applyResult.LabelResults
             .Select(result => result.RepositoryFullName)
             .Union(applyResult.MilestoneResults.Select(result => result.RepositoryFullName), StringComparer.OrdinalIgnoreCase)
+            .Union(applyResult.ProjectBoardStatusResults.Select(result => result.RepositoryFullName), StringComparer.OrdinalIgnoreCase)
             .OrderBy(fullName => fullName, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
@@ -344,6 +598,10 @@ public partial class Migration : ComponentBase
         => previewResult.MilestonePreviews.FirstOrDefault(item => item.RepositoryFullName.Equals(repositoryFullName, StringComparison.OrdinalIgnoreCase))
             ?? new MilestoneSyncRepositoryPreviewDto(repositoryFullName, [], [], [], []);
 
+    private ProjectBoardStatusSyncRepositoryPreviewDto GetStatusPreview(string repositoryFullName)
+        => previewResult.ProjectBoardStatusPreviews.FirstOrDefault(item => item.RepositoryFullName.Equals(repositoryFullName, StringComparison.OrdinalIgnoreCase))
+            ?? new ProjectBoardStatusSyncRepositoryPreviewDto(repositoryFullName, null, false, [], [], [], [], [], 0, 0);
+
     private LabelSyncRepositoryResultDto GetLabelResult(string repositoryFullName)
         => applyResult.LabelResults.FirstOrDefault(item => item.RepositoryFullName.Equals(repositoryFullName, StringComparison.OrdinalIgnoreCase))
             ?? new LabelSyncRepositoryResultDto(repositoryFullName, 0, 0, 0, 0, null);
@@ -352,9 +610,30 @@ public partial class Migration : ComponentBase
         => applyResult.MilestoneResults.FirstOrDefault(item => item.RepositoryFullName.Equals(repositoryFullName, StringComparison.OrdinalIgnoreCase))
             ?? new MilestoneSyncRepositoryResultDto(repositoryFullName, 0, 0, 0, 0, null);
 
-    private static bool HasActionableChanges(LabelSyncRepositoryPreviewDto labelPreview, MilestoneSyncRepositoryPreviewDto milestonePreview)
+    private ProjectBoardStatusSyncRepositoryResultDto GetStatusResult(string repositoryFullName)
+        => applyResult.ProjectBoardStatusResults.FirstOrDefault(item => item.RepositoryFullName.Equals(repositoryFullName, StringComparison.OrdinalIgnoreCase))
+            ?? new ProjectBoardStatusSyncRepositoryResultDto(repositoryFullName, 0, 0, 0, 0, null, [], null);
+
+    private IReadOnlyList<MigrationProjectBoardOptionDto> GetSourceBoardOptions()
+        => sourceBoardDiscovery?.Options ?? [];
+
+    private IReadOnlyList<MigrationProjectBoardOptionDto> GetTargetBoardOptions(string repositoryFullName)
+        => targetBoardDiscoveries.TryGetValue(repositoryFullName, out var discovery)
+            ? discovery.Options
+            : [];
+
+    private string GetTargetBoardSelection(string repositoryFullName)
+        => targetProjectBoardSelections.TryGetValue(repositoryFullName, out var selection)
+            ? selection
+            : string.Empty;
+
+    private static bool HasActionableChanges(
+        LabelSyncRepositoryPreviewDto labelPreview,
+        MilestoneSyncRepositoryPreviewDto milestonePreview,
+        ProjectBoardStatusSyncRepositoryPreviewDto statusPreview)
         => (labelPreview.ToCreate.Count + labelPreview.ToUpdate.Count + labelPreview.ToDelete.Count
-            + milestonePreview.ToCreate.Count + milestonePreview.ToUpdate.Count + milestonePreview.ToDelete.Count) > 0;
+            + milestonePreview.ToCreate.Count + milestonePreview.ToUpdate.Count + milestonePreview.ToDelete.Count
+            + statusPreview.ToCreate.Count + statusPreview.ToUpdate.Count + statusPreview.ToDelete.Count) > 0;
 
     private void ResetWorkflow()
     {
@@ -362,8 +641,21 @@ public partial class Migration : ComponentBase
         targetRepositoryFullNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         migrateLabels = true;
         migrateMilestones = true;
+        migrateProjectBoardColumns = false;
         conflictStrategy = MigrationConflictStrategy.Skip;
+        ClearBoardSelectionState();
         ResetPreviewAndResults();
+    }
+
+    private void ClearBoardSelectionState()
+    {
+        sourceProjectBoardId = string.Empty;
+        sourceBoardDiscovery = null;
+        targetProjectBoardSelections = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        targetBoardDiscoveries = new Dictionary<string, MigrationProjectBoardDiscoveryDto>(StringComparer.OrdinalIgnoreCase);
+        inaccessibleProjectBoardsWarning = null;
+        isLoadingSourceBoards = false;
+        isLoadingTargetBoards = false;
     }
 
     private void ResetPreviewAndResults()
@@ -399,10 +691,76 @@ public partial class Migration : ComponentBase
             .Where(target => !target.Equals(sourceRepositoryFullName, StringComparison.OrdinalIgnoreCase))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
+        targetProjectBoardSelections = targetProjectBoardSelections
+            .Where(entry => targetRepositoryFullNames.Contains(entry.Key))
+            .ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.OrdinalIgnoreCase);
+
+        targetBoardDiscoveries = targetBoardDiscoveries
+            .Where(entry => targetRepositoryFullNames.Contains(entry.Key))
+            .ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.OrdinalIgnoreCase);
+
         ResetPreviewAndResults();
     }
 
-    private MigrationScopeDto BuildScope() => new(migrateLabels, migrateMilestones);
+    private MigrationScopeDto BuildScope() => new(migrateLabels, migrateMilestones, migrateProjectBoardColumns);
+
+    private MigrationBoardSelectionDto? BuildBoardSelection()
+    {
+        if (!migrateProjectBoardColumns)
+        {
+            return null;
+        }
+
+        var targetSelections = targetRepositoryFullNames
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .Select(targetRepositoryFullName =>
+            {
+                var selection = targetProjectBoardSelections[targetRepositoryFullName];
+                if (selection.Equals(CreateNewBoardOptionValue, StringComparison.Ordinal))
+                {
+                    var repoName = SplitRepositoryFullName(targetRepositoryFullName).Name;
+                    return new MigrationTargetBoardSelectionDto(targetRepositoryFullName, null, $"{repoName} board");
+                }
+
+                return new MigrationTargetBoardSelectionDto(targetRepositoryFullName, selection, null);
+            })
+            .ToArray();
+
+        return new MigrationBoardSelectionDto(sourceProjectBoardId, targetSelections);
+    }
+
+    private string GetPreviewBlockedMessage()
+    {
+        if (!HasValidScopeSelection)
+        {
+            return "Select at least one migration item before previewing migration.";
+        }
+
+        if (migrateProjectBoardColumns && !HasCompleteBoardSelections)
+        {
+            return "Select a source project board and choose a target board (or create a new board) for each target repository before previewing migration.";
+        }
+
+        return "Select one source repository, at least one target repository, and at least one migration item before previewing migration.";
+    }
+
+    private static RepositoryCoordinates SplitRepositoryFullName(string fullName)
+    {
+        if (string.IsNullOrWhiteSpace(fullName))
+        {
+            throw new ArgumentException("Repository full name must be provided.", nameof(fullName));
+        }
+
+        var parts = fullName.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length != 2)
+        {
+            throw new ArgumentException($"Repository '{fullName}' must be in owner/repository format.", nameof(fullName));
+        }
+
+        return new RepositoryCoordinates(parts[0], parts[1]);
+    }
 
     private sealed record ConflictOption(MigrationConflictStrategy Value, string Label, string Description);
+
+    private sealed record RepositoryCoordinates(string Owner, string Name);
 }

--- a/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/Migration/Pages/Migration.razor.cs
@@ -47,6 +47,8 @@ public partial class Migration : ComponentBase
     private Dictionary<string, MigrationProjectBoardDiscoveryDto> targetBoardDiscoveries = new(StringComparer.OrdinalIgnoreCase);
     private bool isLoadingSourceBoards;
     private bool isLoadingTargetBoards;
+    private CancellationTokenSource? _sourceProjectBoardsLoadCts;
+    private CancellationTokenSource? _targetProjectBoardsLoadCts;
     private MigrationConflictStrategy conflictStrategy = MigrationConflictStrategy.Skip;
     private MigrationPreviewDto previewResult = new(MigrationConflictStrategy.Skip, [], [], []);
     private MigrationResultDto applyResult = new(MigrationConflictStrategy.Skip, [], [], []);
@@ -224,48 +226,76 @@ public partial class Migration : ComponentBase
             .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
+        var targetLoadCts = BeginTargetProjectBoardsLoad();
+        var targetCancellationToken = targetLoadCts.Token;
         isLoadingTargetBoards = targetNames.Length > 0;
+
         try
         {
             foreach (var targetRepositoryFullName in targetNames)
             {
-                await LoadTargetBoardOptionsAsync(targetRepositoryFullName);
+                await LoadTargetBoardOptionsAsync(targetRepositoryFullName, targetLoadCts, targetCancellationToken);
             }
         }
         finally
         {
-            isLoadingTargetBoards = false;
+            if (ReferenceEquals(_targetProjectBoardsLoadCts, targetLoadCts))
+            {
+                isLoadingTargetBoards = false;
+            }
         }
 
-        UpdateInaccessibleProjectBoardsWarning();
+        if (!IsStaleTargetProjectBoardsBatch(targetLoadCts))
+        {
+            UpdateInaccessibleProjectBoardsWarning();
+        }
     }
 
     private async Task LoadSourceBoardOptionsAsync()
     {
         if (!migrateProjectBoardColumns || string.IsNullOrWhiteSpace(sourceRepositoryFullName))
         {
+            CancelBoardLoads();
             sourceBoardDiscovery = null;
             sourceProjectBoardId = string.Empty;
+            isLoadingSourceBoards = false;
             return;
         }
 
-        var coordinates = SplitRepositoryFullName(sourceRepositoryFullName);
+        var expectedSourceRepositoryFullName = sourceRepositoryFullName;
+        var coordinates = SplitRepositoryFullName(expectedSourceRepositoryFullName);
+        var loadCts = BeginSourceProjectBoardsLoad();
+        var cancellationToken = loadCts.Token;
+
         isLoadingSourceBoards = true;
+        sourceBoardDiscovery = null;
+        inaccessibleProjectBoardsWarning = null;
 
         try
         {
-            sourceBoardDiscovery = await MigrationService.GetProjectBoardOptionsAsync(
-                coordinates.Owner,
-                coordinates.Name);
+            var discovery = await MigrationService
+                .GetProjectBoardOptionsAsync(coordinates.Owner, coordinates.Name, cancellationToken)
+                .ConfigureAwait(false);
 
-            if (sourceBoardDiscovery.Options.Count == 1)
+            if (IsStaleSourceProjectBoardsLoad(loadCts, expectedSourceRepositoryFullName))
             {
-                sourceProjectBoardId = sourceBoardDiscovery.Options[0].Id;
+                return;
             }
-            else if (!sourceBoardDiscovery.Options.Any(option => option.Id.Equals(sourceProjectBoardId, StringComparison.Ordinal)))
+
+            sourceBoardDiscovery = discovery;
+
+            if (discovery.Options.Count == 1)
+            {
+                sourceProjectBoardId = discovery.Options[0].Id;
+            }
+            else if (!discovery.Options.Any(option => option.Id.Equals(sourceProjectBoardId, StringComparison.Ordinal)))
             {
                 sourceProjectBoardId = string.Empty;
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
         }
         catch (Exception ex) when (ex is HostedAuthenticationRequiredException or GitHubPatConnectivityRequiredException)
         {
@@ -276,7 +306,12 @@ public partial class Migration : ComponentBase
         }
         catch (HttpRequestException ex)
         {
-            Logger.LogError(ex, "GitHub API request failed while loading source project boards for {SourceRepository}.", sourceRepositoryFullName);
+            if (IsStaleSourceProjectBoardsLoad(loadCts, expectedSourceRepositoryFullName))
+            {
+                return;
+            }
+
+            Logger.LogError(ex, "GitHub API request failed while loading source project boards for {SourceRepository}.", expectedSourceRepositoryFullName);
             operationSeverity = Severity.Error;
             operationMessage = $"GitHub API request failed while loading source project boards. {ex.Message}";
             sourceBoardDiscovery = null;
@@ -284,7 +319,12 @@ public partial class Migration : ComponentBase
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Failed to load source project boards for {SourceRepository}.", sourceRepositoryFullName);
+            if (IsStaleSourceProjectBoardsLoad(loadCts, expectedSourceRepositoryFullName))
+            {
+                return;
+            }
+
+            Logger.LogError(ex, "Failed to load source project boards for {SourceRepository}.", expectedSourceRepositoryFullName);
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while loading source project boards.";
             sourceBoardDiscovery = null;
@@ -292,19 +332,35 @@ public partial class Migration : ComponentBase
         }
         finally
         {
-            isLoadingSourceBoards = false;
+            if (ReferenceEquals(_sourceProjectBoardsLoadCts, loadCts))
+            {
+                isLoadingSourceBoards = false;
+            }
         }
     }
 
-    private async Task LoadTargetBoardOptionsAsync(string targetRepositoryFullName)
+    private async Task LoadTargetBoardOptionsAsync(
+        string targetRepositoryFullName,
+        CancellationTokenSource loadCts,
+        CancellationToken cancellationToken)
     {
+        if (IsStaleTargetProjectBoardsLoad(loadCts, targetRepositoryFullName))
+        {
+            return;
+        }
+
         var coordinates = SplitRepositoryFullName(targetRepositoryFullName);
 
         try
         {
-            var discovery = await MigrationService.GetProjectBoardOptionsAsync(
-                coordinates.Owner,
-                coordinates.Name);
+            var discovery = await MigrationService
+                .GetProjectBoardOptionsAsync(coordinates.Owner, coordinates.Name, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (IsStaleTargetProjectBoardsLoad(loadCts, targetRepositoryFullName))
+            {
+                return;
+            }
 
             targetBoardDiscoveries[targetRepositoryFullName] = discovery;
 
@@ -323,6 +379,10 @@ public partial class Migration : ComponentBase
                 targetProjectBoardSelections[targetRepositoryFullName] = string.Empty;
             }
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
         catch (Exception ex) when (ex is HostedAuthenticationRequiredException or GitHubPatConnectivityRequiredException)
         {
             if (GitHubAuthRecovery.TryInitiateRecovery(ex))
@@ -332,6 +392,11 @@ public partial class Migration : ComponentBase
         }
         catch (HttpRequestException ex)
         {
+            if (IsStaleTargetProjectBoardsLoad(loadCts, targetRepositoryFullName))
+            {
+                return;
+            }
+
             Logger.LogError(ex, "GitHub API request failed while loading target project boards for {TargetRepository}.", targetRepositoryFullName);
             operationSeverity = Severity.Error;
             operationMessage = $"GitHub API request failed while loading target project boards. {ex.Message}";
@@ -340,6 +405,11 @@ public partial class Migration : ComponentBase
         }
         catch (Exception ex)
         {
+            if (IsStaleTargetProjectBoardsLoad(loadCts, targetRepositoryFullName))
+            {
+                return;
+            }
+
             Logger.LogError(ex, "Failed to load target project boards for {TargetRepository}.", targetRepositoryFullName);
             operationSeverity = Severity.Error;
             operationMessage = "An unexpected error occurred while loading target project boards.";
@@ -649,6 +719,7 @@ public partial class Migration : ComponentBase
 
     private void ClearBoardSelectionState()
     {
+        CancelBoardLoads();
         sourceProjectBoardId = string.Empty;
         sourceBoardDiscovery = null;
         targetProjectBoardSelections = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -759,6 +830,54 @@ public partial class Migration : ComponentBase
 
         return new RepositoryCoordinates(parts[0], parts[1]);
     }
+
+    private CancellationTokenSource BeginSourceProjectBoardsLoad()
+    {
+        CancelTargetProjectBoardsLoad();
+        CancelSourceProjectBoardsLoad();
+        _sourceProjectBoardsLoadCts = new CancellationTokenSource();
+        return _sourceProjectBoardsLoadCts;
+    }
+
+    private CancellationTokenSource BeginTargetProjectBoardsLoad()
+    {
+        CancelTargetProjectBoardsLoad();
+        _targetProjectBoardsLoadCts = new CancellationTokenSource();
+        return _targetProjectBoardsLoadCts;
+    }
+
+    private void CancelBoardLoads()
+    {
+        CancelSourceProjectBoardsLoad();
+        CancelTargetProjectBoardsLoad();
+    }
+
+    private void CancelSourceProjectBoardsLoad()
+    {
+        _sourceProjectBoardsLoadCts?.Cancel();
+        _sourceProjectBoardsLoadCts?.Dispose();
+        _sourceProjectBoardsLoadCts = null;
+    }
+
+    private void CancelTargetProjectBoardsLoad()
+    {
+        _targetProjectBoardsLoadCts?.Cancel();
+        _targetProjectBoardsLoadCts?.Dispose();
+        _targetProjectBoardsLoadCts = null;
+    }
+
+    private bool IsStaleSourceProjectBoardsLoad(CancellationTokenSource loadCts, string expectedSourceRepositoryFullName)
+        => loadCts.IsCancellationRequested
+            || !ReferenceEquals(_sourceProjectBoardsLoadCts, loadCts)
+            || !string.Equals(sourceRepositoryFullName, expectedSourceRepositoryFullName, StringComparison.OrdinalIgnoreCase);
+
+    private bool IsStaleTargetProjectBoardsLoad(CancellationTokenSource loadCts, string targetRepositoryFullName)
+        => loadCts.IsCancellationRequested
+            || !ReferenceEquals(_targetProjectBoardsLoadCts, loadCts)
+            || !targetRepositoryFullNames.Contains(targetRepositoryFullName);
+
+    private bool IsStaleTargetProjectBoardsBatch(CancellationTokenSource loadCts)
+        => loadCts.IsCancellationRequested || !ReferenceEquals(_targetProjectBoardsLoadCts, loadCts);
 
     private sealed record ConflictOption(MigrationConflictStrategy Value, string Label, string Description);
 

--- a/src/Application/SoloDevBoard.Application/Services/Migration/IMigrationService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/IMigrationService.cs
@@ -34,4 +34,14 @@ public interface IMigrationService
         MigrationConflictStrategy conflictStrategy,
         MigrationBoardSelectionDto? boardSelection = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>Discovers supported project boards for column migration on a repository.</summary>
+    /// <param name="owner">The GitHub account owner login.</param>
+    /// <param name="repo">The repository name.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>Supported boards and linked-project visibility metadata.</returns>
+    Task<MigrationProjectBoardDiscoveryDto> GetProjectBoardOptionsAsync(
+        string owner,
+        string repo,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Application/SoloDevBoard.Application/Services/Migration/MigrationProjectBoardDiscoveryDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/MigrationProjectBoardDiscoveryDto.cs
@@ -1,0 +1,10 @@
+namespace SoloDevBoard.Application.Services.Migration;
+
+/// <summary>Supported project board options and visibility metadata for column migration.</summary>
+/// <param name="Options">Supported GitHub Project v2 boards that expose a Status field.</param>
+/// <param name="TotalLinkedProjectCount">The number of project boards GitHub reports as linked to the repository.</param>
+/// <param name="InaccessibleLinkedProjectCount">Linked project boards that could not be read with the current credentials.</param>
+public sealed record MigrationProjectBoardDiscoveryDto(
+    IReadOnlyList<MigrationProjectBoardOptionDto> Options,
+    int TotalLinkedProjectCount,
+    int InaccessibleLinkedProjectCount);

--- a/src/Application/SoloDevBoard.Application/Services/Migration/MigrationProjectBoardOptionDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/MigrationProjectBoardOptionDto.cs
@@ -1,0 +1,8 @@
+namespace SoloDevBoard.Application.Services.Migration;
+
+/// <summary>Represents a supported GitHub Project v2 board available for column migration.</summary>
+/// <param name="Id">The GitHub node identifier for the project board.</param>
+/// <param name="Title">The project board title.</param>
+public sealed record MigrationProjectBoardOptionDto(
+    string Id,
+    string Title);

--- a/src/Application/SoloDevBoard.Application/Services/Migration/MigrationService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Migration/MigrationService.cs
@@ -31,6 +31,30 @@ public sealed class MigrationService : IMigrationService
     }
 
     /// <inheritdoc/>
+    public async Task<MigrationProjectBoardDiscoveryDto> GetProjectBoardOptionsAsync(
+        string owner,
+        string repo,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var discovery = await _projectBoardStructureRepository
+            .DiscoverBoardsAsync(owner, repo, cancellationToken)
+            .ConfigureAwait(false);
+
+        var options = discovery.SupportedBoards
+            .Select(board => new MigrationProjectBoardOptionDto(board.ProjectId, board.ProjectTitle))
+            .OrderBy(board => board.Title, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return new MigrationProjectBoardDiscoveryDto(
+            options,
+            discovery.TotalLinkedProjectCount,
+            discovery.InaccessibleLinkedProjectCount);
+    }
+
+    /// <inheritdoc/>
     public async Task<MigrationPreviewDto> PreviewMigrationAsync(
         string sourceRepositoryFullName,
         IReadOnlyList<string> targetRepositoryFullNames,

--- a/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
@@ -18,6 +18,53 @@ public sealed class MigrationTests
     private readonly IMigrationService _migrationService = Substitute.For<IMigrationService>();
 
     [Fact]
+    public async Task Migration_ProjectBoardColumnsScopeSwitch_RendersInScopeCard()
+    {
+        // Arrange
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
+                CreateRepository("owner", "repo-a"),
+                CreateRepository("owner", "repo-b"),
+            ]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Migration>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotNull(cut.Find("[data-testid='migration-scope-columns-switch']"));
+            Assert.Contains("Project board columns", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task Migration_OverwriteStrategy_RendersStatusOptionWarning()
+    {
+        // Arrange
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([
+                CreateRepository("owner", "repo-a"),
+                CreateRepository("owner", "repo-b"),
+            ]);
+
+        await using var ctx = CreateContext();
+
+        // Act
+        var cut = ctx.Render<Migration>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='migration-repository-autocomplete']"));
+
+        var strategySelect = cut.FindComponents<MudSelect<MigrationConflictStrategy>>().Single();
+        await cut.InvokeAsync(() => strategySelect.Instance.ValueChanged.InvokeAsync(MigrationConflictStrategy.Overwrite));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("unused Status options", cut.Markup);
+        });
+    }
+
+    [Fact]
     public async Task Migration_ConflictStrategyOptions_RenderExplanatoryText()
     {
         // Arrange

--- a/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
@@ -40,6 +40,87 @@ public sealed class MigrationTests
     }
 
     [Fact]
+    public async Task Migration_RapidSourceRepositoryChange_IgnoresStaleProjectBoardResponse()
+    {
+        // Arrange
+        var repositoryA = CreateRepository("owner", "repo-a");
+        var repositoryB = CreateRepository("owner", "repo-b");
+        var repositoryC = CreateRepository("owner", "repo-c");
+        var repositoryADiscoveryTask = new TaskCompletionSource<MigrationProjectBoardDiscoveryDto>();
+
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([repositoryA, repositoryB, repositoryC]);
+
+        _migrationService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(repositoryADiscoveryTask.Task);
+
+        _migrationService.GetProjectBoardOptionsAsync("owner", "repo-b", Arg.Any<CancellationToken>()).Returns(
+            new MigrationProjectBoardDiscoveryDto(
+                [new MigrationProjectBoardOptionDto("PVT_beta", "Beta Board")],
+                1,
+                0));
+
+        _migrationService.GetProjectBoardOptionsAsync("owner", "repo-c", Arg.Any<CancellationToken>()).Returns(
+            new MigrationProjectBoardDiscoveryDto([], 0, 0));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<Migration>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='migration-repository-autocomplete']"));
+
+        await SelectRepositoriesAsync(cut, repositoryA, repositoryB, repositoryC);
+        await EnableProjectBoardColumnsScopeAsync(cut);
+
+        await ChangeSourceRepositoryAsync(cut, repositoryB.FullName);
+        cut.WaitForAssertion(() => Assert.Contains("Beta Board", cut.Markup));
+
+        repositoryADiscoveryTask.SetResult(new MigrationProjectBoardDiscoveryDto(
+            [new MigrationProjectBoardOptionDto("PVT_alpha", "Alpha Board")],
+            1,
+            0));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Beta Board", cut.Markup);
+            Assert.DoesNotContain("Alpha Board", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task Migration_TargetBoardsLoading_HidesTargetSelectors()
+    {
+        // Arrange
+        var sourceRepository = CreateRepository("owner", "repo-a");
+        var targetRepository = CreateRepository("owner", "repo-b");
+        var targetBoardsTask = new TaskCompletionSource<MigrationProjectBoardDiscoveryDto>();
+
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
+
+        _migrationService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(
+            new MigrationProjectBoardDiscoveryDto([], 0, 0));
+
+        _migrationService.GetProjectBoardOptionsAsync("owner", "repo-b", Arg.Any<CancellationToken>()).Returns(targetBoardsTask.Task);
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<Migration>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='migration-repository-autocomplete']"));
+
+        await SelectRepositoriesAsync(cut, sourceRepository, targetRepository);
+        await EnableProjectBoardColumnsScopeAsync(cut);
+        var enableTargetTask = EnableTargetRepositoryAsync(cut, targetRepository);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotNull(cut.Find("[data-testid='migration-target-boards-loading-state']"));
+            Assert.Empty(cut.FindAll("[data-testid='migration-target-board-selector']"));
+        });
+
+        targetBoardsTask.SetResult(new MigrationProjectBoardDiscoveryDto([], 0, 0));
+        await enableTargetTask;
+
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("[data-testid='migration-target-board-selector']")));
+    }
+
+    [Fact]
     public async Task Migration_OverwriteStrategy_RendersStatusOptionWarning()
     {
         // Arrange
@@ -448,6 +529,28 @@ public sealed class MigrationTests
         var selectedFullNames = repositories.Select(repository => repository.FullName).ToArray();
 
         await cut.InvokeAsync(() => selector.Instance.SelectedRepositoriesChanged.InvokeAsync(selectedFullNames));
+    }
+
+    private static async Task EnableProjectBoardColumnsScopeAsync(IRenderedComponent<Migration> cut)
+    {
+        cut.Find("[data-testid='migration-scope-columns-switch']").Change(true);
+        await cut.InvokeAsync(() => { });
+    }
+
+    private static Task EnableTargetRepositoryAsync(IRenderedComponent<Migration> cut, RepositoryDto repository)
+    {
+        var targetCheckbox = cut.FindComponents<MudCheckBox<bool>>()
+            .Single(checkbox => string.Equals(checkbox.Instance.Label, repository.FullName, StringComparison.Ordinal));
+
+        return cut.InvokeAsync(() => targetCheckbox.Instance.ValueChanged.InvokeAsync(true));
+    }
+
+    private static async Task ChangeSourceRepositoryAsync(IRenderedComponent<Migration> cut, string repositoryFullName)
+    {
+        var sourceSelect = cut.FindComponents<MudSelect<string>>()
+            .Single(select => string.Equals(select.Instance.Label, "Source repository", StringComparison.Ordinal));
+
+        await cut.InvokeAsync(() => sourceSelect.Instance.ValueChanged.InvokeAsync(repositoryFullName));
     }
 
     private static RepositoryDto CreateRepository(string owner, string name)

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
@@ -206,6 +206,36 @@ public sealed class MigrationServiceTests
         await _milestoneRepository.DidNotReceive().DeleteMilestoneAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), cancellationToken);
     }
 
+    [Fact]
+    public async Task GetProjectBoardOptionsAsync_ReturnsSupportedBoardOptionsOrderedByTitle()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        _projectBoardStructureRepository
+            .DiscoverBoardsAsync("owner", "source", cancellationToken)
+            .Returns(new ProjectBoardDiscovery
+            {
+                SupportedBoards =
+                [
+                    new ProjectBoardStatusStructure { ProjectId = "PVT_2", ProjectTitle = "Zeta board" },
+                    new ProjectBoardStatusStructure { ProjectId = "PVT_1", ProjectTitle = "Alpha board" },
+                ],
+                TotalLinkedProjectCount = 2,
+                InaccessibleLinkedProjectCount = 0,
+            });
+
+        var sut = CreateSubject();
+
+        var result = await sut.GetProjectBoardOptionsAsync("owner", "source", cancellationToken);
+
+        Assert.Equal(2, result.Options.Count);
+        Assert.Equal("Alpha board", result.Options[0].Title);
+        Assert.Equal("PVT_1", result.Options[0].Id);
+        Assert.Equal("Zeta board", result.Options[1].Title);
+        Assert.Equal(2, result.TotalLinkedProjectCount);
+        Assert.Equal(0, result.InaccessibleLinkedProjectCount);
+    }
+
     private MigrationService CreateSubject()
         => new(_labelRepository, _milestoneRepository, _projectBoardStructureRepository);
 

--- a/website/content/docs/one-click-migration.md
+++ b/website/content/docs/one-click-migration.md
@@ -3,22 +3,18 @@ weight: 60
 title: One-Click Migration
 landing: true
 landingIcon: swap_horiz
-landingSubtitle: "Migrate labels and milestones from one repository to another in a single action."
-guideStatus: Partially Available
----
-
-> **Scope note** — Labels and milestones migration is available now. Project board configuration migration is planned for a later slice and is not part of this guide.
-
+landingSubtitle: "Migrate labels, milestones, and project board Status columns from one repository to another."
+guideStatus: Available
 ---
 
 ## Overview
 
-One-Click Migration allows you to copy label taxonomies and milestones from one GitHub repository to another in a single action. This is particularly useful when bootstrapping a new repository to match the conventions of an existing project.
+One-Click Migration allows you to copy label taxonomies, milestones, and Projects v2 Status column structure from one GitHub repository to another in a single action. This is particularly useful when bootstrapping a new repository to match the conventions of an existing project.
 
 ![One-Click Migration setup with markheydon/solo-dev-board selected](/images/one-click-migration/overview.png)
 
 Key goals of One-Click Migration:
-- Eliminate the repetitive manual work of recreating labels and milestones in new repositories.
+- Eliminate the repetitive manual work of recreating labels, milestones, and board columns in new repositories.
 - Ensure consistency across related repositories.
 - Provide a preview of changes before they are applied, so nothing is overwritten accidentally.
 
@@ -31,11 +27,11 @@ One-Click Migration and Label Manager both help you keep repositories consistent
 - Use Label Manager when you want to manage labels as a living taxonomy across repositories over time.
 - Use Label Manager when you need label-specific operations such as creating, renaming, recolouring, deleting, or re-synchronising labels without treating the whole repository setup as a migration.
 
-For the current planned Phase 3 delivery slice, One-Click Migration covers labels and milestones. Project board configuration migration remains planned for a later slice.
+One-Click Migration covers labels, milestones, and Projects v2 Status columns (the board-view Status field). It does not copy cards, views, automations, or other custom fields.
 
 ## Example Use Cases
 
-- You create a new repository and want it to inherit the labels and milestones from an existing repository you already run successfully. Use One-Click Migration.
+- You create a new repository and want it to inherit the labels, milestones, and Status columns from an existing repository you already run successfully. Use One-Click Migration.
 - You already have several active repositories and want to rename a label, change its colour, or push one new label to all of them. Use Label Manager.
 - You want to compare a source repository with one or more targets, review a preview, choose a conflict strategy, and then apply the result. Use One-Click Migration.
 - You want an ongoing operational tool for label housekeeping and taxonomy enforcement. Use Label Manager.
@@ -54,8 +50,16 @@ Use the toggle switches to select which artefact types to include:
 
 - **Labels** — copies the full label taxonomy from the source repository.
 - **Milestones** — copies milestone titles, descriptions, states, and due dates.
+- **Project board columns** — copies Projects v2 Status option names, colours, descriptions, and order from a selected source board.
 
-Both are enabled by default. At least one must remain on or the Preview button will be unavailable.
+Labels and milestones are enabled by default. At least one scope toggle must remain on or the Preview button will be unavailable.
+
+When **Project board columns** is enabled, additional board selectors appear:
+
+- Choose the **source project board** whose Status columns are copied. If the source repository has exactly one supported board, it is selected automatically.
+- For each target repository, choose an existing linked board or **Create a new board**. Preview stays disabled until every target has a board selection.
+
+If GitHub reports linked boards that cannot be loaded with the current sign-in (commonly private user-owned boards under GitHub App sign-in), an on-page warning is shown with the same guidance as Triage.
 
 ### Step 3 — Choose a conflict resolution strategy
 
@@ -64,18 +68,19 @@ Select how existing artefacts in each target repository are handled when a match
 | Strategy | Behaviour |
 |---|---|
 | **Skip** | Conflicting items in the target are left unchanged. |
-| **Overwrite** | Conflicting items are replaced with those from the source. A warning is shown before you confirm. |
+| **Overwrite** | Conflicting items are replaced with those from the source. Unused target-only Status options may be removed when no board items use them. A warning is shown before you confirm. |
 | **Merge** | Conflicting items are replaced with source values; items that exist only in the target are preserved. |
 
 
 ### Step 4 — Review the preview and status guidance
 
-Click **Preview** to generate a read-only diff for each target repository. No changes are made at this stage.
+Click **Preview migration** to generate a read-only diff for each target repository. No changes are made at this stage.
 
 The preview card for each target shows:
 
 - **Labels** — tables listing labels to create, update, and delete, with colour, name, and description for each row.
 - **Milestones** — tables listing milestones to create, update, and delete, with title, state, due date, and description for each row.
+- **Status columns** — tables listing Status options to create, update, and delete, with name, colour, description, and order for each row. Warnings explain when a new board will be created or when options cannot be removed safely.
 
 If the preview shows no actionable changes for a target repository, an information notice is displayed instead and the **Apply** button is not shown.
 
@@ -83,9 +88,9 @@ The status and guidance region provides immediate status updates, warnings, and 
 
 ### Step 5 — Apply the migration
 
-Once you are satisfied with the preview, click **Apply**. This button only appears when there is at least one actionable change across all target repositories.
+Once you are satisfied with the preview, click **Apply migration**. This button only appears when there is at least one actionable change across all target repositories.
 
-If you selected the **Overwrite** strategy, an on-page warning is shown before destructive changes are applied.
+If you selected the **Overwrite** strategy, an on-page warning is shown before destructive changes are applied, including Status options that may be removed when unused.
 
 Partial failures are reported per target repository — a failure for one target does not abort the remaining targets.
 
@@ -93,11 +98,9 @@ Partial failures are reported per target repository — a failure for one target
 
 After migration completes, a summary view is shown for each target repository in the post-migration summary region.
 
-- **Labels** and **Milestones** rows display the number of items created, updated, deleted, and skipped for each artefact type.
+- **Labels**, **Milestones**, and **Status columns** rows display the number of items created, updated, deleted, and skipped for each enabled artefact type.
 - Partial failures are reported per target repository, with error messages shown inline for any unsuccessful operations.
-- If a target has no operations for an enabled artefact type, the summary still displays that artefact row with zero counts.
-
-**Note:** Project board configuration migration is not included in the current delivery. Only labels and milestones are supported at this time.
+- Status column warnings (for example, options that could not be removed because items still use them) are shown inline after apply.
 
 ---
 
@@ -106,5 +109,9 @@ After migration completes, a summary view is shown for each target repository in
 One-Click Migration is configured entirely through the UI workflow. There are no `appsettings.json` entries specific to this feature.
 
 - Conflict resolution strategy (skip, overwrite, or merge) is selected per migration run.
-- Scope selection (labels and/or milestones) is toggled per migration run and defaults to both enabled.
+- Scope selection (labels, milestones, and/or project board columns) is toggled per migration run. Labels and milestones default to enabled.
 - Deletion of artefacts present in the target but absent from the source is available via the **Overwrite** strategy.
+
+### Authentication for project board columns
+
+Reading linked boards requires the same Projects access as Triage (`read:project` for PAT mode). Applying Status column changes additionally requires write access to Projects (`project` scope for PAT mode, or repository/organisation **Projects: Write** for hosted GitHub App sign-in on accessible boards).


### PR DESCRIPTION
## Summary of Changes

Extend the `/migrate` page with a **Project board columns** scope toggle, board discovery and selection controls, Status column preview tables, post-migration summaries, and inaccessible-board warnings. Adds `IMigrationService.GetProjectBoardOptionsAsync` for Application-layer board discovery. Updates the user guide and PAT operator docs for write `project` scope.

## Related Issue(s)

Closes #416

## Type of Change

- [x] ✨ Feature (non-breaking change that adds functionality)
- [x] 📝 Documentation (updates to docs, comments, or README)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

Docs-capture screenshot refresh is tracked on test issue #415.

## Additional Notes

- Builds on enabler #414 (`IProjectBoardStructureRepository` and `MigrationService` Status column preview/apply).
- Playwright and full bUnit matrix for columns scope remain on test issue #415.