### PR TITLE
[Test] Complete Iteration Planning PM Workflow coverage (#387)

### DIFF
--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowPlanningTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowPlanningTests.cs
@@ -23,6 +23,7 @@ public sealed class PmWorkflowPlanningTests
     {
         StoredJson = """{"planningBoardNodeId":"PVT_board","capacity":8,"stallDays":3,"neglectDays":14,"excludedRepositories":[]}""",
     };
+    private IRenderedComponent<MudSnackbarProvider> _snackbarProvider = default!;
 
     [Fact]
     public async Task PmWorkflowPlanning_RouteShell_ExposesPageTestIdAndHeading()
@@ -341,7 +342,6 @@ public sealed class PmWorkflowPlanningTests
                 FocusOrderSkipped: false));
 
         await using var ctx = CreateContext();
-        var snackbarProvider = ctx.Render<MudSnackbarProvider>();
         var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
 
         cut.WaitForAssertion(() => Assert.Contains("data-testid=\"pm-workflow-planning-add-button\"", cut.Markup));
@@ -350,7 +350,7 @@ public sealed class PmWorkflowPlanningTests
 
         cut.WaitForAssertion(() =>
         {
-            var snackbar = snackbarProvider.Find(".mud-snackbar");
+            var snackbar = _snackbarProvider.Find(".mud-snackbar");
             Assert.Contains("Added owner/repo-a#50 to Up Next with Focus Order 2.", snackbar.TextContent, StringComparison.Ordinal);
         });
     }
@@ -373,7 +373,6 @@ public sealed class PmWorkflowPlanningTests
                 new InvalidOperationException("Resolve stalled Up Next items before adding new work.")));
 
         await using var ctx = CreateContext();
-        var snackbarProvider = ctx.Render<MudSnackbarProvider>();
         var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
 
         cut.WaitForAssertion(() => Assert.Contains("data-testid=\"pm-workflow-planning-add-button\"", cut.Markup));
@@ -382,7 +381,7 @@ public sealed class PmWorkflowPlanningTests
 
         cut.WaitForAssertion(() =>
         {
-            var snackbar = snackbarProvider.Find(".mud-snackbar");
+            var snackbar = _snackbarProvider.Find(".mud-snackbar");
             Assert.Contains("Resolve stalled Up Next items before adding new work.", snackbar.TextContent, StringComparison.Ordinal);
         });
     }
@@ -459,6 +458,7 @@ public sealed class PmWorkflowPlanningTests
 
         ctx.Render<MudPopoverProvider>();
         ctx.Render<MudDialogProvider>();
+        _snackbarProvider = ctx.Render<MudSnackbarProvider>();
 
         return ctx;
     }

--- a/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowPlanningTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/PmWorkflowPlanningTests.cs
@@ -320,6 +320,74 @@ public sealed class PmWorkflowPlanningTests
     }
 
     [Fact]
