### PR TITLE
[Chore] Document area/repositories label and update Aspire dependencies

### DIFF
--- a/.agents/skills/repo-github-issues/SKILL.md
+++ b/.agents/skills/repo-github-issues/SKILL.md
@@ -126,7 +126,9 @@ Always apply at least one `type/` and one `priority/` label.
 | `type/` | `type/epic`, `type/feature`, `type/story`, `type/enabler`, `type/test`, `type/bug`, `type/chore`, `type/documentation` |
 | `priority/` | `priority/critical`, `priority/high`, `priority/medium`, `priority/low` |
 | `status/` | `status/todo`, `status/in-progress`, `status/blocked`, `status/ice-box`, `status/in-review`, `status/done` |
-| `area/` | `area/dashboard`, `area/migration`, `area/labels`, `area/board-rules`, `area/triage`, `area/workflows`, `area/infrastructure`, `area/docs` |
+| `area/` | `area/dashboard`, `area/repositories`, `area/migration`, `area/labels`, `area/board-rules`, `area/triage`, `area/workflows`, `area/infrastructure`, `area/docs` |
+
+Use `area/repositories` for the Repositories catalogue (`/repositories`), not `area/dashboard`. See `plan/LABEL_STRATEGY.md` for the full `area/` guidance. `area/*` labels are for this repository's triage only; they are not exported via Label Manager's recommended catalogue ([#446](https://github.com/markheydon/solo-dev-board/issues/446)).
 | `size/` | `size/xs`, `size/s`, `size/m`, `size/l`, `size/xl` |
 
 ## Issue relationships (agents must set these)

--- a/.agents/skills/repo-github-issues/references/TEMPLATE_SYNC.md
+++ b/.agents/skills/repo-github-issues/references/TEMPLATE_SYNC.md
@@ -59,7 +59,7 @@ The following **must** stay synchronised across formats:
 - Must align with `plan/LABEL_STRATEGY.md` taxonomy:
   - `type/` — bug, feature, chore, documentation, epic
   - `priority/` — critical, high, medium, low
-  - `area/` — dashboard, migration, labels, board-rules, triage, workflows, infrastructure, docs
+  - `area/` — dashboard, repositories, migration, labels, board-rules, triage, workflows, infrastructure, docs
   - `size/` — xs, s, m, l, xl (typically added by PM during planning)
   - `status/` — todo, in-progress, blocked, in-review, done (lifecycle state)
 
@@ -146,7 +146,7 @@ YAML templates have `dropdown` fields for priority and area. Markdown templates 
 
 Example:
 ```markdown
-**Labels to apply:** `type/story`, `priority/medium` (default), optionally add `area/` label (dashboard, migration, labels, board-rules, triage, workflows, infrastructure, docs)
+**Labels to apply:** `type/story`, `priority/medium` (default), optionally add `area/` label (dashboard, repositories, migration, labels, board-rules, triage, workflows, infrastructure, docs)
 ```
 
 ### User Story Template Pattern

--- a/.agents/skills/repo-github-issues/references/templates.md
+++ b/.agents/skills/repo-github-issues/references/templates.md
@@ -56,7 +56,7 @@
 
 **Mirrors:** `.github/ISSUE_TEMPLATE/feature.yml`
 
-**Labels to apply:** `type/story`, `priority/medium` (default), optionally add `area/` label (dashboard, migration, labels, board-rules, triage, workflows, infrastructure, docs)
+**Labels to apply:** `type/story`, `priority/medium` (default), optionally add `area/` label (dashboard, repositories, migration, labels, board-rules, triage, workflows, infrastructure, docs)
 
 > Use `type/feature` for Feature-tier issues grouping multiple stories. Use `type/enabler` for technical prerequisite issues. Use `type/test` for test coverage issues.
 
@@ -120,7 +120,7 @@ Examples:
 - [ ] [Add more as needed]
 
 ## Area
-[Which area of the codebase does this relate to? dashboard, migration, labels, board-rules, triage, workflows, infrastructure, docs]
+[Which area of the codebase does this relate to? dashboard, repositories, migration, labels, board-rules, triage, workflows, infrastructure, docs]
 
 ## Implementation References
 - **Wireframe:** N/A

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -52,6 +52,7 @@ body:
       description: "Which area of the codebase or project does this chore relate to?"
       options:
         - "area/dashboard"
+        - "area/repositories"
         - "area/migration"
         - "area/labels"
         - "area/board-rules"

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -75,6 +75,7 @@ body:
       description: "Which area of SoloDevBoard does this feature relate to?"
       options:
         - "area/dashboard"
+        - "area/repositories"
         - "area/migration"
         - "area/labels"
         - "area/board-rules"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,10 +9,10 @@
   <!-- UI -->
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="1.7.1" />
-    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.5.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ContainerRegistry" Version="13.5.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="13.5.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="13.5.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.5.2" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ContainerRegistry" Version="13.5.2" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="13.5.2" />
+    <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="13.5.2" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.6.0" />
     <PackageVersion Include="MessagePack" Version="3.1.8" />
     <PackageVersion Include="MudBlazor" Version="9.8.0" />
@@ -26,11 +26,11 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.9.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
   </ItemGroup>
   <!-- Testing -->
   <ItemGroup>

--- a/plan/LABEL_STRATEGY.md
+++ b/plan/LABEL_STRATEGY.md
@@ -131,6 +131,9 @@ A script to create all labels at once will be provided in `infra/scripts/create-
 #### `area/` - Apply when the scope is clear
 - Apply the relevant `area/` label to all issues and PRs.
 - Multiple `area/` labels may be applied if the issue spans more than one feature.
+- Apply `area/dashboard` to the Audit Dashboard (`/`) and cross-repo PM Workflow surfaces (Daily Focus, Backlog Review, Iteration Planning, and Repo Management under `/pm-workflow`).
+- Apply `area/repositories` to the Repositories catalogue page (`/repositories`), including search and refresh, catalogue status, OSS classification and filters ([#440](https://github.com/markheydon/solo-dev-board/issues/440)), repository groups ([#381](https://github.com/markheydon/solo-dev-board/issues/381)), catalogue management actions ([#435](https://github.com/markheydon/solo-dev-board/issues/435)), and overnight OSS hygiene views that scan the catalogue ([#438](https://github.com/markheydon/solo-dev-board/issues/438), [#439](https://github.com/markheydon/solo-dev-board/issues/439)). Do not use `area/dashboard` as a stand-in when the primary deliverable is the Repositories catalogue.
+- `area/*` labels on this repository describe SoloDevBoard's own feature map for issue and PR triage. They are **not** part of Label Manager's cross-repository recommended catalogue ([#446](https://github.com/markheydon/solo-dev-board/issues/446)); create or update `area/*` labels on `solo-dev-board` manually when the taxonomy changes.
 
 #### `size/` - Apply during sprint planning
 - Size labels are added during planning. They are not required when an issue is first created.

--- a/plan/oss-catalogue-identification-issues-checklist.md
+++ b/plan/oss-catalogue-identification-issues-checklist.md
@@ -7,7 +7,7 @@ Parent Feature: [#440](https://github.com/markheydon/solo-dev-board/issues/440).
 - [x] Scope validated (`plan/SCOPE.md` Repositories catalogue increment).
 - [x] Decision recorded (DEC-032).
 - [x] Wireframe updated (`plan/wireframes/repositories-wireframe.md`).
-- [x] Feature #440 already exists (`type/feature`, `priority/low`, `status/todo`, `area/dashboard`, `size/m`, milestone v1.1.0).
+- [x] Feature #440 already exists (`type/feature`, `priority/low`, `status/todo`, `area/repositories`, `size/m`, milestone v1.1.0).
 
 ## Issues
 

--- a/src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
+++ b/src/SoloDevBoard.AppHost/SoloDevBoard.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.2">
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Azure.AppContainers" />


### PR DESCRIPTION
## Summary of Changes

Documents the new `area/repositories` label across planning artefacts, GitHub issue templates, and agent skills, including when to use it instead of `area/dashboard` and the #446 note that `area/*` labels are for this repository only.

Also bumps Aspire hosting packages and the AppHost SDK from 13.5.0 to 13.5.2, and OpenTelemetry packages from 1.17.0 to 1.18.0.

GitHub issues and PRs for Repositories catalogue work were relabelled on the remote (`area/dashboard` or `area/infrastructure` → `area/repositories` where appropriate); that relabelling is not in this diff.

## Related Issue(s)

References #446

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds functionality)
- [x] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [ ] All new and existing tests pass (`dotnet test`)
- [ ] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [ ] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

N/A — planning and dependency updates only.

## Additional Notes

**Dependency updates**
- `Aspire.AppHost.Sdk` and Azure hosting packages: 13.5.0 → 13.5.2
- OpenTelemetry exporter, hosting, and instrumentation packages: 1.17.0 → 1.18.0

**GitHub relabelling (done on remote, not in this branch)**
- Swapped `area/dashboard` → `area/repositories` on #381, #438, #439
- Swapped `area/infrastructure` → `area/repositories` on #8, #11, #67, #131, #132 and PRs #18, #137
- Added `area/repositories` on #408, #435 and PRs #78, #409, #72
- Added dual `area/dashboard` + `area/repositories` on #11 and PR #72


Made with [Cursor](https://cursor.com)