### PR TITLE
[Story] Optionally assign milestone to planned items in a single step (#286)

### DIFF
--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor
@@ -187,6 +187,7 @@
                         <MudSimpleTable Hover="true" Dense="true" data-testid="pm-workflow-planning-up-next-table">
                             <thead>
                                 <tr>
+                                    <th></th>
                                     <th>#</th>
                                     <th>Kind</th>
                                     <th>Item</th>
@@ -198,6 +199,12 @@
                                 @foreach (var (item, index) in planningView.UpNextItems.Select((item, index) => (item, index + 1)))
                                 {
                                     <tr data-testid="pm-workflow-planning-up-next-row">
+                                        <td>
+                                            <MudCheckBox T="bool"
+                                                         Value="@IsUpNextItemSelected(item)"
+                                                         ValueChanged="@(value => OnUpNextItemSelectionChanged(item, value))"
+                                                         data-testid="pm-workflow-planning-up-next-checkbox" />
+                                        </td>
                                         <td>@index</td>
                                         <td>
                                             <MudChip T="string"
@@ -251,6 +258,44 @@
                                 }
                             </tbody>
                         </MudSimpleTable>
+
+                        <MudStack Row="true"
+                                  Wrap="Wrap.Wrap"
+                                  Spacing="2"
+                                  AlignItems="AlignItems.End"
+                                  data-testid="pm-workflow-planning-bulk-milestone">
+                            <MudSelect T="string"
+                                       Label="Assign milestone to selected"
+                                       Variant="Variant.Outlined"
+                                       Dense="true"
+                                       Disabled="@(SelectedUpNextItems.Count == 0 || isLoadingMilestoneOptions || isApplyingBulkMilestone)"
+                                       Value="selectedMilestoneTitle"
+                                       ValueChanged="OnBulkMilestoneSelectionChanged"
+                                       data-testid="pm-workflow-planning-milestone-select">
+                                @if (SelectedUpNextItems.Count == 0)
+                                {
+                                    <MudSelectItem T="string" Value="@string.Empty">Select batch items first</MudSelectItem>
+                                }
+                                else if (milestoneOptions.Count == 0 && !isLoadingMilestoneOptions)
+                                {
+                                    <MudSelectItem T="string" Value="@string.Empty">No shared milestones on selected repos</MudSelectItem>
+                                }
+                                else
+                                {
+                                    @foreach (var option in milestoneOptions)
+                                    {
+                                        <MudSelectItem T="string" Value="@option.Title">@option.Title</MudSelectItem>
+                                    }
+                                }
+                            </MudSelect>
+                            <MudButton Variant="Variant.Outlined"
+                                       Color="Color.Primary"
+                                       Disabled="@(!CanApplyBulkMilestone)"
+                                       OnClick="ApplyBulkMilestoneAsync"
+                                       data-testid="pm-workflow-planning-milestone-apply">
+                                Apply
+                            </MudButton>
+                        </MudStack>
                     }
                 </MudStack>
             </MudPaper>

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor.cs
@@ -616,10 +616,10 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
 
             Snackbar.Add(
                 FormatBulkMilestoneMessage(result, selectedMilestoneTitle),
-                result.AppliedCount > 0 ? Severity.Success : Severity.Warning,
+                ResolveBulkMilestoneSnackbarSeverity(result),
                 configure: config => config.VisibleStateDuration = 6000);
 
-            if (result.AppliedCount > 0 && ChromeState?.Settings.PlanningBoardNodeId is { } boardId)
+            if ((result.AppliedCount > 0 || result.Failures.Count > 0) && ChromeState?.Settings.PlanningBoardNodeId is { } boardId)
             {
                 ChromeCoordinator.ClearBacklogReview();
                 await ReloadPlanningDataAsync(boardId).ConfigureAwait(false);
@@ -660,21 +660,45 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
         }
     }
 
