### PR TITLE
[Test] Add project board column migration test coverage (#415)

### DIFF
--- a/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/MigrationTests.cs
@@ -121,6 +121,90 @@ public sealed class MigrationTests
     }
 
     [Fact]
+    public async Task Migration_ProjectBoardColumnsEnabled_PreviewLockedUntilBoardsChosen()
+    {
+        // Arrange
+        var sourceRepository = CreateRepository("owner", "repo-a");
+        var targetRepository = CreateRepository("owner", "repo-b");
+
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
+
+        _migrationService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(
+            new MigrationProjectBoardDiscoveryDto(
+                [
+                    new MigrationProjectBoardOptionDto("PVT_alpha", "Alpha Board"),
+                    new MigrationProjectBoardOptionDto("PVT_beta", "Beta Board"),
+                ],
+                2,
+                0));
+
+        _migrationService.GetProjectBoardOptionsAsync("owner", "repo-b", Arg.Any<CancellationToken>()).Returns(
+            new MigrationProjectBoardDiscoveryDto(
+                [new MigrationProjectBoardOptionDto("PVT_target", "Target Board")],
+                1,
+                0));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<Migration>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='migration-repository-autocomplete']"));
+
+        await SelectRepositoriesAsync(cut, sourceRepository, targetRepository);
+        await DisableLabelsAndMilestonesScopeAsync(cut);
+        await EnableProjectBoardColumnsScopeAsync(cut);
+        await EnableTargetRepositoryAsync(cut, targetRepository);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("unlock preview", cut.Markup, StringComparison.OrdinalIgnoreCase);
+            Assert.True(cut.Find("[data-testid='migration-preview-button']").HasAttribute("disabled"));
+        });
+
+        await _migrationService.DidNotReceive().PreviewMigrationAsync(
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<MigrationScopeDto>(),
+            Arg.Any<MigrationConflictStrategy>(),
+            Arg.Any<MigrationBoardSelectionDto?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Migration_InaccessibleLinkedProjectBoards_ShowsWarning()
+    {
+        // Arrange
+        var sourceRepository = CreateRepository("owner", "repo-a");
+        var targetRepository = CreateRepository("owner", "repo-b");
+
+        _repositoryService.GetActiveRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([sourceRepository, targetRepository]);
+
+        _migrationService.GetProjectBoardOptionsAsync("owner", "repo-a", Arg.Any<CancellationToken>()).Returns(
+            new MigrationProjectBoardDiscoveryDto(
+                [new MigrationProjectBoardOptionDto("PVT_public", "Public Board")],
+                2,
+                1));
+
+        _migrationService.GetProjectBoardOptionsAsync("owner", "repo-b", Arg.Any<CancellationToken>()).Returns(
+            new MigrationProjectBoardDiscoveryDto([], 0, 0));
+
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<Migration>();
+        cut.WaitForAssertion(() => _ = cut.Find("[data-testid='migration-repository-autocomplete']"));
+
+        await SelectRepositoriesAsync(cut, sourceRepository, targetRepository);
+        await EnableProjectBoardColumnsScopeAsync(cut);
+        await EnableTargetRepositoryAsync(cut, targetRepository);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("2 linked project boards", cut.Markup, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("1 board could not be loaded", cut.Markup, StringComparison.OrdinalIgnoreCase);
+            Assert.Single(cut.FindAll("[data-testid='migration-inaccessible-project-boards-warning']"));
+        });
+    }
+
+    [Fact]
     public async Task Migration_OverwriteStrategy_RendersStatusOptionWarning()
     {
         // Arrange
@@ -534,6 +618,13 @@ public sealed class MigrationTests
     private static async Task EnableProjectBoardColumnsScopeAsync(IRenderedComponent<Migration> cut)
     {
         cut.Find("[data-testid='migration-scope-columns-switch']").Change(true);
+        await cut.InvokeAsync(() => { });
+    }
+
+    private static async Task DisableLabelsAndMilestonesScopeAsync(IRenderedComponent<Migration> cut)
+    {
+        cut.Find("[data-testid='migration-scope-labels-switch']").Change(false);
+        cut.Find("[data-testid='migration-scope-milestones-switch']").Change(false);
         await cut.InvokeAsync(() => { });
     }
 

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/MigrationServiceTests.cs
@@ -635,6 +635,32 @@ public sealed class MigrationServiceTests
     }
 
     [Fact]