+    public async Task PmWorkflowPlanning_WhenAddToUpNextSucceeds_ShowsSuccessSnackbar()
+    {
+        ConfigureDefaults();
+        var initialView = CreatePlanningViewWithCandidate();
+        _planningService.GetPlanningViewAsync("PVT_board", 8, 3, Arg.Any<CancellationToken>()).Returns(
+            initialView,
+            initialView);
+        _planningService.AddToUpNextAsync(
+            "PVT_board",
+            PmWorkItemTypeDto.Issue,
+            "owner/repo-a",
+            50,
+            Arg.Any<IReadOnlyList<string>>(),
+            3,
+            Arg.Any<CancellationToken>()).Returns(
+            new IterationPlanningAddToUpNextResultDto(
+                AddedBoardCard: false,
+                FocusOrderAssigned: 2,
+                FocusOrderSkipped: false));
+
+        await using var ctx = CreateContext();
+        var snackbarProvider = ctx.Render<MudSnackbarProvider>();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
+
+        cut.WaitForAssertion(() => Assert.Contains("data-testid=\"pm-workflow-planning-add-button\"", cut.Markup));
+
+        await cut.InvokeAsync(() => cut.Find("[data-testid='pm-workflow-planning-add-button']").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            var snackbar = snackbarProvider.Find(".mud-snackbar");
+            Assert.Contains("Added owner/repo-a#50 to Up Next with Focus Order 2.", snackbar.TextContent, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public async Task PmWorkflowPlanning_WhenAddToUpNextFails_ShowsErrorSnackbar()
+    {
+        ConfigureDefaults();
+        _planningService.GetPlanningViewAsync("PVT_board", 8, 3, Arg.Any<CancellationToken>()).Returns(
+            CreatePlanningViewWithCandidate());
+        _planningService.AddToUpNextAsync(
+            Arg.Any<string>(),
+            Arg.Any<PmWorkItemTypeDto>(),
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>()).Returns(
+            Task.FromException<IterationPlanningAddToUpNextResultDto>(
+                new InvalidOperationException("Resolve stalled Up Next items before adding new work.")));
+
+        await using var ctx = CreateContext();
+        var snackbarProvider = ctx.Render<MudSnackbarProvider>();
+        var cut = ctx.RenderPmWorkflowPage<PmWorkflowPlanning>();
+
+        cut.WaitForAssertion(() => Assert.Contains("data-testid=\"pm-workflow-planning-add-button\"", cut.Markup));
+
+        await cut.InvokeAsync(() => cut.Find("[data-testid='pm-workflow-planning-add-button']").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            var snackbar = snackbarProvider.Find(".mud-snackbar");
+            Assert.Contains("Resolve stalled Up Next items before adding new work.", snackbar.TextContent, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
     public async Task PmWorkflowPlanning_WhenBoardHasUpNextItems_ShowsBulkMilestoneControls()
     {
         ConfigureDefaults();
@@ -391,12 +459,17 @@ public sealed class PmWorkflowPlanningTests
 
         ctx.Render<MudPopoverProvider>();
         ctx.Render<MudDialogProvider>();
-        ctx.Render<MudSnackbarProvider>();
 
         return ctx;
     }
 
     private static IterationPlanningViewDto CreateAtCapacityPlanningView() =>
+        CreatePlanningViewWithCandidate(activeLoad: 8, capacity: 8, isAtOrOverCapacity: true);
+
+    private static IterationPlanningViewDto CreatePlanningViewWithCandidate(
+        int activeLoad = 1,
+        int capacity = 8,
+        bool isAtOrOverCapacity = false) =>
         new(
             [],
             [
@@ -412,10 +485,10 @@ public sealed class PmWorkflowPlanningTests
             ],
             [],
             true,
-            1,
-            8,
-            8,
-            true,
+            2,
+            activeLoad,
+            capacity,
+            isAtOrOverCapacity,
             []);
 
     private static RepositoryDto CreateRepository(string owner, string name) =>

--- a/tests/E2E/USER_DOCS_ALIGNMENT.md
+++ b/tests/E2E/USER_DOCS_ALIGNMENT.md
@@ -157,6 +157,11 @@ Issue [#387](https://github.com/markheydon/solo-dev-board/issues/387) tracks the
 | Focus Order sequencing for story, enabler, and test labels | `PlanningFocusOrderSequencerTests` | Unit/component only |
 | Up Next and candidate mapping | `IterationPlanningViewMapperTests` | Unit/component only |
 | Add to Up Next writes (status, triage add, Focus Order) | `IterationPlanningServiceTests` | Unit/component only |
+| Active load capacity flag and at-capacity warning | `IterationPlanningViewMapperTests`, `PmWorkflowPlanningTests` | Unit/component only |
+| Capacity exceeded confirmation dialog before add | `PmWorkflowPlanningTests` | Unit/component only |
+| Stalled Up Next gate disables add | `PmWorkflowPlanningTests` | Unit/component only |
+| Bulk milestone skip when milestone missing on a repository | `PlanningBulkMilestoneAssignerTests`, `IterationPlanningServiceTests` | Unit/component only |
+| Add to Up Next success and failure snackbars | `PmWorkflowPlanningTests` | Unit/component only |
 | Route shell, no-board copy, Up Next and candidate regions, empty copy, load error, partial failure | `PmWorkflowPlanningTests` | `pm-workflow.spec.ts` `Iteration Planning` describe — route shell and no-board/empty/error/warning copy |
 
 See [CRITICAL_JOURNEYS.md](CRITICAL_JOURNEYS.md) Tier 2 — PM Workflow row — for the journey-level summary.


### PR DESCRIPTION
## Summary of Changes

Completes Iteration Planning test coverage for issue #387 by adding bUnit assertions for add-to-Up-Next success and failure snackbars, and expanding `USER_DOCS_ALIGNMENT.md` to record the full planning test matrix (Focus Order, capacity, stalled gate, bulk milestone skip, and Playwright shell).

## Related Issue(s)

Closes #387

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — test-only change.

## Additional Notes

- Unit and component coverage for Focus Order, capacity flags, stalled gate, capacity dialog, bulk milestone skip, and Playwright planning shell was already delivered with stories #283–#286; this PR closes the remaining snackbar bUnit gap and documents the matrix in `tests/E2E/USER_DOCS_ALIGNMENT.md`.
- `dotnet clean SoloDevBoard.slnx && dotnet test SoloDevBoard.slnx` — 918 tests passed.