### PR TITLE
[Story] Show active load and warn when exceeding capacity limit (#284)

### DIFF
--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor
@@ -55,6 +55,32 @@
                 </MudAlert>
             }
 
+            <MudPaper Class="pa-4" Elevation="1" data-testid="pm-workflow-planning-capacity">
+                <MudStack Spacing="2">
+                    <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2" AlignItems="AlignItems.Center">
+                        <MudText Typo="Typo.h6">Capacity</MudText>
+                        <MudText Typo="Typo.body1"
+                                 aria-live="polite"
+                                 data-testid="pm-workflow-planning-active-load">
+                            @planningView.ActiveLoad / @planningView.Capacity
+                        </MudText>
+                        @if (planningView.IsAtOrOverCapacity)
+                        {
+                            <MudText Typo="Typo.caption" Color="Color.Warning" data-testid="pm-workflow-planning-capacity-warning">
+                                At or above your capacity limit
+                            </MudText>
+                        }
+                    </MudStack>
+                    <MudProgressLinear Value="@GetCapacityProgressValue(planningView)"
+                                       Color="@(planningView.IsAtOrOverCapacity ? Color.Warning : Color.Primary)"
+                                       aria-label="@FormatCapacityProgressAriaLabel(planningView)"
+                                       data-testid="pm-workflow-planning-capacity-bar" />
+                    <MudText Typo="Typo.caption">
+                        Active load is Up Next plus In Progress. Edit the capacity limit on the Repos tab.
+                    </MudText>
+                </MudStack>
+            </MudPaper>
+
             <MudPaper Class="pa-4" Elevation="1" data-testid="pm-workflow-planning-up-next">
                 <MudStack Spacing="2">
                     <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2" AlignItems="AlignItems.Center">

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor.cs
@@ -32,6 +32,9 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
     [Inject]
     public ILogger<PmWorkflowPlanningPanel> Logger { get; set; } = default!;
 
+    [Inject]
+    public IDialogService DialogService { get; set; } = default!;
+
     private IterationPlanningViewDto? planningView;
     private bool isLoadingView;
     private bool isAddingToUpNext;
@@ -168,7 +171,7 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
         try
         {
             var view = await PlanningService
-                .GetPlanningViewAsync(boardId, cancellationToken)
+                .GetPlanningViewAsync(boardId, ChromeState!.Settings.Capacity, cancellationToken)
                 .ConfigureAwait(false);
 
             if (loadGeneration != viewLoadGeneration || cancellationToken.IsCancellationRequested)
@@ -234,6 +237,18 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
         if (ChromeState is null || !ChromeState.HasPlanningBoardSelected || isAddingToUpNext)
         {
             return;
+        }
+
+        if (planningView is not null
+            && PlanningCapacityEvaluator.WouldExceedCapacityAfterAdd(
+                planningView.ActiveLoad,
+                ChromeState.Settings.Capacity))
+        {
+            var confirmed = await ConfirmCapacityExceededAsync().ConfigureAwait(false);
+            if (!confirmed)
+            {
+                return;
+            }
         }
 
         var boardId = ChromeState.Settings.PlanningBoardNodeId!;
@@ -357,4 +372,29 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
         var noun = failures.Count == 1 ? "repository" : "repositories";
         return $"Loaded candidates from included repositories, but {failures.Count} {noun} failed: {repositories}.";
     }