+    public async Task ApplyMigrationAsync_StatusColumnsMissingStatusField_ReturnsErrorResult()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SetupStatusColumnData();
+        var sut = CreateSubject();
+        var boardSelection = CreateBoardSelection("source-project", "owner/target", "target-project");
+
+        _projectBoardStructureRepository
+            .GetStatusStructureAsync("target-project", cancellationToken)
+            .Returns(Task.FromException<ProjectBoardStatusStructure>(
+                new HttpRequestException("GraphQL response did not contain a supported Status field structure.")));
+
+        var result = await sut.ApplyMigrationAsync(
+            "owner/source",
+            ["owner/target"],
+            new MigrationScopeDto(false, false, true),
+            MigrationConflictStrategy.Merge,
+            boardSelection,
+            cancellationToken);
+
+        var statusResult = Assert.Single(result.ProjectBoardStatusResults);
+        Assert.True(statusResult.HasError);
+        Assert.Contains("Status field structure", statusResult.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ApplyMigrationAsync_CreateNewBoardOverwrite_RemovesDefaultOptionsNotInSource()
     {
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/E2E/CRITICAL_JOURNEYS.md
+++ b/tests/E2E/CRITICAL_JOURNEYS.md
@@ -38,7 +38,7 @@ For data-driven journeys against a real GitHub account, run the PAT suite locall
 |---------|------|-------------------|
 | Audit Dashboard repository selector failure | `audit-dashboard.spec.ts` | Feedback region and unable-to-load message; `/audit` alias. |
 | Repositories command strip and load failure | `repositories.spec.ts` | Refresh control, search field, error state with retry, and no horizontal overflow at an iPhone 12 viewport. |
-| One-Click Migration setup shell | `migrate.spec.ts` | Workflow controls, disabled preview, and API failure feedback. |
+| One-Click Migration setup shell | `migrate.spec.ts` | Workflow controls, columns scope switch, disabled preview, and API failure feedback. |
 | Board Rules selector and compare mode | `board-rules.spec.ts` | Selector region, compare toggle, and repository load failure. |
 | Label Manager taxonomy tabs and empty repository state | `labels.spec.ts` | Tab strip, disabled actions, and no-repositories message. |
 | Workflow template browse, filter, and select | `workflows.spec.ts` | Built-in templates load; repository selector shows error. |

--- a/tests/E2E/README.md
+++ b/tests/E2E/README.md
@@ -18,7 +18,7 @@ Published user guides must stay aligned with these tests like-for-like. See [USE
 | `auth-entry-hosted.spec.ts` | Hosted-mode login gate, welcome landing, and Blazor negotiate |
 | `audit-dashboard.spec.ts` | Audit Dashboard shell and repository load failure; `/audit` alias |
 | `repositories.spec.ts` | Repositories command strip, load failure handling, and phone-width overflow guard |
-| `migrate.spec.ts` | One-Click Migration setup shell and API failure feedback |
+| `migrate.spec.ts` | One-Click Migration setup shell, columns scope switch, and API failure feedback |
 | `board-rules.spec.ts` | Board Rules selector region, compare mode, and load failure |
 | `labels.spec.ts` | Label Manager shell, tabs, and empty-repository state |
 | `workflows.spec.ts` | Built-in template browse/filter/select and repository error state |

--- a/tests/E2E/USER_DOCS_ALIGNMENT.md
+++ b/tests/E2E/USER_DOCS_ALIGNMENT.md
@@ -29,7 +29,7 @@ When you add or change an end-user feature, update the user guide, the relevant 
 | [In-app home dashboard](../../website/content/docs/) | `/` | `smoke.spec.ts`, `navigation.spec.ts`, `accessibility.spec.ts` | `dashboard/home.png` | Tier 1 | In-app home lists eight feature cards; About and Appearance are reached via the app bar. |
 | [Audit Dashboard](../../website/content/docs/audit-dashboard.md) | `/audit-dashboard`, `/audit` | `audit-dashboard.spec.ts`, `accessibility.spec.ts` | `audit-dashboard/overview.png` | Tier 2 | Guide describes KPI cards, health sections (including label consistency), auto-refresh, and export; CI asserts shell, feedback region, and `/audit` alias with load failure. |
 | [Repositories](../../website/content/docs/repositories.md) | `/repositories` | `repositories.spec.ts`, `accessibility.spec.ts` | `repositories/overview.png` | Tier 2 | Guide describes command strip, search, and a phone-safe stacked grid; CI asserts refresh, search, error-state retry, and no horizontal overflow at 390px. |
-| [One-Click Migration](../../website/content/docs/one-click-migration.md) | `/migrate` | `migrate.spec.ts`, `accessibility.spec.ts` | `one-click-migration/overview.png` | Tier 2 | Guide describes preview/apply workflow and conflict strategies; CI asserts setup shell, disabled preview, and API failure feedback. |
+| [One-Click Migration](../../website/content/docs/one-click-migration.md) | `/migrate` | `migrate.spec.ts`, `accessibility.spec.ts` | `one-click-migration/overview.png` | Tier 2 | Guide describes labels, milestones, and Projects v2 Status column migration with board selectors and conflict strategies; CI asserts setup shell, columns scope control, disabled preview, and API failure feedback. |
 | [Label Manager](../../website/content/docs/label-manager.md) | `/labels` | `labels.spec.ts`, `accessibility.spec.ts` | `label-manager/overview.png` | Tier 2 | Guide describes three tabs and taxonomy workflows; CI asserts tab strip, disabled actions, and no-repositories message. |
 | [Board Rules Visualiser](../../website/content/docs/board-rules-visualiser.md) | `/board-rules` | `board-rules.spec.ts`, `accessibility.spec.ts` | `board-rules-visualiser/overview.png` | Tier 2 | Guide describes compare mode and board selection; CI asserts selector region, compare toggle, and load failure. |
 | [Triage UI](../../website/content/docs/triage-ui.md) | `/triage` | `triage.spec.ts`, `accessibility.spec.ts` | `triage-ui/overview.png` | Tier 2 | Guide describes session queue, shortcuts, milestones, and project board actions; CI asserts not-started region and no-repositories alert. |
@@ -73,6 +73,33 @@ Use this when extending specs so assertions track documented workflows.
 | Accessing (`/repositories`) | `repositories.spec.ts` URL and title | `docs-capture` |
 | Command strip, search, and load failure | Refresh control, search field, error state with retry | `prepareRepositoriesForCapture` |
 | Phone-width stacked grid without horizontal overflow | `repositories.spec.ts` 390×844 viewport overflow check (error-state shell in CI) | `docs-capture` plus component tests for long names and chips |
+
+### One-Click Migration
+
+| Guide section | CI assertion | Loaded-state validation |
+|---------------|--------------|-------------------------|
+| Accessing (`/migrate`) | `migrate.spec.ts` URL and title | `docs-capture` |
+| Migration setup shell and disabled preview | Workflow controls card, columns scope switch, disabled preview button | `docs-capture` |
+| Repository load failure | Feedback region and GitHub API failure message | — |
+| Project board columns scope, board selectors, preview lock, inaccessible-board warning | `MigrationTests` (bUnit) | `docs-capture` |
+| Conflict strategies and Status overwrite warning | `MigrationTests` (bUnit) | `docs-capture` |
+| Preview tables and apply summary for Status columns | — | `docs-capture` + Application tests |
+
+### Project board column migration automated coverage ([#415](https://github.com/markheydon/solo-dev-board/issues/415))
+
+Issue [#415](https://github.com/markheydon/solo-dev-board/issues/415) closes the test slice for feature [#291](https://github.com/markheydon/solo-dev-board/issues/291) (parent feature for Projects v2 Status column migration). Keep this mapping aligned with [one-click-migration.md](../../website/content/docs/one-click-migration.md).
+
+| Behaviour | Unit / component | Playwright (CI placeholder auth) |
+|-----------|------------------|----------------------------------|
+| Skip / Merge / Overwrite conflict matrix for Status options | `MigrationServiceTests` | — |
+| Create-new board path and preserve target option ids on name match | `MigrationServiceTests` | — |
+| Overwrite does not delete options still referenced by items | `MigrationServiceTests` | — |
+| Missing Status field and inaccessible boards | `MigrationServiceTests`, `GitHubServiceTests` | — |
+| GraphQL discovery, `createProjectV2`, and update payload retains existing option ids | `GitHubServiceTests` | — |
+| Columns scope switch, board selectors, preview locked until boards chosen | `MigrationTests` | `migrate.spec.ts` columns scope switch |
+| Overwrite warning copy and inaccessible-board alert | `MigrationTests` | — |
+| Setup shell, disabled preview, API failure feedback | — | `migrate.spec.ts` |
+| Migration overview screenshot with board selectors | — | `docs-capture` (`one-click-migration/overview.png`) |
 
 ### Appearance
 

--- a/tests/E2E/tests/migrate.spec.ts
+++ b/tests/E2E/tests/migrate.spec.ts
@@ -8,6 +8,8 @@ test.describe('One-Click Migration shell', () => {
     await expect(page.getByRole('heading', { name: 'One-Click Migration' })).toBeVisible();
     await expect(page.getByTestId('migration-workflow-controls-card')).toBeVisible();
     await expect(page.getByTestId('migration-workflow-controls-heading')).toHaveText('Migration setup');
+    await expect(page.getByTestId('migration-scope-columns-switch')).toBeVisible();
+    await expect(page.getByText('Project board columns')).toBeVisible();
     await expect(page.getByTestId('migration-preview-button')).toBeDisabled();
     await expect(page.getByTestId('migration-preview-empty-state')).toBeVisible();
   });

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -1518,7 +1518,7 @@ public sealed class GitHubServiceTests
     }
 
     [Fact]
-    public async Task GetProjectBoardStatusStructureAsync_StatusFieldMissing_ThrowsInvalidResponseException()
+    public async Task GetProjectBoardStatusStructureAsync_StatusFieldMissing_ThrowsHttpRequestException()
     {
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         var handler = new QueueMessageHandler(

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/GitHubServiceTests.cs
@@ -1518,6 +1518,44 @@ public sealed class GitHubServiceTests
     }
 
     [Fact]
+    public async Task GetProjectBoardStatusStructureAsync_StatusFieldMissing_ThrowsInvalidResponseException()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var handler = new QueueMessageHandler(
+        [
+            CreateJsonResponse(HttpStatusCode.OK, """
+            {
+                "data": {
+                    "node": {
+                        "id": "PVT_no_status",
+                        "title": "Unsupported Board",
+                        "fields": {
+                            "nodes": [
+                                {
+                                    "id": "PVTF_priority",
+                                    "name": "Priority",
+                                    "options": [
+                                        { "id": "option-one", "name": "High", "color": "RED", "description": "" }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                "errors": []
+            }
+            """),
+        ]);
+
+        var sut = CreateSubject(handler);
+
+        var action = async () => await sut.GetProjectBoardStatusStructureAsync("PVT_no_status", cancellationToken);
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(action);
+        Assert.Contains("Status field structure", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task CreateRepositoryLinkedProjectAsync_ValidResponse_ReturnsDefaultStatusStructure()
     {
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;


### PR DESCRIPTION
## Summary of Changes

Completes the remaining test and E2E alignment slice for Projects v2 Status column migration (issue #415). Adds Application, Infrastructure, bUnit, and Playwright coverage for missing Status field errors, preview locking until board selection, inaccessible-board warnings, and the columns scope control. Updates `USER_DOCS_ALIGNMENT.md` and `CRITICAL_JOURNEYS.md` to match the published One-Click Migration user guide.

## Related Issue(s)

Closes #415

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [ ] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [x] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

No UI changes. Docs-capture refresh for `one-click-migration/overview.png` remains a manual step (requires a real PAT and `DocsCapture:Enabled=true` per DEC-020).

## Additional Notes

- **4 new tests** (922 total, all passing): Application missing Status field apply error, Infrastructure `GetProjectBoardStatusStructureAsync` missing Status field, bUnit preview lock and inaccessible-board warning, Playwright columns scope switch assertion.
- Most conflict-matrix, GraphQL fixture, and board-selector coverage was already on `main` from the enabler (#414) and story (#416) work; this PR closes the remaining gaps listed in issue #415.