### PR TITLE
[Story] Resolve stalled Up Next items before adding new work (#285)

### DIFF
--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor
@@ -81,6 +81,81 @@
                 </MudStack>
             </MudPaper>
 
+            @if (planningView.StalledUpNextItems.Count > 0)
+            {
+                <MudAlert Severity="Severity.Warning"
+                          Variant="Variant.Outlined"
+                          data-testid="pm-workflow-planning-stall-gate-alert">
+                    Resolve stalled Up Next items before adding new work. Add to Up Next stays disabled until every stalled item below is handled.
+                </MudAlert>
+
+                <MudPaper Class="pa-4" Elevation="1" data-testid="pm-workflow-planning-stalled">
+                    <MudStack Spacing="2">
+                        <MudText Typo="Typo.h6">Resolve stalled Up Next before adding</MudText>
+                        <MudSimpleTable Hover="true" Dense="true" data-testid="pm-workflow-planning-stalled-table">
+                            <thead>
+                                <tr>
+                                    <th>Item</th>
+                                    <th>Title</th>
+                                    <th>Age</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var stalledItem in planningView.StalledUpNextItems)
+                                {
+                                    <tr data-testid="pm-workflow-planning-stalled-row">
+                                        <td>
+                                            <MudLink Href="@stalledItem.HtmlUrl"
+                                                     Target="_blank"
+                                                     rel="noopener noreferrer">
+                                                @FormatItemReference(stalledItem.RepositoryFullName, stalledItem.Number)
+                                            </MudLink>
+                                        </td>
+                                        <td>@stalledItem.Title</td>
+                                        <td>@FormatStallAge(stalledItem.AgeInDays)</td>
+                                        <td>
+                                            <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1">
+                                                <MudButton Variant="Variant.Outlined"
+                                                           Size="Size.Small"
+                                                           Disabled="@IsResolvingStalledItem(stalledItem)"
+                                                           OnClick="@(() => ReCommitStalledItemAsync(stalledItem))"
+                                                           data-testid="pm-workflow-planning-recommit-button">
+                                                    Re-commit
+                                                </MudButton>
+                                                <MudButton Variant="Variant.Outlined"
+                                                           Size="Size.Small"
+                                                           Color="Color.Warning"
+                                                           Disabled="@IsResolvingStalledItem(stalledItem)"
+                                                           OnClick="@(() => MarkStalledItemBlockedAsync(stalledItem))"
+                                                           data-testid="pm-workflow-planning-mark-blocked-button">
+                                                    Mark Blocked
+                                                </MudButton>
+                                                <MudButton Variant="Variant.Outlined"
+                                                           Size="Size.Small"
+                                                           Disabled="@IsResolvingStalledItem(stalledItem)"
+                                                           OnClick="@(() => MoveStalledItemToIceBoxAsync(stalledItem))"
+                                                           data-testid="pm-workflow-planning-ice-box-button">
+                                                    Ice Box
+                                                </MudButton>
+                                                <MudButton Variant="Variant.Outlined"
+                                                           Size="Size.Small"
+                                                           Color="Color.Error"
+                                                           Disabled="@IsResolvingStalledItem(stalledItem)"
+                                                           OnClick="@(() => RemoveStalledItemAsync(stalledItem))"
+                                                           data-testid="pm-workflow-planning-remove-button">
+                                                    Remove
+                                                </MudButton>
+                                            </MudStack>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </MudSimpleTable>
+                    </MudStack>
+                </MudPaper>
+            }
+
             <MudPaper Class="pa-4" Elevation="1" data-testid="pm-workflow-planning-up-next">
                 <MudStack Spacing="2">
                     <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2" AlignItems="AlignItems.Center">
@@ -278,7 +353,7 @@
                                         <td>
                                             <MudButton Variant="Variant.Outlined"
                                                        Color="Color.Primary"
-                                                       Disabled="@(isAddingToUpNext || IsAddingCandidate(candidate))"
+                                                       Disabled="@(isAddingToUpNext || IsAddingCandidate(candidate) || IsAddToUpNextDisabled)"
                                                        OnClick="@(() => AddToUpNextAsync(candidate))"
                                                        data-testid="pm-workflow-planning-add-button">
                                                 Add to Up Next

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor.cs
@@ -245,7 +245,7 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
 
     private async Task AddToUpNextAsync(IterationPlanningCandidateDto candidate)
     {
-        if (ChromeState is null || !ChromeState.HasPlanningBoardSelected || isAddingToUpNext)
+        if (ChromeState is null || !ChromeState.HasPlanningBoardSelected || isAddingToUpNext || IsAddToUpNextDisabled)
         {
             return;
         }
@@ -282,6 +282,7 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
                     candidate.RepositoryFullName,
                     candidate.Number,
                     candidate.Labels,
+                    ChromeState.Settings.StallDays,
                     cancellationToken)
                 .ConfigureAwait(false);
 

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor.cs
@@ -42,9 +42,14 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
     private string candidateSearch = string.Empty;
     private string selectedTypeFilter = PmWorkflowItemKindFormatting.AllTypesFilter;
     private string? addingCandidateKey;
+    private string? resolvingStalledItemId;
     private int viewLoadGeneration;
     private CancellationTokenSource? viewLoadCts;
     private CancellationTokenSource? addToUpNextCts;
+    private CancellationTokenSource? resolveStalledCts;
+
+    private bool IsAddToUpNextDisabled =>
+        planningView is not null && planningView.StalledUpNextItems.Count > 0;
 
     private IEnumerable<IterationPlanningCandidateDto> FilteredCandidates
     {
@@ -106,6 +111,8 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
         viewLoadCts?.Dispose();
         addToUpNextCts?.Cancel();
         addToUpNextCts?.Dispose();
+        resolveStalledCts?.Cancel();
+        resolveStalledCts?.Dispose();
     }
 
     private Task RetryLoadAsync()
@@ -171,7 +178,11 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
         try
         {
             var view = await PlanningService
-                .GetPlanningViewAsync(boardId, ChromeState!.Settings.Capacity, cancellationToken)
+                .GetPlanningViewAsync(
+                    boardId,
+                    ChromeState!.Settings.Capacity,
+                    ChromeState.Settings.StallDays,
+                    cancellationToken)
                 .ConfigureAwait(false);
 
             if (loadGeneration != viewLoadGeneration || cancellationToken.IsCancellationRequested)
@@ -330,6 +341,113 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
     private bool IsAddingCandidate(IterationPlanningCandidateDto candidate) =>
         isAddingToUpNext && addingCandidateKey == BuildCandidateKey(candidate);
 
+    private bool IsResolvingStalledItem(IterationPlanningStalledItemDto item) =>
+        !string.IsNullOrWhiteSpace(resolvingStalledItemId)
+        && resolvingStalledItemId.Equals(item.ProjectItemId, StringComparison.Ordinal);
+
+    private Task ReCommitStalledItemAsync(IterationPlanningStalledItemDto item) =>
+        ResolveStalledItemAsync(
+            item,
+            (projectId, cancellationToken) =>
+                PlanningService.ReCommitStalledUpNextItemAsync(projectId, item.ProjectItemId, cancellationToken),
+            $"Re-committed {FormatItemReference(item.RepositoryFullName, item.Number)} to Up Next.");
+
+    private Task MarkStalledItemBlockedAsync(IterationPlanningStalledItemDto item) =>
+        ResolveStalledItemAsync(
+            item,
+            (projectId, cancellationToken) =>
+                PlanningService.MarkStalledUpNextItemBlockedAsync(projectId, item, cancellationToken),
+            $"Marked {FormatItemReference(item.RepositoryFullName, item.Number)} as blocked.");
+
+    private Task MoveStalledItemToIceBoxAsync(IterationPlanningStalledItemDto item) =>
+        ResolveStalledItemAsync(
+            item,
+            (projectId, cancellationToken) =>
+                PlanningService.MoveStalledUpNextItemToIceBoxAsync(projectId, item, cancellationToken),
+            $"Moved {FormatItemReference(item.RepositoryFullName, item.Number)} to Ice Box.");
+
+    private Task RemoveStalledItemAsync(IterationPlanningStalledItemDto item) =>
+        ResolveStalledItemAsync(
+            item,
+            (projectId, cancellationToken) =>
+                PlanningService.RemoveStalledUpNextItemAsync(projectId, item, cancellationToken),
+            $"Removed {FormatItemReference(item.RepositoryFullName, item.Number)} from Up Next.");
+
+    private async Task ResolveStalledItemAsync(
+        IterationPlanningStalledItemDto item,
+        Func<string, CancellationToken, Task> action,
+        string successMessage)
+    {
+        if (ChromeState is null || !ChromeState.HasPlanningBoardSelected || IsResolvingStalledItem(item))
+        {
+            return;
+        }
+
+        var boardId = ChromeState.Settings.PlanningBoardNodeId!;
+        resolveStalledCts?.Cancel();
+        resolveStalledCts?.Dispose();
+        resolveStalledCts = new CancellationTokenSource();
+        var cancellationToken = resolveStalledCts.Token;
+
+        resolvingStalledItemId = item.ProjectItemId;
+        await InvokeAsync(StateHasChanged).ConfigureAwait(false);
+
+        try
+        {
+            await action(boardId, cancellationToken).ConfigureAwait(false);
+
+            Snackbar.Add(successMessage, Severity.Success, configure: config => config.VisibleStateDuration = 5000);
+            await ReloadPlanningDataAsync(boardId).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception ex) when (ex is HostedAuthenticationRequiredException or GitHubPatConnectivityRequiredException)
+        {
+            if (GitHubAuthRecovery.TryInitiateRecovery(ex))
+            {
+                return;
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while resolving stalled item {ProjectItemId}.", item.ProjectItemId);
+            Snackbar.Add(
+                $"GitHub API request failed while resolving the stalled item. {ex.Message}",
+                Severity.Error,
+                configure: config => config.VisibleStateDuration = 6000);
+        }
+        catch (InvalidOperationException ex)
+        {
+            Logger.LogError(ex, "Unable to resolve stalled item {ProjectItemId}.", item.ProjectItemId);
+            Snackbar.Add(ex.Message, Severity.Error, configure: config => config.VisibleStateDuration = 6000);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unexpected error while resolving stalled item {ProjectItemId}.", item.ProjectItemId);
+            Snackbar.Add(
+                "An unexpected error occurred while resolving the stalled item.",
+                Severity.Error,
+                configure: config => config.VisibleStateDuration = 6000);
+        }
+        finally
+        {
+            resolvingStalledItemId = null;
+            await InvokeAsync(StateHasChanged).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ReloadPlanningDataAsync(string boardId)
+    {
+        ChromeCoordinator.ClearDailyFocusBoardState();
+        ChromeCoordinator.ClearDailyFocusRecommendations();
+        ChromeCoordinator.ClearBacklogReview();
+        ChromeCoordinator.ClearIterationPlanning();
+        ChromeState?.MarkDataChanged();
+        await LoadPlanningViewAsync(boardId, forceReload: true).ConfigureAwait(false);
+    }
+
     private static string BuildCandidateKey(IterationPlanningCandidateDto candidate) =>
         PmWorkItemJoinKey.For(
             candidate.ItemType == PmWorkItemTypeDto.PullRequest,
@@ -397,4 +515,7 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
 
     private static string FormatCapacityProgressAriaLabel(IterationPlanningViewDto view) =>
         $"Capacity progress: {view.ActiveLoad} of {view.Capacity}";
+
+    private static string FormatStallAge(int ageInDays) =>
+        ageInDays == 1 ? "1 day" : $"{ageInDays} days";
 }

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IIterationPlanningService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IIterationPlanningService.cs
@@ -8,6 +8,7 @@ public interface IIterationPlanningService
     /// </summary>
     /// <param name="projectId">The GitHub Project v2 node identifier.</param>
     /// <param name="capacity">The persisted planning capacity from PM settings.</param>
+    /// <param name="stallDays">The inclusive stall threshold in days from PM settings.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>The planning view snapshot.</returns>
     /// <exception cref="InvalidOperationException">
@@ -16,6 +17,7 @@ public interface IIterationPlanningService
     Task<IterationPlanningViewDto> GetPlanningViewAsync(
         string projectId,
         int capacity,
+        int stallDays,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -34,5 +36,53 @@ public interface IIterationPlanningService
         string repositoryFullName,
         int number,
         IReadOnlyList<string> labels,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Restarts the stall clock for a stalled Up Next item by moving it away from Up Next and back.
+    /// </summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="projectItemId">The project-item node identifier.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous update operation.</returns>
+    Task ReCommitStalledUpNextItemAsync(
+        string projectId,
+        string projectItemId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks a stalled Up Next item as blocked on the board and applies <c>status/blocked</c> on the work item.
+    /// </summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="item">The stalled Up Next item to update.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous update operation.</returns>
+    Task MarkStalledUpNextItemBlockedAsync(
+        string projectId,
+        IterationPlanningStalledItemDto item,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Moves a stalled Up Next item to Ice Box on the board, applies <c>status/ice-box</c>, and clears Focus Order.
+    /// </summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="item">The stalled Up Next item to update.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous update operation.</returns>
+    Task MoveStalledUpNextItemToIceBoxAsync(
+        string projectId,
+        IterationPlanningStalledItemDto item,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns a stalled Up Next item to Todo on the board and clears Focus Order.
+    /// </summary>
+    /// <param name="projectId">The GitHub Project v2 node identifier.</param>
+    /// <param name="item">The stalled Up Next item to remove from the batch.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous update operation.</returns>
+    Task RemoveStalledUpNextItemAsync(
+        string projectId,
+        IterationPlanningStalledItemDto item,
         CancellationToken cancellationToken = default);
 }

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IIterationPlanningService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IIterationPlanningService.cs
@@ -28,6 +28,7 @@ public interface IIterationPlanningService
     /// <param name="repositoryFullName">The repository in <c>owner/name</c> form.</param>
     /// <param name="number">The repository-scoped item number.</param>
     /// <param name="labels">Label names on the work item, used to decide Focus Order assignment.</param>
+    /// <param name="stallDays">The inclusive stall threshold in days from PM settings.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>The add outcome, including any Focus Order assigned.</returns>
     Task<IterationPlanningAddToUpNextResultDto> AddToUpNextAsync(
@@ -36,6 +37,7 @@ public interface IIterationPlanningService
         string repositoryFullName,
         int number,
         IReadOnlyList<string> labels,
+        int stallDays,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningService.cs
@@ -73,6 +73,7 @@ public sealed class IterationPlanningService : IIterationPlanningService
         string repositoryFullName,
         int number,
         IReadOnlyList<string> labels,
+        int stallDays,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -95,6 +96,8 @@ public sealed class IterationPlanningService : IIterationPlanningService
         var catalogue = await _projectItemCatalogueService
             .GetCatalogueAsync(projectId, cancellationToken)
             .ConfigureAwait(false);
+
+        EnsureNoStalledUpNextItemsRemain(catalogue.Items, stallDays, _timeProvider.GetUtcNow());
 
         var upNextOption = PlanningBoardStatusResolver.ResolveStatusOption(
             catalogue.StatusOptions,
@@ -190,14 +193,41 @@ public sealed class IterationPlanningService : IIterationPlanningService
                 cancellationToken)
             .ConfigureAwait(false);
 
-        await _gitHubService
-            .UpdateProjectBoardItemStatusAsync(
-                projectId,
-                projectItemId,
-                catalogue.FieldIds.StatusFieldId,
-                upNextOption.OptionId,
-                cancellationToken)
-            .ConfigureAwait(false);
+        try
+        {
+            await _gitHubService
+                .UpdateProjectBoardItemStatusAsync(
+                    projectId,
+                    projectItemId,
+                    catalogue.FieldIds.StatusFieldId,
+                    upNextOption.OptionId,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            try
+            {
+                await _gitHubService
+                    .UpdateProjectBoardItemStatusAsync(
+                        projectId,
+                        projectItemId,
+                        catalogue.FieldIds.StatusFieldId,
+                        upNextOption.OptionId,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception rollbackEx) when (rollbackEx is not OperationCanceledException)
+            {
+                throw new InvalidOperationException(
+                    "Re-commit moved the item to Todo but failed to return it to Up Next. Refresh Iteration Planning and use Re-commit again, or set the item status to Up Next manually on the board.",
+                    ex);
+            }
+
+            throw new InvalidOperationException(
+                "Re-commit moved the item to Todo but failed to return it to Up Next. The item has been restored to Up Next; refresh Iteration Planning and try Re-commit again.",
+                ex);
+        }
 
         _projectItemCatalogueService.InvalidateCatalogue(projectId);
     }
@@ -375,6 +405,27 @@ public sealed class IterationPlanningService : IIterationPlanningService
             .Select(static label => label.Trim())
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
+    }
+
+    private static void EnsureNoStalledUpNextItemsRemain(
+        IReadOnlyList<ProjectBoardItemDto> boardItems,
+        int stallDays,
+        DateTimeOffset utcNow)
+    {
+        ArgumentNullException.ThrowIfNull(boardItems);
+
+        var resolvedStallDays = stallDays > 0 ? stallDays : PmSettingsDefaults.StallDays;
+
+        var hasStalledUpNextItems = boardItems.Any(item =>
+            DailyFocusBoardStateMapper.IsUpNextStatus(item.Status?.Name)
+            && DailyFocusBoardStateMapper.HasStallClock(item.ActivityTimestamp)
+            && DailyFocusBoardStateMapper.GetAgeInDays(item.ActivityTimestamp, utcNow) >= resolvedStallDays);
+
+        if (hasStalledUpNextItems)
+        {
+            throw new InvalidOperationException(
+                "Resolve stalled Up Next items before adding new work.");
+        }
     }
 
     private static void ValidateStatusField(string statusFieldId)

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningService.cs
@@ -8,29 +8,35 @@ public sealed class IterationPlanningService : IIterationPlanningService
     private readonly IPmWorkItemCatalogueService _workItemCatalogueService;
     private readonly IProjectItemCatalogueService _projectItemCatalogueService;
     private readonly IGitHubService _gitHubService;
+    private readonly TimeProvider _timeProvider;
 
     /// <summary>Initialises a new instance of the <see cref="IterationPlanningService"/> class.</summary>
     /// <param name="workItemCatalogueService">The cross-repository work-item catalogue.</param>
     /// <param name="projectItemCatalogueService">The project board item catalogue.</param>
     /// <param name="gitHubService">The GitHub service used to add items and update board fields.</param>
+    /// <param name="timeProvider">The time provider used to compute stall age.</param>
     public IterationPlanningService(
         IPmWorkItemCatalogueService workItemCatalogueService,
         IProjectItemCatalogueService projectItemCatalogueService,
-        IGitHubService gitHubService)
+        IGitHubService gitHubService,
+        TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(workItemCatalogueService);
         ArgumentNullException.ThrowIfNull(projectItemCatalogueService);
         ArgumentNullException.ThrowIfNull(gitHubService);
+        ArgumentNullException.ThrowIfNull(timeProvider);
 
         _workItemCatalogueService = workItemCatalogueService;
         _projectItemCatalogueService = projectItemCatalogueService;
         _gitHubService = gitHubService;
+        _timeProvider = timeProvider;
     }
 
     /// <inheritdoc/>
     public async Task<IterationPlanningViewDto> GetPlanningViewAsync(
         string projectId,
         int capacity,
+        int stallDays,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -55,7 +61,9 @@ public sealed class IterationPlanningService : IIterationPlanningService
             boardCatalogue.Items,
             workItems.Failures,
             hasFocusOrderField,
-            capacity);
+            capacity,
+            stallDays,
+            _timeProvider.GetUtcNow());
     }
 
     /// <inheritdoc/>
@@ -88,7 +96,9 @@ public sealed class IterationPlanningService : IIterationPlanningService
             .GetCatalogueAsync(projectId, cancellationToken)
             .ConfigureAwait(false);
 
-        var upNextOption = ResolveUpNextStatusOption(catalogue.StatusOptions);
+        var upNextOption = PlanningBoardStatusResolver.ResolveStatusOption(
+            catalogue.StatusOptions,
+            DailyFocusBoardStateMapper.UpNextStatusName);
         ValidateStatusField(catalogue.FieldIds.StatusFieldId);
 
         var joinKey = PmWorkItemJoinKey.For(itemType == PmWorkItemTypeDto.PullRequest, repositoryFullName, number);
@@ -149,21 +159,222 @@ public sealed class IterationPlanningService : IIterationPlanningService
             focusOrderSkipped);
     }
 
-    private static ProjectBoardStatusOptionDto ResolveUpNextStatusOption(
-        IReadOnlyList<ProjectBoardStatusOptionDto> statusOptions)
+    /// <inheritdoc/>
+    public async Task ReCommitStalledUpNextItemAsync(
+        string projectId,
+        string projectItemId,
+        CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(statusOptions);
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectItemId);
 
-        var upNextOption = statusOptions.FirstOrDefault(option =>
-            option.Name.Equals(DailyFocusBoardStateMapper.UpNextStatusName, StringComparison.OrdinalIgnoreCase));
+        var catalogue = await _projectItemCatalogueService
+            .GetCatalogueAsync(projectId, cancellationToken)
+            .ConfigureAwait(false);
 
-        if (upNextOption is null)
+        ValidateStatusField(catalogue.FieldIds.StatusFieldId);
+        var todoOption = PlanningBoardStatusResolver.ResolveStatusOption(
+            catalogue.StatusOptions,
+            PlanningBoardStatusResolver.TodoStatusName);
+        var upNextOption = PlanningBoardStatusResolver.ResolveStatusOption(
+            catalogue.StatusOptions,
+            DailyFocusBoardStateMapper.UpNextStatusName);
+
+        await _gitHubService
+            .UpdateProjectBoardItemStatusAsync(
+                projectId,
+                projectItemId,
+                catalogue.FieldIds.StatusFieldId,
+                todoOption.OptionId,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        await _gitHubService
+            .UpdateProjectBoardItemStatusAsync(
+                projectId,
+                projectItemId,
+                catalogue.FieldIds.StatusFieldId,
+                upNextOption.OptionId,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        _projectItemCatalogueService.InvalidateCatalogue(projectId);
+    }
+
+    /// <inheritdoc/>
+    public async Task MarkStalledUpNextItemBlockedAsync(
+        string projectId,
+        IterationPlanningStalledItemDto item,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentNullException.ThrowIfNull(item);
+
+        var catalogue = await LoadCatalogueForStalledItemUpdateAsync(projectId, item, cancellationToken)
+            .ConfigureAwait(false);
+        var blockedOption = PlanningBoardStatusResolver.ResolveStatusOption(
+            catalogue.StatusOptions,
+            DailyFocusRecommendationMapper.BlockedStatusName);
+
+        await UpdateBoardStatusAsync(
+            projectId,
+            item.ProjectItemId,
+            catalogue.FieldIds.StatusFieldId,
+            blockedOption.OptionId,
+            cancellationToken).ConfigureAwait(false);
+
+        await ApplyWorkItemLabelsAsync(
+            item,
+            MergeStatusLabel(item.Labels, PmLabelHelpers.BlockedStatusLabel, PmLabelHelpers.IceBoxStatusLabel),
+            cancellationToken).ConfigureAwait(false);
+
+        _projectItemCatalogueService.InvalidateCatalogue(projectId);
+    }
+
+    /// <inheritdoc/>
+    public async Task MoveStalledUpNextItemToIceBoxAsync(
+        string projectId,
+        IterationPlanningStalledItemDto item,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentNullException.ThrowIfNull(item);
+
+        var catalogue = await LoadCatalogueForStalledItemUpdateAsync(projectId, item, cancellationToken)
+            .ConfigureAwait(false);
+        var iceBoxOption = PlanningBoardStatusResolver.ResolveStatusOption(
+            catalogue.StatusOptions,
+            DailyFocusRecommendationMapper.IceBoxStatusName);
+
+        await UpdateBoardStatusAsync(
+            projectId,
+            item.ProjectItemId,
+            catalogue.FieldIds.StatusFieldId,
+            iceBoxOption.OptionId,
+            cancellationToken).ConfigureAwait(false);
+
+        await ClearFocusOrderWhenPresentAsync(projectId, item.ProjectItemId, catalogue, cancellationToken)
+            .ConfigureAwait(false);
+
+        await ApplyWorkItemLabelsAsync(
+            item,
+            MergeStatusLabel(item.Labels, PmLabelHelpers.IceBoxStatusLabel, PmLabelHelpers.BlockedStatusLabel),
+            cancellationToken).ConfigureAwait(false);
+
+        _projectItemCatalogueService.InvalidateCatalogue(projectId);
+    }
+
+    /// <inheritdoc/>
+    public async Task RemoveStalledUpNextItemAsync(
+        string projectId,
+        IterationPlanningStalledItemDto item,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentNullException.ThrowIfNull(item);
+
+        var catalogue = await LoadCatalogueForStalledItemUpdateAsync(projectId, item, cancellationToken)
+            .ConfigureAwait(false);
+        var todoOption = PlanningBoardStatusResolver.ResolveStatusOption(
+            catalogue.StatusOptions,
+            PlanningBoardStatusResolver.TodoStatusName);
+
+        await UpdateBoardStatusAsync(
+            projectId,
+            item.ProjectItemId,
+            catalogue.FieldIds.StatusFieldId,
+            todoOption.OptionId,
+            cancellationToken).ConfigureAwait(false);
+
+        await ClearFocusOrderWhenPresentAsync(projectId, item.ProjectItemId, catalogue, cancellationToken)
+            .ConfigureAwait(false);
+
+        _projectItemCatalogueService.InvalidateCatalogue(projectId);
+    }
+
+    private async Task<ProjectBoardItemCatalogueDto> LoadCatalogueForStalledItemUpdateAsync(
+        string projectId,
+        IterationPlanningStalledItemDto item,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(item.ProjectItemId);
+
+        var catalogue = await _projectItemCatalogueService
+            .GetCatalogueAsync(projectId, cancellationToken)
+            .ConfigureAwait(false);
+
+        ValidateStatusField(catalogue.FieldIds.StatusFieldId);
+        return catalogue;
+    }
+
+    private Task UpdateBoardStatusAsync(
+        string projectId,
+        string projectItemId,
+        string statusFieldId,
+        string statusOptionId,
+        CancellationToken cancellationToken) =>
+        _gitHubService.UpdateProjectBoardItemStatusAsync(
+            projectId,
+            projectItemId,
+            statusFieldId,
+            statusOptionId,
+            cancellationToken);
+
+    private async Task ClearFocusOrderWhenPresentAsync(
+        string projectId,
+        string projectItemId,
+        ProjectBoardItemCatalogueDto catalogue,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(catalogue.FieldIds.FocusOrderFieldId))
         {
-            throw new InvalidOperationException(
-                "The planning board does not expose an Up Next Status option.");
+            return;
         }
 
-        return upNextOption;
+        await _projectItemCatalogueService
+            .ClearFocusOrderAsync(
+                projectId,
+                projectItemId,
+                catalogue.FieldIds.FocusOrderFieldId,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task ApplyWorkItemLabelsAsync(
+        IterationPlanningStalledItemDto item,
+        IReadOnlyList<string> labelNames,
+        CancellationToken cancellationToken)
+    {
+        if (!TryParseRepositoryFullName(item.RepositoryFullName, out var owner, out var repo))
+        {
+            throw new ArgumentException(
+                $"Repository scope '{item.RepositoryFullName}' must be in owner/repository format.",
+                nameof(item));
+        }
+
+        await _gitHubService
+            .ApplyLabelsToTriageItemAsync(owner, repo, item.Number, labelNames, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static IReadOnlyList<string> MergeStatusLabel(
+        IReadOnlyList<string> currentLabels,
+        string labelToAdd,
+        string labelToRemove)
+    {
+        ArgumentNullException.ThrowIfNull(currentLabels);
+
+        return currentLabels
+            .Where(label => !label.Equals(labelToRemove, StringComparison.OrdinalIgnoreCase))
+            .Concat([labelToAdd])
+            .Where(static label => !string.IsNullOrWhiteSpace(label))
+            .Select(static label => label.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     private static void ValidateStatusField(string statusFieldId)

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningStalledItemDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningStalledItemDto.cs
@@ -1,0 +1,22 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Stalled Up Next row on the Iteration Planning page.</summary>
+/// <param name="ProjectItemId">The project-item node identifier.</param>
+/// <param name="ItemType">Whether the linked content is an issue or pull request.</param>
+/// <param name="Number">The repository-scoped item number.</param>
+/// <param name="Title">The item title.</param>
+/// <param name="HtmlUrl">The browser URL for the item.</param>
+/// <param name="RepositoryFullName">The repository in <c>owner/name</c> form.</param>
+/// <param name="AgeInDays">Whole days since the stall clock started.</param>
+/// <param name="UsedUpdatedAtFallback">Whether age used item last-updated time.</param>
+/// <param name="Labels">Label names currently applied to the item.</param>
+public sealed record IterationPlanningStalledItemDto(
+    string ProjectItemId,
+    PmWorkItemTypeDto ItemType,
+    int Number,
+    string Title,
+    string HtmlUrl,
+    string RepositoryFullName,
+    int AgeInDays,
+    bool UsedUpdatedAtFallback,
+    IReadOnlyList<string> Labels);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningViewDto.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningViewDto.cs
@@ -9,6 +9,7 @@ namespace SoloDevBoard.Application.Services.PmWorkflow;
 /// <param name="ActiveLoad">The count of Up Next plus In Progress items on the board.</param>
 /// <param name="Capacity">The resolved planning capacity limit.</param>
 /// <param name="IsAtOrOverCapacity"><see langword="true" /> when <paramref name="ActiveLoad"/> is at or above <paramref name="Capacity"/>.</param>
+/// <param name="StalledUpNextItems">Up Next items that have exceeded the stall threshold.</param>
 public sealed record IterationPlanningViewDto(
     IReadOnlyList<IterationPlanningUpNextItemDto> UpNextItems,
     IReadOnlyList<IterationPlanningCandidateDto> Candidates,
@@ -17,4 +18,5 @@ public sealed record IterationPlanningViewDto(
     double NextStoryFocusOrder,
     int ActiveLoad,
     int Capacity,
-    bool IsAtOrOverCapacity);
+    bool IsAtOrOverCapacity,
+    IReadOnlyList<IterationPlanningStalledItemDto> StalledUpNextItems);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningViewMapper.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningViewMapper.cs
@@ -11,13 +11,17 @@ public static class IterationPlanningViewMapper
     /// <param name="failures">Per-repository catalogue failures to carry through to the view.</param>
     /// <param name="hasFocusOrderField"><see langword="true" /> when the selected board exposes a Focus Order field.</param>
     /// <param name="capacity">The persisted planning capacity from PM settings.</param>
+    /// <param name="stallDays">The inclusive stall threshold in days from PM settings.</param>
+    /// <param name="utcNow">The current UTC time used to compute stall age.</param>
     /// <returns>The planning view snapshot.</returns>
     public static IterationPlanningViewDto Map(
         IReadOnlyList<PmWorkItemDto> workItems,
         IReadOnlyList<ProjectBoardItemDto> boardItems,
         IReadOnlyList<PmRepositoryCatalogueFailureDto> failures,
         bool hasFocusOrderField,
-        int capacity)
+        int capacity,
+        int stallDays,
+        DateTimeOffset utcNow)
     {
         ArgumentNullException.ThrowIfNull(workItems);
         ArgumentNullException.ThrowIfNull(boardItems);
@@ -49,6 +53,8 @@ public static class IterationPlanningViewMapper
 
         var activeLoad = PlanningCapacityEvaluator.CountActiveLoad(boardItems);
         var resolvedCapacity = PlanningCapacityEvaluator.ResolveCapacity(capacity);
+        var resolvedStallDays = stallDays > 0 ? stallDays : PmSettingsDefaults.StallDays;
+        var stalledUpNextItems = MapStalledUpNextItems(upNextBoardItems, labelsByKey, resolvedStallDays, utcNow);
 
         return new IterationPlanningViewDto(
             upNextItems,
@@ -58,7 +64,44 @@ public static class IterationPlanningViewMapper
             nextStoryFocusOrder,
             activeLoad,
             resolvedCapacity,
-            PlanningCapacityEvaluator.IsAtOrOverCapacity(activeLoad, capacity));
+            PlanningCapacityEvaluator.IsAtOrOverCapacity(activeLoad, capacity),
+            stalledUpNextItems);
+    }
+
+    private static IReadOnlyList<IterationPlanningStalledItemDto> MapStalledUpNextItems(
+        IReadOnlyList<ProjectBoardItemDto> upNextBoardItems,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> labelsByKey,
+        int stallDays,
+        DateTimeOffset utcNow)
+    {
+        return upNextBoardItems
+            .Where(item => DailyFocusBoardStateMapper.HasStallClock(item.ActivityTimestamp))
+            .Select(item => MapStalledUpNextItem(item, labelsByKey, utcNow))
+            .Where(item => item.AgeInDays >= stallDays)
+            .OrderByDescending(item => item.AgeInDays)
+            .ThenBy(item => item.Title, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static IterationPlanningStalledItemDto MapStalledUpNextItem(
+        ProjectBoardItemDto boardItem,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> labelsByKey,
+        DateTimeOffset utcNow)
+    {
+        labelsByKey.TryGetValue(PmWorkItemJoinKey.For(boardItem), out var labels);
+
+        return new IterationPlanningStalledItemDto(
+            boardItem.ProjectItemId,
+            boardItem.Content.ContentType == ProjectBoardItemContentTypeDto.PullRequest
+                ? PmWorkItemTypeDto.PullRequest
+                : PmWorkItemTypeDto.Issue,
+            boardItem.Content.Number,
+            boardItem.Content.Title,
+            boardItem.Content.Url,
+            $"{boardItem.Content.RepositoryOwner}/{boardItem.Content.RepositoryName}",
+            DailyFocusBoardStateMapper.GetAgeInDays(boardItem.ActivityTimestamp, utcNow),
+            boardItem.UsedItemUpdatedAtFallback,
+            labels ?? []);
     }
 
     /// <summary>

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PlanningBoardStatusResolver.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PlanningBoardStatusResolver.cs
@@ -1,0 +1,34 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Resolves discovered planning-board Status options by display name.</summary>
+public static class PlanningBoardStatusResolver
+{
+    /// <summary>Status option name for unstarted work.</summary>
+    public const string TodoStatusName = "Todo";
+
+    /// <summary>
+    /// Returns the Status option whose display name matches <paramref name="statusName"/>.
+    /// </summary>
+    /// <param name="statusOptions">Status options discovered on the selected board.</param>
+    /// <param name="statusName">The Status display name to resolve.</param>
+    /// <returns>The matching Status option.</returns>
+    /// <exception cref="InvalidOperationException">The board does not expose the requested Status option.</exception>
+    public static ProjectBoardStatusOptionDto ResolveStatusOption(
+        IReadOnlyList<ProjectBoardStatusOptionDto> statusOptions,
+        string statusName)
+    {
+        ArgumentNullException.ThrowIfNull(statusOptions);
+        ArgumentException.ThrowIfNullOrWhiteSpace(statusName);
+
+        var option = statusOptions.FirstOrDefault(candidate =>
+            candidate.Name.Equals(statusName, StringComparison.OrdinalIgnoreCase));
+
+        if (option is null)
+        {
+            throw new InvalidOperationException(
+                $"The planning board does not expose a {statusName} Status option.");
+        }
+
+        return option;
+    }
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowBacklogTests.cs
@@ -67,8 +67,8 @@ public sealed class PmWorkflowBacklogTests
     {
         ConfigureDefaults();
         var planningService = Substitute.For<IIterationPlanningService>();
-        planningService.GetPlanningViewAsync("PVT_board", 8, Arg.Any<CancellationToken>()).Returns(
-            new IterationPlanningViewDto([], [], [], true, 1, 0, 8, false));
+        planningService.GetPlanningViewAsync("PVT_board", 8, 3, Arg.Any<CancellationToken>()).Returns(
+            new IterationPlanningViewDto([], [], [], true, 1, 0, 8, false, []));
 
         await using var ctx = CreateContext(planningService);
         var planning = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
@@ -82,6 +82,7 @@ public sealed class PmWorkflowBacklogTests
         await planningService.Received(1).GetPlanningViewAsync(
             "PVT_board",
             8,
+            3,
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowChromeCoordinatorTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowChromeCoordinatorTests.cs
@@ -90,7 +90,7 @@ public sealed class PmWorkflowChromeCoordinatorTests
         coordinator.SetBacklogReview("PVT_board", EmptyBacklogResult(), null, isLoading: false);
         coordinator.SetIterationPlanning(
             "PVT_board",
-            new IterationPlanningViewDto([], [], [], true, 1, 0, 8, false),
+            new IterationPlanningViewDto([], [], [], true, 1, 0, 8, false, []),
             null,
             isLoading: false);
 

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowPlanningTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowPlanningTests.cs
@@ -66,7 +66,7 @@ public sealed class PmWorkflowPlanningTests
     public async Task PmWorkflowPlanning_WhenBoardIsSelected_ShowsUpNextAndCandidates()
     {
         ConfigureDefaults();
-        _planningService.GetPlanningViewAsync("PVT_board", 8, Arg.Any<CancellationToken>()).Returns(
+        _planningService.GetPlanningViewAsync("PVT_board", 8, 3, Arg.Any<CancellationToken>()).Returns(
             new IterationPlanningViewDto(
                 [
                     new IterationPlanningUpNextItemDto(
@@ -95,7 +95,8 @@ public sealed class PmWorkflowPlanningTests
                 2,
                 1,
                 8,
-                false));
+                false,
+                []));
 
         await using var ctx = CreateContext();
         var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
@@ -120,7 +121,7 @@ public sealed class PmWorkflowPlanningTests
     public async Task PmWorkflowPlanning_WhenBoardHasNoFocusOrderField_ShowsWarning()
     {
         ConfigureDefaults();
-        _planningService.GetPlanningViewAsync("PVT_board", 8, Arg.Any<CancellationToken>()).Returns(
+        _planningService.GetPlanningViewAsync("PVT_board", 8, 3, Arg.Any<CancellationToken>()).Returns(
             new IterationPlanningViewDto(
                 [],
                 [
@@ -139,7 +140,8 @@ public sealed class PmWorkflowPlanningTests
                 0,
                 0,
                 8,
-                false));
+                false,
+                []));
 
         await using var ctx = CreateContext();
         var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
@@ -155,7 +157,7 @@ public sealed class PmWorkflowPlanningTests
     public async Task PmWorkflowPlanning_WhenActiveLoadAtCapacity_ShowsCapacityWarning()
     {
         ConfigureDefaults();
-        _planningService.GetPlanningViewAsync("PVT_board", 8, Arg.Any<CancellationToken>()).Returns(
+        _planningService.GetPlanningViewAsync("PVT_board", 8, 3, Arg.Any<CancellationToken>()).Returns(
             CreateAtCapacityPlanningView());
 
         await using var ctx = CreateContext();
@@ -185,7 +187,7 @@ public sealed class PmWorkflowPlanningTests
             .Returns((bool?)null);
 
         ConfigureDefaults();
-        _planningService.GetPlanningViewAsync("PVT_board", 8, Arg.Any<CancellationToken>()).Returns(
+        _planningService.GetPlanningViewAsync("PVT_board", 8, 3, Arg.Any<CancellationToken>()).Returns(
             CreateAtCapacityPlanningView());
 
         await using var ctx = CreateContext(dialogService);
@@ -209,6 +211,7 @@ public sealed class PmWorkflowPlanningTests
             Arg.Any<string>(),
             Arg.Any<int>(),
             Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<int>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -226,7 +229,7 @@ public sealed class PmWorkflowPlanningTests
             .Returns((bool?)true);
 
         ConfigureDefaults();
-        _planningService.GetPlanningViewAsync("PVT_board", 8, Arg.Any<CancellationToken>()).Returns(
+        _planningService.GetPlanningViewAsync("PVT_board", 8, 3, Arg.Any<CancellationToken>()).Returns(
             CreateAtCapacityPlanningView(),
             CreateAtCapacityPlanningView());
         _planningService.AddToUpNextAsync(
@@ -235,6 +238,7 @@ public sealed class PmWorkflowPlanningTests
             "owner/repo-a",
             50,
             Arg.Any<IReadOnlyList<string>>(),
+            3,
             Arg.Any<CancellationToken>()).Returns(
             new IterationPlanningAddToUpNextResultDto(AddedBoardCard: false, FocusOrderAssigned: 2, FocusOrderSkipped: false));
 
@@ -261,7 +265,57 @@ public sealed class PmWorkflowPlanningTests
                 "owner/repo-a",
                 50,
                 Arg.Any<IReadOnlyList<string>>(),
+                3,
                 Arg.Any<CancellationToken>());
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowPlanning_WhenStalledUpNextItemsExist_DisablesAddToUpNext()
+    {
+        ConfigureDefaults();
+        _planningService.GetPlanningViewAsync("PVT_board", 8, 3, Arg.Any<CancellationToken>()).Returns(
+            new IterationPlanningViewDto(
+                [],
+                [
+                    new IterationPlanningCandidateDto(
+                        PmWorkItemTypeDto.Issue,
+                        50,
+                        "Candidate story",
+                        "https://github.com/owner/repo-a/issues/50",
+                        "owner/repo-a",
+                        ["type/story", "priority/high"],
+                        "Todo",
+                        "PVTI_candidate"),
+                ],
+                [],
+                true,
+                1,
+                1,
+                8,
+                false,
+                [
+                    new IterationPlanningStalledItemDto(
+                        "PVTI_stalled",
+                        PmWorkItemTypeDto.Issue,
+                        275,
+                        "Stalled story",
+                        "https://github.com/owner/repo-a/issues/275",
+                        "owner/repo-a",
+                        4,
+                        false,
+                        ["type/story"]),
+                ]));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("data-testid=\"pm-workflow-planning-stall-gate-alert\"", cut.Markup);
+            Assert.Contains("Resolve stalled Up Next items before adding new work", cut.Markup);
+            var addButton = cut.Find("[data-testid=\"pm-workflow-planning-add-button\"]");
+            Assert.True(addButton.HasAttribute("disabled"));
         });
     }
 
@@ -323,7 +377,8 @@ public sealed class PmWorkflowPlanningTests
             1,
             8,
             8,
-            true);
+            true,
+            []);
 
     private static RepositoryDto CreateRepository(string owner, string name) =>
         new(1, name, $"{owner}/{name}", string.Empty, $"https://github.com/{owner}/{name}", false, false, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/IterationPlanningServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/IterationPlanningServiceTests.cs
@@ -32,6 +32,7 @@ public sealed class IterationPlanningServiceTests
             "owner/repo",
             50,
             labels,
+            3,
             cancellationToken);
 
         Assert.True(result.AddedBoardCard);
@@ -73,6 +74,7 @@ public sealed class IterationPlanningServiceTests
             "owner/repo",
             51,
             labels,
+            3,
             cancellationToken);
 
         Assert.False(result.AddedBoardCard);
@@ -116,6 +118,7 @@ public sealed class IterationPlanningServiceTests
             "owner/repo",
             52,
             labels,
+            3,
             cancellationToken);
 
         Assert.True(result.AddedBoardCard);
@@ -153,6 +156,7 @@ public sealed class IterationPlanningServiceTests
             "owner/repo",
             54,
             labels,
+            3,
             cancellationToken);
 
         Assert.True(result.AddedBoardCard);
@@ -195,10 +199,43 @@ public sealed class IterationPlanningServiceTests
             "owner/repo",
             53,
             ["type/story"],
+            3,
             cancellationToken);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(action);
         Assert.Contains("Up Next", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AddToUpNextAsync_WhenStalledUpNextItemsRemain_ThrowsInvalidOperationException()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var stalledItem = CreateBoardItem(
+            "PVTI_stalled",
+            "Up Next",
+            focusOrder: 1,
+            number: 99,
+            activityTimestamp: DateTimeOffset.UtcNow.AddDays(-5));
+        var catalogue = CreateCatalogue(stalledItem);
+        _projectItemCatalogueService
+            .GetCatalogueAsync("project-id", cancellationToken)
+            .Returns(catalogue);
+
+        var sut = CreateSut();
+
+        var action = async () => await sut.AddToUpNextAsync(
+            "project-id",
+            PmWorkItemTypeDto.Issue,
+            "owner/repo",
+            53,
+            ["type/story"],
+            3,
+            cancellationToken);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(action);
+        Assert.Contains("Resolve stalled Up Next items", exception.Message, StringComparison.Ordinal);
+        await _gitHubService.DidNotReceive()
+            .AddTriageItemToProjectBoardAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -229,6 +266,47 @@ public sealed class IterationPlanningServiceTests
                 "opt-up-next",
                 cancellationToken);
         _projectItemCatalogueService.Received(1).InvalidateCatalogue("project-id");
+    }
+
+    [Fact]
+    public async Task ReCommitStalledUpNextItemAsync_WhenUpNextUpdateFails_RestoresUpNextAndThrows()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var catalogue = CreateCatalogue(existingItem: null);
+        _projectItemCatalogueService
+            .GetCatalogueAsync("project-id", cancellationToken)
+            .Returns(catalogue);
+        _gitHubService
+            .UpdateProjectBoardItemStatusAsync(
+                Arg.Any<string>(),
+                "PVTI_one",
+                "PVTF_status",
+                "opt-up-next",
+                cancellationToken)
+            .Returns(
+                _ => throw new HttpRequestException("GitHub unavailable"),
+                _ => Task.CompletedTask);
+
+        var sut = CreateSut();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.ReCommitStalledUpNextItemAsync("project-id", "PVTI_one", cancellationToken));
+
+        Assert.Contains("restored to Up Next", exception.Message, StringComparison.Ordinal);
+        await _gitHubService.Received(1)
+            .UpdateProjectBoardItemStatusAsync(
+                "project-id",
+                "PVTI_one",
+                "PVTF_status",
+                "opt-todo",
+                cancellationToken);
+        await _gitHubService.Received(2)
+            .UpdateProjectBoardItemStatusAsync(
+                "project-id",
+                "PVTI_one",
+                "PVTF_status",
+                "opt-up-next",
+                cancellationToken);
     }
 
     [Fact]
@@ -270,6 +348,50 @@ public sealed class IterationPlanningServiceTests
                     labels.Contains("type/story")
                     && labels.Contains("priority/medium")
                     && labels.Contains(PmLabelHelpers.BlockedStatusLabel)),
+                cancellationToken);
+    }
+
+    [Fact]
+    public async Task MoveStalledUpNextItemToIceBoxAsync_ValidItem_UpdatesStatusClearsFocusOrderAndLabels()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var catalogue = CreateCatalogue(existingItem: null);
+        _projectItemCatalogueService
+            .GetCatalogueAsync("project-id", cancellationToken)
+            .Returns(catalogue);
+
+        var sut = CreateSut();
+        var item = new IterationPlanningStalledItemDto(
+            "PVTI_one",
+            PmWorkItemTypeDto.Issue,
+            40,
+            "Ice box story",
+            "https://github.com/owner/repo/issues/40",
+            "owner/repo",
+            4,
+            false,
+            ["type/story", "priority/medium"]);
+
+        await sut.MoveStalledUpNextItemToIceBoxAsync("project-id", item, cancellationToken);
+
+        await _gitHubService.Received(1)
+            .UpdateProjectBoardItemStatusAsync(
+                "project-id",
+                "PVTI_one",
+                "PVTF_status",
+                "opt-ice-box",
+                cancellationToken);
+        await _projectItemCatalogueService.Received(1)
+            .ClearFocusOrderAsync("project-id", "PVTI_one", "PVTF_focus", cancellationToken);
+        await _gitHubService.Received(1)
+            .ApplyLabelsToTriageItemAsync(
+                "owner",
+                "repo",
+                40,
+                Arg.Is<IReadOnlyList<string>>(labels =>
+                    labels.Contains("type/story")
+                    && labels.Contains("priority/medium")
+                    && labels.Contains(PmLabelHelpers.IceBoxStatusLabel)),
                 cancellationToken);
     }
 
@@ -350,7 +472,8 @@ public sealed class IterationPlanningServiceTests
         string projectItemId,
         string statusName,
         double? focusOrder,
-        int number) =>
+        int number,
+        DateTimeOffset? activityTimestamp = null) =>
         new(
             projectItemId,
             new ProjectBoardItemStatusDto($"opt-{statusName.Replace(' ', '-').ToLowerInvariant()}", statusName),
@@ -362,6 +485,6 @@ public sealed class IterationPlanningServiceTests
                 "repo",
                 $"Title {number}",
                 $"https://github.com/owner/repo/issues/{number}"),
-            DateTimeOffset.UtcNow,
+            activityTimestamp ?? DateTimeOffset.UtcNow,
             UsedItemUpdatedAtFallback: false);
 }

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/IterationPlanningServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/IterationPlanningServiceTests.cs
@@ -201,8 +201,114 @@ public sealed class IterationPlanningServiceTests
         Assert.Contains("Up Next", exception.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task ReCommitStalledUpNextItemAsync_ValidItem_MovesTodoThenUpNext()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var catalogue = CreateCatalogue(existingItem: null);
+        _projectItemCatalogueService
+            .GetCatalogueAsync("project-id", cancellationToken)
+            .Returns(catalogue);
+
+        var sut = CreateSut();
+
+        await sut.ReCommitStalledUpNextItemAsync("project-id", "PVTI_one", cancellationToken);
+
+        await _gitHubService.Received(1)
+            .UpdateProjectBoardItemStatusAsync(
+                "project-id",
+                "PVTI_one",
+                "PVTF_status",
+                "opt-todo",
+                cancellationToken);
+        await _gitHubService.Received(1)
+            .UpdateProjectBoardItemStatusAsync(
+                "project-id",
+                "PVTI_one",
+                "PVTF_status",
+                "opt-up-next",
+                cancellationToken);
+        _projectItemCatalogueService.Received(1).InvalidateCatalogue("project-id");
+    }
+
+    [Fact]
+    public async Task MarkStalledUpNextItemBlockedAsync_ValidItem_UpdatesStatusAndLabels()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var catalogue = CreateCatalogue(existingItem: null);
+        _projectItemCatalogueService
+            .GetCatalogueAsync("project-id", cancellationToken)
+            .Returns(catalogue);
+
+        var sut = CreateSut();
+        var item = new IterationPlanningStalledItemDto(
+            "PVTI_one",
+            PmWorkItemTypeDto.Issue,
+            40,
+            "Blocked story",
+            "https://github.com/owner/repo/issues/40",
+            "owner/repo",
+            4,
+            false,
+            ["type/story", "priority/medium"]);
+
+        await sut.MarkStalledUpNextItemBlockedAsync("project-id", item, cancellationToken);
+
+        await _gitHubService.Received(1)
+            .UpdateProjectBoardItemStatusAsync(
+                "project-id",
+                "PVTI_one",
+                "PVTF_status",
+                "opt-blocked",
+                cancellationToken);
+        await _gitHubService.Received(1)
+            .ApplyLabelsToTriageItemAsync(
+                "owner",
+                "repo",
+                40,
+                Arg.Is<IReadOnlyList<string>>(labels =>
+                    labels.Contains("type/story")
+                    && labels.Contains("priority/medium")
+                    && labels.Contains(PmLabelHelpers.BlockedStatusLabel)),
+                cancellationToken);
+    }
+
+    [Fact]
+    public async Task RemoveStalledUpNextItemAsync_ValidItem_MovesToTodoAndClearsFocusOrder()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var catalogue = CreateCatalogue(existingItem: null);
+        _projectItemCatalogueService
+            .GetCatalogueAsync("project-id", cancellationToken)
+            .Returns(catalogue);
+
+        var sut = CreateSut();
+        var item = new IterationPlanningStalledItemDto(
+            "PVTI_one",
+            PmWorkItemTypeDto.Issue,
+            40,
+            "Remove me",
+            "https://github.com/owner/repo/issues/40",
+            "owner/repo",
+            5,
+            false,
+            ["type/story"]);
+
+        await sut.RemoveStalledUpNextItemAsync("project-id", item, cancellationToken);
+
+        await _gitHubService.Received(1)
+            .UpdateProjectBoardItemStatusAsync(
+                "project-id",
+                "PVTI_one",
+                "PVTF_status",
+                "opt-todo",
+                cancellationToken);
+        await _projectItemCatalogueService.Received(1)
+            .ClearFocusOrderAsync("project-id", "PVTI_one", "PVTF_focus", cancellationToken);
+    }
+
     private IterationPlanningService CreateSut() =>