+    private static Severity ResolveBulkMilestoneSnackbarSeverity(IterationPlanningBulkMilestoneResultDto result)
+    {
+        if (result.Failures.Count > 0)
+        {
+            return result.AppliedCount > 0 ? Severity.Warning : Severity.Error;
+        }
+
+        return result.AppliedCount > 0 ? Severity.Success : Severity.Warning;
+    }
+
     private static string FormatBulkMilestoneMessage(
         IterationPlanningBulkMilestoneResultDto result,
         string milestoneTitle)
     {
-        if (result.AppliedCount == 0 && result.SkippedRepositories.Count == 0)
+        if (result.AppliedCount == 0 && result.SkippedRepositories.Count == 0 && result.Failures.Count == 0)
         {
             return $"No batch items received milestone '{milestoneTitle}'.";
         }
 
-        if (result.SkippedRepositories.Count == 0)
+        var message = result.AppliedCount > 0
+            ? $"Assigned milestone '{milestoneTitle}' to {result.AppliedCount} batch item(s)."
+            : $"No batch items received milestone '{milestoneTitle}'.";
+
+        if (result.SkippedRepositories.Count > 0)
         {
-            return $"Assigned milestone '{milestoneTitle}' to {result.AppliedCount} batch item(s).";
+            var skipped = string.Join(", ", result.SkippedRepositories);
+            message += $" Skipped repositories without that milestone: {skipped}.";
         }
 
-        var skipped = string.Join(", ", result.SkippedRepositories);
-        return $"Assigned milestone '{milestoneTitle}' to {result.AppliedCount} batch item(s). Skipped repositories without that milestone: {skipped}.";
+        if (result.Failures.Count > 0)
+        {
+            var failedItems = string.Join(
+                ", ",
+                result.Failures.Select(static failure => $"{failure.RepositoryFullName}#{failure.Number}"));
+            message += result.AppliedCount > 0
+                ? $" Failed on: {failedItems}."
+                : $" Failed items: {failedItems}.";
+        }
+
+        return message;
     }
 }

--- a/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/PmWorkflow/PmWorkflowPlanningPanel.razor.cs
@@ -43,6 +43,11 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
     private string selectedTypeFilter = PmWorkflowItemKindFormatting.AllTypesFilter;
     private string? addingCandidateKey;
     private string? resolvingStalledItemId;
+    private readonly HashSet<string> selectedUpNextItemIds = new(StringComparer.Ordinal);
+    private IReadOnlyList<IterationPlanningMilestoneOptionDto> milestoneOptions = [];
+    private string? selectedMilestoneTitle;
+    private bool isLoadingMilestoneOptions;
+    private bool isApplyingBulkMilestone;
     private int viewLoadGeneration;
     private CancellationTokenSource? viewLoadCts;
     private CancellationTokenSource? addToUpNextCts;
@@ -50,6 +55,18 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
 
     private bool IsAddToUpNextDisabled =>
         planningView is not null && planningView.StalledUpNextItems.Count > 0;