+
+    private async Task<bool> ConfirmCapacityExceededAsync()
+    {
+        var result = await DialogService.ShowMessageBoxAsync(
+            "Exceed capacity limit?",
+            "Active load is already at or above your capacity limit. Add this item anyway?",
+            yesText: "Add anyway",
+            cancelText: "Cancel").ConfigureAwait(false);
+
+        return result == true;
+    }
+
+    private static double GetCapacityProgressValue(IterationPlanningViewDto view)
+    {
+        if (view.Capacity <= 0)
+        {
+            return 0;
+        }
+
+        var percentage = (double)view.ActiveLoad / view.Capacity * 100;
+        return Math.Min(percentage, 100);
+    }
+
+    private static string FormatCapacityProgressAriaLabel(IterationPlanningViewDto view) =>
+        $"Capacity progress: {view.ActiveLoad} of {view.Capacity}";
 }

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor.cs
@@ -242,7 +242,7 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
         if (planningView is not null
             && PlanningCapacityEvaluator.WouldExceedCapacityAfterAdd(
                 planningView.ActiveLoad,
-                ChromeState.Settings.Capacity))
+                planningView.Capacity))
         {
             var confirmed = await ConfirmCapacityExceededAsync().ConfigureAwait(false);
             if (!confirmed)

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IIterationPlanningService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IIterationPlanningService.cs
@@ -7,6 +7,7 @@ public interface IIterationPlanningService
     /// Loads the current Up Next batch and cross-repository candidates for the selected planning board.
     /// </summary>
     /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="capacity">The persisted planning capacity from PM settings.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>The planning view snapshot.</returns>
     /// <exception cref="InvalidOperationException">
@@ -14,6 +15,7 @@ public interface IIterationPlanningService
     /// </exception>
     Task<IterationPlanningViewDto> GetPlanningViewAsync(
         string projectId,
+        int capacity,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningService.cs
@@ -30,6 +30,7 @@ public sealed class IterationPlanningService : IIterationPlanningService
     /// <inheritdoc/>
     public async Task<IterationPlanningViewDto> GetPlanningViewAsync(
         string projectId,
+        int capacity,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -53,7 +54,8 @@ public sealed class IterationPlanningService : IIterationPlanningService
             workItems.Items,
             boardCatalogue.Items,
             workItems.Failures,
-            hasFocusOrderField);
+            hasFocusOrderField,
+            capacity);
     }
 
     /// <inheritdoc/>

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningViewDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningViewDto.cs
@@ -6,9 +6,15 @@ namespace SoloDevBoard.Application.Services.PmWorkflow;
 /// <param name="CatalogueFailures">Per-repository catalogue failures that did not prevent loading candidates.</param>
 /// <param name="HasFocusOrderField"><see langword="true" /> when the selected board exposes a Focus Order field.</param>
 /// <param name="NextStoryFocusOrder">The next sequential Focus Order value for story, enabler, and test cards.</param>
+/// <param name="ActiveLoad">The count of Up Next plus In Progress items on the board.</param>
+/// <param name="Capacity">The resolved planning capacity limit.</param>
+/// <param name="IsAtOrOverCapacity"><see langword="true" /> when <paramref name="ActiveLoad"/> is at or above <paramref name="Capacity"/>.</param>
 public sealed record IterationPlanningViewDto(
     IReadOnlyList<IterationPlanningUpNextItemDto> UpNextItems,
     IReadOnlyList<IterationPlanningCandidateDto> Candidates,
     IReadOnlyList<PmRepositoryCatalogueFailureDto> CatalogueFailures,
     bool HasFocusOrderField,
-    double NextStoryFocusOrder);
+    double NextStoryFocusOrder,
+    int ActiveLoad,
+    int Capacity,
+    bool IsAtOrOverCapacity);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningViewMapper.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningViewMapper.cs
@@ -10,12 +10,14 @@ public static class IterationPlanningViewMapper
     /// <param name="boardItems">Items currently on the selected planning board.</param>
     /// <param name="failures">Per-repository catalogue failures to carry through to the view.</param>
     /// <param name="hasFocusOrderField"><see langword="true" /> when the selected board exposes a Focus Order field.</param>