-        new(_workItemCatalogueService, _projectItemCatalogueService, _gitHubService);
+        new(_workItemCatalogueService, _projectItemCatalogueService, _gitHubService, TimeProvider.System);
 
     private static ProjectBoardItemCatalogueDto CreateCatalogue(
         ProjectBoardItemDto? existingItem,
@@ -217,6 +323,8 @@ public sealed class IterationPlanningServiceTests
         if (includeUpNextOption)
         {
             statusOptions.Add(new ProjectBoardStatusOptionDto("opt-up-next", "Up Next"));
+            statusOptions.Add(new ProjectBoardStatusOptionDto("opt-blocked", "Blocked"));
+            statusOptions.Add(new ProjectBoardStatusOptionDto("opt-ice-box", "Ice Box"));
         }
 
         var items = new List<ProjectBoardItemDto>

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/IterationPlanningViewMapperTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/IterationPlanningViewMapperTests.cs
@@ -5,6 +5,7 @@ namespace SoloDevBoard.Application.Tests;
 /// <summary>Tests for <see cref="IterationPlanningViewMapper"/>.</summary>
 public sealed class IterationPlanningViewMapperTests
 {
+    private static readonly DateTimeOffset UtcNow = new(2026, 8, 20, 12, 0, 0, TimeSpan.Zero);
     [Fact]
     public void Map_UpNextItems_SortedByFocusOrderThenTitle()
     {
@@ -15,7 +16,7 @@ public sealed class IterationPlanningViewMapperTests
             CreateBoardItem("PVTI_todo", "Todo", null, "Later"),
         };
 
-        var result = IterationPlanningViewMapper.Map([], boardItems, [], hasFocusOrderField: true, capacity: 8);
+        var result = Map([], boardItems, [], hasFocusOrderField: true, capacity: 8);
 
         Assert.Equal(2, result.UpNextItems.Count);
         Assert.Equal("Alpha", result.UpNextItems[0].Title);
@@ -40,7 +41,7 @@ public sealed class IterationPlanningViewMapperTests
             CreateBoardItem("PVTI_in-progress", "In Progress", null, "In Progress item", 12),
         };
 
-        var result = IterationPlanningViewMapper.Map(workItems, boardItems, [], hasFocusOrderField: true, capacity: 8);
+        var result = Map(workItems, boardItems, [], hasFocusOrderField: true, capacity: 8);
 
         Assert.Single(result.Candidates);
         Assert.Equal(10, result.Candidates[0].Number);
@@ -55,7 +56,7 @@ public sealed class IterationPlanningViewMapperTests
             CreateBoardItem("PVTI_b", "Up Next", 3, "Beta"),
         };
 