+
+    private IReadOnlyList<IterationPlanningUpNextItemDto> SelectedUpNextItems =>
+        planningView?.UpNextItems
+            .Where(item => selectedUpNextItemIds.Contains(item.ProjectItemId))
+            .ToArray()
+        ?? [];
+
+    private bool CanApplyBulkMilestone =>
+        SelectedUpNextItems.Count > 0
+        && !string.IsNullOrWhiteSpace(selectedMilestoneTitle)
+        && !isApplyingBulkMilestone
+        && !isLoadingMilestoneOptions;
 
     private IEnumerable<IterationPlanningCandidateDto> FilteredCandidates
     {
@@ -192,6 +209,9 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
 
             planningView = view;
             ChromeCoordinator.SetIterationPlanning(boardId, view, null, isLoading: false);
+            selectedUpNextItemIds.Clear();
+            selectedMilestoneTitle = null;
+            milestoneOptions = [];
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -519,4 +539,142 @@ public partial class PmWorkflowPlanningPanel : ComponentBase, IDisposable
 
     private static string FormatStallAge(int ageInDays) =>
         ageInDays == 1 ? "1 day" : $"{ageInDays} days";
+
+    private bool IsUpNextItemSelected(IterationPlanningUpNextItemDto item) =>
+        selectedUpNextItemIds.Contains(item.ProjectItemId);
+
+    private async Task OnUpNextItemSelectionChanged(IterationPlanningUpNextItemDto item, bool isSelected)
+    {
+        if (isSelected)
+        {
+            selectedUpNextItemIds.Add(item.ProjectItemId);
+        }
+        else
+        {
+            selectedUpNextItemIds.Remove(item.ProjectItemId);
+        }
+
+        selectedMilestoneTitle = null;
+        await LoadBulkMilestoneOptionsAsync().ConfigureAwait(false);
+        await InvokeAsync(StateHasChanged).ConfigureAwait(false);
+    }
+
+    private Task OnBulkMilestoneSelectionChanged(string? value)
+    {
+        selectedMilestoneTitle = string.IsNullOrWhiteSpace(value) ? null : value;
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    private async Task LoadBulkMilestoneOptionsAsync()
+    {
+        if (SelectedUpNextItems.Count == 0)
+        {
+            milestoneOptions = [];
+            return;
+        }
+
+        isLoadingMilestoneOptions = true;
+        await InvokeAsync(StateHasChanged).ConfigureAwait(false);
+
+        try
+        {
+            milestoneOptions = await PlanningService
+                .GetBulkMilestoneOptionsAsync(SelectedUpNextItems)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load bulk milestone options for selected Up Next items.");
+            milestoneOptions = [];
+            Snackbar.Add(
+                "Unable to load milestone options for the selected batch items.",
+                Severity.Error,
+                configure: config => config.VisibleStateDuration = 6000);
+        }
+        finally
+        {
+            isLoadingMilestoneOptions = false;
+        }
+    }
+
+    private async Task ApplyBulkMilestoneAsync()
+    {
+        if (!CanApplyBulkMilestone || string.IsNullOrWhiteSpace(selectedMilestoneTitle))
+        {
+            return;
+        }
+
+        isApplyingBulkMilestone = true;
+        await InvokeAsync(StateHasChanged).ConfigureAwait(false);
+
+        try
+        {
+            var result = await PlanningService
+                .ApplyBulkMilestoneAsync(SelectedUpNextItems, selectedMilestoneTitle)
+                .ConfigureAwait(false);
+
+            Snackbar.Add(
+                FormatBulkMilestoneMessage(result, selectedMilestoneTitle),
+                result.AppliedCount > 0 ? Severity.Success : Severity.Warning,
+                configure: config => config.VisibleStateDuration = 6000);
+
+            if (result.AppliedCount > 0 && ChromeState?.Settings.PlanningBoardNodeId is { } boardId)
+            {
+                ChromeCoordinator.ClearBacklogReview();
+                await ReloadPlanningDataAsync(boardId).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex) when (ex is HostedAuthenticationRequiredException or GitHubPatConnectivityRequiredException)
+        {
+            if (GitHubAuthRecovery.TryInitiateRecovery(ex))
+            {
+                return;
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogError(ex, "GitHub API request failed while applying bulk milestone.");
+            Snackbar.Add(
+                $"GitHub API request failed while assigning the milestone. {ex.Message}",
+                Severity.Error,
+                configure: config => config.VisibleStateDuration = 6000);
+        }
+        catch (InvalidOperationException ex)
+        {
+            Logger.LogError(ex, "Unable to apply bulk milestone.");
+            Snackbar.Add(ex.Message, Severity.Error, configure: config => config.VisibleStateDuration = 6000);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unexpected error while applying bulk milestone.");
+            Snackbar.Add(
+                "An unexpected error occurred while assigning the milestone.",
+                Severity.Error,
+                configure: config => config.VisibleStateDuration = 6000);
+        }
+        finally
+        {
+            isApplyingBulkMilestone = false;
+            await InvokeAsync(StateHasChanged).ConfigureAwait(false);
+        }
+    }
+
+    private static string FormatBulkMilestoneMessage(
+        IterationPlanningBulkMilestoneResultDto result,
+        string milestoneTitle)
+    {
+        if (result.AppliedCount == 0 && result.SkippedRepositories.Count == 0)
+        {
+            return $"No batch items received milestone '{milestoneTitle}'.";
+        }
+
+        if (result.SkippedRepositories.Count == 0)
+        {
+            return $"Assigned milestone '{milestoneTitle}' to {result.AppliedCount} batch item(s).";
+        }
+
+        var skipped = string.Join(", ", result.SkippedRepositories);
+        return $"Assigned milestone '{milestoneTitle}' to {result.AppliedCount} batch item(s). Skipped repositories without that milestone: {skipped}.";
+    }
 }

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IIterationPlanningService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IIterationPlanningService.cs
@@ -87,4 +87,26 @@ public interface IIterationPlanningService
         string projectId,
         IterationPlanningStalledItemDto item,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads the union of milestone titles available on the selected Up Next items' repositories.
+    /// </summary>
+    /// <param name="selectedItems">Checked Up Next items in the current batch.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>Deduplicated milestone options ordered by title.</returns>
+    Task<IReadOnlyList<IterationPlanningMilestoneOptionDto>> GetBulkMilestoneOptionsAsync(
+        IReadOnlyList<IterationPlanningUpNextItemDto> selectedItems,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Assigns a milestone title to the selected Up Next items, skipping repositories where it is missing.
+    /// </summary>
+    /// <param name="selectedItems">Checked Up Next items in the current batch.</param>
+    /// <param name="milestoneTitle">The milestone title to assign.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <returns>The apply outcome, including repositories skipped.</returns>
+    Task<IterationPlanningBulkMilestoneResultDto> ApplyBulkMilestoneAsync(
+        IReadOnlyList<IterationPlanningUpNextItemDto> selectedItems,
+        string milestoneTitle,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningBulkMilestoneDtos.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningBulkMilestoneDtos.cs
@@ -1,0 +1,15 @@
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Milestone title option for bulk assignment across selected Up Next items.</summary>
+/// <param name="Title">The milestone title shared across one or more repositories.</param>
+/// <param name="RepositoryFullNames">Repositories in the current selection that expose this milestone title.</param>
+public sealed record IterationPlanningMilestoneOptionDto(
+    string Title,
+    IReadOnlyList<string> RepositoryFullNames);
+
+/// <summary>Outcome of applying a milestone to a checked Up Next batch.</summary>
+/// <param name="AppliedCount">Items that received the milestone.</param>
+/// <param name="SkippedRepositories">Repositories skipped because the milestone title was missing.</param>
+public sealed record IterationPlanningBulkMilestoneResultDto(
+    int AppliedCount,
+    IReadOnlyList<string> SkippedRepositories);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningBulkMilestoneDtos.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningBulkMilestoneDtos.cs
@@ -10,6 +10,17 @@ public sealed record IterationPlanningMilestoneOptionDto(
 /// <summary>Outcome of applying a milestone to a checked Up Next batch.</summary>
 /// <param name="AppliedCount">Items that received the milestone.</param>
 /// <param name="SkippedRepositories">Repositories skipped because the milestone title was missing.</param>
+/// <param name="Failures">Per-item assignment failures after earlier items succeeded.</param>
 public sealed record IterationPlanningBulkMilestoneResultDto(
     int AppliedCount,
-    IReadOnlyList<string> SkippedRepositories);
+    IReadOnlyList<string> SkippedRepositories,
+    IReadOnlyList<IterationPlanningBulkMilestoneFailureDto> Failures);
+
+/// <summary>Per-item failure while applying a bulk milestone assignment.</summary>
+/// <param name="RepositoryFullName">The repository in <c>owner/name</c> form.</param>
+/// <param name="Number">The repository-scoped item number.</param>
+/// <param name="Message">The error message returned for this item.</param>
+public sealed record IterationPlanningBulkMilestoneFailureDto(
+    string RepositoryFullName,
+    int Number,
+    string Message);

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningService.cs
@@ -1,4 +1,5 @@
 using SoloDevBoard.Application.Services.GitHub;
+using SoloDevBoard.Domain.Entities.Milestones;
 
 namespace SoloDevBoard.Application.Services.PmWorkflow;
 
@@ -324,6 +325,107 @@ public sealed class IterationPlanningService : IIterationPlanningService
             .ConfigureAwait(false);
 
         _projectItemCatalogueService.InvalidateCatalogue(projectId);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<IterationPlanningMilestoneOptionDto>> GetBulkMilestoneOptionsAsync(
+        IReadOnlyList<IterationPlanningUpNextItemDto> selectedItems,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(selectedItems);
+
+        var milestonesByRepository = await LoadMilestonesByRepositoryAsync(selectedItems, cancellationToken)
+            .ConfigureAwait(false);
+
+        return PlanningBulkMilestoneAssigner.BuildMilestoneOptions(selectedItems, milestonesByRepository);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IterationPlanningBulkMilestoneResultDto> ApplyBulkMilestoneAsync(
+        IReadOnlyList<IterationPlanningUpNextItemDto> selectedItems,
+        string milestoneTitle,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(selectedItems);
+        ArgumentException.ThrowIfNullOrWhiteSpace(milestoneTitle);
+
+        if (selectedItems.Count == 0)
+        {
+            return new IterationPlanningBulkMilestoneResultDto(0, []);
+        }
+
+        var milestonesByRepository = await LoadMilestonesByRepositoryAsync(selectedItems, cancellationToken)
+            .ConfigureAwait(false);
+        var skippedRepositories = PlanningBulkMilestoneAssigner.BuildSkipList(
+            selectedItems,
+            milestonesByRepository,
+            milestoneTitle);
+        var skippedSet = skippedRepositories.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var appliedCount = 0;
+
+        foreach (var item in selectedItems)
+        {
+            if (skippedSet.Contains(item.RepositoryFullName))
+            {
+                continue;
+            }
+
+            if (!TryParseRepositoryFullName(item.RepositoryFullName, out var owner, out var repo))
+            {
+                throw new ArgumentException(
+                    $"Repository scope '{item.RepositoryFullName}' must be in owner/repository format.",
+                    nameof(selectedItems));
+            }
+
+            if (!milestonesByRepository.TryGetValue(item.RepositoryFullName, out var milestones))
+            {
+                continue;
+            }
+
+            var milestoneNumber = PlanningBulkMilestoneAssigner.ResolveMilestoneNumber(milestones, milestoneTitle);
+            if (milestoneNumber is null)
+            {
+                continue;
+            }
+
+            await _gitHubService
+                .AssignMilestoneToTriageItemAsync(owner, repo, item.Number, milestoneNumber, cancellationToken)
+                .ConfigureAwait(false);
+            appliedCount++;
+        }
+
+        return new IterationPlanningBulkMilestoneResultDto(appliedCount, skippedRepositories);
+    }
+
+    private async Task<Dictionary<string, IReadOnlyList<Milestone>>> LoadMilestonesByRepositoryAsync(
+        IReadOnlyList<IterationPlanningUpNextItemDto> selectedItems,
+        CancellationToken cancellationToken)
+    {
+        var repositories = selectedItems
+            .Select(static item => item.RepositoryFullName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var milestonesByRepository = new Dictionary<string, IReadOnlyList<Milestone>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var repositoryFullName in repositories)
+        {
+            if (!TryParseRepositoryFullName(repositoryFullName, out var owner, out var repo))
+            {
+                throw new ArgumentException(
+                    $"Repository scope '{repositoryFullName}' must be in owner/repository format.",
+                    nameof(selectedItems));
+            }
+
+            var milestones = await _gitHubService
+                .GetMilestonesAsync(owner, repo, cancellationToken)
+                .ConfigureAwait(false);
+            milestonesByRepository[repositoryFullName] = milestones;
+        }
+
+        return milestonesByRepository;
     }
 
     private async Task<ProjectBoardItemCatalogueDto> LoadCatalogueForStalledItemUpdateAsync(

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/IterationPlanningService.cs
@@ -353,7 +353,7 @@ public sealed class IterationPlanningService : IIterationPlanningService
 
         if (selectedItems.Count == 0)
         {
-            return new IterationPlanningBulkMilestoneResultDto(0, []);
+            return new IterationPlanningBulkMilestoneResultDto(0, [], []);
         }
 
         var milestonesByRepository = await LoadMilestonesByRepositoryAsync(selectedItems, cancellationToken)
@@ -364,6 +364,7 @@ public sealed class IterationPlanningService : IIterationPlanningService
             milestoneTitle);
         var skippedSet = skippedRepositories.ToHashSet(StringComparer.OrdinalIgnoreCase);
         var appliedCount = 0;
+        var failures = new List<IterationPlanningBulkMilestoneFailureDto>();
 
         foreach (var item in selectedItems)
         {
@@ -390,13 +391,23 @@ public sealed class IterationPlanningService : IIterationPlanningService
                 continue;
             }
 
-            await _gitHubService
-                .AssignMilestoneToTriageItemAsync(owner, repo, item.Number, milestoneNumber, cancellationToken)
-                .ConfigureAwait(false);
-            appliedCount++;
+            try
+            {
+                await _gitHubService
+                    .AssignMilestoneToTriageItemAsync(owner, repo, item.Number, milestoneNumber.Value, cancellationToken)
+                    .ConfigureAwait(false);
+                appliedCount++;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                failures.Add(new IterationPlanningBulkMilestoneFailureDto(
+                    item.RepositoryFullName,
+                    item.Number,
+                    ex.Message));
+            }
         }
 
-        return new IterationPlanningBulkMilestoneResultDto(appliedCount, skippedRepositories);
+        return new IterationPlanningBulkMilestoneResultDto(appliedCount, skippedRepositories, failures);
     }
 
     private async Task<Dictionary<string, IReadOnlyList<Milestone>>> LoadMilestonesByRepositoryAsync(

--- a/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PlanningBulkMilestoneAssigner.cs
+++ b/src/Application/SoloDevBoard.Application/Services/PmWorkflow/PlanningBulkMilestoneAssigner.cs
@@ -1,0 +1,106 @@
+using SoloDevBoard.Domain.Entities.Milestones;
+
+namespace SoloDevBoard.Application.Services.PmWorkflow;
+
+/// <summary>Builds milestone unions and skip lists for Iteration Planning bulk assignment.</summary>
+public static class PlanningBulkMilestoneAssigner
+{
+    /// <summary>
+    /// Builds the union of milestone titles available on the selected items' repositories.
+    /// </summary>
+    /// <param name="selectedItems">Checked Up Next items in the current batch.</param>
+    /// <param name="milestonesByRepository">Milestone catalogues keyed by repository full name.</param>
+    /// <returns>Deduplicated milestone options ordered by title.</returns>
+    public static IReadOnlyList<IterationPlanningMilestoneOptionDto> BuildMilestoneOptions(
+        IReadOnlyList<IterationPlanningUpNextItemDto> selectedItems,
+        IReadOnlyDictionary<string, IReadOnlyList<Milestone>> milestonesByRepository)
+    {
+        ArgumentNullException.ThrowIfNull(selectedItems);
+        ArgumentNullException.ThrowIfNull(milestonesByRepository);
+
+        var titlesByRepository = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var item in selectedItems)
+        {
+            if (!milestonesByRepository.TryGetValue(item.RepositoryFullName, out var milestones))
+            {
+                continue;
+            }
+
+            foreach (var milestone in milestones)
+            {
+                if (string.IsNullOrWhiteSpace(milestone.Title))
+                {
+                    continue;
+                }
+
+                if (!titlesByRepository.TryGetValue(milestone.Title, out var repositories))
+                {
+                    repositories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    titlesByRepository[milestone.Title] = repositories;
+                }
+
+                repositories.Add(item.RepositoryFullName);
+            }
+        }
+
+        return titlesByRepository
+            .OrderBy(static entry => entry.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(entry => new IterationPlanningMilestoneOptionDto(
+                entry.Key,
+                entry.Value.OrderBy(static repository => repository, StringComparer.OrdinalIgnoreCase).ToArray()))
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Returns repositories in the selection that do not expose the requested milestone title.
+    /// </summary>
+    /// <param name="selectedItems">Checked Up Next items in the current batch.</param>
+    /// <param name="milestonesByRepository">Milestone catalogues keyed by repository full name.</param>
+    /// <param name="milestoneTitle">The milestone title to assign.</param>
+    /// <returns>Distinct repository full names to skip, ordered alphabetically.</returns>
+    public static IReadOnlyList<string> BuildSkipList(
+        IReadOnlyList<IterationPlanningUpNextItemDto> selectedItems,
+        IReadOnlyDictionary<string, IReadOnlyList<Milestone>> milestonesByRepository,
+        string milestoneTitle)
+    {
+        ArgumentNullException.ThrowIfNull(selectedItems);
+        ArgumentNullException.ThrowIfNull(milestonesByRepository);
+        ArgumentException.ThrowIfNullOrWhiteSpace(milestoneTitle);
+
+        var skipped = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var item in selectedItems)
+        {
+            if (!milestonesByRepository.TryGetValue(item.RepositoryFullName, out var milestones)
+                || !milestones.Any(milestone =>
+                    milestone.Title.Equals(milestoneTitle, StringComparison.OrdinalIgnoreCase)))
+            {
+                skipped.Add(item.RepositoryFullName);
+            }
+        }
+
+        return skipped
+            .OrderBy(static repository => repository, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Resolves the repository-scoped milestone number for a title, when present.
+    /// </summary>
+    /// <param name="milestones">Milestones on the target repository.</param>
+    /// <param name="milestoneTitle">The milestone title to resolve.</param>
+    /// <returns>The milestone number when found; otherwise, <see langword="null"/>.</returns>
+    public static int? ResolveMilestoneNumber(
+        IReadOnlyList<Milestone> milestones,
+        string milestoneTitle)
+    {
+        ArgumentNullException.ThrowIfNull(milestones);
+        ArgumentException.ThrowIfNullOrWhiteSpace(milestoneTitle);
+
+        return milestones
+            .FirstOrDefault(milestone =>
+                milestone.Title.Equals(milestoneTitle, StringComparison.OrdinalIgnoreCase))
+            ?.Number;
+    }
+}

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowPlanningTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowPlanningTests.cs
@@ -319,6 +319,44 @@ public sealed class PmWorkflowPlanningTests
         });
     }
 
+    [Fact]
+    public async Task PmWorkflowPlanning_WhenBoardHasUpNextItems_ShowsBulkMilestoneControls()
+    {
+        ConfigureDefaults();
+        _planningService.GetPlanningViewAsync("PVT_board", 8, 3, Arg.Any<CancellationToken>()).Returns(
+            new IterationPlanningViewDto(
+                [
+                    new IterationPlanningUpNextItemDto(
+                        "PVTI_one",
+                        PmWorkItemTypeDto.Issue,
+                        40,
+                        "Existing Up Next",
+                        "https://github.com/owner/repo-a/issues/40",
+                        "owner/repo-a",
+                        1,
+                        ["type/story", "priority/medium"]),
+                ],
+                [],
+                [],
+                true,
+                2,
+                1,
+                8,
+                false,
+                []));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("data-testid=\"pm-workflow-planning-bulk-milestone\"", cut.Markup);
+            Assert.Contains("data-testid=\"pm-workflow-planning-milestone-select\"", cut.Markup);
+            Assert.Contains("data-testid=\"pm-workflow-planning-milestone-apply\"", cut.Markup);
+            Assert.Contains("data-testid=\"pm-workflow-planning-up-next-checkbox\"", cut.Markup);
+        });
+    }
+
     private void ConfigureDefaults()
     {
         _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/IterationPlanningServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/IterationPlanningServiceTests.cs
@@ -1,6 +1,7 @@
 using NSubstitute;
 using SoloDevBoard.Application.Services.GitHub;
 using SoloDevBoard.Application.Services.PmWorkflow;
+using SoloDevBoard.Domain.Entities.Milestones;
 
 namespace SoloDevBoard.Application.Tests;
 
@@ -429,6 +430,63 @@ public sealed class IterationPlanningServiceTests
             .ClearFocusOrderAsync("project-id", "PVTI_one", "PVTF_focus", cancellationToken);
     }
 
+    [Fact]
+    public async Task ApplyBulkMilestoneAsync_ValidSelection_AssignsMilestoneToEachItem()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var selectedItems = new[]
+        {
+            CreateUpNextItem("owner/repo-a", 10),
+            CreateUpNextItem("owner/repo-a", 11),
+        };
+        _gitHubService
+            .GetMilestonesAsync("owner", "repo-a", cancellationToken)
+            .Returns([CreateMilestone("v1.0.0", 5)]);
+
+        var sut = CreateSut();
+
+        var result = await sut.ApplyBulkMilestoneAsync(selectedItems, "v1.0.0", cancellationToken);
+
+        Assert.Equal(2, result.AppliedCount);
+        Assert.Empty(result.SkippedRepositories);
+        Assert.Empty(result.Failures);
+        await _gitHubService.Received(1)
+            .AssignMilestoneToTriageItemAsync("owner", "repo-a", 10, 5, cancellationToken);
+        await _gitHubService.Received(1)
+            .AssignMilestoneToTriageItemAsync("owner", "repo-a", 11, 5, cancellationToken);
+    }
+
+    [Fact]
+    public async Task ApplyBulkMilestoneAsync_WhenSecondAssignmentFails_ReturnsPartialResult()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var selectedItems = new[]
+        {
+            CreateUpNextItem("owner/repo-a", 10),
+            CreateUpNextItem("owner/repo-a", 11),
+        };
+        _gitHubService
+            .GetMilestonesAsync("owner", "repo-a", cancellationToken)
+            .Returns([CreateMilestone("v1.0.0", 5)]);
+        _gitHubService
+            .AssignMilestoneToTriageItemAsync("owner", "repo-a", 10, 5, cancellationToken)
+            .Returns(Task.CompletedTask);
+        _gitHubService
+            .AssignMilestoneToTriageItemAsync("owner", "repo-a", 11, 5, cancellationToken)
+            .Returns(_ => throw new HttpRequestException("GitHub unavailable"));
+
+        var sut = CreateSut();
+
+        var result = await sut.ApplyBulkMilestoneAsync(selectedItems, "v1.0.0", cancellationToken);
+
+        Assert.Equal(1, result.AppliedCount);
+        Assert.Empty(result.SkippedRepositories);
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal("owner/repo-a", failure.RepositoryFullName);
+        Assert.Equal(11, failure.Number);
+        Assert.Contains("GitHub unavailable", failure.Message, StringComparison.Ordinal);
+    }
+
     private IterationPlanningService CreateSut() =>
         new(_workItemCatalogueService, _projectItemCatalogueService, _gitHubService, TimeProvider.System);
 