+    /// <param name="capacity">The persisted planning capacity from PM settings.</param>
     /// <returns>The planning view snapshot.</returns>
     public static IterationPlanningViewDto Map(
         IReadOnlyList<PmWorkItemDto> workItems,
         IReadOnlyList<ProjectBoardItemDto> boardItems,
         IReadOnlyList<PmRepositoryCatalogueFailureDto> failures,
-        bool hasFocusOrderField)
+        bool hasFocusOrderField,
+        int capacity)
     {
         ArgumentNullException.ThrowIfNull(workItems);
         ArgumentNullException.ThrowIfNull(boardItems);
@@ -45,12 +47,18 @@ public static class IterationPlanningViewMapper
             .ThenBy(static candidate => candidate.Number)
             .ToArray();
 
+        var activeLoad = PlanningCapacityEvaluator.CountActiveLoad(boardItems);
+        var resolvedCapacity = PlanningCapacityEvaluator.ResolveCapacity(capacity);
+
         return new IterationPlanningViewDto(
             upNextItems,
             candidates,
             failures,
             hasFocusOrderField,
-            nextStoryFocusOrder);
+            nextStoryFocusOrder,
+            activeLoad,
+            resolvedCapacity,
+            PlanningCapacityEvaluator.IsAtOrOverCapacity(activeLoad, capacity));
     }
 
     /// <summary>

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PlanningCapacityEvaluator.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PlanningCapacityEvaluator.cs
@@ -1,0 +1,39 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Evaluates Iteration Planning active load against the persisted capacity limit.</summary>
+public static class PlanningCapacityEvaluator
+{
+    /// <summary>Counts board items whose Status is Up Next or In Progress.</summary>
+    /// <param name="boardItems">Items currently on the selected planning board.</param>
+    /// <returns>The active load count.</returns>
+    public static int CountActiveLoad(IReadOnlyList<ProjectBoardItemDto> boardItems)
+    {
+        ArgumentNullException.ThrowIfNull(boardItems);
+
+        return boardItems.Count(static item => DailyFocusBoardStateMapper.IsActiveLoadStatus(item.Status?.Name));
+    }
+
+    /// <summary>Resolves a persisted capacity value, falling back to the default when invalid.</summary>
+    /// <param name="capacity">The persisted capacity from PM settings.</param>
+    /// <returns>A positive capacity limit.</returns>
+    public static int ResolveCapacity(int capacity) =>
+        capacity > 0 ? capacity : PmSettingsDefaults.Capacity;
+
+    /// <summary>
+    /// Returns whether active load has reached or exceeded the capacity limit.
+    /// </summary>
+    /// <param name="activeLoad">The current Up Next plus In Progress count.</param>
+    /// <param name="capacity">The persisted capacity from PM settings.</param>
+    /// <returns><see langword="true" /> when at or over the limit; otherwise, <see langword="false" />.</returns>
+    public static bool IsAtOrOverCapacity(int activeLoad, int capacity) =>
+        activeLoad >= ResolveCapacity(capacity);
+
+    /// <summary>
+    /// Returns whether adding one more item would exceed the capacity limit.
+    /// </summary>
+    /// <param name="activeLoad">The current Up Next plus In Progress count.</param>
+    /// <param name="capacity">The persisted capacity from PM settings.</param>
+    /// <returns><see langword="true" /> when the add would exceed capacity; otherwise, <see langword="false" />.</returns>
+    public static bool WouldExceedCapacityAfterAdd(int activeLoad, int capacity) =>
+        activeLoad + 1 > ResolveCapacity(capacity);
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
@@ -67,8 +67,8 @@ public sealed class PmWorkflowBacklogTests
     {
         ConfigureDefaults();
         var planningService = Substitute.For<IIterationPlanningService>();
-        planningService.GetPlanningViewAsync("PVT_board", Arg.Any<CancellationToken>()).Returns(
-            new IterationPlanningViewDto([], [], [], true, 1));
+        planningService.GetPlanningViewAsync("PVT_board", 8, Arg.Any<CancellationToken>()).Returns(
+            new IterationPlanningViewDto([], [], [], true, 1, 0, 8, false));
 
         await using var ctx = CreateContext(planningService);
         var planning = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
@@ -81,6 +81,7 @@ public sealed class PmWorkflowBacklogTests
 
         await planningService.Received(1).GetPlanningViewAsync(
             "PVT_board",
+            8,
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowChromeCoordinatorTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowChromeCoordinatorTests.cs
@@ -90,7 +90,7 @@ public sealed class PmWorkflowChromeCoordinatorTests
         coordinator.SetBacklogReview("PVT_board", EmptyBacklogResult(), null, isLoading: false);
         coordinator.SetIterationPlanning(
             "PVT_board",
-            new IterationPlanningViewDto([], [], [], true, 1),
+            new IterationPlanningViewDto([], [], [], true, 1, 0, 8, false),
             null,
             isLoading: false);
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowPlanningTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowPlanningTests.cs
@@ -156,25 +156,7 @@ public sealed class PmWorkflowPlanningTests
     {
         ConfigureDefaults();
         _planningService.GetPlanningViewAsync("PVT_board", 8, Arg.Any<CancellationToken>()).Returns(
-            new IterationPlanningViewDto(
-                [],
-                [
-                    new IterationPlanningCandidateDto(
-                        PmWorkItemTypeDto.Issue,
-                        50,
-                        "Candidate story",
-                        "https://github.com/owner/repo-a/issues/50",
-                        "owner/repo-a",
-                        ["type/story", "priority/high"],
-                        "Todo",
-                        "PVTI_candidate"),
-                ],
-                [],
-                true,
-                1,
-                8,
-                8,
-                true));
+            CreateAtCapacityPlanningView());
 
         await using var ctx = CreateContext();
         var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
@@ -186,6 +168,100 @@ public sealed class PmWorkflowPlanningTests
             Assert.Contains("8 / 8", cut.Markup);
             Assert.Contains("data-testid=\"pm-workflow-planning-capacity-warning\"", cut.Markup);
             Assert.Contains("At or above your capacity limit", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowPlanning_WhenAtCapacityAndAddCancelled_DoesNotCallAddToUpNext()
+    {
+        var dialogService = Substitute.For<IDialogService>();
+        dialogService.ShowMessageBoxAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<DialogOptions>())
+            .Returns((bool?)null);
+
+        ConfigureDefaults();
+        _planningService.GetPlanningViewAsync("PVT_board", 8, Arg.Any<CancellationToken>()).Returns(
+            CreateAtCapacityPlanningView());
+
+        await using var ctx = CreateContext(dialogService);
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
+
+        cut.WaitForAssertion(() => Assert.Contains("data-testid=\"pm-workflow-planning-add-button\"", cut.Markup));
+
+        await cut.InvokeAsync(() => cut.Find("[data-testid='pm-workflow-planning-add-button']").Click());
+
+        await dialogService.Received(1).ShowMessageBoxAsync(
+            "Exceed capacity limit?",
+            "Active load is already at or above your capacity limit. Add this item anyway?",
+            "Add anyway",
+            null,
+            "Cancel",
+            Arg.Any<DialogOptions>());
+
+        await _planningService.DidNotReceive().AddToUpNextAsync(
+            Arg.Any<string>(),
+            Arg.Any<PmWorkItemTypeDto>(),
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PmWorkflowPlanning_WhenAtCapacityAndAddConfirmed_CallsAddToUpNext()
+    {
+        var dialogService = Substitute.For<IDialogService>();
+        dialogService.ShowMessageBoxAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<DialogOptions>())
+            .Returns((bool?)true);
+
+        ConfigureDefaults();
+        _planningService.GetPlanningViewAsync("PVT_board", 8, Arg.Any<CancellationToken>()).Returns(
+            CreateAtCapacityPlanningView(),
+            CreateAtCapacityPlanningView());
+        _planningService.AddToUpNextAsync(
+            "PVT_board",
+            PmWorkItemTypeDto.Issue,
+            "owner/repo-a",
+            50,
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<CancellationToken>()).Returns(
+            new IterationPlanningAddToUpNextResultDto(AddedBoardCard: false, FocusOrderAssigned: 2, FocusOrderSkipped: false));
+
+        await using var ctx = CreateContext(dialogService);
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
+
+        cut.WaitForAssertion(() => Assert.Contains("data-testid=\"pm-workflow-planning-add-button\"", cut.Markup));
+
+        await cut.InvokeAsync(() => cut.Find("[data-testid='pm-workflow-planning-add-button']").Click());
+
+        await dialogService.Received(1).ShowMessageBoxAsync(
+            "Exceed capacity limit?",
+            "Active load is already at or above your capacity limit. Add this item anyway?",
+            "Add anyway",
+            null,
+            "Cancel",
+            Arg.Any<DialogOptions>());
+
+        cut.WaitForAssertion(() =>
+        {
+            _planningService.Received(1).AddToUpNextAsync(
+                "PVT_board",
+                PmWorkItemTypeDto.Issue,
+                "owner/repo-a",
+                50,
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<CancellationToken>());
         });
     }
 
@@ -203,11 +279,15 @@ public sealed class PmWorkflowPlanningTests
                 0));
     }
 
-    private BunitContext CreateContext()
+    private BunitContext CreateContext(IDialogService? dialogService = null)
     {
         var ctx = new BunitContext();
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
+        if (dialogService is not null)
+        {
+            ctx.Services.AddSingleton(dialogService);
+        }
         ctx.Services.AddTestGitHubAuthenticationRecovery();
         ctx.Services.AddSingleton<IPmSettingsStorage>(_settingsStorage);
         ctx.Services.AddScoped<IPmSettingsService, PmSettingsService>();
@@ -223,6 +303,27 @@ public sealed class PmWorkflowPlanningTests
 
         return ctx;
     }
+
+    private static IterationPlanningViewDto CreateAtCapacityPlanningView() =>
+        new(
+            [],
+            [
+                new IterationPlanningCandidateDto(
+                    PmWorkItemTypeDto.Issue,
+                    50,
+                    "Candidate story",
+                    "https://github.com/owner/repo-a/issues/50",
+                    "owner/repo-a",
+                    ["type/story", "priority/high"],
+                    "Todo",
+                    "PVTI_candidate"),
+            ],
+            [],
+            true,
+            1,
+            8,
+            8,
+            true);
 
     private static RepositoryDto CreateRepository(string owner, string name) =>
         new(1, name, $"{owner}/{name}", string.Empty, $"https://github.com/{owner}/{name}", false, false, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowPlanningTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowPlanningTests.cs
@@ -66,7 +66,7 @@ public sealed class PmWorkflowPlanningTests
     public async Task PmWorkflowPlanning_WhenBoardIsSelected_ShowsUpNextAndCandidates()
     {
         ConfigureDefaults();
-        _planningService.GetPlanningViewAsync("PVT_board", Arg.Any<CancellationToken>()).Returns(
+        _planningService.GetPlanningViewAsync("PVT_board", 8, Arg.Any<CancellationToken>()).Returns(
             new IterationPlanningViewDto(
                 [
                     new IterationPlanningUpNextItemDto(
@@ -92,7 +92,10 @@ public sealed class PmWorkflowPlanningTests
                 ],
                 [],
                 true,
-                2));
+                2,
+                1,
+                8,
+                false));
 
         await using var ctx = CreateContext();
         var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
@@ -117,7 +120,7 @@ public sealed class PmWorkflowPlanningTests
     public async Task PmWorkflowPlanning_WhenBoardHasNoFocusOrderField_ShowsWarning()
     {
         ConfigureDefaults();
-        _planningService.GetPlanningViewAsync("PVT_board", Arg.Any<CancellationToken>()).Returns(
+        _planningService.GetPlanningViewAsync("PVT_board", 8, Arg.Any<CancellationToken>()).Returns(
             new IterationPlanningViewDto(
                 [],
                 [
@@ -133,7 +136,10 @@ public sealed class PmWorkflowPlanningTests
                 ],
                 [],
                 false,
-                0));
+                0,
+                0,
+                8,
+                false));
 
         await using var ctx = CreateContext();
         var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
@@ -142,6 +148,44 @@ public sealed class PmWorkflowPlanningTests
         {
             Assert.Contains("data-testid=\"pm-workflow-planning-no-focus-order-field\"", cut.Markup);
             Assert.Contains("Unavailable on this board", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowPlanning_WhenActiveLoadAtCapacity_ShowsCapacityWarning()
+    {
+        ConfigureDefaults();
+        _planningService.GetPlanningViewAsync("PVT_board", 8, Arg.Any<CancellationToken>()).Returns(
+            new IterationPlanningViewDto(
+                [],
+                [
+                    new IterationPlanningCandidateDto(
+                        PmWorkItemTypeDto.Issue,
+                        50,
+                        "Candidate story",
+                        "https://github.com/owner/repo-a/issues/50",
+                        "owner/repo-a",
+                        ["type/story", "priority/high"],
+                        "Todo",
+                        "PVTI_candidate"),
+                ],
+                [],
+                true,
+                1,
+                8,
+                8,
+                true));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("data-testid=\"pm-workflow-planning-capacity\"", cut.Markup);
+            Assert.Contains("data-testid=\"pm-workflow-planning-active-load\"", cut.Markup);
+            Assert.Contains("8 / 8", cut.Markup);
+            Assert.Contains("data-testid=\"pm-workflow-planning-capacity-warning\"", cut.Markup);
+            Assert.Contains("At or above your capacity limit", cut.Markup);
         });
     }
 

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/IterationPlanningViewMapperTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/IterationPlanningViewMapperTests.cs
@@ -15,7 +15,7 @@ public sealed class IterationPlanningViewMapperTests
             CreateBoardItem("PVTI_todo", "Todo", null, "Later"),
         };
 
-        var result = IterationPlanningViewMapper.Map([], boardItems, [], hasFocusOrderField: true);
+        var result = IterationPlanningViewMapper.Map([], boardItems, [], hasFocusOrderField: true, capacity: 8);
 
         Assert.Equal(2, result.UpNextItems.Count);
         Assert.Equal("Alpha", result.UpNextItems[0].Title);
@@ -40,7 +40,7 @@ public sealed class IterationPlanningViewMapperTests
             CreateBoardItem("PVTI_in-progress", "In Progress", null, "In Progress item", 12),
         };
 
-        var result = IterationPlanningViewMapper.Map(workItems, boardItems, [], hasFocusOrderField: true);
+        var result = IterationPlanningViewMapper.Map(workItems, boardItems, [], hasFocusOrderField: true, capacity: 8);
 
         Assert.Single(result.Candidates);
         Assert.Equal(10, result.Candidates[0].Number);
@@ -55,7 +55,7 @@ public sealed class IterationPlanningViewMapperTests
             CreateBoardItem("PVTI_b", "Up Next", 3, "Beta"),
         };
 