-        var result = IterationPlanningViewMapper.Map([], boardItems, [], hasFocusOrderField: true, capacity: 8);
+        var result = Map([], boardItems, [], hasFocusOrderField: true, capacity: 8);
 
         Assert.True(result.HasFocusOrderField);
         Assert.Equal(4, result.NextStoryFocusOrder);
@@ -69,7 +70,7 @@ public sealed class IterationPlanningViewMapperTests
             CreateBoardItem("PVTI_a", "Up Next", 1, "Alpha"),
         };
 
-        var result = IterationPlanningViewMapper.Map([], boardItems, [], hasFocusOrderField: false, capacity: 8);
+        var result = Map([], boardItems, [], hasFocusOrderField: false, capacity: 8);
 
         Assert.False(result.HasFocusOrderField);
         Assert.Equal(0, result.NextStoryFocusOrder);
@@ -85,7 +86,7 @@ public sealed class IterationPlanningViewMapperTests
             CreateBoardItem("PVTI_todo", "Todo", null, "Later"),
         };
 
-        var result = IterationPlanningViewMapper.Map([], boardItems, [], hasFocusOrderField: true, capacity: 8);
+        var result = Map([], boardItems, [], hasFocusOrderField: true, capacity: 8);
 
         Assert.Equal(2, result.ActiveLoad);
         Assert.Equal(8, result.Capacity);
