### PR TITLE
[Feature] Add build timestamp to About page for staging identification

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -375,7 +375,7 @@ After a successful deploy:
    - Sign in with an allow-listed GitHub account completes and returns to the app.
    - One feature page (for example **Repositories**) loads GitHub data without errors.
    - Sign out returns to `/welcome`.
-5. **Deployment version check:** open **More options → About**. Staging should show a version with a `staging` pre-release suffix (for example `1.0.1-staging.0.42`); production should show a clean SemVer matching the release tag (for example `1.0.0`). The **Build** line links to the deployed commit — compare it with the commit SHA from the GitHub Actions deploy run or the tip of the deployed branch/tag.
+5. **Deployment version check:** open **More options → About**. Staging should show a version with a `staging` pre-release suffix (for example `1.0.1-staging.0.42`) and a **Built** timestamp in UK local time (for example `23 Aug 26 @ 15:11 BST`); production should show a clean SemVer matching the release tag (for example `1.0.0`) with no **Built** line. The **Build** line links to the deployed commit — compare it with the commit SHA from the GitHub Actions deploy run or the tip of the deployed branch/tag.
 6. **Container App environment verification:** confirm `GitHubAuth__HostedGitHubAppClientId` and `HostedAdmissionControl__AllowedUserLogins` on the active revision show real values (not `-` placeholders). If they still show `-`, the GitHub Environment variables were not applied — see [Fork and independent operators](#fork-and-independent-operators).
 
 ## Deploy locally (operator testing)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,7 +139,7 @@ dotnet run --project src/App/SoloDevBoard.App
 
 > **Recommendation:** Aspire is the standardised path for local development. It ensures consistent behaviour across all environments and prepares you for production deployment to Azure Container Apps.
 
-When you run locally, open **More options → About** to see the MinVer-calculated application version and build commit SHA. Local builds use the same git-based versioning as CI; staging-style pre-release suffixes appear when your checkout is ahead of the latest `v*` tag.
+When you run locally, open **More options → About** to see the MinVer-calculated application version, build commit SHA, and (for pre-release builds) a **Built** timestamp in UK local time. Local builds use the same git-based versioning as CI; staging-style pre-release suffixes appear when your checkout is ahead of the latest `v*` tag.
 
 ---
 

--- a/plan/RELEASE_PLAN.md
+++ b/plan/RELEASE_PLAN.md
@@ -14,15 +14,15 @@ During the pre-1.0 development phase (`0.x.y`), minor version bumps may include 
 
 Application version numbers are calculated automatically at build time by [MinVer](https://github.com/adamralph/minver) from git tags on `SoloDevBoard.App`. The About page and GitHub API user-agent both read this stamped assembly metadata.
 
-| Deploy tier | Git state | Example About version | Example build metadata |
-|---|---|---|---|
-| **Production** | Build at tag `v1.0.0` | `1.0.0` | Short commit SHA (for example `abc1234`) |
-| **Staging** | `main` commits after the latest tag | `1.0.1-staging.0.42` | Short commit SHA |
-| **Local dev** | Untagged working tree | `1.0.x-staging.0.n` (from git history) | Short commit SHA when git metadata is available |
+| Deploy tier | Git state | Example About version | Example built at | Example build metadata |
+|---|---|---|---|---|
+| **Production** | Build at tag `v1.0.0` | `1.0.0` | *(not shown)* | Short commit SHA (for example `abc1234`) |
+| **Staging** | `main` commits after the latest tag | `1.0.1-staging.0.42` | `23 Aug 26 @ 15:11 BST` | Short commit SHA |
+| **Local dev** | Untagged working tree | `1.0.x-staging.0.n` (from git history) | `23 Aug 26 @ 15:11 BST` | Short commit SHA when git metadata is available |
 
 **Production source of truth:** the `vX.Y.Z` git tag pushed for the release. Pushing that tag triggers production CD; MinVer stamps the tag version into the deployed assembly.
 
-**Staging identification:** staging builds use the `staging.0` pre-release identifier so the About version is clearly not a production release. Compare the About **Build** value with the commit SHA on `main` in GitHub to confirm which deployment you are viewing.
+**Staging identification:** staging builds use the `staging.0` pre-release identifier so the About version is clearly not a production release. The About **Built** line shows the compile-time stamp in UK local time (for example `23 Aug 26 @ 15:11 BST`) so you can confirm a new deploy without memorising the MinVer suffix. Compare the About **Build** value with the commit SHA on `main` in GitHub to confirm which deployment you are viewing.
 
 **CI requirement:** CD and CI workflows check out the repository with `fetch-depth: 0` so MinVer can read tags and commit history.
 
@@ -129,7 +129,7 @@ Feature branch → Pull Request → CI passes → Code review → Merge to main 
 ### Step-by-Step
 
 1. **Merge to `main`:** All features for the release are merged via PRs with the CI pipeline passing. CD deploys automatically to the **staging** Azure Container Apps environment.
-2. **Final smoke test:** Verify the deployment to the staging environment is healthy. Open **More options → About** and confirm the version shows a `staging` pre-release suffix and that the **Build** commit SHA matches the latest commit on `main` for that deploy.
+2. **Final smoke test:** Verify the deployment to the staging environment is healthy. Open **More options → About** and confirm the version shows a `staging` pre-release suffix, the **Built** timestamp reflects the latest deploy, and the **Build** commit SHA matches the latest commit on `main` for that deploy.
 3. **Update documentation:** Ensure all user-facing docs on `main` reflect the released features (validated by `hugo-validate` on PRs; not published until tagged).
 4. **Tag the release:**
    ```bash

--- a/src/App/SoloDevBoard.App/Components/Features/About/Pages/About.razor
+++ b/src/App/SoloDevBoard.App/Components/Features/About/Pages/About.razor
@@ -15,6 +15,14 @@
                 <MudText Typo="Typo.body2" data-testid="about-version">@Version</MudText>
             </MudStack>
 
+            @if (!string.IsNullOrWhiteSpace(BuiltAtDisplay))
+            {
+                <MudStack Row="true" Spacing="1">
+                    <MudText Typo="Typo.subtitle2">Built:</MudText>
+                    <MudText Typo="Typo.body2" data-testid="about-built-at">@BuiltAtDisplay</MudText>
+                </MudStack>
+            }
+
             @if (!string.IsNullOrWhiteSpace(BuildMetadata))
             {
                 <MudStack Row="true" Spacing="1">

--- a/src/App/SoloDevBoard.App/Components/Features/About/Pages/About.razor.cs
+++ b/src/App/SoloDevBoard.App/Components/Features/About/Pages/About.razor.cs
@@ -24,6 +24,8 @@ public partial class About : ComponentBase
 
     private string Version => AppVersionService.Version;
 
+    private string BuiltAtDisplay => AppVersionService.BuiltAtDisplay;
+
     private string BuildMetadata => AppVersionService.BuildMetadata;
 
     private string? BuildCommitUrl =>

--- a/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj
+++ b/src/App/SoloDevBoard.App/SoloDevBoard.App.csproj
@@ -11,6 +11,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<AssemblyMetadata Include="BuildTimestampUtc" Value="$([System.DateTime]::UtcNow.ToString('o'))" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="Markdig" />
 		<PackageReference Include="MinVer">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/Application/SoloDevBoard.Application/Services/Common/AppVersionBuiltAtFormatter.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/AppVersionBuiltAtFormatter.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+
+namespace SoloDevBoard.Application.Services.Common;
+
+/// <summary>Formats build timestamps for display on the About page.</summary>
+internal static class AppVersionBuiltAtFormatter
+{
+    private static readonly TimeZoneInfo LondonTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/London");
+    private static readonly CultureInfo UnitedKingdomCulture = CultureInfo.GetCultureInfo("en-GB");
+
+    /// <summary>
+    /// Formats a UTC build timestamp for pre-release versions.
+    /// Returns an empty string for release versions or when no timestamp is available.
+    /// </summary>
+    /// <param name="version">The application version string.</param>
+    /// <param name="buildTimestampUtc">The UTC build timestamp, when stamped at compile time.</param>
+    /// <returns>A UK-localised display string, or empty when not applicable.</returns>
+    public static string FormatDisplay(string version, DateTimeOffset? buildTimestampUtc)
+    {
+        if (string.IsNullOrWhiteSpace(version) || !version.Contains('-', StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        if (buildTimestampUtc is null)
+        {
+            return string.Empty;
+        }
+
+        var utc = buildTimestampUtc.Value.UtcDateTime;
+        var london = TimeZoneInfo.ConvertTimeFromUtc(utc, LondonTimeZone);
+        var timeZoneAbbreviation = LondonTimeZone.IsDaylightSavingTime(london) ? "BST" : "GMT";
+        var formatted = london.ToString("d MMM yy @ HH:mm", UnitedKingdomCulture);
+        return $"{formatted} {timeZoneAbbreviation}";
+    }
+}

--- a/src/Application/SoloDevBoard.Application/Services/Common/AppVersionMetadata.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/AppVersionMetadata.cs
@@ -1,8 +1,8 @@
 namespace SoloDevBoard.Application.Services.Common;
 
 /// <summary>Parsed application version metadata from assembly attributes.</summary>
-internal readonly record struct AppVersionMetadata(string Version, string BuildMetadata)
+internal readonly record struct AppVersionMetadata(string Version, string BuildMetadata, DateTimeOffset? BuildTimestampUtc = null)
 {
     /// <summary>Gets empty metadata when no version attributes are available.</summary>
-    public static AppVersionMetadata Empty { get; } = new("unknown", string.Empty);
+    public static AppVersionMetadata Empty { get; } = new("unknown", string.Empty, null);
 }

--- a/src/Application/SoloDevBoard.Application/Services/Common/AppVersionMetadataParser.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/AppVersionMetadataParser.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Reflection;
 
 namespace SoloDevBoard.Application.Services.Common;
@@ -5,6 +6,8 @@ namespace SoloDevBoard.Application.Services.Common;
 /// <summary>Parses version metadata from assembly attributes.</summary>
 internal static class AppVersionMetadataParser
 {
+    private const string BuildTimestampMetadataKey = "BuildTimestampUtc";
+
     /// <summary>Parses version and build metadata from the supplied assembly.</summary>
     /// <param name="assembly">The assembly to inspect.</param>
     /// <returns>Parsed version metadata.</returns>
@@ -12,31 +15,58 @@ internal static class AppVersionMetadataParser
     {
         ArgumentNullException.ThrowIfNull(assembly);
 
+        var buildTimestampUtc = TryParseBuildTimestampUtc(assembly);
+
         var informationalVersion = assembly
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
             .InformationalVersion;
 
         if (!string.IsNullOrWhiteSpace(informationalVersion))
         {
-            return ParseInformationalVersion(informationalVersion);
+            var (version, buildMetadata) = SplitInformationalVersion(informationalVersion);
+            return new AppVersionMetadata(version, buildMetadata, buildTimestampUtc);
         }
 
         var assemblyVersion = assembly.GetName().Version?.ToString();
         return string.IsNullOrWhiteSpace(assemblyVersion)
             ? AppVersionMetadata.Empty
-            : new AppVersionMetadata(assemblyVersion, string.Empty);
+            : new AppVersionMetadata(assemblyVersion, string.Empty, buildTimestampUtc);
     }
 
-    private static AppVersionMetadata ParseInformationalVersion(string informationalVersion)
+    private static (string Version, string BuildMetadata) SplitInformationalVersion(string informationalVersion)
     {
         var metadataSeparatorIndex = informationalVersion.IndexOf('+', StringComparison.Ordinal);
         if (metadataSeparatorIndex < 0)
         {
-            return new AppVersionMetadata(informationalVersion, string.Empty);
+            return (informationalVersion, string.Empty);
         }
 
         var version = informationalVersion[..metadataSeparatorIndex];
         var buildMetadata = informationalVersion[(metadataSeparatorIndex + 1)..];
-        return new AppVersionMetadata(version, buildMetadata);
+        return (version, buildMetadata);
+    }
+
+    private static DateTimeOffset? TryParseBuildTimestampUtc(Assembly assembly)
+    {
+        var buildTimestampValue = assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(attribute => string.Equals(
+                attribute.Key,
+                BuildTimestampMetadataKey,
+                StringComparison.Ordinal))?
+            .Value;
+
+        if (string.IsNullOrWhiteSpace(buildTimestampValue))
+        {
+            return null;
+        }
+
+        return DateTimeOffset.TryParse(
+            buildTimestampValue,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var buildTimestampUtc)
+            ? buildTimestampUtc
+            : null;
     }
 }

--- a/src/Application/SoloDevBoard.Application/Services/Common/AppVersionService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/AppVersionService.cs
@@ -13,6 +13,7 @@ public sealed class AppVersionService : IAppVersionService
         var metadata = ResolveMetadata();
         Version = metadata.Version;
         BuildMetadata = metadata.BuildMetadata;
+        BuiltAtDisplay = AppVersionBuiltAtFormatter.FormatDisplay(metadata.Version, metadata.BuildTimestampUtc);
     }
 
     /// <inheritdoc/>
@@ -20,6 +21,9 @@ public sealed class AppVersionService : IAppVersionService
 
     /// <inheritdoc/>
     public string BuildMetadata { get; }
+
+    /// <inheritdoc/>
+    public string BuiltAtDisplay { get; }
 
     /// <inheritdoc/>
     public string UserAgent => $"{ApplicationName}/{Version}";

--- a/src/Application/SoloDevBoard.Application/Services/Common/IAppVersionService.cs
+++ b/src/Application/SoloDevBoard.Application/Services/Common/IAppVersionService.cs
@@ -9,6 +9,11 @@ public interface IAppVersionService
     /// <summary>Gets build metadata from the assembly informational version, such as a commit SHA.</summary>
     string BuildMetadata { get; }
 
+    /// <summary>
+    /// Gets a UK-localised build timestamp for pre-release versions, or an empty string for production releases.
+    /// </summary>
+    string BuiltAtDisplay { get; }
+
     /// <summary>Gets the user-agent value for outbound HTTP requests.</summary>
     string UserAgent { get; }
 }

--- a/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
+++ b/tests/App.Tests/SoloDevBoard.App.Tests/AboutTests.cs
@@ -13,6 +13,7 @@ public sealed class AboutTests : BunitContext
 {
     private const string TestVersion = "1.2.3";
     private const string TestBuildMetadata = "abc1234";
+    private const string TestBuiltAtDisplay = "23 Aug 26 @ 15:11 BST";
     private readonly IAppVersionService _appVersionService = Substitute.For<IAppVersionService>();
     private readonly IGitHubAuthenticationSummaryService _authenticationSummaryService = Substitute.For<IGitHubAuthenticationSummaryService>();
 
@@ -31,6 +32,7 @@ public sealed class AboutTests : BunitContext
     {
         _appVersionService.Version.Returns(TestVersion);
         _appVersionService.BuildMetadata.Returns(TestBuildMetadata);
+        _appVersionService.BuiltAtDisplay.Returns(string.Empty);
         _appVersionService.UserAgent.Returns($"SoloDevBoard/{TestVersion}");
     }
 
@@ -89,6 +91,30 @@ public sealed class AboutTests : BunitContext
 
         // Assert
         Assert.Empty(cut.FindAll("[data-testid='about-build']"));
+    }
+
+    [Fact]
+    public void AboutPage_RenderedWithBuiltAtDisplay_DisplaysBuiltRow()
+    {
+        // Arrange
+        _appVersionService.BuiltAtDisplay.Returns(TestBuiltAtDisplay);
+
+        // Act
+        var cut = Render<About>();
+
+        // Assert
+        var builtAt = cut.Find("[data-testid='about-built-at']");
+        Assert.Equal(TestBuiltAtDisplay, builtAt.TextContent.Trim());
+    }
+
+    [Fact]
+    public void AboutPage_RenderedWithoutBuiltAtDisplay_HidesBuiltRow()
+    {
+        // Act
+        var cut = Render<About>();
+
+        // Assert
+        Assert.Empty(cut.FindAll("[data-testid='about-built-at']"));
     }
 
     [Fact]

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/AppVersionBuiltAtFormatterTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/AppVersionBuiltAtFormatterTests.cs
@@ -1,0 +1,47 @@
+using SoloDevBoard.Application.Services.Common;
+
+namespace SoloDevBoard.Application.Tests;
+
+/// <summary>Tests for <see cref="AppVersionBuiltAtFormatter"/>.</summary>
+public sealed class AppVersionBuiltAtFormatterTests
+{
+    [Theory]
+    [InlineData("1.0.0")]
+    [InlineData("2.3.4")]
+    public void FormatDisplay_ReleaseVersion_ReturnsEmptyString(string version)
+    {
+        var buildTimestampUtc = new DateTimeOffset(2026, 8, 23, 14, 11, 0, TimeSpan.Zero);
+
+        var display = AppVersionBuiltAtFormatter.FormatDisplay(version, buildTimestampUtc);
+
+        Assert.Equal(string.Empty, display);
+    }
+
+    [Fact]
+    public void FormatDisplay_PreReleaseVersionWithoutTimestamp_ReturnsEmptyString()
+    {
+        var display = AppVersionBuiltAtFormatter.FormatDisplay("1.0.1-staging.0.49", null);
+
+        Assert.Equal(string.Empty, display);
+    }
+
+    [Fact]
+    public void FormatDisplay_PreReleaseVersionWithSummerTimestamp_ReturnsUkLocalisedDisplay()
+    {
+        var buildTimestampUtc = new DateTimeOffset(2026, 8, 23, 14, 11, 0, TimeSpan.Zero);
+
+        var display = AppVersionBuiltAtFormatter.FormatDisplay("1.0.1-staging.0.49", buildTimestampUtc);
+
+        Assert.Equal("23 Aug 26 @ 15:11 BST", display);
+    }
+
+    [Fact]
+    public void FormatDisplay_PreReleaseVersionWithWinterTimestamp_ReturnsGmtAbbreviation()
+    {
+        var buildTimestampUtc = new DateTimeOffset(2026, 1, 15, 12, 30, 0, TimeSpan.Zero);
+
+        var display = AppVersionBuiltAtFormatter.FormatDisplay("1.0.1-staging.0.12", buildTimestampUtc);
+
+        Assert.Equal("15 Jan 26 @ 12:30 GMT", display);
+    }
+}

--- a/tests/Application.Tests/SoloDevBoard.Application.Tests/AppVersionMetadataParserTests.cs
+++ b/tests/Application.Tests/SoloDevBoard.Application.Tests/AppVersionMetadataParserTests.cs
@@ -16,41 +16,74 @@ public sealed class AppVersionMetadataParserTests
         string expectedVersion,
         string expectedBuildMetadata)
     {
-        // Arrange
-        var assembly = CreateAssemblyWithInformationalVersion(informationalVersion);
+        var assembly = CreateAssembly(informationalVersion);
 
-        // Act
         var metadata = AppVersionMetadataParser.Parse(assembly);
 
-        // Assert
         Assert.Equal(expectedVersion, metadata.Version);
         Assert.Equal(expectedBuildMetadata, metadata.BuildMetadata);
+        Assert.Null(metadata.BuildTimestampUtc);
+    }
+
+    [Fact]
+    public void Parse_BuildTimestampMetadataPresent_ReturnsParsedUtcTimestamp()
+    {
+        var assembly = CreateAssembly(
+            "1.0.1-staging.0.49+abc1234",
+            buildTimestampUtc: "2026-08-23T14:11:00.0000000Z");
+
+        var metadata = AppVersionMetadataParser.Parse(assembly);
+
+        Assert.Equal("1.0.1-staging.0.49", metadata.Version);
+        Assert.Equal("abc1234", metadata.BuildMetadata);
+        Assert.Equal(new DateTimeOffset(2026, 8, 23, 14, 11, 0, TimeSpan.Zero), metadata.BuildTimestampUtc);
+    }
+
+    [Fact]
+    public void Parse_InvalidBuildTimestampMetadata_ReturnsNullTimestamp()
+    {
+        var assembly = CreateAssembly(
+            "1.0.1-staging.0.49+abc1234",
+            buildTimestampUtc: "not-a-timestamp");
+
+        var metadata = AppVersionMetadataParser.Parse(assembly);
+
+        Assert.Null(metadata.BuildTimestampUtc);
     }
 
     [Fact]
     public void Parse_AssemblyVersionOnly_ReturnsNonEmptyVersion()
     {
-        // Arrange
         var assembly = typeof(AppVersionMetadataParserTests).Assembly;
 
-        // Act
         var metadata = AppVersionMetadataParser.Parse(assembly);
 
-        // Assert
         Assert.False(string.IsNullOrWhiteSpace(metadata.Version));
     }
 
-    private static Assembly CreateAssemblyWithInformationalVersion(string informationalVersion)
+    private static Assembly CreateAssembly(
+        string informationalVersion,
+        string? buildTimestampUtc = null)
     {
         var assemblyName = new AssemblyName(Guid.NewGuid().ToString("N"));
         var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
             assemblyName,
             AssemblyBuilderAccess.Run);
         assemblyBuilder.DefineDynamicModule("TestModule");
-        var attributeBuilder = new CustomAttributeBuilder(
+
+        var informationalVersionAttributeBuilder = new CustomAttributeBuilder(
             typeof(AssemblyInformationalVersionAttribute).GetConstructor([typeof(string)])!,
             [informationalVersion]);
-        assemblyBuilder.SetCustomAttribute(attributeBuilder);
+        assemblyBuilder.SetCustomAttribute(informationalVersionAttributeBuilder);
+
+        if (!string.IsNullOrWhiteSpace(buildTimestampUtc))
+        {
+            var buildTimestampAttributeBuilder = new CustomAttributeBuilder(
+                typeof(AssemblyMetadataAttribute).GetConstructor([typeof(string), typeof(string)])!,
+                ["BuildTimestampUtc", buildTimestampUtc]);
+            assemblyBuilder.SetCustomAttribute(buildTimestampAttributeBuilder);
+        }
+
         return assemblyBuilder;
     }
 }

--- a/tests/E2E/tests/about.spec.ts
+++ b/tests/E2E/tests/about.spec.ts
@@ -19,6 +19,10 @@ test('about page shows deployment metadata from the shell menu', async ({ page }
   await expect(page).toHaveTitle(/About/);
   await expect(page.getByTestId('about-application-name')).toContainText('SoloDevBoard');
   await expect(page.getByTestId('about-version')).not.toBeEmpty();
+  const versionText = await page.getByTestId('about-version').textContent();
+  if (versionText?.includes('-')) {
+    await expect(page.getByTestId('about-built-at')).not.toBeEmpty();
+  }
   await expect(page.getByTestId('about-build')).not.toBeEmpty();
   await expect(page.getByTestId('about-dotnet-version')).toHaveText(/\d+\.\d+/);
   await expect(page.getByTestId('about-auth-mode')).toContainText('PAT-only local trusted mode');

--- a/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/InfrastructureServiceExtensionsTests.cs
+++ b/tests/Infrastructure.Tests/SoloDevBoard.Infrastructure.Tests/InfrastructureServiceExtensionsTests.cs
@@ -156,5 +156,7 @@ internal sealed class TestAppVersionService : IAppVersionService
 
     public string BuildMetadata => "test-build";
 
+    public string BuiltAtDisplay => string.Empty;
+
     public string UserAgent => "SoloDevBoard/1.0.0-test";
 }

--- a/website/content/docs/app-shell/about.md
+++ b/website/content/docs/app-shell/about.md
@@ -12,6 +12,7 @@ The About page provides essential information about the SoloDevBoard application
 
 - Application name and branding.
 - Application version (SemVer from git tags via MinVer at build time).
+- Build timestamp (pre-release builds only), shown in UK local time so you can tell whether a staging or local deploy is newer than the last one you checked.
 - Build commit SHA (when available), linked to the source repository for verification.
 - .NET runtime version currently in use.
 - GitHub authentication mode (hosted sign-in or PAT-only local trusted mode).


### PR DESCRIPTION
## Summary of Changes

Adds a **Built** row to the About page for pre-release builds (staging and local MinVer versions) so operators can tell whether they are viewing a newer deploy without memorising the MinVer suffix. Production releases continue to show a clean SemVer with no **Built** line.

Compile-time UTC metadata is stamped into `SoloDevBoard.App` at build and formatted in UK local time (`23 Aug 26 @ 15:11 BST`). `IAppVersionService.Version` and the GitHub user-agent are unchanged.

## Related Issue(s)

Ad-hoc UX improvement — no tracking issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds functionality)
- [ ] 🔧 Chore / maintenance (dependency update, refactoring, tooling)
- [ ] ♻️ Refactoring (no functional change, improves code quality)
- [x] 📝 Documentation (updates to docs, comments, or README)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes follow the coding conventions in `AGENTS.md`
- [x] All new and existing tests pass (`dotnet test`)
- [x] I have added or updated tests to cover my changes
- [x] I have updated relevant documentation in `docs/` or `plan/`
- [x] No new compiler warnings have been introduced
- [x] All text in comments, strings, and docs is written in **UK English**
- [ ] If this adds a new feature, a GitHub Issue exists (or is updated), Project #8 is synced, and end-user docs under `website/` (or developer docs under `docs/`) have been updated

## Screenshots (if applicable)

_Not captured in this PR — About docs screenshot can be refreshed via docs-capture after merge._

## Additional Notes

**Test plan:**
- [x] `dotnet test` — Application AppVersion tests, About bUnit tests
- [x] Build verifies `BuildTimestampUtc` is stamped in the assembly
- [ ] Confirm **Built** row appears on staging About after CD deploy
- [ ] Confirm production About shows no **Built** row on next release

**Example staging display:**
```
Version: 1.0.1-staging.0.49
Built:   23 Aug 26 @ 15:11 BST
Build:   abc1234
```

Made with [Cursor](https://cursor.com)