-        var result = IterationPlanningViewMapper.Map([], boardItems, [], hasFocusOrderField: true);
+        var result = IterationPlanningViewMapper.Map([], boardItems, [], hasFocusOrderField: true, capacity: 8);
 
         Assert.True(result.HasFocusOrderField);
         Assert.Equal(4, result.NextStoryFocusOrder);
@@ -69,10 +69,48 @@ public sealed class IterationPlanningViewMapperTests
             CreateBoardItem("PVTI_a", "Up Next", 1, "Alpha"),
         };
 
-        var result = IterationPlanningViewMapper.Map([], boardItems, [], hasFocusOrderField: false);
+        var result = IterationPlanningViewMapper.Map([], boardItems, [], hasFocusOrderField: false, capacity: 8);
 
         Assert.False(result.HasFocusOrderField);
         Assert.Equal(0, result.NextStoryFocusOrder);
+    }
+
+    [Fact]
+    public void Map_UpNextAndInProgressItems_ComputesActiveLoadAndCapacityFlags()
+    {
+        var boardItems = new[]
+        {
+            CreateBoardItem("PVTI_a", "Up Next", 1, "Alpha"),
+            CreateBoardItem("PVTI_b", "In Progress", null, "Beta"),
+            CreateBoardItem("PVTI_todo", "Todo", null, "Later"),
+        };
+
+        var result = IterationPlanningViewMapper.Map([], boardItems, [], hasFocusOrderField: true, capacity: 8);
+
+        Assert.Equal(2, result.ActiveLoad);
+        Assert.Equal(8, result.Capacity);
+        Assert.False(result.IsAtOrOverCapacity);
+    }
+
+    [Fact]
+    public void Map_ActiveLoadAtCapacity_SetsAtOrOverCapacityFlag()
+    {
+        var boardItems = new[]
+        {
+            CreateBoardItem("PVTI_a", "Up Next", 1, "One"),
+            CreateBoardItem("PVTI_b", "Up Next", 2, "Two"),
+            CreateBoardItem("PVTI_c", "In Progress", null, "Three"),
+            CreateBoardItem("PVTI_d", "Up Next", 3, "Four"),
+            CreateBoardItem("PVTI_e", "In Progress", null, "Five"),
+            CreateBoardItem("PVTI_f", "Up Next", 4, "Six"),
+            CreateBoardItem("PVTI_g", "Up Next", 5, "Seven"),
+            CreateBoardItem("PVTI_h", "In Progress", null, "Eight"),
+        };
+
+        var result = IterationPlanningViewMapper.Map([], boardItems, [], hasFocusOrderField: true, capacity: 8);
+
+        Assert.Equal(8, result.ActiveLoad);
+        Assert.True(result.IsAtOrOverCapacity);
     }
 
     [Theory]

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/PlanningCapacityEvaluatorTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/PlanningCapacityEvaluatorTests.cs
@@ -1,0 +1,78 @@
+using SoloDevBoard.Application.Services.PmWorkflow;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="PlanningCapacityEvaluator"/>.</summary>
+public sealed class PlanningCapacityEvaluatorTests
+{
+    [Fact]
+    public void IsAtOrOverCapacity_ActiveLoadEqualsCapacity_ReturnsTrue()
+    {
+        var result = PlanningCapacityEvaluator.IsAtOrOverCapacity(activeLoad: 8, capacity: 8);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsAtOrOverCapacity_ActiveLoadGreaterThanCapacity_ReturnsTrue()
+    {
+        var result = PlanningCapacityEvaluator.IsAtOrOverCapacity(activeLoad: 9, capacity: 8);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsAtOrOverCapacity_ActiveLoadBelowCapacity_ReturnsFalse()
+    {
+        var result = PlanningCapacityEvaluator.IsAtOrOverCapacity(activeLoad: 7, capacity: 8);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void WouldExceedCapacityAfterAdd_AtLimit_ReturnsTrue()
+    {
+        var result = PlanningCapacityEvaluator.WouldExceedCapacityAfterAdd(activeLoad: 8, capacity: 8);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void WouldExceedCapacityAfterAdd_BelowLimit_ReturnsFalse()
+    {
+        var result = PlanningCapacityEvaluator.WouldExceedCapacityAfterAdd(activeLoad: 7, capacity: 8);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void CountActiveLoad_UpNextAndInProgressItems_ReturnsSum()
+    {
+        var boardItems = new[]
+        {
+            CreateBoardItem("Up Next"),
+            CreateBoardItem("Up Next"),
+            CreateBoardItem("In Progress"),
+            CreateBoardItem("Todo"),
+        };
+
+        var result = PlanningCapacityEvaluator.CountActiveLoad(boardItems);
+
+        Assert.Equal(3, result);
+    }
+
+    private static ProjectBoardItemDto CreateBoardItem(string statusName) =>
+        new(
+            "PVTI_item",
+            new ProjectBoardItemStatusDto("opt", statusName),
+            null,
+            new ProjectBoardItemContentDto(
+                ProjectBoardItemContentTypeDto.Issue,
+                1,
+                "owner",
+                "repo",
+                "Title",
+                "https://github.com/owner/repo/issues/1"),
+            DateTimeOffset.UtcNow,
+            UsedItemUpdatedAtFallback: false);
+}


### PR DESCRIPTION
## Summary of Changes

- Add `PlanningCapacityEvaluator` to compute active load (Up Next + In Progress) against persisted PM capacity.
- Extend the Iteration Planning view and panel with a capacity bar, amber at-limit warning, and a soft-cap `MudDialog` confirmation before adding when at or over the limit.
- Unit and component tests cover at-limit and over-limit behaviour.

## Related Issue(s)

Closes #284

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [ ] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — docs-capture screenshots deferred to test issue #387.

## Additional Notes

Capacity is read from persisted PM settings (`IPmSettingsService`); editing on the Repos tab (#287) is already wired and reflected on reload after save.

### Test plan

- [x] `dotnet clean SoloDevBoard.slnx && dotnet test SoloDevBoard.slnx` (899 passed)
- [ ] Manual: open `/pm-workflow/planning`, confirm capacity bar shows active load, amber warning at limit, and confirmation dialog when adding at/over capacity

Made with [Cursor](https://cursor.com)