@@ -107,10 +108,49 @@ public sealed class IterationPlanningViewMapperTests
             CreateBoardItem("PVTI_h", "In Progress", null, "Eight"),
         };
 
-        var result = IterationPlanningViewMapper.Map([], boardItems, [], hasFocusOrderField: true, capacity: 8);
+        var result = Map([], boardItems, [], hasFocusOrderField: true, capacity: 8);
 
         Assert.Equal(8, result.ActiveLoad);
         Assert.True(result.IsAtOrOverCapacity);
+    }
+
+    [Fact]
+    public void Map_UpNextItemAgedThreeDays_IsStalled()
+    {
+        var boardItems = new[]
+        {
+            CreateBoardItem(
+                "PVTI_stalled",
+                "Up Next",
+                1,
+                "Stalled story",
+                activityTimestamp: UtcNow.AddDays(-3)),
+        };
+
+        var result = Map([], boardItems, [], hasFocusOrderField: true, capacity: 8, stallDays: 3);
+
+        var stalled = Assert.Single(result.StalledUpNextItems);
+        Assert.Equal("Stalled story", stalled.Title);
+        Assert.Equal(3, stalled.AgeInDays);
+        Assert.Equal(1, stalled.Number);
+    }
+
+    [Fact]
+    public void Map_UpNextItemAgedTwoDays_IsNotStalled()
+    {
+        var boardItems = new[]
+        {
+            CreateBoardItem(
+                "PVTI_fresh",
+                "Up Next",
+                1,
+                "Fresh story",
+                activityTimestamp: UtcNow.AddDays(-2)),
+        };
+
+        var result = Map([], boardItems, [], hasFocusOrderField: true, capacity: 8, stallDays: 3);
+
+        Assert.Empty(result.StalledUpNextItems);
     }
 
     [Theory]