@@ -487,4 +545,23 @@ public sealed class IterationPlanningServiceTests
                 $"https://github.com/owner/repo/issues/{number}"),
             activityTimestamp ?? DateTimeOffset.UtcNow,
             UsedItemUpdatedAtFallback: false);
+
+    private static IterationPlanningUpNextItemDto CreateUpNextItem(string repositoryFullName, int number) =>
+        new(
+            $"PVTI_{number}",
+            PmWorkItemTypeDto.Issue,
+            number,
+            $"Title {number}",
+            $"https://github.com/{repositoryFullName}/issues/{number}",
+            repositoryFullName,
+            1,
+            ["type/story"]);
+
+    private static Milestone CreateMilestone(string title, int number) =>
+        new()
+        {
+            Title = title,
+            Number = number,
+            State = "open",
+        };
 }

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/PlanningBulkMilestoneAssignerTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/PlanningBulkMilestoneAssignerTests.cs
@@ -1,0 +1,84 @@
+using SoloDevBoard.Application.Services.PmWorkflow;
+using SoloDevBoard.Domain.Entities.Milestones;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="PlanningBulkMilestoneAssigner"/>.</summary>
+public sealed class PlanningBulkMilestoneAssignerTests
+{
+    [Fact]
+    public void BuildSkipList_MissingMilestoneOnOneRepo_ReturnsThatRepository()
+    {
+        var selectedItems = new[]
+        {
+            CreateUpNextItem("owner/has-milestone", 10),
+            CreateUpNextItem("owner/missing-milestone", 20),
+        };
+
+        var milestonesByRepository = new Dictionary<string, IReadOnlyList<Milestone>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["owner/has-milestone"] = [CreateMilestone("v1.1.0", 1)],
+            ["owner/missing-milestone"] = [CreateMilestone("v1.0.0", 2)],
+        };
+
+        var result = PlanningBulkMilestoneAssigner.BuildSkipList(
+            selectedItems,
+            milestonesByRepository,
+            "v1.1.0");
+
+        Assert.Equal(["owner/missing-milestone"], result);
+    }
+
+    [Fact]
+    public void BuildMilestoneOptions_UnionAcrossRepositories_ReturnsDistinctTitles()
+    {
+        var selectedItems = new[]
+        {
+            CreateUpNextItem("owner/repo-a", 10),
+            CreateUpNextItem("owner/repo-b", 20),
+        };
+
+        var milestonesByRepository = new Dictionary<string, IReadOnlyList<Milestone>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["owner/repo-a"] = [CreateMilestone("v1.1.0", 1), CreateMilestone("v1.0.0", 2)],
+            ["owner/repo-b"] = [CreateMilestone("v1.1.0", 3)],
+        };
+
+        var result = PlanningBulkMilestoneAssigner.BuildMilestoneOptions(selectedItems, milestonesByRepository);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("v1.0.0", result[0].Title);
+        Assert.Equal(["owner/repo-a"], result[0].RepositoryFullNames);
+        Assert.Equal("v1.1.0", result[1].Title);
+        Assert.Equal(["owner/repo-a", "owner/repo-b"], result[1].RepositoryFullNames);
+    }
+
+    [Fact]
+    public void ResolveMilestoneNumber_TitleMatch_ReturnsNumber()
+    {
+        var milestones = new[] { CreateMilestone("v1.1.0", 7) };
+
+        var result = PlanningBulkMilestoneAssigner.ResolveMilestoneNumber(milestones, "v1.1.0");
+
+        Assert.Equal(7, result);
+    }
+
+    private static IterationPlanningUpNextItemDto CreateUpNextItem(string repositoryFullName, int number) =>
+        new(
+            $"PVTI_{number}",
+            PmWorkItemTypeDto.Issue,
+            number,
+            $"Title {number}",
+            $"https://github.com/{repositoryFullName}/issues/{number}",
+            repositoryFullName,
+            1,
+            ["type/story"]);
+
+    private static Milestone CreateMilestone(string title, int number) =>
+        new()
+        {
+            Title = title,
+            Number = number,
+            State = "open",
+        };
+}


### PR DESCRIPTION
## Summary of Changes

- Add `PlanningBulkMilestoneAssigner` to union milestone titles across selected Up Next repositories and compute skip lists when a title is missing.
- Extend `IIterationPlanningService` with bulk milestone option loading and apply-by-title (no milestone creation).
- Add batch checkboxes, milestone picker, and Apply control on the Up Next table with snackbar summaries for skipped repositories.

## Related Issue(s)

Closes #286

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [ ] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — docs-capture screenshots deferred to test issue #387.

## Additional Notes

This PR stacks on #430 (`feature/issue-285-stalled-up-next`), which stacks on #429. Merge in order: #429 → #430 → this PR.

### Test plan

- [x] `dotnet clean SoloDevBoard.slnx && dotnet test SoloDevBoard.slnx` (908 passed)
- [ ] Manual: select Up Next batch items, choose a shared milestone title, apply, and confirm snackbar lists repos skipped when the title is absent

Made with [Cursor](https://cursor.com)