@@ -144,12 +184,29 @@ public sealed class IterationPlanningViewMapperTests
             null,
             null);
 
+    private static IterationPlanningViewDto Map(
+        IReadOnlyList<PmWorkItemDto> workItems,
+        IReadOnlyList<ProjectBoardItemDto> boardItems,
+        IReadOnlyList<PmRepositoryCatalogueFailureDto> failures,
+        bool hasFocusOrderField,
+        int capacity,
+        int stallDays = PmSettingsDefaults.StallDays) =>
+        IterationPlanningViewMapper.Map(
+            workItems,
+            boardItems,
+            failures,
+            hasFocusOrderField,
+            capacity,
+            stallDays,
+            UtcNow);
+
     private static ProjectBoardItemDto CreateBoardItem(
         string projectItemId,
         string statusName,
         double? focusOrder,
         string title,
-        int number = 1) =>
+        int number = 1,
+        DateTimeOffset? activityTimestamp = null) =>
         new(
             projectItemId,
             new ProjectBoardItemStatusDto($"opt-{statusName.Replace(' ', '-').ToLowerInvariant()}", statusName),
@@ -161,6 +218,6 @@ public sealed class IterationPlanningViewMapperTests
                 "repo",
                 title,
                 $"https://github.com/owner/repo/issues/{number}"),
-            DateTimeOffset.UtcNow,
+            activityTimestamp ?? UtcNow,
             UsedItemUpdatedAtFallback: false);
 }


### PR DESCRIPTION
## Summary of Changes

- Extend the Iteration Planning view with stalled Up Next items using the same stall rule as Daily Focus (#275).
- Add Re-commit, Mark Blocked, Ice Box, and Remove actions that update board Status, labels, and Focus Order as required.
- Disable Add to Up Next while stalled items remain, with an explanatory alert; bUnit covers the disabled control.

## Related Issue(s)

Closes #285

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [ ] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — docs-capture screenshots deferred to test issue #387.

## Additional Notes

This PR stacks on #429 (`feature/issue-284-capacity-warning`). GitHub will show the combined diff against `main`; merge #429 first.

### Test plan

- [x] `dotnet clean SoloDevBoard.slnx && dotnet test SoloDevBoard.slnx` (905 passed)
- [ ] Manual: confirm stalled section, action buttons, and disabled Add to Up Next until all stalled items are resolved

Made with [Cursor](https://cursor.com)